### PR TITLE
Add PUT to generic object definitions API

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -829,7 +829,7 @@
     :description: Generic Object Definitions
     :options:
     - :collection
-    :verbs: *gpd
+    :verbs: *gpppd
     :klass: GenericObjectDefinition
     :collection_actions:
       :get:
@@ -851,6 +851,9 @@
         :identifier: generic_object_definition_edit
       - :name: delete
         :identifier: generic_object_definition_delete
+      :put:
+      - :name: edit
+        :identifier: generic_object_definition_edit
       :delete:
       - :name: delete
         :identifier: generic_object_definition_delete

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -309,4 +309,23 @@ RSpec.describe 'GenericObjectDefinitions API' do
       expect(response).to have_http_status(:no_content)
     end
   end
+
+  describe 'PUT /api/generic_object_definitions/:id' do
+    it 'can edit a generic object definition' do
+      api_basic_authorize action_identifier(:generic_object_definitions, :edit)
+
+      request = {
+        'name'        => 'LoadBalancer Updated',
+        'description' => 'LoadBalancer description Updated'
+      }
+      run_put(generic_object_definitions_url(object_def.name), request)
+
+      expected = {
+        'name'        => 'LoadBalancer Updated',
+        'description' => 'LoadBalancer description Updated'
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
Add the ability to use PUT to edit a generic object definition (cc: @AparnaKarve)

### Example usage
```
PUT /api/generic_object_definitions/:id
{
   "name" : "updated name",
   "description": "updated description"
}
```

@miq-bot add_label enhancement
@miq-bot assign @abellotti 