### PR TITLE
Send back full dialog on create and edit

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -18,7 +18,8 @@ module Api
     end
 
     def create_resource(_type, _id, data)
-      DialogImportService.new.import(data)
+      dialog = DialogImportService.new.import(data)
+      fetch_service_dialogs_content(dialog).first
     rescue => e
       raise BadRequestError, "Failed to create a new dialog - #{e}"
     end
@@ -31,7 +32,7 @@ module Api
       rescue => err
         raise BadRequestError, "Failed to update service dialog - #{err}"
       end
-      service_dialog
+      fetch_service_dialogs_content(service_dialog).first
     end
 
     def copy_resource(type, id, data)

--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -137,9 +137,12 @@ describe "Service Dialogs API" do
         }
 
         expected = {
-          'href'  => a_string_including(api_service_dialog_url(nil, dialog.compressed_id)),
-          'id'    => dialog.compressed_id,
-          'label' => 'updated label'
+          'href'        => a_string_including(api_service_dialog_url(nil, dialog.compressed_id)),
+          'id'          => dialog.compressed_id,
+          'label'       => 'updated label',
+          'dialog_tabs' => a_collection_including(
+            a_hash_including('label' => 'updated tab label')
+          )
         }
 
         expect do
@@ -402,7 +405,8 @@ describe "Service Dialogs API" do
         "results" => [
           a_hash_including(
             "description" => "Dialog",
-            "label"       => "dialog_label"
+            "label"       => "dialog_label",
+            "dialog_tabs" => a_collection_including(a_hash_including("description" => "Dialog tab"))
           )
         ]
       }


### PR DESCRIPTION
When the dialog is created or edited, the entire contents of the dialog need to be returned.

cc: @romanblanco 

@miq-bot add_label enhancement 
@miq-bot assign @abellotti 