### PR TITLE
Generic Object Definition CRUD

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -142,8 +142,12 @@ module Api
       def resource_search(id, type, klass)
         validate_id(id, klass)
         target = respond_to?("find_#{type}") ? public_send("find_#{type}", id) : klass.find(id)
+        filter_resource(target, type, klass)
+      end
+
+      def filter_resource(target, type, klass)
         res = Rbac.filtered_object(target, :user => User.current_user, :class => klass)
-        raise ForbiddenError, "Access to the resource #{type}/#{id} is forbidden" unless res
+        raise ForbiddenError, "Access to the resource #{type}/#{target.id} is forbidden" unless res
         res
       end
 

--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -1,0 +1,40 @@
+module Api
+  class GenericObjectDefinitionsController < BaseController
+    def show
+      object = fetch_generic_object_definition(@req.c_id)
+      render_resource(:generic_object_definitions, object)
+    end
+
+    def create_resource(_type, _id, data)
+      klass = collection_class(:generic_object_definitions)
+      klass.create!(data.deep_symbolize_keys)
+    rescue => err
+      raise BadRequestError, "Failed to create new generic object definition - #{err}"
+    end
+
+    def edit_resource(_type, id, data)
+      id ||= data['name']
+      go_def = fetch_generic_object_definition(id)
+      updated_data = data['resource'].try(:deep_symbolize_keys) || data.deep_symbolize_keys
+      go_def.update_attributes!(updated_data) if data.present?
+      go_def
+    rescue => err
+      raise BadRequestError, "Failed to update generic object definition - #{err}"
+    end
+
+    def delete_resource(_type, id, data = {})
+      id ||= data['name']
+      go_def = fetch_generic_object_definition(id)
+      go_def.destroy!
+    rescue => err
+      raise BadRequestError, "Failed to delete generic object definition - #{err}"
+    end
+
+    private
+
+    def fetch_generic_object_definition(id)
+      klass = collection_class(:generic_object_definitions)
+      klass.find_by(:name => id) || klass.find(id)
+    end
+  end
+end

--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -34,7 +34,10 @@ module Api
 
     def fetch_generic_object_definition(id)
       klass = collection_class(:generic_object_definitions)
-      klass.find_by(:name => id) || klass.find(id)
+      go_def = klass.find_by(:name => id) || klass.find(id)
+      go_def = Rbac.filtered_object(go_def, :user => User.current_user, :class => klass)
+      raise ForbiddenError, "Access to Generic Object Definition id: #{id} is forbidden" unless go_def
+      go_def
     end
   end
 end

--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -1,10 +1,5 @@
 module Api
   class GenericObjectDefinitionsController < BaseController
-    def show
-      object = fetch_generic_object_definition(@req.c_id)
-      render_resource(:generic_object_definitions, object)
-    end
-
     def create_resource(_type, _id, data)
       klass = collection_class(:generic_object_definitions)
       klass.create!(data.deep_symbolize_keys)
@@ -12,9 +7,9 @@ module Api
       raise BadRequestError, "Failed to create new generic object definition - #{err}"
     end
 
-    def edit_resource(_type, id, data)
+    def edit_resource(type, id, data)
       id ||= data['name']
-      go_def = fetch_generic_object_definition(id)
+      go_def = resource_search(id, type, collection_class(:generic_object_definitions))
       updated_data = data['resource'].try(:deep_symbolize_keys) || data.deep_symbolize_keys
       go_def.update_attributes!(updated_data) if data.present?
       go_def
@@ -22,9 +17,9 @@ module Api
       raise BadRequestError, "Failed to update generic object definition - #{err}"
     end
 
-    def delete_resource(_type, id, data = {})
+    def delete_resource(type, id, data = {})
       id ||= data['name']
-      go_def = fetch_generic_object_definition(id)
+      go_def = resource_search(id, type, collection_class(:generic_object_definitions))
       go_def.destroy!
     rescue => err
       raise BadRequestError, "Failed to delete generic object definition - #{err}"
@@ -32,12 +27,13 @@ module Api
 
     private
 
-    def fetch_generic_object_definition(id)
-      klass = collection_class(:generic_object_definitions)
-      go_def = klass.find_by(:name => id) || klass.find(id)
-      go_def = Rbac.filtered_object(go_def, :user => User.current_user, :class => klass)
-      raise ForbiddenError, "Access to Generic Object Definition id: #{id} is forbidden" unless go_def
-      go_def
+    def resource_search(id, type, klass)
+      if ApplicationRecord.compressed_id?(id)
+        super
+      else
+        go_def = klass.find_by!(:name => id)
+        filter_resource(go_def, type, klass)
+      end
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -825,6 +825,35 @@
       :get:
       - :name: read
         :identifier: floating_ip_show
