### PR TITLE
Move init_env code into after_initialize hook

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,3 +1,4 @@
 GlobalVars:
   AllowedVariables:
   - $evm
+  - $api_log

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -21,21 +21,4 @@ module Api
   def self.resource_attribute?(attr)
     Environment.resource_attributes.include?(attr.to_s)
   end
-
-  def self.init_env
-    $api_log.info("Initializing Environment for #{ApiConfig.base[:name]}")
-    $api_log.info("")
-    $api_log.info("Static Configuration")
-    ApiConfig.base.each { |key, val| log_kv(key, val) }
-
-    $api_log.info("")
-    $api_log.info("Dynamic Configuration")
-    Environment.user_token_service.api_config.each { |key, val| log_kv(key, val) }
-  end
-
-  def self.log_kv(key, val)
-    $api_log.info("  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
-  end
 end
-
-Api.init_env

--- a/lib/manageiq/api/engine.rb
+++ b/lib/manageiq/api/engine.rb
@@ -7,6 +7,21 @@ module ManageIQ
       config.autoload_paths << root.join('lib', 'services').expand_path
       config.autoload_paths << root.join('lib').expand_path
 
+      config.after_initialize do
+        $api_log.info("Initializing Environment for #{::Api::ApiConfig.base[:name]}")
+        $api_log.info("")
+        $api_log.info("Static Configuration")
+        ::Api::ApiConfig.base.each { |key, val| log_kv(key, val) }
+
+        $api_log.info("")
+        $api_log.info("Dynamic Configuration")
+        ::Api::Environment.user_token_service.api_config.each { |key, val| log_kv(key, val) }
+      end
+
+      def self.log_kv(key, val)
+        $api_log.info("  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
+      end
+
       def vmdb_plugin?
         true
       end


### PR DESCRIPTION
This helps to isolate things a bit better  - I'd like to be able to (at least) in theory require lib/api.rb without having to load all of Rails with it. The `after_initialize` hook seems like a better place to put this code, rather than invoking it at the time when lib/api.rb is required

/cc @jrafanie 
@miq-bot add-label technical debt
@miq-bot assign @abellotti 