### PR TITLE
Set the current userid when running a report

### DIFF
--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -17,7 +17,7 @@ module Api
 
     def run_resource(type, id, _data)
       report = resource_search(id, type, MiqReport)
-      report_result = MiqReportResult.find(report.queue_generate_table)
+      report_result = MiqReportResult.find(report.queue_generate_table(:userid => User.current_user.userid))
       run_report_result(true,
                         "running report #{report.id}",
                         :task_id          => report_result.miq_task_id,

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -215,6 +215,8 @@ RSpec.describe "reports API" do
         :success => true,
         :message => "running report #{report.id}"
       )
+      actual = MiqReportResult.find(ApplicationRecord.uncompress_id(response.parsed_body["result_id"]))
+      expect(actual.userid).to eq("api_user_id")
     end
 
     it "can schedule a run" do


### PR DESCRIPTION
With nothing specified it defaults to "system". Since we now enforce
checking the ownership of report results, the report results' userid
must be set to the current user instead.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1479296

@miq-bot add-label bug
@miq-bot assign @abellotti 
/cc @gtanzillo @yrudman 

UPDATE:

Just verified this.

### Before:

```
GET http://localhost:3000/api/results/1r1

{
    "error": {
        "kind": "not_found",
        "message": "Couldn't find MiqReportResult with 'id'=1000000000001 [WHERE \"miq_report_results\".\"miq_group_id\" = 1000000000004]",
        "klass": "ActiveRecord::RecordNotFound"
    }
}
```

### After

```
GET http://localhost:3000/api/results/1r2

{
    "href": "http://localhost:3000/api/results/1r2",
    "id": "1r2",
    "name": "VMs with Volume Free Space > 50% by Department",
    "miq_report_id": "1r1",
    "miq_task_id": "1r2",
    "userid": "tim",
    "report_source": "Requested by user",
    "db": "Vm",
    "created_on": "2017-08-21T23:53:22Z",
    "miq_group_id": "1r4",
    "result_set": []
}
```