### PR TITLE
Replace custom entrypoint_url with Rails helper

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # Enablement for the REST API
 
   namespace :api, :path => "api(/:version)", :version => Api::VERSION_REGEX, :defaults => {:format => "json"} do
-    root :to => "api#index"
+    root :to => "api#index", :as => :entrypoint
     match "/", :to => "api#options", :via => :options
 
     # Redirect of /tasks subcollections to /request_tasks

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -8,7 +8,7 @@ describe "Authentication API" do
     it "test basic authentication with bad credentials" do
       basic_authorize "baduser", "badpassword"
 
-      run_get entrypoint_url
+      run_get api_entrypoint_url
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -16,7 +16,7 @@ describe "Authentication API" do
     it "test basic authentication with correct credentials" do
       api_basic_authorize
 
-      run_get entrypoint_url
+      run_get api_entrypoint_url
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -28,7 +28,7 @@ describe "Authentication API" do
 
       api_basic_authorize
 
-      run_get entrypoint_url
+      run_get api_entrypoint_url
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -39,7 +39,7 @@ describe "Authentication API" do
 
       api_basic_authorize
 
-      run_get entrypoint_url
+      run_get api_entrypoint_url
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -57,7 +57,7 @@ describe "Authentication API" do
     it "test basic authentication with incorrect group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => "bogus_group"}
+      run_get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => "bogus_group"}
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -65,7 +65,7 @@ describe "Authentication API" do
     it "test basic authentication with a primary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group1.description}
+      run_get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group1.description}
 
       expect(response).to have_http_status(:ok)
     end
@@ -73,7 +73,7 @@ describe "Authentication API" do
     it "test basic authentication with a secondary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group2.description}
+      run_get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group2.description}
 
       expect(response).to have_http_status(:ok)
     end
@@ -91,7 +91,7 @@ describe "Authentication API" do
     it "basic authentication with a secondary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group2.description}
+      run_get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group2.description}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -112,7 +112,7 @@ describe "Authentication API" do
     it "querying user's authorization" do
       api_basic_authorize
 
-      run_get entrypoint_url, :attributes => "authorization"
+      run_get api_entrypoint_url, :attributes => "authorization"
 
       expect(response).to have_http_status(:ok)
       expected = {"authorization" => hash_including("product_features")}
@@ -136,7 +136,7 @@ describe "Authentication API" do
         end
 
         it "authentication using a bad token" do
-          run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => "badtoken"}
+          run_get api_entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => "badtoken"}
 
           expect(response).to have_http_status(:unauthorized)
         end
@@ -151,7 +151,7 @@ describe "Authentication API" do
 
           auth_token = response.parsed_body["auth_token"]
 
-          run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
+          run_get api_entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
 
           expect(response).to have_http_status(:ok)
           expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -173,7 +173,7 @@ describe "Authentication API" do
           expect(token_info[:expires_on].utc.iso8601).to eq(token_expires_on)
 
           expect_any_instance_of(TokenManager).to receive(:reset_token).with(auth_token)
-          run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
+          run_get api_entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
 
           expect(response).to have_http_status(:ok)
           expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -232,7 +232,7 @@ describe "Authentication API" do
             run_get auth_url, :requester_type => 'ws'
             ws_token = response.parsed_body["auth_token"]
 
-            run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => ws_token}
+            run_get api_entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => ws_token}
 
             expect(response).to have_http_status(:unauthorized)
           end
@@ -249,7 +249,7 @@ describe "Authentication API" do
     end
 
     it "authentication using a bad token" do
-      run_get entrypoint_url,
+      run_get api_entrypoint_url,
               :headers => {Api::HttpHeaders::MIQ_TOKEN => "badtoken"}
 
       expect(response).to have_http_status(:unauthorized)
@@ -259,7 +259,7 @@ describe "Authentication API" do
     end
 
     it "authentication using a token with a bad server guid" do
-      run_get entrypoint_url,
+      run_get api_entrypoint_url,
               :headers => {Api::HttpHeaders::MIQ_TOKEN => systoken("bad_server_guid", api_config(:user), Time.now.utc)}
 
       expect(response).to have_http_status(:unauthorized)
@@ -269,7 +269,7 @@ describe "Authentication API" do
     end
 
     it "authentication using a token with bad user" do
-      run_get entrypoint_url,
+      run_get api_entrypoint_url,
               :headers => {Api::HttpHeaders::MIQ_TOKEN => systoken(MiqServer.first.guid, "bad_user_id", Time.now.utc)}
 
       expect(response).to have_http_status(:unauthorized)
@@ -281,7 +281,7 @@ describe "Authentication API" do
     it "authentication using a token with an old timestamp" do
       miq_token = systoken(MiqServer.first.guid, api_config(:user), 10.minutes.ago.utc)
 
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
+      run_get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -292,7 +292,7 @@ describe "Authentication API" do
     it "authentication using a valid token succeeds" do
       miq_token = systoken(MiqServer.first.guid, api_config(:user), Time.now.utc)
 
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
+      run_get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)

--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "API entrypoint" do
   it "returns a :settings hash" do
     api_basic_authorize
 
-    run_get entrypoint_url
+    run_get api_entrypoint_url
 
     expect(response).to have_http_status(:ok)
     expect_result_to_have_keys(%w(settings))
@@ -12,7 +12,7 @@ RSpec.describe "API entrypoint" do
   it "returns a locale" do
     api_basic_authorize
 
