### PR TITLE
metric rollups subcollection

### DIFF
--- a/app/controllers/api/metric_rollups_controller.rb
+++ b/app/controllers/api/metric_rollups_controller.rb
@@ -1,7 +1,11 @@
 module Api
   class MetricRollupsController < BaseController
     def index
-      resources = MetricRollupsService.query_metric_rollups(params)
+      params[:offset] ||= 0
+      params[:limit] ||= Settings.api.metrics_default_limit
+
+      rollups_service = MetricRollupsService.new(params)
+      resources = rollups_service.query_metric_rollups
       res = collection_filterer(resources, :metric_rollups, MetricRollup).flatten
       counts = Api::QueryCounts.new(MetricRollup.count, res.count, resources.count)
 

--- a/app/controllers/api/metric_rollups_controller.rb
+++ b/app/controllers/api/metric_rollups_controller.rb
@@ -1,32 +1,11 @@
 module Api
   class MetricRollupsController < BaseController
-    REQUIRED_PARAMS = %w(resource_type capture_interval start_date).freeze
-
     def index
-      validate_params
-      params[:offset] ||= 0
-      params[:limit]  ||= Settings.api.metrics_default_limit
-
-      start_date = params[:start_date].to_date
-      end_date = params[:end_date].try(:to_date)
-
-      resources = MetricRollup.rollups_in_range(params[:resource_type], params[:resource_ids], params[:capture_interval], start_date, end_date)
+      resources = MetricRollupsService.query_metric_rollups(params)
       res = collection_filterer(resources, :metric_rollups, MetricRollup).flatten
       counts = Api::QueryCounts.new(MetricRollup.count, res.count, resources.count)
 
       render_collection(:metric_rollups, res, :counts => counts, :expand_resources => @req.expand?(:resources))
-    end
-
-    private
-
-    def validate_params
-      REQUIRED_PARAMS.each do |key|
-        raise BadRequestError, "Must specify #{REQUIRED_PARAMS.join(', ')}" unless params[key.to_sym]
-      end
-
-      unless MetricRollup::CAPTURE_INTERVAL_NAMES.include?(params[:capture_interval])
-        raise BadRequestError, "Capture interval must be one of #{MetricRollup::CAPTURE_INTERVAL_NAMES.join(', ')}"
-      end
     end
   end
 end

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -4,6 +4,7 @@ module Api
     include Subcollections::Tags
     include Subcollections::Vms
     include Subcollections::OrchestrationStacks
+    include Subcollections::MetricRollups
 
     def create_resource(_type, _id, data)
       validate_service_data(data)

--- a/app/controllers/api/subcollections/metric_rollups.rb
+++ b/app/controllers/api/subcollections/metric_rollups.rb
@@ -1,0 +1,16 @@
+module Api
+  module Subcollections
+    module MetricRollups
+      RESOURCE_TYPES = {
+        'vms' => 'VmOrTemplate'
+      }.freeze
+
+      def metric_rollups_query_resource(object)
+        params[:resource_type] = RESOURCE_TYPES[@req.collection] || object.class.to_s
+        params[:resource_ids] ||= [object.id]
+
+        MetricRollupsService.query_metric_rollups(params)
+      end
+    end
+  end
+end

--- a/app/controllers/api/subcollections/metric_rollups.rb
+++ b/app/controllers/api/subcollections/metric_rollups.rb
@@ -6,10 +6,13 @@ module Api
       }.freeze
 
       def metric_rollups_query_resource(object)
+        params[:offset] ||= 0
+        params[:limit] ||= Settings.api.metrics_default_limit
         params[:resource_type] = RESOURCE_TYPES[@req.collection] || object.class.to_s
         params[:resource_ids] ||= [object.id]
 
-        MetricRollupsService.query_metric_rollups(params)
+        rollups_service = MetricRollupsService.new(params)
+        rollups_service.query_metric_rollups
       end
     end
   end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -7,6 +7,7 @@ module Api
     include Subcollections::CustomAttributes
     include Subcollections::Software
     include Subcollections::Snapshots
+    include Subcollections::MetricRollups
 
     VALID_EDIT_ATTRS = %w(description child_resources parent_resource).freeze
     RELATIONSHIP_COLLECTIONS = [:vms, :templates].freeze

--- a/config/api.yml
+++ b/config/api.yml
@@ -1073,9 +1073,14 @@
     :identifier: metrics
     :options:
     - :collection
+    - :subcollection
     :verbs: *g
     :klass: MetricRollup
     :collection_actions:
+      :get:
+      - :name: read
+        :identifier: metrics_view
+    :subcollection_actions:
       :get:
       - :name: read
         :identifier: metrics_view
