### PR TITLE
Raise not found on DELETE 

### DIFF
--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -18,14 +18,12 @@ module Api
     end
 
     def delete_resource(type, id, _data = {})
-      auth = resource_search(id, type, collection_class(:authentications))
-      raise "Delete not supported for #{authentication_ident(auth)}" unless auth.respond_to?(:delete_in_provider_queue)
-      task_id = auth.delete_in_provider_queue
-      action_result(true, "Deleting #{authentication_ident(auth)}", :task_id => task_id)
-    rescue ActiveRecord::RecordNotFound => err
-      @req.method == :delete ? raise(err) : action_result(false, err.to_s)
-    rescue => err
-      action_result(false, err.to_s)
+      delete_action_handler do
+        auth = resource_search(id, type, collection_class(:authentications))
+        raise "Delete not supported for #{authentication_ident(auth)}" unless auth.respond_to?(:delete_in_provider_queue)
+        task_id = auth.delete_in_provider_queue
+        action_result(true, "Deleting #{authentication_ident(auth)}", :task_id => task_id)
+      end
     end
 
     def refresh_resource(type, id, _data)

--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -3,6 +3,14 @@ module Api
     module Results
       private
 
+      def delete_action_handler
+        yield
+      rescue ActiveRecord::RecordNotFound => err
+        @req.method == :delete ? raise(err) : action_result(false, err.to_s)
+      rescue => err
+        action_result(false, err.to_s)
+      end
+
       def action_result(success, message = nil, options = {})
         res = {:success => success}
         res[:message] = message if message.present?

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -1,11 +1,11 @@
 module Api
   class CloudVolumesController < BaseController
     def delete_resource(type, id, _data = {})
-      cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))
-      task_id = cloud_volume.delete_volume_queue(User.current_user)
-      action_result(true, "Deleting Cloud Volume #{cloud_volume.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+      delete_action_handler do
+        cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))
+        task_id = cloud_volume.delete_volume_queue(User.current_user)
+        action_result(true, "Deleting Cloud Volume #{cloud_volume.name}", :task_id => task_id)
+      end
     end
   end
 end

--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -12,12 +12,12 @@ module Api
     end
 
     def delete_resource(type, id, _data = {})
-      config_script_src = resource_search(id, type, collection_class(:configuration_script_sources))
-      raise "Delete not supported for #{config_script_src_ident(config_script_src)}" unless config_script_src.respond_to?(:delete_in_provider_queue)
-      task_id = config_script_src.delete_in_provider_queue
-      action_result(true, "Deleting #{config_script_src_ident(config_script_src)}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+      delete_action_handler do
+        config_script_src = resource_search(id, type, collection_class(:configuration_script_sources))
+        raise "Delete not supported for #{config_script_src_ident(config_script_src)}" unless config_script_src.respond_to?(:delete_in_provider_queue)
+        task_id = config_script_src.delete_in_provider_queue
+        action_result(true, "Deleting #{config_script_src_ident(config_script_src)}", :task_id => task_id)
+      end
     end
 
     def create_resource(_type, _id, data)

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -92,6 +92,14 @@ describe "Cloud Volumes API" do
     expect(response).to have_http_status(:forbidden)
   end
 
+  it 'DELETE will raise an error if the cloud volume does not exist' do
+    api_basic_authorize action_identifier(:cloud_volumes, :delete, :resource_actions, :delete)
+
+    delete(api_cloud_volume_url(nil, 999_999))
+
+    expect(response).to have_http_status(:not_found)
+  end
+
   it 'can delete cloud volumes through POST' do
     zone = FactoryGirl.create(:zone, :name => "api_zone")
     aws = FactoryGirl.create(:ems_amazon, :zone => zone)

--- a/spec/requests/configuration_script_sources_spec.rb
+++ b/spec/requests/configuration_script_sources_spec.rb
@@ -431,6 +431,14 @@ RSpec.describe 'Configuration Script Sources API' do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'will raise an error if the configuration_script_source does not exist' do
+      api_basic_authorize action_identifier(:configuration_script_sources, :delete, :resource_actions, :delete)
+
+      delete(api_configuration_script_source_url(nil, 999_999))
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe 'GET /api/configuration_script_sources/:id/configuration_script_payloads' do


### PR DESCRIPTION
Currently, many delete methods implement `action_result`. When this is called via DELETE, it raises a `204` response even on a not found, leading the user to believe that it has been deleted. The RecordNotFound needs to be raised if the method is DELETE.

@miq-bot add_label bug 
@miq-bot assign @abellotti 