-    run_get entrypoint_url
+    run_get api_entrypoint_url
 
     expect(%w(en en_US)).to include(response.parsed_body['settings']['locale'])
   end
@@ -23,7 +23,7 @@ RSpec.describe "API entrypoint" do
     test_settings = {:cartoons => {:saturday => {:tom_jerry => 'n', :bugs_bunny => 'y'}}}
     @user.update_attributes!(:settings => test_settings)
 
-    run_get entrypoint_url
+    run_get api_entrypoint_url
 
     expect(response.parsed_body).to include("settings" => a_hash_including(test_settings.deep_stringify_keys))
   end
@@ -31,7 +31,7 @@ RSpec.describe "API entrypoint" do
   it "collection query is sorted" do
     api_basic_authorize
 
-    run_get entrypoint_url
+    run_get api_entrypoint_url
 
     collection_names = response.parsed_body['collections'].map { |c| c['name'] }
     expect(collection_names).to eq(collection_names.sort)
@@ -40,7 +40,7 @@ RSpec.describe "API entrypoint" do
   it "returns server_info" do
     api_basic_authorize
 
-    run_get entrypoint_url
+    run_get api_entrypoint_url
 
     expect(response.parsed_body).to include(
       "server_info" => a_hash_including(
@@ -57,7 +57,7 @@ RSpec.describe "API entrypoint" do
   it "returns product_info" do
     api_basic_authorize
 
-    run_get entrypoint_url
+    run_get api_entrypoint_url
 
     expect(response.parsed_body).to include(
       "product_info" => a_hash_including(

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Headers" do
     it "returns JSON when set to application/json" do
       api_basic_authorize
 
-      get entrypoint_url, :headers => headers.merge("Accept" => "application/json")
+      get api_entrypoint_url, :headers => headers.merge("Accept" => "application/json")
 
       expect(response.parsed_body).to include("name" => "API", "description" => "REST API")
       expect(response).to have_http_status(:ok)
@@ -12,7 +12,7 @@ RSpec.describe "Headers" do
     it "returns JSON when not provided" do
       api_basic_authorize
 
-      get entrypoint_url, :headers => headers
+      get api_entrypoint_url, :headers => headers
 
       expect(response.parsed_body).to include("name" => "API", "description" => "REST API")
       expect(response).to have_http_status(:ok)
@@ -21,7 +21,7 @@ RSpec.describe "Headers" do
     it "responds with an error for unsupported mime-types" do
       api_basic_authorize
 
-      get entrypoint_url, :headers => headers.merge("Accept" => "application/xml")
+      get api_entrypoint_url, :headers => headers.merge("Accept" => "application/xml")
 
       expected = {
         "error" => a_hash_including(
@@ -69,7 +69,7 @@ RSpec.describe "Headers" do
     it "returns some headers related to security" do
       api_basic_authorize
 
-      run_get(entrypoint_url)
+      run_get(api_entrypoint_url)
 
       expected = {
         "X-Content-Type-Options"            => "nosniff",

--- a/spec/requests/logging_spec.rb
+++ b/spec/requests/logging_spec.rb
@@ -25,7 +25,7 @@ describe "Logging" do
     it "logs all hash entries about the request" do
       api_basic_authorize
 
-      run_get entrypoint_url
+      run_get api_entrypoint_url
 
       @log.rewind
       request_log_line = @log.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
@@ -54,7 +54,7 @@ describe "Logging" do
 
         miq_token = MiqPassword.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
 
-        run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
+        run_get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
 
         expect(@log.string).to include(
           "System Auth:    {:x_miq_token=>\"#{miq_token}\", :server_guid=>\"#{server_guid}\", " \

--- a/spec/requests/versioning_spec.rb
+++ b/spec/requests/versioning_spec.rb
@@ -6,7 +6,7 @@ describe "Versioning" do
     it "test versioning query" do
       api_basic_authorize
 
-      run_get entrypoint_url
+      run_get api_entrypoint_url
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(name description version versions collections))
@@ -16,7 +16,7 @@ describe "Versioning" do
       api_basic_authorize
 
       # Let's get the versions
-      run_get entrypoint_url
+      run_get api_entrypoint_url
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(versions))
@@ -33,7 +33,7 @@ describe "Versioning" do
       ident = ver["href"].split("/").last
 
       # Let's try to access that version API URL
-      run_get "#{entrypoint_url}/#{ident}"
+      run_get api_entrypoint_url(ident)
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(name description version versions collections))
@@ -42,7 +42,7 @@ describe "Versioning" do
     it "test query with an invalid version" do
       api_basic_authorize
 
-      run_get "#{entrypoint_url}/v9999.9999"
+      run_get api_entrypoint_url("v9999.9999")
 
       expect(response).to have_http_status(:bad_request)
     end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -68,10 +68,6 @@ module Spec
         define_user
       end
 
-      def entrypoint_url
-        api_config(:entrypoint)
-      end
-
       def auth_url
         "#{api_config(:entrypoint)}/auth"
       end


### PR DESCRIPTION
Could do a lot more with this, but starting small. This small, one line change enables us to:

* ✂️ some code
* leverage more of Rails
* avoid doing so much interpolation as in https://github.com/ManageIQ/manageiq-api/compare/master...imtayadeway:url-helpers?expand=1#diff-66949d857e0cae98626c54e33f6ebcd3L36

@miq-bot add-label refactoring, test, technical debt
@miq-bot assign @abellotti 