@@ -2047,6 +2052,7 @@
     - :service_dialogs
     - :vms
     - :orchestration_stacks
+    - :metric_rollups
     :collection_actions:
       :get:
       - :name: read
@@ -2389,6 +2395,7 @@
     - :custom_attributes
     - :software
     - :snapshots
+    - :metric_rollups
     :collection_actions:
       :get:
       - :name: read

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+:api:
+  :metrics_default_limit: 10000

--- a/lib/services/api/metric_rollups_service.rb
+++ b/lib/services/api/metric_rollups_service.rb
@@ -2,27 +2,33 @@ module Api
   class MetricRollupsService
     REQUIRED_PARAMS = %w(resource_type capture_interval start_date).freeze
 
-    def self.query_metric_rollups(params)
-      validate_params(params)
+    attr_reader :params
 
-      params[:offset] ||= 0
-      params[:limit] ||= Settings.api.metrics_default_limit
+    def initialize(params)
+      @params = params
+      validate_required_params
+      validate_capture_interval
+    end
 
+    def query_metric_rollups
       start_date = params[:start_date].to_date
       end_date = params[:end_date].try(:to_date)
 
       MetricRollup.rollups_in_range(params[:resource_type], params[:resource_ids], params[:capture_interval], start_date, end_date)
     end
 
-    def self.validate_params(params)
+    private
+
+    def validate_required_params
       REQUIRED_PARAMS.each do |key|
         raise BadRequestError, "Must specify #{REQUIRED_PARAMS.join(', ')}" unless params[key.to_sym]
       end
+    end
 
+    def validate_capture_interval
       unless MetricRollup::CAPTURE_INTERVAL_NAMES.include?(params[:capture_interval])
         raise BadRequestError, "Capture interval must be one of #{MetricRollup::CAPTURE_INTERVAL_NAMES.join(', ')}"
       end
     end
-    private_class_method :validate_params
   end
 end

--- a/lib/services/api/metric_rollups_service.rb
+++ b/lib/services/api/metric_rollups_service.rb
@@ -1,0 +1,28 @@
+module Api
+  class MetricRollupsService
+    REQUIRED_PARAMS = %w(resource_type capture_interval start_date).freeze
+
+    def self.query_metric_rollups(params)
+      validate_params(params)
+
+      params[:offset] ||= 0
+      params[:limit] ||= Settings.api.metrics_default_limit
+
+      start_date = params[:start_date].to_date
+      end_date = params[:end_date].try(:to_date)
+
+      MetricRollup.rollups_in_range(params[:resource_type], params[:resource_ids], params[:capture_interval], start_date, end_date)
+    end
+
+    def self.validate_params(params)
+      REQUIRED_PARAMS.each do |key|
+        raise BadRequestError, "Must specify #{REQUIRED_PARAMS.join(', ')}" unless params[key.to_sym]
+      end
+
+      unless MetricRollup::CAPTURE_INTERVAL_NAMES.include?(params[:capture_interval])
+        raise BadRequestError, "Capture interval must be one of #{MetricRollup::CAPTURE_INTERVAL_NAMES.join(', ')}"
+      end
+    end
+    private_class_method :validate_params
+  end
+end

--- a/spec/lib/services/api/metric_rollups_service_spec.rb
+++ b/spec/lib/services/api/metric_rollups_service_spec.rb
@@ -1,0 +1,19 @@
+describe Api::MetricRollupsService do
+  before do
+    allow(Settings.api).to receive(:metrics_default_limit).and_return(1000)
+  end
+
+  it 'validates that all of the parameters are present' do
+    expect do
+      described_class.query_metric_rollups({})
+    end.to raise_error(Api::BadRequestError, a_string_including('Must specify'))
+  end
+
+  it 'validates the capture interval' do
+    expect do
+      described_class.query_metric_rollups(:resource_type    => 'Service',
+                                           :start_date       => Time.zone.today.to_s,
+                                           :capture_interval => 'bad_interval')
+    end.to raise_error(Api::BadRequestError, a_string_including('Capture interval must be one of '))
+  end
+end

--- a/spec/lib/services/api/metric_rollups_service_spec.rb
+++ b/spec/lib/services/api/metric_rollups_service_spec.rb
@@ -1,19 +1,17 @@
 describe Api::MetricRollupsService do
-  before do
-    allow(Settings.api).to receive(:metrics_default_limit).and_return(1000)
-  end
+  context ".new" do
+    it 'validates that all of the parameters are present' do
+      expect do
+        described_class.new({})
+      end.to raise_error(Api::BadRequestError, a_string_including('Must specify'))
+    end
 
