### PR TITLE
missing_user_features now lives in the User model

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -49,8 +49,7 @@ module Api
       end
 
       def validate_user_identity(user_obj)
-        @user_validation_service ||= UserValidationService.new(self)
-        missing_feature = @user_validation_service.missing_user_features(user_obj)
+        missing_feature = User.missing_user_features(user_obj)
         if missing_feature
           raise AuthenticationError, "Invalid User #{user_obj.userid} specified, User's #{missing_feature} is missing"
         end


### PR DESCRIPTION
- [x] depends on https://github.com/ManageIQ/manageiq/pull/15779 [MERGED]

Note, it doesn't look like the actual user validation service was needed
other than to call this method, so the instantiation of it and the
caching in an instance variable were removed.