### PR TITLE
Don't include AuthRequestHelper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.include Spec::Support::ApiHelper, :type => :request
-  config.include Spec::Support::AuthRequestHelper, :type => :request
   config.define_derived_metadata(:type => :request) do |metadata|
     metadata[:aggregate_failures] = true
   end


### PR DESCRIPTION
This provides one method, `http_login`, which isn't used anywhere.

Links:

https://github.com/ManageIQ/manageiq/blob/master/spec/support/auth_helper.rb#L47-L50

@miq-bot add-label test, technical debt
@miq-bot assign @abellotti 