-  it 'validates that all of the parameters are present' do
-    expect do
-      described_class.query_metric_rollups({})
-    end.to raise_error(Api::BadRequestError, a_string_including('Must specify'))
-  end
-
-  it 'validates the capture interval' do
-    expect do
-      described_class.query_metric_rollups(:resource_type    => 'Service',
-                                           :start_date       => Time.zone.today.to_s,
-                                           :capture_interval => 'bad_interval')
-    end.to raise_error(Api::BadRequestError, a_string_including('Capture interval must be one of '))
+    it 'validates the capture interval' do
+      expect do
+        described_class.new(:resource_type    => 'Service',
+                            :start_date       => Time.zone.today.to_s,
+                            :capture_interval => 'bad_interval')
+      end.to raise_error(Api::BadRequestError, a_string_including('Capture interval must be one of '))
+    end
   end
 end

--- a/spec/requests/metric_rollups_spec.rb
+++ b/spec/requests/metric_rollups_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe 'MetricRollups API' do
       FactoryGirl.create(:metric_rollup_vm_hr)
       FactoryGirl.create(:metric_rollup_vm_daily)
       FactoryGirl.create(:metric_rollup_host_daily)
-
-      allow(Settings.api).to receive(:metrics_default_limit).and_return(1000)
     end
 
     it 'returns metric_rollups for a specific resource_type' do

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1013,8 +1013,6 @@ describe "Services API" do
       FactoryGirl.create_list(:metric_rollup_vm_hr, 3, :resource => svc)
       FactoryGirl.create_list(:metric_rollup_vm_daily, 1, :resource => svc)
       FactoryGirl.create_list(:metric_rollup_vm_hr, 1, :resource => svc1)
-
-      allow(Settings.api).to receive(:metrics_default_limit).and_return(1000)
     end
 
     it 'returns the metric rollups for the service' do

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1608,8 +1608,6 @@ describe "Vms API" do
       FactoryGirl.create_list(:metric_rollup_vm_hr, 3, :resource => vm)
       FactoryGirl.create_list(:metric_rollup_vm_daily, 1, :resource => vm)
       FactoryGirl.create_list(:metric_rollup_vm_hr, 1, :resource => vm1)
-
-      allow(Settings.api).to receive(:metrics_default_limit).and_return(1000)
     end
 
     it 'returns the metric rollups for the vm' do

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1600,4 +1600,39 @@ describe "Vms API" do
       expect(vm.reload.miq_server).to be_nil
     end
   end
+
+  describe "metric rollups subcollection" do
+    let(:url) { "#{vms_url(vm.id)}/metric_rollups" }
+
+    before do
+      FactoryGirl.create_list(:metric_rollup_vm_hr, 3, :resource => vm)
+      FactoryGirl.create_list(:metric_rollup_vm_daily, 1, :resource => vm)
+      FactoryGirl.create_list(:metric_rollup_vm_hr, 1, :resource => vm1)
+
+      allow(Settings.api).to receive(:metrics_default_limit).and_return(1000)
+    end
+
+    it 'returns the metric rollups for the vm' do
+      api_basic_authorize subcollection_action_identifier(:vms, :metric_rollups, :read, :get)
+
+      run_get(url, :capture_interval => 'hourly', :start_date => Time.zone.today.to_s)
+
+      expected = {
+        'count'    => 5,
+        'subcount' => 3,
+        'pages'    => 1
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+      expect(response.parsed_body['links'].keys).to match_array(%w(self first last))
+    end
+
+    it 'will not return metric rollups without an appropriate role' do
+      api_basic_authorize
+
+      run_get(url, :capture_interval => 'hourly', :start_date => Time.zone.today.to_s)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
 end


### PR DESCRIPTION
Adds Metric Rollups as a subcollection to services and vms

## Usage
### Required parameters
The following parameters are required to query metric rollups as a subcollection
* capture_interval (either 'hourly' or 'daily')
* start_date

### Optional parameters:
* end_date
  * if no end_date is specified, it will use the current date 
* limit
  * If no limit is specified, the default value in the api settings will be used.

### Paging 
* Paging will be automatically applied to these metric rollup requests 
* the limit may be overriden, but is set by default in the api settings (use parameter `limit` to override)

### Examples
#### Minimum attributes:
`GET /api/services/:id/metric_rollups?capture_interval=hourly&start_date=2017-08-01`
#### End date:
`GET /api/services/:id/metric_rollups?capture_interval=daily&start_date=2017-08-01&end_date=2017-08-22`
#### Limit:
`GET /api/services/:id/metric_rollups?capture_interval=daily&start_date=2017-08-01&end_date=2017-08-22&limit=2000`

#### Dates are in the format:
`YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ`


@miq-bot add_label wip, enhancement 