### PR TITLE
Don't require authorization for OPTIONS

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -19,12 +19,12 @@ module Api
     include_concern 'Authentication'
     include ActionController::HttpAuthentication::Basic::ControllerMethods
 
-    before_action :require_api_user_or_token, :except => [:handle_options_request]
+    before_action :require_api_user_or_token, :except => [:options]
     before_action :set_gettext_locale
     before_action :set_access_control_headers
     before_action :parse_api_request, :log_api_request, :validate_api_request
     before_action :validate_api_action, :except => [:options]
-    before_action :log_request_initiated, :only => [:handle_options_request]
+    before_action :log_request_initiated, :only => [:options]
     before_action :validate_response_format, :except => [:destroy]
     after_action :log_api_response
 

--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -9,11 +9,19 @@ module Api
       # TODO: this service is rendering resources which (a) require
       # authentication (problematic for CORS compatibility), and (b)
       # are not being properly filtered by RBAC
-      if [HttpHeaders::MIQ_TOKEN, HttpHeaders::AUTH_TOKEN, "HTTP_AUTHORIZATION"].any? { |header| request.headers.include?(header) }
+      if authentication_requested?
         require_api_user_or_token
         render_options(:container_deployments, ContainerDeploymentService.new.all_data)
       else
         super
+      end
+    end
+
+    private
+
+    def authentication_requested?
+      [HttpHeaders::MIQ_TOKEN, HttpHeaders::AUTH_TOKEN, "HTTP_AUTHORIZATION"].any? do |header|
+        request.headers.include?(header)
       end
     end
   end

--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -9,7 +9,12 @@ module Api
       # TODO: this service is rendering resources which (a) require
       # authentication (problematic for CORS compatibility), and (b)
       # are not being properly filtered by RBAC
-      render_options(:container_deployments, ContainerDeploymentService.new.all_data)
+      if [HttpHeaders::MIQ_TOKEN, HttpHeaders::AUTH_TOKEN, "HTTP_AUTHORIZATION"].any? { |header| request.headers.include?(header) }
+        require_api_user_or_token
+        render_options(:container_deployments, ContainerDeploymentService.new.all_data)
+      else
+        super
+      end
     end
   end
 end

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -470,8 +470,6 @@ RSpec.describe 'Authentications API' do
 
   describe 'OPTIONS /api/authentications' do
     it 'returns expected and additional attributes' do
-      api_basic_authorize
-
       run_options(authentications_url)
 
       additional_options = {

--- a/spec/requests/clusters_spec.rb
+++ b/spec/requests/clusters_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe 'Clusters API' do
   context 'OPTIONS /api/clusters' do
     it 'returns clusters node_types' do
-      api_basic_authorize
-
       expected_data = {"node_types" => EmsCluster.node_types.to_s}
 
       run_options(clusters_url)

--- a/spec/requests/container_deployments_spec.rb
+++ b/spec/requests/container_deployments_spec.rb
@@ -1,4 +1,10 @@
 describe "Container Deployments API" do
+  it "supports OPTIONS requests without authorization" do
+    run_options container_deployments_url
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["data"]).to be_empty
+  end
+
   it "supports collect-data with OPTIONS" do
     allow_any_instance_of(ContainerDeploymentService).to receive(:cloud_init_template_id).and_return(1)
     api_basic_authorize

--- a/spec/requests/hosts_spec.rb
+++ b/spec/requests/hosts_spec.rb
@@ -80,8 +80,6 @@ RSpec.describe "hosts API" do
 
     context 'OPTIONS /api/hosts' do
       it 'returns hosts node_types' do
-        api_basic_authorize
-
         expected_data = {"node_types" => Host.node_types.to_s}
 
         run_options(hosts_url)

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -913,8 +913,6 @@ describe "Querying" do
 
   describe 'OPTIONS /api/vms' do
     it 'returns the options information' do
-      api_basic_authorize
-
       run_options(vms_url)
       expect_options_results(:vms)
     end


### PR DESCRIPTION
CORS states that no authorization should be done in pre-flight
requests. For the problematic Container Deployments collection, we
will now render the sensitive data if authorized, but don't require
authorization, rendering no data if none is stipulated.

@miq-bot add-label bug
@miq-bot assign @abellotti 

/cc @jntullo 