+  :generic_object_definitions:
+    :description: Generic Object Definitions
+    :options:
+    - :collection
+    :verbs: *gpd
+    :klass: GenericObjectDefinition
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: generic_object_definition_show_list
+      :post:
+      - :name: create
+        :identifier: generic_object_definition_new
+      - :name: edit
+        :identifier: generic_object_definition_edit
+      - :name: delete
+        :identifier: generic_object_definition_delete
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: generic_object_definition_view
+      :post:
+      - :name: edit
+        :identifier: generic_object_definition_edit
+      - :name: delete
+        :identifier: generic_object_definition_delete
+      :delete:
+      - :name: delete
+        :identifier: generic_object_definition_delete
   :groups:
     :description: Groups
     :identifier: rbac_group

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -1,0 +1,312 @@
+# rubocop:disable Style/WordArray
+RSpec.describe 'GenericObjectDefinitions API' do
+  let(:object_def) { FactoryGirl.create(:generic_object_definition, :name => 'foo') }
+
+  describe 'GET /api/generic_object_definitions' do
+    it 'does not list object definitions without an appropriate role' do
+      api_basic_authorize
+
+      run_get(generic_object_definitions_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'lists all generic object definitions with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:generic_object_definitions, :read, :get)
+      object_def_href = generic_object_definitions_url(object_def.compressed_id)
+
+      run_get(generic_object_definitions_url)
+
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'generic_object_definitions',
+        'resources' => [
+          hash_including('href' => a_string_matching(object_def_href))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'GET /api/generic_object_definitions/:id' do
+    it 'does not let you query object definitions without an appropriate role' do
+      api_basic_authorize
+
+      run_get(generic_object_definitions_url(object_def.compressed_id))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can query an object definition by its id' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :read, :resource_actions, :get)
+
+      run_get(generic_object_definitions_url(object_def.id))
+
+      expected = {
+        'id'   => object_def.compressed_id,
+        'name' => object_def.name
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'can query an object definition by its name' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :read, :resource_actions, :get)
+
+      run_get(generic_object_definitions_url(object_def.name))
+
+      expected = {
+        'id'   => object_def.compressed_id,
+        'name' => object_def.name
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'raises a record not found error if no object definition is found' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :read, :resource_actions, :get)
+
+      run_get(generic_object_definitions_url('bar'))
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'POST /api/generic_object_definitions' do
+    it 'can create a new generic_object_definition' do
+      api_basic_authorize collection_action_identifier(:generic_object_definitions, :create)
+
+      object_definition = {
+        'name'        => 'LoadBalancer',
+        'description' => 'LoadBalancer description',
+        'properties'  => {
+          'attributes'   => {
+            'address'      => 'string',
+            'last_restart' => 'datetime'
+          },
+          'associations' => {
+            'vms'      => 'Vm',
+            'services' => 'Service'
+          },
+          'methods'      => [
+            'add_vm',
+            'remove_vm'
+          ]
+        }
+      }
+      run_post(generic_object_definitions_url, object_definition)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['results'].first).to include(object_definition)
+    end
+
+    it 'cannot create an invalid generic_object_definition' do
+      api_basic_authorize collection_action_identifier(:generic_object_definitions, :create)
+
+      request = {
+        'name'        => 'foo',
+        'description' => 'LoadBalancer description',
+        'properties'  => {
+          'attributes' => {
+            'last_restart' => 'date'
+          }
+        }
+      }
+      run_post(generic_object_definitions_url, request)
+
+      expected = {
+        'error' => a_hash_including(
+          'kind'    => 'bad_request',
+          'message' => a_string_including('Failed to create new generic object definition - Validation failed')
+        )
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'can edit generic_object_definitions by id, name, or href' do
+      object_def2 = FactoryGirl.create(:generic_object_definition, :name => 'foo 2')
+      object_def3 = FactoryGirl.create(:generic_object_definition, :name => 'foo 3')
+      api_basic_authorize collection_action_identifier(:generic_object_definitions, :edit)
+
+      request = {
+        'action'    => 'edit',
+        'resources' => [
+          { 'name' => object_def.name, 'resource' => { 'name' => 'updated 1' } },
+          { 'id' => object_def2.compressed_id, 'resource' => { 'name' => 'updated 2' }},
+          { 'href' => generic_object_definitions_url(object_def3.compressed_id), 'resource' => { 'name' => 'updated 3' }}
+        ]
+      }
+      run_post(generic_object_definitions_url, request)
+
+      expected = {
+        'results' => a_collection_including(
+          a_hash_including('id' => object_def.compressed_id, 'name' => 'updated 1'),
+          a_hash_including('id' => object_def2.compressed_id, 'name' => 'updated 2'),
+          a_hash_including('id' => object_def3.compressed_id, 'name' => 'updated 3')
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'POST /api/generic_object_definitions/:id' do
+    it 'can update an object definition by name' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :edit)
+
+      request = {
+        'action'      => 'edit',
+        'name'        => 'LoadBalancer Updated',
+        'description' => 'LoadBalancer description Updated',
+        'properties'  => {
+          'attributes'   => {
+            'last_updated' => 'string',
+          },
+          'associations' => {
+            'vms'      => 'Vm',
+            'services' => 'Service'
+          },
+          'methods'      => [
+            'add_vm',
+            'remove_vm',
+            'new_method'
+          ]
+        }
+      }
+      run_post(generic_object_definitions_url(object_def.name), request)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(request.except('action'))
+    end
+
+    it 'can update an object definition by id' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :edit)
+
+      request = {
+        'action'      => 'edit',
+        'name'        => 'LoadBalancer Updated',
+        'description' => 'LoadBalancer description Updated',
+        'properties'  => {
+          'attributes'   => {
+            'last_updated' => 'string',
+          },
+          'associations' => {
+            'vms'      => 'Vm',
+            'services' => 'Service'
+          },
+          'methods'      => [
+            'add_vm',
+            'remove_vm',
+            'new_method'
+          ]
+        }
+      }
+      run_post(generic_object_definitions_url(object_def.compressed_id), request)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(request.except('action'))
+    end
+
+    it 'cannot update an object with bad data' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :edit)
+
+      request = {
+        'action'     => 'edit',
+        'properties' => {
+          'attributes' => {
+            'last_updated' => 'date',
+          }
+        }
+      }
+      run_post(generic_object_definitions_url(object_def.compressed_id), request)
+
+      expected = {
+        'error' => a_hash_including(
+          'kind'    => 'bad_request',
+          'message' => a_string_including('Failed to update generic object definition - Validation failed')
+        )
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'can delete an object definition by name' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :delete)
+
+      run_post(generic_object_definitions_url(object_def.name), :action => 'delete')
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'can delete an object definition by id' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :delete)
+
+      run_post(generic_object_definitions_url(object_def.compressed_id), :action => 'delete')
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'will not delete a generic_object_definition if it is in use' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :delete, :resource_actions, :delete)
+      object_def.create_object(:name => 'foo object')
+
+      run_post(generic_object_definitions_url(object_def.name), :action => 'delete')
+
+      expected = {
+        'error' => a_hash_including(
+          'kind'    => 'bad_request',
+          'message' => a_string_including('Failed to delete generic object definition')
+        )
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'can delete generic_object_definition in bulk by name, id, or href' do
+      object_def2 = FactoryGirl.create(:generic_object_definition, :name => 'foo 2')
+      object_def3 = FactoryGirl.create(:generic_object_definition, :name => 'foo 3')
+      api_basic_authorize collection_action_identifier(:generic_object_definitions, :delete)
+
+      request = {
+        'action'    => 'delete',
+        'resources' => [
+          { 'name' => object_def.name },
+          { 'id' => object_def2.compressed_id},
+          { 'href' => generic_object_definitions_url(object_def3.compressed_id)}
+        ]
+      }
+      run_post(generic_object_definitions_url, request)
+
+      expected = {
+        'results' => a_collection_including(
+          a_hash_including('id' => object_def.compressed_id),
+          a_hash_including('id' => object_def2.compressed_id),
+          a_hash_including('id' => object_def3.compressed_id)
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'DELETE /api/generic_object_definitions/:id' do
+    it 'can delete a generic_object_definition by id' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :delete, :resource_actions, :delete)
+
+      run_delete(generic_object_definitions_url(object_def.compressed_id))
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'can delete a generic_object_definition by name' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :delete, :resource_actions, :delete)
+
+      run_delete(generic_object_definitions_url(object_def.name))
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end


### PR DESCRIPTION
`manageiq-api` version of https://github.com/ManageIQ/manageiq/pull/15374

This PR adds:
```
GET /api/generic_object_definitions/
GET /api/generic_object_definitions/:id
GET /api/generic_object_definitions/:name

DELETE /api/generic_object_definitions/:id
DELETE /api/generic_object_definitions/:name
POST /api/generic_object_definitions/:id      action: "delete"
POST /api/generic_object_definitions/:name    action: "delete"
POST /api/generic_object_definitions          action: "delete" (works with name, id, href)

POST /api/generic_object_definitions

POST /api/generic_object_definitions/:id      action: "edit"
POST /api/generic_object_definitions/:name    action: "edit"
POST /api/generic_object_definitions          action: "edit" (works with name, id, href)
```

Example of create:
```
POST /api/generic_object_definitions
{
  "name"        : "LoadBalancer",
  "description" : "LoadBalancer description",
  "properties"  : {
    "attributes"   : {
      "address"      : "string",
      "last_restart" : "datetime"
    },
    "associations" : {
      "vms"      : "Vm",
      "services" : "Service"
    },
    "methods"      : [
      "add_vm",
      "remove_vm"
    ]
  }
}
```
Editing a generic object definition. Properties will be updated as is - IE if you remove "methods" as in the below example, properties will no longer have methods and contain the attributes and associations passed in.
```
POST /api/generic_object_definitions/:id
{
 "action"       : "edit",
  "name"        : "LoadBalancer",
  "description" : "LoadBalancer description",
  "properties"  : {
    "attributes"   : {
      "address"      : "string",
      "last_restart" : "datetime"
    },
    "associations" : {
      "vms"      : "Vm",
      "services" : "Service"
    }
  }
}
```

@miq-bot add_label enhancement, wip
@miq-bot assign @abellotti 