### PR TITLE
Use Rails path helpers for all routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,27 +13,34 @@ Rails.application.routes.draw do
 
     Api::ApiConfig.collections.each do |collection_name, collection|
       # OPTIONS action for each collection
-      match collection_name.to_s, :controller => collection_name, :action => :options, :via => :options
+      match collection_name.to_s, :controller => collection_name, :action => :options, :via => :options, :as => nil
 
       scope collection_name, :controller => collection_name do
         collection.verbs.each do |verb|
-          root :action => Api::VERBS_ACTIONS_MAP[verb], :via => verb if collection.options.include?(:primary)
+          if collection.options.include?(:primary)
+            case verb
+            when :get
+              root :action => Api::VERBS_ACTIONS_MAP[verb], :as => collection_name
+            else
+              root :action => Api::VERBS_ACTIONS_MAP[verb], :via => verb
+            end
+          end
 
           next unless collection.options.include?(:collection)
 
           if collection.options.include?(:arbitrary_resource_path)
             case verb
             when :get
-              root :action => :index
-              get "/*c_suffix", :action => :show
+              root :action => :index, :as => collection_name.to_s.pluralize
+              get "/*c_suffix", :action => :show, :as => collection_name.to_s.singularize
             else
               match "(/*c_suffix)", :action => Api::VERBS_ACTIONS_MAP[verb], :via => verb
             end
           else
             case verb
             when :get
-              root :action => :index
-              get "/:c_id", :action => :show
+              root :action => :index, :as => collection_name
+              get "/:c_id", :action => :show, :as => collection_name.to_s.singularize
             when :put
               put "/:c_id", :action => :update
             when :patch
@@ -50,8 +57,8 @@ Rails.application.routes.draw do
           Api::ApiConfig.collections[subcollection_name].verbs.each do |verb|
             case verb
             when :get
-              get "/:c_id/#{subcollection_name}", :action => :index
-              get "/:c_id/#{subcollection_name}/:s_id", :action => :show
+              get "/:c_id/#{subcollection_name}", :action => :index, :as => "#{collection_name.to_s.singularize}_#{subcollection_name.to_s.pluralize}"
+              get "/:c_id/#{subcollection_name}/:s_id", :action => :show, :as => "#{collection_name.to_s.singularize}_#{subcollection_name.to_s.singularize}"
             when :put
               put "/:c_id/#{subcollection_name}/:s_id", :action => :update
             when :patch

--- a/spec/requests/actions_spec.rb
+++ b/spec/requests/actions_spec.rb
@@ -10,20 +10,20 @@ describe "Actions API" do
         :options     => {:ae_message => "message", :ae_request => "request", :ae_hash => {"key"=>"value"}}
       }
     end
-    let(:action_url) { actions_url(action.id) }
+    let(:action_url) { api_action_url(nil, action) }
 
     it "forbids access to actions without an appropriate role" do
       action
       api_basic_authorize
 
-      run_get(actions_url)
+      run_get(api_actions_url)
 
       expect(response).to have_http_status(:forbidden)
     end
 
     it "creates new action" do
       api_basic_authorize collection_action_identifier(:actions, :create)
-      run_post(actions_url, sample_action)
+      run_post(api_actions_url, sample_action)
 
       expect(response).to have_http_status(:ok)
 
@@ -34,7 +34,7 @@ describe "Actions API" do
 
     it "creates new actions" do
       api_basic_authorize collection_action_identifier(:actions, :create)
-      run_post(actions_url, gen_request(:create, [sample_action,
+      run_post(api_actions_url, gen_request(:create, [sample_action,
                                                   sample_action.merge(:name => "foo", :description => "bar")]))
       expect(response).to have_http_status(:ok)
 
@@ -44,7 +44,7 @@ describe "Actions API" do
     it "reads all actions" do
       api_basic_authorize collection_action_identifier(:actions, :read, :get)
       FactoryGirl.create(:miq_action)
-      run_get(actions_url)
+      run_get(api_actions_url)
       expect(response).to have_http_status(:ok)
 
       actions_amount = response.parsed_body["count"]
@@ -54,7 +54,7 @@ describe "Actions API" do
 
     it "deletes action" do
       api_basic_authorize collection_action_identifier(:actions, :delete)
-      run_post(actions_url, gen_request(:delete, "name" => action.name, "href" => action_url))
+      run_post(api_actions_url, gen_request(:delete, "name" => action.name, "href" => action_url))
 
       expect(response).to have_http_status(:ok)
 
@@ -63,10 +63,10 @@ describe "Actions API" do
 
     it "deletes actions" do
       api_basic_authorize collection_action_identifier(:actions, :delete)
-      run_post(actions_url, gen_request(:delete, [{"name" => actions.first.name,
-                                                   "href" => actions_url(actions.first.id)},
-                                                  {"name" => actions.second.name,
-                                                   "href" => actions_url(actions.second.id)}]))
+      run_post(api_actions_url, gen_request(:delete, [{"name" => actions.first.name,
+                                                       "href" => api_action_url(nil, actions.first)},
+                                                      {"name" => actions.second.name,
+                                                       "href" => api_action_url(nil, actions.second)}]))
 
       expect(response).to have_http_status(:ok)
 
@@ -76,7 +76,7 @@ describe "Actions API" do
     it "deletes action via DELETE" do
       api_basic_authorize collection_action_identifier(:actions, :delete)
 
-      run_delete(actions_url(action.id))
+      run_delete(api_action_url(nil, action))
 
       expect(response).to have_http_status(:no_content)
       expect(MiqAction.exists?(action.id)).to be_falsey
@@ -93,7 +93,7 @@ describe "Actions API" do
 
     it "edits new actions" do
       api_basic_authorize collection_action_identifier(:actions, :edit)
-      run_post(actions_url, gen_request(:edit, [{"id" => actions.first.id, "description" => "change"},
+      run_post(api_actions_url, gen_request(:edit, [{"id" => actions.first.id, "description" => "change"},
                                                 {"id" => actions.second.id, "description" => "change2"}]))
       expect(response).to have_http_status(:ok)
 

--- a/spec/requests/alert_definitions_spec.rb
+++ b/spec/requests/alert_definitions_spec.rb
@@ -9,14 +9,14 @@
 describe "Alerts Definitions API" do
   it "forbids access to alert definitions list without an appropriate role" do
     api_basic_authorize
-    run_get(alert_definitions_url)
+    run_get(api_alert_definitions_url)
     expect(response).to have_http_status(:forbidden)
   end
 
   it "reads 2 alert definitions as a collection" do
     api_basic_authorize collection_action_identifier(:alert_definitions, :read, :get)
     alert_definitions = FactoryGirl.create_list(:miq_alert, 2)
-    run_get(alert_definitions_url)
+    run_get(api_alert_definitions_url)
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
       "name"      => "alert_definitions",
@@ -24,10 +24,10 @@ describe "Alerts Definitions API" do
       "subcount"  => 2,
       "resources" => a_collection_containing_exactly(
         {
-          "href" => a_string_matching(alert_definitions_url(alert_definitions[0].compressed_id))
+          "href" => api_alert_definition_url(nil, alert_definitions[0].compressed_id)
         },
         {
-          "href" => a_string_matching(alert_definitions_url(alert_definitions[1].compressed_id))
+          "href" => api_alert_definition_url(nil, alert_definitions[1].compressed_id)
         }
       )
     )
@@ -36,7 +36,7 @@ describe "Alerts Definitions API" do
   it "forbids access to an alert definition resource without an appropriate role" do
     api_basic_authorize
     alert_definition = FactoryGirl.create(:miq_alert)
-    run_get(alert_definitions_url(alert_definition.id))
+    run_get(api_alert_definition_url(nil, alert_definition))
     expect(response).to have_http_status(:forbidden)
   end
 
@@ -46,10 +46,10 @@ describe "Alerts Definitions API" do
       :miq_alert,
       :miq_expression => MiqExpression.new("=" => {"field" => "Vm-name", "value" => "foo"})
     )
-    run_get(alert_definitions_url(alert_definition.id))
+    run_get(api_alert_definition_url(nil, alert_definition))
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href"        => a_string_matching(alert_definitions_url(alert_definition.compressed_id)),
+      "href"        => api_alert_definition_url(nil, alert_definition.compressed_id),
       "id"          => alert_definition.compressed_id,
       "description" => alert_definition.description,
       "guid"        => alert_definition.guid,
@@ -63,7 +63,7 @@ describe "Alerts Definitions API" do
       "description" => "Test Alert Definition",
       "db"          => "ContainerNode"
     }
-    run_post(alert_definitions_url, alert_definition)
+    run_post(api_alert_definitions_url, alert_definition)
     expect(response).to have_http_status(:forbidden)
   end
 
@@ -76,7 +76,7 @@ describe "Alerts Definitions API" do
       "enabled"     => true
     }
     api_basic_authorize collection_action_identifier(:alert_definitions, :create)
-    run_post(alert_definitions_url, sample_alert_definition)
+    run_post(api_alert_definitions_url, sample_alert_definition)
     expect(response).to have_http_status(:ok)
     alert_definition = MiqAlert.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
     expect(alert_definition).to be_truthy
@@ -94,17 +94,17 @@ describe "Alerts Definitions API" do
   it "deletes an alert definition via POST" do
     api_basic_authorize action_identifier(:alert_definitions, :delete, :resource_actions, :post)
     alert_definition = FactoryGirl.create(:miq_alert)
-    run_post(alert_definitions_url(alert_definition.id), gen_request(:delete))
+    run_post(api_alert_definition_url(nil, alert_definition), gen_request(:delete))
     expect(response).to have_http_status(:ok)
     expect_single_action_result(:success => true,
                                 :message => "alert_definitions id: #{alert_definition.id} deleting",
-                                :href    => alert_definitions_url(alert_definition.compressed_id))
+                                :href    => api_alert_definition_url(nil, alert_definition.compressed_id))
   end
 
   it "deletes an alert definition via DELETE" do
     api_basic_authorize action_identifier(:alert_definitions, :delete, :resource_actions, :delete)
     alert_definition = FactoryGirl.create(:miq_alert)
-    run_delete(alert_definitions_url(alert_definition.id))
+    run_delete(api_alert_definition_url(nil, alert_definition))
     expect(response).to have_http_status(:no_content)
     expect(MiqAlert.exists?(alert_definition.id)).to be_falsey
   end
@@ -112,7 +112,7 @@ describe "Alerts Definitions API" do
   it "deletes alert definitions" do
     api_basic_authorize collection_action_identifier(:alert_definitions, :delete)
     alert_definitions = FactoryGirl.create_list(:miq_alert, 2)
-    run_post(alert_definitions_url, gen_request(:delete, [{"id" => alert_definitions.first.id},
+    run_post(api_alert_definitions_url, gen_request(:delete, [{"id" => alert_definitions.first.id},
                                                           {"id" => alert_definitions.second.id}]))
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body["results"].count).to eq(2)
@@ -127,7 +127,7 @@ describe "Alerts Definitions API" do
     )
 
     run_post(
-      alert_definitions_url(alert_definition.id),
+      api_alert_definition_url(nil, alert_definition),
       :action  => "edit",
       :options => { :notifications => {:delay_next_evaluation => 60, :evm_event => {} } }
     )
@@ -152,7 +152,7 @@ describe "Alerts Definitions API" do
   it "edits alert definitions" do
     api_basic_authorize collection_action_identifier(:alert_definitions, :edit)
     alert_definitions = FactoryGirl.create_list(:miq_alert, 2)
-    run_post(alert_definitions_url, gen_request(:edit, [{"id"          => alert_definitions.first.id,
+    run_post(api_alert_definitions_url, gen_request(:edit, [{"id"          => alert_definitions.first.id,
                                                          "description" => "Updated Test Alert 1"},
                                                         {"id"          => alert_definitions.second.id,
                                                          "description" => "Updated Test Alert 2"}]))
@@ -167,7 +167,7 @@ end
 describe "Alerts Definition Profiles API" do
   it "forbids access to alert definition profiles list without an appropriate role" do
     api_basic_authorize
-    run_get(alert_definition_profiles_url)
+    run_get(api_alert_definition_profiles_url)
 
     expect(response).to have_http_status(:forbidden)
   end
@@ -175,7 +175,7 @@ describe "Alerts Definition Profiles API" do
   it "forbids access to an alert definition profile without an appropriate role" do
     api_basic_authorize
     alert_definition_profile = FactoryGirl.create(:miq_alert_set)
-    run_get(alert_definition_profiles_url(alert_definition_profile.id))
+    run_get(api_alert_definition_profile_url(nil, alert_definition_profile))
 
     expect(response).to have_http_status(:forbidden)
   end
@@ -183,25 +183,25 @@ describe "Alerts Definition Profiles API" do
   it "reads 2 alert definition profiles as a collection" do
     api_basic_authorize collection_action_identifier(:alert_definition_profiles, :read, :get)
     alert_definition_profiles = FactoryGirl.create_list(:miq_alert_set, 2)
-    run_get(alert_definition_profiles_url)
+    run_get(api_alert_definition_profiles_url)
 
     expect(response).to have_http_status(:ok)
     expect_query_result(:alert_definition_profiles, 2, 2)
     expect_result_resources_to_include_hrefs(
       "resources",
-      [alert_definition_profiles_url(alert_definition_profiles.first.compressed_id),
-       alert_definition_profiles_url(alert_definition_profiles.second.compressed_id)]
+      [api_alert_definition_profile_url(nil, alert_definition_profiles.first.compressed_id),
+       api_alert_definition_profile_url(nil, alert_definition_profiles.second.compressed_id)]
     )
   end
 
   it "reads an alert definition profile as a resource" do
     api_basic_authorize action_identifier(:alert_definition_profiles, :read, :resource_actions, :get)
     alert_definition_profile = FactoryGirl.create(:miq_alert_set)
-    run_get(alert_definition_profiles_url(alert_definition_profile.id))
+    run_get(api_alert_definition_profile_url(nil, alert_definition_profile))
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href"        => a_string_matching(alert_definition_profiles_url(alert_definition_profile.compressed_id)),
+      "href"        => api_alert_definition_profile_url(nil, alert_definition_profile.compressed_id),
       "description" => alert_definition_profile.description,
       "guid"        => alert_definition_profile.guid
     )
@@ -212,13 +212,13 @@ describe "Alerts Definition Profiles API" do
 
     alert_definitions = FactoryGirl.create_list(:miq_alert, 2)
     alert_definition_profile = FactoryGirl.create(:miq_alert_set, :alerts => alert_definitions)
-    run_get "#{alert_definition_profiles_url}/#{alert_definition_profile.id}/alert_definitions", :expand => "resources"
+    run_get(api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile), :expand => "resources")
 
     expect(response).to have_http_status(:ok)
     expect_result_resources_to_include_hrefs(
       "resources",
-      ["#{alert_definition_profiles_url}/#{alert_definition_profile.compressed_id}/alert_definitions/#{alert_definitions.first.compressed_id}",
-       "#{alert_definition_profiles_url}/#{alert_definition_profile.compressed_id}/alert_definitions/#{alert_definitions.first.compressed_id}"]
+      [api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile.compressed_id, alert_definitions.first.compressed_id),
+       api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile.compressed_id, alert_definitions.first.compressed_id)]
     )
   end
 
@@ -227,7 +227,7 @@ describe "Alerts Definition Profiles API" do
 
     alert_definition = FactoryGirl.create(:miq_alert)
     alert_definition_profile = FactoryGirl.create(:miq_alert_set, :alerts => [alert_definition])
-    run_get "#{alert_definition_profiles_url}/#{alert_definition_profile.id}", :expand => "alert_definitions"
+    run_get(api_alert_definition_profile_url(nil, alert_definition_profile), :expand => "alert_definitions")
 
     expect(response).to have_http_status(:ok)
     expect_single_resource_query(
@@ -245,7 +245,7 @@ describe "Alerts Definition Profiles API" do
       "mode"        => "ContainerNode",
     }
     api_basic_authorize collection_action_identifier(:alert_definition_profiles, :create)
-    run_post(alert_definition_profiles_url, sample_alert_definition_profile)
+    run_post(api_alert_definition_profiles_url, sample_alert_definition_profile)
 
     expect(response).to have_http_status(:ok)
     id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
@@ -260,18 +260,18 @@ describe "Alerts Definition Profiles API" do
   it "deletes an alert definition profile via POST" do
     api_basic_authorize action_identifier(:alert_definition_profiles, :delete, :resource_actions, :post)
     alert_definition_profile = FactoryGirl.create(:miq_alert_set)
-    run_post(alert_definition_profiles_url(alert_definition_profile.id), gen_request(:delete))
+    run_post(api_alert_definition_profile_url(nil, alert_definition_profile), gen_request(:delete))
 
     expect(response).to have_http_status(:ok)
     expect_single_action_result(:success => true,
                                 :message => "alert_definition_profiles id: #{alert_definition_profile.id} deleting",
-                                :href    => alert_definition_profiles_url(alert_definition_profile.compressed_id))
+                                :href    => api_alert_definition_profile_url(nil, alert_definition_profile.compressed_id))
   end
 
   it "deletes an alert definition profile via DELETE" do
     api_basic_authorize action_identifier(:alert_definition_profiles, :delete, :resource_actions, :delete)
     alert_definition_profile = FactoryGirl.create(:miq_alert_set)
-    run_delete(alert_definition_profiles_url(alert_definition_profile.id))
+    run_delete(api_alert_definition_profile_url(nil, alert_definition_profile))
 
     expect(response).to have_http_status(:no_content)
     expect(MiqAlertSet.exists?(alert_definition_profile.id)).to be_falsey
@@ -280,7 +280,7 @@ describe "Alerts Definition Profiles API" do
   it "deletes alert definition profiles" do
     api_basic_authorize collection_action_identifier(:alert_definition_profiles, :delete)
     alert_definition_profiles = FactoryGirl.create_list(:miq_alert_set, 2)
-    run_post(alert_definition_profiles_url, gen_request(:delete, [{"id" => alert_definition_profiles.first.id},
+    run_post(api_alert_definition_profiles_url, gen_request(:delete, [{"id" => alert_definition_profiles.first.id},
                                                                   {"id" => alert_definition_profiles.second.id}]))
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body["results"].count).to eq(2)
@@ -289,7 +289,7 @@ describe "Alerts Definition Profiles API" do
   it "edits alert definition profiles" do
     api_basic_authorize action_identifier(:alert_definition_profiles, :edit, :resource_actions, :post)
     alert_definition_profiles = FactoryGirl.create_list(:miq_alert_set, 2)
-    run_post(alert_definition_profiles_url, gen_request(:edit,
+    run_post(api_alert_definition_profiles_url, gen_request(:edit,
                                                         [{"id"          => alert_definition_profiles.first.id,
                                                           "description" => "Updated Test Alert Profile 1"},
                                                          {"id"          => alert_definition_profiles.second.id,

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -129,7 +129,7 @@ describe "Authentication API" do
         it "gets a token based identifier" do
           api_basic_authorize
 
-          run_get auth_url
+          run_get api_auth_url
 
           expect(response).to have_http_status(:ok)
           expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
@@ -144,7 +144,7 @@ describe "Authentication API" do
         it "authentication using a valid token" do
           api_basic_authorize
 
-          run_get auth_url
+          run_get api_auth_url
 
           expect(response).to have_http_status(:ok)
           expect_result_to_have_keys(%w(auth_token))
@@ -160,7 +160,7 @@ describe "Authentication API" do
         it "authentication using a valid token updates the token's expiration time" do
           api_basic_authorize
 
-          run_get auth_url
+          run_get api_auth_url
 
           expect(response).to have_http_status(:ok)
           expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
@@ -181,7 +181,7 @@ describe "Authentication API" do
 
         it "gets a token based identifier with the default API based token_ttl" do
           api_basic_authorize
-          run_get auth_url
+          run_get api_auth_url
 
           expect(response).to have_http_status(:ok)
           expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
@@ -191,7 +191,7 @@ describe "Authentication API" do
         it "gets a token based identifier with an invalid requester_type" do
           api_basic_authorize
 
-          run_get auth_url, :requester_type => "bogus_type"
+          run_get api_auth_url, :requester_type => "bogus_type"
 
           expect_bad_request(/invalid requester_type/i)
         end
@@ -199,7 +199,7 @@ describe "Authentication API" do
         it "gets a token based identifier with a UI based token_ttl" do
           api_basic_authorize
 
-          run_get auth_url, :requester_type => "ui"
+          run_get api_auth_url, :requester_type => "ui"
 
           expect(response).to have_http_status(:ok)
           expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
@@ -209,19 +209,19 @@ describe "Authentication API" do
         it "forgets the current token when asked to" do
           api_basic_authorize
 
-          run_get auth_url
+          run_get api_auth_url
 
           auth_token = response.parsed_body["auth_token"]
 
           expect_any_instance_of(TokenManager).to receive(:invalidate_token).with(auth_token)
-          run_delete auth_url, Api::HttpHeaders::AUTH_TOKEN => auth_token
+          run_delete api_auth_url, Api::HttpHeaders::AUTH_TOKEN => auth_token
         end
 
         context 'Tokens for Web Sockets' do
           it 'gets a UI based token_ttl when requesting token for web sockets' do
             api_basic_authorize
 
-            run_get auth_url, :requester_type => 'ws'
+            run_get api_auth_url, :requester_type => 'ws'
             expect(response).to have_http_status(:ok)
             expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
             expect(response.parsed_body["token_ttl"]).to eq(::Settings.session.timeout.to_i_with_method)
@@ -229,7 +229,7 @@ describe "Authentication API" do
 
           it 'cannot authorize user to api based on token that is dedicated for web sockets' do
             api_basic_authorize
-            run_get auth_url, :requester_type => 'ws'
+            run_get api_auth_url, :requester_type => 'ws'
             ws_token = response.parsed_body["auth_token"]
 
             run_get api_entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => ws_token}
@@ -309,7 +309,7 @@ describe "Authentication API" do
         stub_api_action_role(:vms, :collection_actions, :get, :read, "vm_view_role1")
         api_basic_authorize
 
-        run_get vms_url
+        run_get api_vms_url
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -318,7 +318,7 @@ describe "Authentication API" do
         stub_api_action_role(:vms, :collection_actions, :get, :read, "vm_view_role1")
         api_basic_authorize "vm_view_role1"
 
-        run_get vms_url
+        run_get api_vms_url
 
         expect_query_result(:vms, 1, 1)
       end
@@ -329,7 +329,7 @@ describe "Authentication API" do
         stub_api_action_role(:vms, :collection_actions, :get, :read, %w(vm_view_role1 vm_view_role2))
         api_basic_authorize
 
-        run_get vms_url
+        run_get api_vms_url
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -338,7 +338,7 @@ describe "Authentication API" do
         stub_api_action_role(:vms, :collection_actions, :get, :read, %w(vm_view_role1 vm_view_role2))
         api_basic_authorize "vm_view_role2"
 
-        run_get vms_url
+        run_get api_vms_url
 
         expect_query_result(:vms, 1, 1)
       end

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe 'Authentications API' do
       auth = FactoryGirl.create(:authentication)
       api_basic_authorize collection_action_identifier(:authentications, :read, :get)
 
-      run_get(authentications_url)
+      run_get(api_authentications_url)
 
       expected = {
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'authentications',
-        'resources' => [hash_including('href' => a_string_matching(authentications_url(auth.compressed_id)))]
+        'resources' => [hash_including('href' => api_authentication_url(nil, auth.compressed_id))]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -23,7 +23,7 @@ RSpec.describe 'Authentications API' do
     it 'forbids access to authentication configuration script bases without an appropriate role' do
       api_basic_authorize
 
-      run_get(authentications_url)
+      run_get(api_authentications_url)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -33,10 +33,10 @@ RSpec.describe 'Authentications API' do
     it 'will show an authentication configuration script base' do
       api_basic_authorize action_identifier(:authentications, :read, :resource_actions, :get)
 
-      run_get(authentications_url(auth.id))
+      run_get(api_authentication_url(nil, auth))
 
       expected = {
-        'href' => a_string_matching(authentications_url(auth.compressed_id))
+        'href' => api_authentication_url(nil, auth.compressed_id)
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -45,7 +45,7 @@ RSpec.describe 'Authentications API' do
     it 'forbids access to an authentication configuration script base' do
       api_basic_authorize
 
-      run_get(authentications_url(auth.id))
+      run_get(api_authentication_url(nil, auth))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -73,7 +73,7 @@ RSpec.describe 'Authentications API' do
           )
         ]
       }
-      run_post(authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
+      run_post(api_authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
 
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -83,7 +83,7 @@ RSpec.describe 'Authentications API' do
       api_basic_authorize collection_action_identifier(:authentications, :delete, :post)
       auth = FactoryGirl.create(:authentication)
 
-      run_post(authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
+      run_post(api_authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
 
       expected = {
         'results' => [
@@ -114,7 +114,7 @@ RSpec.describe 'Authentications API' do
           )
         ]
       }
-      run_post(authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }, { 'id' => auth_2.id }])
+      run_post(api_authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }, { 'id' => auth_2.id }])
 
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -124,14 +124,14 @@ RSpec.describe 'Authentications API' do
       auth = FactoryGirl.create(:authentication)
       api_basic_authorize
 
-      run_post(authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
+      run_post(api_authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'can update an authentication with an appropriate role' do
       api_basic_authorize collection_action_identifier(:authentications, :edit)
 
-      run_post(authentications_url, :action => 'edit', :resources => [params])
+      run_post(api_authentications_url, :action => 'edit', :resources => [params])
 
       expected = {
         'results' => [
@@ -150,7 +150,7 @@ RSpec.describe 'Authentications API' do
       params2 = params.dup.merge(:id => auth_2.id)
       api_basic_authorize collection_action_identifier(:authentications, :edit)
 
-      run_post(authentications_url, :action => 'edit', :resources => [params, params2])
+      run_post(api_authentications_url, :action => 'edit', :resources => [params, params2])
 
       expected = {
         'results' => [
@@ -173,7 +173,7 @@ RSpec.describe 'Authentications API' do
     it 'will forbid update to an authentication without appropriate role' do
       api_basic_authorize
 
-      run_post(authentications_url, :action => 'edit', :resources => [params])
+      run_post(api_authentications_url, :action => 'edit', :resources => [params])
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -185,14 +185,14 @@ RSpec.describe 'Authentications API' do
         :name             => "A Credential",
         :related          => {},
         :type             => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Credential',
-        :manager_resource => { :href => providers_url(manager.id) }
+        :manager_resource => { :href => api_provider_url(nil, manager) }
       }
     end
 
     it 'requires a manager resource when creating an authentication' do
       api_basic_authorize collection_action_identifier(:authentications, :create, :post)
 
-      run_post(authentications_url, :action => 'create', :type => 'Authentication')
+      run_post(api_authentications_url, :action => 'create', :type => 'Authentication')
 
       expected = {
         'results' => [
@@ -206,7 +206,7 @@ RSpec.describe 'Authentications API' do
     it 'requires that the type support create_in_provider_queue' do
       api_basic_authorize collection_action_identifier(:authentications, :create, :post)
 
-      run_post(authentications_url, :action => 'create', :type => 'Authentication', :manager_resource => { :href => providers_url(manager.id) })
+      run_post(api_authentications_url, :action => 'create', :type => 'Authentication', :manager_resource => { :href => api_provider_url(nil, manager) })
 
       expected = {
         'results' => [
@@ -227,7 +227,7 @@ RSpec.describe 'Authentications API' do
           'task_id' => a_kind_of(String)
         )]
       }
-      run_post(authentications_url, create_params)
+      run_post(api_authentications_url, create_params)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -250,7 +250,7 @@ RSpec.describe 'Authentications API' do
           )
         ]
       }
-      run_post(authentications_url, :resources => [create_params, create_params])
+      run_post(api_authentications_url, :resources => [create_params, create_params])
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -268,7 +268,7 @@ RSpec.describe 'Authentications API' do
           )
         ]
       }
-      run_post(authentications_url, :resources => [create_params])
+      run_post(api_authentications_url, :resources => [create_params])
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -277,7 +277,7 @@ RSpec.describe 'Authentications API' do
     it 'will forbid creation of an authentication without appropriate role' do
       api_basic_authorize
 
-      run_post(authentications_url, :action => 'create')
+      run_post(api_authentications_url, :action => 'create')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -285,7 +285,7 @@ RSpec.describe 'Authentications API' do
     it 'can refresh multiple authentications with an appropriate role' do
       api_basic_authorize collection_action_identifier(:authentications, :refresh, :post)
 
-      run_post(authentications_url, :action => :refresh, :resources => [{ :id => auth.id}, {:id => auth_2.id}])
+      run_post(api_authentications_url, :action => :refresh, :resources => [{ :id => auth.id}, {:id => auth_2.id}])
 
       expected = {
         'results' => [
@@ -321,7 +321,7 @@ RSpec.describe 'Authentications API' do
     it 'can update an authentication with an appropriate role' do
       api_basic_authorize collection_action_identifier(:authentications, :edit)
 
-      run_put(authentications_url(auth.id), :resource => params)
+      run_put(api_authentication_url(nil, auth), :resource => params)
 
       expected = {
         'success' => true,
@@ -345,7 +345,7 @@ RSpec.describe 'Authentications API' do
     it 'can update an authentication with an appropriate role' do
       api_basic_authorize collection_action_identifier(:authentications, :edit)
 
-      run_patch(authentications_url(auth.id), [params])
+      run_patch(api_authentication_url(nil, auth), [params])
 
       expected = {
         'success' => true,
@@ -368,7 +368,7 @@ RSpec.describe 'Authentications API' do
     it 'will delete an authentication' do
       api_basic_authorize action_identifier(:authentications, :delete, :resource_actions, :post)
 
-      run_post(authentications_url(auth.id), :action => 'delete')
+      run_post(api_authentication_url(nil, auth), :action => 'delete')
 
       expected = {
         'success' => true,
@@ -382,7 +382,7 @@ RSpec.describe 'Authentications API' do
     it 'will not delete an authentication without an appropriate role' do
       api_basic_authorize
 
-      run_post(authentications_url(auth.id), :action => 'delete')
+      run_post(api_authentication_url(nil, auth), :action => 'delete')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -390,7 +390,7 @@ RSpec.describe 'Authentications API' do
     it 'can update an authentication with an appropriate role' do
       api_basic_authorize collection_action_identifier(:authentications, :edit)
 
-      run_post(authentications_url(auth.id), :action => 'edit', :resource => params)
+      run_post(api_authentication_url(nil, auth), :action => 'edit', :resource => params)
 
       expected = {
         'success' => true,
@@ -405,7 +405,7 @@ RSpec.describe 'Authentications API' do
       api_basic_authorize collection_action_identifier(:authentications, :edit)
       auth = FactoryGirl.create(:authentication)
 
-      run_post(authentications_url(auth.id), :action => 'edit', :resource => params)
+      run_post(api_authentication_url(nil, auth), :action => 'edit', :resource => params)
 
       expected = {
         'success' => false,
@@ -418,7 +418,7 @@ RSpec.describe 'Authentications API' do
     it 'will forbid update to an authentication without appropriate role' do
       api_basic_authorize
 
-      run_post(authentications_url(auth.id), :action => 'edit', :resource => params)
+      run_post(api_authentication_url(nil, auth), :action => 'edit', :resource => params)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -426,7 +426,7 @@ RSpec.describe 'Authentications API' do
     it 'forbids refresh without an appropriate role' do
       api_basic_authorize
 
-      run_post(authentications_url(auth.id), :action => :refresh)
+      run_post(api_authentication_url(nil, auth), :action => :refresh)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -434,7 +434,7 @@ RSpec.describe 'Authentications API' do
     it 'can refresh a authentications with an appropriate role' do
       api_basic_authorize action_identifier(:authentications, :refresh)
 
-      run_post(authentications_url(auth.id), :action => :refresh)
+      run_post(api_authentication_url(nil, auth), :action => :refresh)
 
       expected = {
         'success'   => true,
@@ -453,7 +453,7 @@ RSpec.describe 'Authentications API' do
       auth = FactoryGirl.create(:authentication)
       api_basic_authorize action_identifier(:authentications, :delete, :resource_actions, :delete)
 
-      run_delete(authentications_url(auth.id))
+      run_delete(api_authentication_url(nil, auth))
 
       expect(response).to have_http_status(:no_content)
     end
@@ -462,7 +462,7 @@ RSpec.describe 'Authentications API' do
       auth = FactoryGirl.create(:authentication)
       api_basic_authorize
 
-      run_delete(authentications_url(auth.id))
+      run_delete(api_authentication_url(nil, auth))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -470,7 +470,7 @@ RSpec.describe 'Authentications API' do
 
   describe 'OPTIONS /api/authentications' do
     it 'returns expected and additional attributes' do
-      run_options(authentications_url)
+      run_options(api_authentications_url)
 
       additional_options = {
         'credential_types' => build_credential_options

--- a/spec/requests/automate_domains_spec.rb
+++ b/spec/requests/automate_domains_spec.rb
@@ -7,7 +7,7 @@ describe "Automate Domains API" do
     it 'forbids access for users without proper permissions' do
       api_basic_authorize
 
-      run_post(automate_domains_url(git_domain.id), gen_request(:refresh_from_source))
+      run_post(api_automate_domain_url(nil, git_domain), gen_request(:refresh_from_source))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -16,7 +16,7 @@ describe "Automate Domains API" do
       api_basic_authorize action_identifier(:automate_domains, :refresh_from_source)
       expect(GitBasedDomainImportService).to receive(:available?).and_return(false)
 
-      run_post(automate_domains_url(git_domain.id), gen_request(:refresh_from_source))
+      run_post(api_automate_domain_url(nil, git_domain), gen_request(:refresh_from_source))
       expect_single_action_result(:success => false,
                                   :message => 'Git owner role is not enabled to be able to import git repositories')
     end
@@ -30,7 +30,7 @@ describe "Automate Domains API" do
       it 'fails to refresh when domain did not originate from git' do
         api_basic_authorize action_identifier(:automate_domains, :refresh_from_source)
 
-        run_post(automate_domains_url(non_git_domain.id), gen_request(:refresh_from_source))
+        run_post(api_automate_domain_url(nil, non_git_domain), gen_request(:refresh_from_source))
         expect_single_action_result(
           :success => false,
           :message => a_string_matching(/Automate Domain .* did not originate from git repository/)
@@ -41,11 +41,11 @@ describe "Automate Domains API" do
         api_basic_authorize action_identifier(:automate_domains, :refresh_from_source)
 
         expect_any_instance_of(GitBasedDomainImportService).to receive(:queue_refresh_and_import)
-        run_post(automate_domains_url(git_domain.id), gen_request(:refresh_from_source))
+        run_post(api_automate_domain_url(nil, git_domain), gen_request(:refresh_from_source))
         expect_single_action_result(
           :success => true,
           :message => a_string_matching(/Refreshing Automate Domain .* from git repository/),
-          :href    => automate_domains_url(git_domain.compressed_id)
+          :href    => api_automate_domain_url(nil, git_domain.compressed_id)
         )
       end
 
@@ -53,11 +53,11 @@ describe "Automate Domains API" do
         api_basic_authorize action_identifier(:automate_domains, :refresh_from_source)
 
         expect_any_instance_of(GitBasedDomainImportService).to receive(:queue_refresh_and_import)
-        run_post(automate_domains_url(git_domain.name), gen_request(:refresh_from_source))
+        run_post(api_automate_domain_url(nil, git_domain.name), gen_request(:refresh_from_source))
         expect_single_action_result(
           :success => true,
           :message => a_string_matching(/Refreshing Automate Domain .* from git repository/),
-          :href    => automate_domains_url(git_domain.name)
+          :href    => api_automate_domain_url(nil, git_domain.name)
         )
       end
     end

--- a/spec/requests/automate_spec.rb
+++ b/spec/requests/automate_spec.rb
@@ -15,7 +15,7 @@ describe "Automate API" do
     it "returns domains by default" do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 
-      run_get automate_url
+      run_get api_automates_url
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
@@ -31,7 +31,7 @@ describe "Automate API" do
     it 'returns only the requested attributes' do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 
-      run_get automate_url, :expand => 'resources', :attributes => 'name'
+      run_get api_automates_url, :expand => 'resources', :attributes => 'name'
 
       expect(response).to have_http_status(:ok)
       response.parsed_body['resources'].each { |res| expect_hash_to_have_only_keys(res, %w(fqname name)) }
@@ -40,7 +40,7 @@ describe "Automate API" do
     it "default to depth 0 for non-root queries" do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 
-      run_get automate_url("custom")
+      run_get api_automate_url(nil, "custom")
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["resources"]).to match(
@@ -51,7 +51,7 @@ describe "Automate API" do
     it "supports depth 1" do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 
-      run_get(automate_url("custom"), :depth => 1)
+      run_get(api_automate_url(nil, "custom"), :depth => 1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["resources"]).to match_array(
@@ -63,7 +63,7 @@ describe "Automate API" do
     it "supports depth -1" do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 
-      run_get(automate_url, :depth => -1)
+      run_get(api_automates_url, :depth => -1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["resources"]).to match_array(
@@ -76,7 +76,7 @@ describe "Automate API" do
     it "supports state_machines search option" do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 
-      run_get(automate_url, :depth => -1, :search_options => "state_machines")
+      run_get(api_automates_url, :depth => -1, :search_options => "state_machines")
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["resources"]).to match_array(
@@ -88,7 +88,7 @@ describe "Automate API" do
     it "always return the fqname" do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 
-      run_get(automate_url("custom/system"), :attributes => "name")
+      run_get(api_automate_url(nil, "custom/system"), :attributes => "name")
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["resources"]).to match_array([{"name" => "System", "fqname" => "/Custom/System"}])

--- a/spec/requests/blueprints_spec.rb
+++ b/spec/requests/blueprints_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize collection_action_identifier(:blueprints, :read, :get)
 
-      run_get(blueprints_url)
+      run_get(api_blueprints_url)
 
       expected = {
         "count"     => 1,
         "subcount"  => 1,
         "name"      => "blueprints",
         "resources" => [
-          hash_including("href" => a_string_matching(blueprints_url(blueprint.compressed_id)))
+          hash_including("href" => api_blueprint_url(nil, blueprint.compressed_id))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -22,7 +22,7 @@ RSpec.describe "Blueprints API" do
       FactoryGirl.create(:blueprint)
       api_basic_authorize
 
-      run_get(blueprints_url)
+      run_get(api_blueprints_url)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -33,9 +33,9 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize action_identifier(:blueprints, :read, :resource_actions, :get)
 
-      run_get(blueprints_url(blueprint.id))
+      run_get(api_blueprint_url(nil, blueprint))
 
-      expect(response.parsed_body).to include("href" => a_string_matching(blueprints_url(blueprint.compressed_id)))
+      expect(response.parsed_body).to include("href" => api_blueprint_url(nil, blueprint.compressed_id))
       expect(response).to have_http_status(:ok)
     end
 
@@ -43,7 +43,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize
 
-      run_get(blueprints_url(blueprint.id))
+      run_get(api_blueprint_url(nil, blueprint))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -59,7 +59,7 @@ RSpec.describe "Blueprints API" do
         :chart_data_model     => {}
       }
 
-      run_post(blueprints_url, :name => "foo", :description => "bar", :ui_properties => ui_properties)
+      run_post(api_blueprints_url, :name => "foo", :description => "bar", :ui_properties => ui_properties)
 
       expected = {
         "results" => [
@@ -82,7 +82,7 @@ RSpec.describe "Blueprints API" do
     it "rejects blueprint creation with id specified" do
       api_basic_authorize collection_action_identifier(:blueprints, :create)
 
-      run_post(blueprints_url, :name => "foo", :description => "bar", :id => 123)
+      run_post(api_blueprints_url, :name => "foo", :description => "bar", :id => 123)
 
       expected = {
         "error" => a_hash_including(
@@ -97,7 +97,7 @@ RSpec.describe "Blueprints API" do
     it "rejects blueprint creation with an href specified" do
       api_basic_authorize collection_action_identifier(:blueprints, :create)
 
-      run_post(blueprints_url, :name => "foo", :description => "bar", :href => blueprints_url(123))
+      run_post(api_blueprints_url, :name => "foo", :description => "bar", :href => api_blueprint_url(nil, 123))
 
       expected = {
         "error" => a_hash_including(
@@ -119,7 +119,7 @@ RSpec.describe "Blueprints API" do
       }
 
       run_post(
-        blueprints_url,
+        api_blueprints_url,
         :resources => [
           {:name => "foo", :description => "bar", :ui_properties => ui_properties},
           {:name => "baz", :description => "qux", :ui_properties => ui_properties}
@@ -128,8 +128,8 @@ RSpec.describe "Blueprints API" do
 
       expected = {
         "results" => a_collection_containing_exactly(
-          a_hash_including("name" => "foo", "description" => "bar", "href" => a_string_including(blueprints_url)),
-          a_hash_including("name" => "baz", "description" => "qux", "href" => a_string_including(blueprints_url))
+          a_hash_including("name" => "foo", "description" => "bar", "href" => a_string_including(api_blueprints_url)),
+          a_hash_including("name" => "baz", "description" => "qux", "href" => a_string_including(api_blueprints_url))
         )
       }
       expect(response.parsed_body).to include(expected)
@@ -139,7 +139,7 @@ RSpec.describe "Blueprints API" do
     it "forbids blueprint creation without an appropriate role" do
       api_basic_authorize
 
-      run_post(blueprints_url, :name => "foo", :description => "bar", :ui_properties => {:some => {:json => "baz"}})
+      run_post(api_blueprints_url, :name => "foo", :description => "bar", :ui_properties => {:some => {:json => "baz"}})
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -151,7 +151,7 @@ RSpec.describe "Blueprints API" do
       blueprint2 = FactoryGirl.create(:blueprint, :name => "bar")
       api_basic_authorize collection_action_identifier(:blueprints, :edit)
 
-      run_post(blueprints_url, :action => "edit", :resources => [{:id => blueprint1.id, :name => "baz"},
+      run_post(api_blueprints_url, :action => "edit", :resources => [{:id => blueprint1.id, :name => "baz"},
                                                                  {:id => blueprint2.id, :name => "qux"}])
 
       expected = {
@@ -175,7 +175,7 @@ RSpec.describe "Blueprints API" do
       blueprint2 = FactoryGirl.create(:blueprint, :name => "bar")
       api_basic_authorize
 
-      run_post(blueprints_url, :action => "edit", :resources => [{:id => blueprint1.id, :name => "baz"},
+      run_post(api_blueprints_url, :action => "edit", :resources => [{:id => blueprint1.id, :name => "baz"},
                                                                  {:id => blueprint2.id, :name => "qux"}])
 
       expect(response).to have_http_status(:forbidden)
@@ -185,7 +185,7 @@ RSpec.describe "Blueprints API" do
       blueprint1, blueprint2 = FactoryGirl.create_list(:blueprint, 2)
       api_basic_authorize collection_action_identifier(:blueprints, :delete)
 
-      run_post(blueprints_url, :action => "delete", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
+      run_post(api_blueprints_url, :action => "delete", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
 
       expect(response).to have_http_status(:ok)
     end
@@ -194,7 +194,7 @@ RSpec.describe "Blueprints API" do
       blueprint1, blueprint2 = FactoryGirl.create_list(:blueprint, 2)
       api_basic_authorize
 
-      run_post(blueprints_url, :action => "delete", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
+      run_post(api_blueprints_url, :action => "delete", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -218,7 +218,7 @@ RSpec.describe "Blueprints API" do
 
       api_basic_authorize collection_action_identifier(:blueprints, :publish)
 
-      run_post(blueprints_url, :action => "publish", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
+      run_post(api_blueprints_url, :action => "publish", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
 
       expected = {
         "results" => a_collection_containing_exactly(
@@ -237,7 +237,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint, :name => "foo", :description => "bar")
       api_basic_authorize
 
-      run_post(blueprints_url(blueprint.id), :action => "edit", :resource => {:name => "baz", :description => "qux"})
+      run_post(api_blueprint_url(nil, blueprint), :action => "edit", :resource => {:name => "baz", :description => "qux"})
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -246,7 +246,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize action_identifier(:blueprints, :delete)
 
-      run_post(blueprints_url(blueprint.id), :action => "delete")
+      run_post(api_blueprint_url(nil, blueprint), :action => "delete")
 
       expect(response).to have_http_status(:ok)
     end
@@ -255,7 +255,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize
 
-      run_post(blueprints_url(blueprint.id), :action => "delete")
+      run_post(api_blueprint_url(nil, blueprint), :action => "delete")
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -278,7 +278,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint, :ui_properties => ui_properties)
       api_basic_authorize action_identifier(:blueprints, :publish)
 
-      run_post(blueprints_url(blueprint.id), :action => "publish")
+      run_post(api_blueprint_url(nil, blueprint), :action => "publish")
 
       expected = {
         "id"     => blueprint.compressed_id,
@@ -292,7 +292,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize action_identifier(:blueprints, :publish)
 
-      run_post(blueprints_url(blueprint.id), :action => "publish")
+      run_post(api_blueprint_url(nil, blueprint), :action => "publish")
 
       expected = {
         "error" => a_hash_including(
@@ -311,7 +311,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize action_identifier(:blueprints, :delete, :resource_actions, :delete)
 
-      run_delete(blueprints_url(blueprint.id))
+      run_delete(api_blueprint_url(nil, blueprint))
 
       expect(response).to have_http_status(:no_content)
     end
@@ -320,7 +320,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize
 
-      run_delete(blueprints_url(blueprint.id))
+      run_delete(api_blueprint_url(nil, blueprint))
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/chargebacks_spec.rb
+++ b/spec/requests/chargebacks_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe "chargebacks API" do
     chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
     api_basic_authorize collection_action_identifier(:chargebacks, :read, :get)
-    run_get chargebacks_url
+    run_get api_chargebacks_url
 
     expect_result_resources_to_include_hrefs(
-      "resources", [chargebacks_url(chargeback_rate.compressed_id)]
+      "resources", [api_chargeback_url(nil, chargeback_rate.compressed_id)]
     )
     expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)
@@ -18,14 +18,14 @@ RSpec.describe "chargebacks API" do
     chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
     api_basic_authorize action_identifier(:chargebacks, :read, :resource_actions, :get)
-    run_get chargebacks_url(chargeback_rate.id)
+    run_get api_chargeback_url(nil, chargeback_rate)
 
     expect_result_to_match_hash(
       response.parsed_body,
       "description" => chargeback_rate.description,
       "guid"        => chargeback_rate.guid,
       "id"          => chargeback_rate.compressed_id,
-      "href"        => chargebacks_url(chargeback_rate.compressed_id)
+      "href"        => api_chargeback_url(nil, chargeback_rate.compressed_id)
     )
     expect(response).to have_http_status(:ok)
   end
@@ -40,12 +40,12 @@ RSpec.describe "chargebacks API" do
                                          :chargeback_rate_details => [chargeback_rate_detail])
 
     api_basic_authorize
-    run_get "#{chargebacks_url(chargeback_rate.id)}/rates"
+    run_get(api_chargeback_rates_url(nil, chargeback_rate))
 
     expect_query_result(:rates, 1, 1)
     expect_result_resources_to_include_hrefs(
       "resources",
-      ["#{chargebacks_url(chargeback_rate.compressed_id)}/rates/#{chargeback_rate_detail.compressed_id}"]
+      [api_chargeback_rate_url(nil, chargeback_rate.compressed_id, chargeback_rate_detail.compressed_id)]
     )
   end
 
@@ -59,12 +59,12 @@ RSpec.describe "chargebacks API" do
                                          :chargeback_rate_details => [chargeback_rate_detail])
 
     api_basic_authorize
-    run_get "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}"
+    run_get(api_chargeback_rate_url(nil, chargeback_rate, chargeback_rate_detail))
 
     expect_result_to_match_hash(
       response.parsed_body,
       "chargeback_rate_id" => chargeback_rate.compressed_id,
-      "href"               => "#{chargebacks_url(chargeback_rate.compressed_id)}/rates/#{chargeback_rate_detail.compressed_id}",
+      "href"               => api_chargeback_rate_url(nil, chargeback_rate.compressed_id, chargeback_rate_detail.compressed_id),
       "id"                 => chargeback_rate_detail.compressed_id,
       "description"        => "rate_1"
     )
@@ -132,7 +132,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:chargebacks, :create, :collection_actions)
 
       expect do
-        run_post chargebacks_url,
+        run_post api_chargebacks_url,
                  :description => "chargeback_0",
                  :rate_type   => "Storage"
       end.to change(ChargebackRate, :count).by(1)
@@ -146,7 +146,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:chargebacks, :create, :collection_actions)
 
       expect do
-        run_post chargebacks_url,
+        run_post api_chargebacks_url,
                  :rate_type   => "Storage"
       end.not_to change(ChargebackRate, :count)
       expect_bad_request(/description can't be blank/i)
@@ -156,7 +156,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate = FactoryGirl.create(:chargeback_rate, :description => "chargeback_0")
 
       api_basic_authorize action_identifier(:chargebacks, :edit)
-      run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
+      run_post api_chargeback_url(nil, chargeback_rate), gen_request(:edit, :description => "chargeback_1")
 
       expect(response.parsed_body["description"]).to eq("chargeback_1")
       expect(response).to have_http_status(:ok)
@@ -167,7 +167,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate = FactoryGirl.create(:chargeback_rate, :description => "chargeback_0")
 
       api_basic_authorize action_identifier(:chargebacks, :edit)
-      run_patch chargebacks_url(chargeback_rate.id), [{:action => "edit",
+      run_patch api_chargeback_url(nil, chargeback_rate), [{:action => "edit",
                                                        :path   => "description",
                                                        :value  => "chargeback_1"}]
 
@@ -182,7 +182,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:chargebacks, :delete)
 
       expect do
-        run_delete chargebacks_url(chargeback_rate.id)
+        run_delete api_chargeback_url(nil, chargeback_rate)
       end.to change(ChargebackRate, :count).by(-1)
       expect(response).to have_http_status(:no_content)
     end
@@ -193,7 +193,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:chargebacks, :delete)
 
       expect do
-        run_post chargebacks_url(chargeback_rate.id), :action => "delete"
+        run_post api_chargeback_url(nil, chargeback_rate), :action => "delete"
       end.to change(ChargebackRate, :count).by(-1)
       expect(response).to have_http_status(:ok)
     end
@@ -203,7 +203,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
       expect do
-        run_post rates_url,
+        run_post api_rates_url,
                  :description         => "rate_0",
                  :group               => "fixed",
                  :chargeback_rate_id  => chargeback_rate.id,
@@ -219,7 +219,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :create, :collection_actions)
 
       expect do
-        run_post rates_url,
+        run_post api_rates_url,
                  :description => "rate_0",
                  :enabled     => true
       end.not_to change(ChargebackRateDetail, :count)
@@ -236,7 +236,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate_detail.save
 
       api_basic_authorize action_identifier(:rates, :edit)
-      run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :description => "rate_1")
+      run_post api_rate_url(nil, chargeback_rate_detail), gen_request(:edit, :description => "rate_1")
 
       expect(response.parsed_body["description"]).to eq("rate_1")
       expect(response).to have_http_status(:ok)
@@ -252,7 +252,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate_detail.save
 
       api_basic_authorize action_identifier(:rates, :edit)
-      run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "description", :value => "rate_1"}]
+      run_patch api_rate_url(nil, chargeback_rate_detail), [{:action => "edit", :path => "description", :value => "rate_1"}]
 
       expect(response.parsed_body["description"]).to eq("rate_1")
       expect(response).to have_http_status(:ok)
@@ -270,7 +270,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :delete)
 
       expect do
-        run_delete rates_url(chargeback_rate_detail.id)
+        run_delete api_rate_url(nil, chargeback_rate_detail)
       end.to change(ChargebackRateDetail, :count).by(-1)
       expect(response).to have_http_status(:no_content)
     end
@@ -286,7 +286,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize action_identifier(:rates, :delete)
 
       expect do
-        run_post rates_url(chargeback_rate_detail.id), :action => "delete"
+        run_post api_rate_url(nil, chargeback_rate_detail), :action => "delete"
       end.to change(ChargebackRateDetail, :count).by(-1)
       expect(response).to have_http_status(:ok)
     end
@@ -296,7 +296,7 @@ RSpec.describe "chargebacks API" do
     it "cannot create a chargeback rate" do
       api_basic_authorize
 
-      expect { run_post chargebacks_url, :description => "chargeback_0" }.not_to change(ChargebackRate,
+      expect { run_post api_chargebacks_url, :description => "chargeback_0" }.not_to change(ChargebackRate,
                                                                                         :count)
       expect(response).to have_http_status(:forbidden)
     end
@@ -307,7 +307,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize
 
       expect do
-        run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
+        run_post api_chargeback_url(nil, chargeback_rate), gen_request(:edit, :description => "chargeback_1")
       end.not_to change { chargeback_rate.reload.description }
       expect(response).to have_http_status(:forbidden)
     end
@@ -318,7 +318,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize
 
       expect do
-        run_delete chargebacks_url(chargeback_rate.id)
+        run_delete api_chargeback_url(nil, chargeback_rate)
       end.not_to change(ChargebackRate, :count)
       expect(response).to have_http_status(:forbidden)
     end
@@ -326,7 +326,7 @@ RSpec.describe "chargebacks API" do
     it "cannot create a chargeback rate detail" do
       api_basic_authorize
 
-      expect { run_post rates_url, :description => "rate_0", :enabled => true }.not_to change(ChargebackRateDetail,
+      expect { run_post api_rates_url, :description => "rate_0", :enabled => true }.not_to change(ChargebackRateDetail,
                                                                                               :count)
       expect(response).to have_http_status(:forbidden)
     end
@@ -342,7 +342,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize
 
       expect do
-        run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :description => "rate_2")
+        run_post api_rate_url(nil, chargeback_rate_detail), gen_request(:edit, :description => "rate_2")
       end.not_to change { chargeback_rate_detail.reload.description }
       expect(response).to have_http_status(:forbidden)
     end
@@ -358,7 +358,7 @@ RSpec.describe "chargebacks API" do
       api_basic_authorize
 
       expect do
-        run_delete rates_url(chargeback_rate_detail.id)
+        run_delete api_rate_url(nil, chargeback_rate_detail)
       end.not_to change(ChargebackRateDetail, :count)
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/cloud_networks_spec.rb
+++ b/spec/requests/cloud_networks_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'Cloud Networks API' do
     it 'rejects request without appropriate role' do
       api_basic_authorize
 
-      run_get cloud_networks_url
+      run_get api_cloud_networks_url
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -12,7 +12,7 @@ RSpec.describe 'Cloud Networks API' do
       FactoryGirl.create_list(:cloud_network, 2)
       api_basic_authorize collection_action_identifier(:cloud_networks, :read, :get)
 
-      run_get cloud_networks_url
+      run_get api_cloud_networks_url
 
       expect_query_result(:cloud_networks, 2)
       expect(response).to have_http_status(:ok)
@@ -21,14 +21,12 @@ RSpec.describe 'Cloud Networks API' do
 
   context 'Providers cloud_networks subcollection' do
     let(:provider) { FactoryGirl.create(:ems_amazon_with_cloud_networks) }
-    let(:provider_url) { providers_url(provider.id) }
-    let(:providers_cloud_networks_url) { "#{provider_url}/cloud_networks" }
 
     it 'queries Providers cloud_networks' do
       cloud_network_ids = provider.cloud_networks.select(:id).collect(&:compressed_id)
       api_basic_authorize subcollection_action_identifier(:providers, :cloud_networks, :read, :get)
 
-      run_get providers_cloud_networks_url, :expand => 'resources'
+      run_get api_provider_cloud_networks_url(nil, provider), :expand => 'resources'
 
       expect_query_result(:cloud_networks, 2)
       expect_result_resources_to_include_data('resources', 'id' => cloud_network_ids)
@@ -37,7 +35,7 @@ RSpec.describe 'Cloud Networks API' do
     it "will not list cloud networks of a provider without the appropriate role" do
       api_basic_authorize
 
-      run_get providers_cloud_networks_url
+      run_get api_provider_cloud_networks_url(nil, provider)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -45,9 +43,8 @@ RSpec.describe 'Cloud Networks API' do
     it 'queries individual provider cloud_network' do
       api_basic_authorize(action_identifier(:cloud_networks, :read, :subresource_actions, :get))
       network = provider.cloud_networks.first
-      cloud_network_url = "#{providers_cloud_networks_url}/#{network.id}"
 
-      run_get cloud_network_url
+      run_get(api_provider_cloud_network_url(nil, provider, network))
 
       expect_single_resource_query('name' => network.name, 'id' => network.compressed_id, 'ems_ref' => network.ems_ref)
     end
@@ -55,9 +52,8 @@ RSpec.describe 'Cloud Networks API' do
     it "will not show the cloud network of a provider without the appropriate role" do
       api_basic_authorize
       network = provider.cloud_networks.first
-      cloud_network_url = "#{providers_cloud_networks_url}/#{network.id}"
 
-      run_get cloud_network_url
+      run_get(api_provider_cloud_network_url(nil, provider, network))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -67,7 +63,7 @@ RSpec.describe 'Cloud Networks API' do
       FactoryGirl.create(:ems_amazon_with_cloud_networks) # Provider with cloud networks
       api_basic_authorize collection_action_identifier(:providers, :read, :get)
 
-      run_get providers_url, :expand => 'resources,cloud_networks'
+      run_get api_providers_url, :expand => 'resources,cloud_networks'
 
       expected = {
         'resources' => a_collection_including(
@@ -86,11 +82,9 @@ RSpec.describe 'Cloud Networks API' do
 
     it 'returns empty resources array when querying on a provider with no cloud_networks attribute' do
       openshift = FactoryGirl.create(:ems_openshift)
-      openshift_cloud_networks_url = "#{providers_url(openshift.id)}/cloud_networks"
-
       api_basic_authorize subcollection_action_identifier(:providers, :cloud_networks, :read, :get)
 
-      run_get openshift_cloud_networks_url, :expand => 'resources'
+      run_get(api_provider_cloud_networks_url(nil, openshift), :expand => 'resources')
 
       expected = {
         'name'      => 'cloud_networks',

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe 'CloudSubnets API' do
     it 'lists all cloud subnets with an appropriate role' do
       cloud_subnet = FactoryGirl.create(:cloud_subnet)
       api_basic_authorize collection_action_identifier(:cloud_subnets, :read, :get)
-      run_get(cloud_subnets_url)
+      run_get(api_cloud_subnets_url)
 
       expected = {
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'cloud_subnets',
         'resources' => [
-          hash_including('href' => a_string_matching(cloud_subnets_url(cloud_subnet.compressed_id)))
+          hash_including('href' => api_cloud_subnet_url(nil, cloud_subnet.compressed_id))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -20,7 +20,7 @@ RSpec.describe 'CloudSubnets API' do
     it 'forbids access to cloud subnets without an appropriate role' do
       api_basic_authorize
 
-      run_get(cloud_subnets_url)
+      run_get(api_cloud_subnets_url)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -31,9 +31,9 @@ RSpec.describe 'CloudSubnets API' do
       cloud_subnet = FactoryGirl.create(:cloud_subnet)
       api_basic_authorize action_identifier(:cloud_subnets, :read, :resource_actions, :get)
 
-      run_get(cloud_subnets_url(cloud_subnet.id))
+      run_get(api_cloud_subnet_url(nil, cloud_subnet))
 
-      expect(response.parsed_body).to include('href' => a_string_matching(cloud_subnets_url(cloud_subnet.compressed_id)))
+      expect(response.parsed_body).to include('href' => api_cloud_subnet_url(nil, cloud_subnet.compressed_id))
       expect(response).to have_http_status(:ok)
     end
 
@@ -41,7 +41,7 @@ RSpec.describe 'CloudSubnets API' do
       cloud_subnet = FactoryGirl.create(:cloud_subnet)
       api_basic_authorize
 
-      run_get(cloud_subnets_url(cloud_subnet.id))
+      run_get(api_cloud_subnet_url(nil, cloud_subnet))
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/cloud_tenants_spec.rb
+++ b/spec/requests/cloud_tenants_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe 'CloudTenants API' do
     it 'lists all cloud tenants with an appropriate role' do
       cloud_tenant = FactoryGirl.create(:cloud_tenant)
       api_basic_authorize collection_action_identifier(:cloud_tenants, :read, :get)
-      run_get(cloud_tenants_url)
+      run_get(api_cloud_tenants_url)
 
       expected = {
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'cloud_tenants',
         'resources' => [
-          hash_including('href' => a_string_matching(cloud_tenants_url(cloud_tenant.compressed_id)))
+          hash_including('href' => api_cloud_tenant_url(nil, cloud_tenant.compressed_id))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -20,7 +20,7 @@ RSpec.describe 'CloudTenants API' do
     it 'forbids access to cloud tenants without an appropriate role' do
       api_basic_authorize
 
-      run_get(cloud_tenants_url)
+      run_get(api_cloud_tenants_url)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -31,9 +31,9 @@ RSpec.describe 'CloudTenants API' do
       cloud_tenant = FactoryGirl.create(:cloud_tenant)
       api_basic_authorize action_identifier(:cloud_tenants, :read, :resource_actions, :get)
 
-      run_get(cloud_tenants_url(cloud_tenant.id))
+      run_get(api_cloud_tenant_url(nil, cloud_tenant))
 
-      expect(response.parsed_body).to include('href' => a_string_matching(cloud_tenants_url(cloud_tenant.compressed_id)))
+      expect(response.parsed_body).to include('href' => api_cloud_tenant_url(nil, cloud_tenant.compressed_id))
       expect(response).to have_http_status(:ok)
     end
 
@@ -41,7 +41,7 @@ RSpec.describe 'CloudTenants API' do
       cloud_tenant = FactoryGirl.create(:cloud_tenant)
       api_basic_authorize
 
-      run_get(cloud_tenants_url(cloud_tenant.id))
+      run_get(api_cloud_tenant_url(nil, cloud_tenant))
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -12,7 +12,7 @@ describe "Cloud Volumes API" do
   it "forbids access to cloud volumes without an appropriate role" do
     api_basic_authorize
 
-    run_get(cloud_volumes_url)
+    run_get(api_cloud_volumes_url)
 
     expect(response).to have_http_status(:forbidden)
   end
@@ -22,7 +22,7 @@ describe "Cloud Volumes API" do
 
     cloud_volume = FactoryGirl.create(:cloud_volume)
 
-    run_get(cloud_volumes_url(cloud_volume.id))
+    run_get(api_cloud_volume_url(nil, cloud_volume))
 
     expect(response).to have_http_status(:forbidden)
   end
@@ -32,11 +32,11 @@ describe "Cloud Volumes API" do
 
     cloud_volume = FactoryGirl.create(:cloud_volume)
 
-    run_get(cloud_volumes_url(cloud_volume.id))
+    run_get(api_cloud_volume_url(nil, cloud_volume))
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href" => a_string_matching(cloud_volumes_url(cloud_volume.compressed_id)),
+      "href" => api_cloud_volume_url(nil, cloud_volume.compressed_id),
       "id"   => cloud_volume.compressed_id
     )
   end
@@ -44,7 +44,7 @@ describe "Cloud Volumes API" do
   it "rejects delete request without appropriate role" do
     api_basic_authorize
 
-    run_post(cloud_volumes_url, :action => 'delete')
+    run_post(api_cloud_volumes_url, :action => 'delete')
 
     expect(response).to have_http_status(:forbidden)
   end
@@ -57,7 +57,7 @@ describe "Cloud Volumes API" do
 
     api_basic_authorize action_identifier(:cloud_volumes, :delete, :resource_actions, :post)
 
-    run_post(cloud_volumes_url(cloud_volume1.id), :action => "delete")
+    run_post(api_cloud_volume_url(nil, cloud_volume1), :action => "delete")
 
     expected = {
       'message' => 'Deleting Cloud Volume CloudVolume1',
@@ -77,7 +77,7 @@ describe "Cloud Volumes API" do
 
     api_basic_authorize action_identifier(:cloud_volumes, :delete, :resource_actions, :delete)
 
-    run_delete cloud_volumes_url(cloud_volume1.id)
+    run_delete api_cloud_volume_url(nil, cloud_volume1)
 
     expect(response).to have_http_status(:no_content)
   end
@@ -87,7 +87,7 @@ describe "Cloud Volumes API" do
 
     api_basic_authorize
 
-    run_delete cloud_volumes_url(cloud_volume.id)
+    run_delete api_cloud_volume_url(nil, cloud_volume)
 
     expect(response).to have_http_status(:forbidden)
   end
@@ -115,7 +115,7 @@ describe "Cloud Volumes API" do
         )
       )
     }
-    run_post(cloud_volumes_url, :action => 'delete', :resources => [{ 'id' => cloud_volume1.id }, { 'id' => cloud_volume2.id }])
+    run_post(api_cloud_volumes_url, :action => 'delete', :resources => [{ 'id' => cloud_volume1.id }, { 'id' => cloud_volume2.id }])
 
     expect(response.parsed_body).to include(expected)
     expect(response).to have_http_status(:ok)

--- a/spec/requests/clusters_spec.rb
+++ b/spec/requests/clusters_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'Clusters API' do
     it 'returns clusters node_types' do
       expected_data = {"node_types" => EmsCluster.node_types.to_s}
 
-      run_options(clusters_url)
+      run_options(api_clusters_url)
       expect_options_results(:clusters, expected_data)
     end
   end

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -26,7 +26,7 @@ describe "Rest API Collections" do
     api_basic_authorize collection_action_identifier(collection, :query)
 
     obj = id.nil? ? klass.first : klass.find(id)
-    url = send("#{collection}_url", obj.compressed_id)
+    url = send("api_#{collection.to_s.singularize}_url", nil, obj.compressed_id)
     attr_list = String(Api::ApiConfig.collections[collection].identifying_attrs).split(",")
     attr_list |= %w(guid) if klass.attribute_method?(:guid)
     resources = [{"id" => obj.compressed_id}, {"href" => url}]
@@ -38,7 +38,7 @@ describe "Rest API Collections" do
     expect(response.parsed_body["results"].size).to eq(resources.size)
     expect(response.parsed_body).to include(
       "results" => all(
-        a_hash_including("id" => obj.compressed_id, "href" => a_string_matching(url))
+        a_hash_including("id" => obj.compressed_id, "href" => url)
       )
     )
   end
@@ -46,27 +46,27 @@ describe "Rest API Collections" do
   context "Collections" do
     it "query Automate Domains" do
       FactoryGirl.create(:miq_ae_domain)
-      test_collection_query(:automate_domains, automate_domains_url, MiqAeDomain)
+      test_collection_query(:automate_domains, api_automate_domains_url, MiqAeDomain)
     end
 
     it "query Automation Requests" do
       FactoryGirl.create(:automation_request, :requester => @user)
-      test_collection_query(:automation_requests, automation_requests_url, AutomationRequest)
+      test_collection_query(:automation_requests, api_automation_requests_url, AutomationRequest)
     end
 
     it "query Availability Zones" do
       FactoryGirl.create(:availability_zone)
-      test_collection_query(:availability_zones, availability_zones_url, AvailabilityZone)
+      test_collection_query(:availability_zones, api_availability_zones_url, AvailabilityZone)
     end
 
     it "query Categories" do
       FactoryGirl.create(:category)
-      test_collection_query(:categories, categories_url, Category)
+      test_collection_query(:categories, api_categories_url, Category)
     end
 
     it "query Chargebacks" do
       FactoryGirl.create(:chargeback_rate)
-      test_collection_query(:chargebacks, chargebacks_url, ChargebackRate)
+      test_collection_query(:chargebacks, api_chargebacks_url, ChargebackRate)
     end
 
     it "query Currencies" do
@@ -81,49 +81,49 @@ describe "Rest API Collections" do
 
     it "query Clusters" do
       FactoryGirl.create(:ems_cluster)
-      test_collection_query(:clusters, clusters_url, EmsCluster)
+      test_collection_query(:clusters, api_clusters_url, EmsCluster)
     end
 
     it "query CloudVolumes" do
       FactoryGirl.create(:cloud_volume)
-      test_collection_query(:cloud_volumes, cloud_volumes_url, CloudVolume)
+      test_collection_query(:cloud_volumes, api_cloud_volumes_url, CloudVolume)
     end
 
     it "query Conditions" do
       FactoryGirl.create(:condition)
-      test_collection_query(:conditions, conditions_url, Condition)
+      test_collection_query(:conditions, api_conditions_url, Condition)
     end
 
     it "query Actions" do
       FactoryGirl.create(:miq_action)
-      test_collection_query(:actions, actions_url, MiqAction)
+      test_collection_query(:actions, api_actions_url, MiqAction)
     end
 
     it "query Data Stores" do
       FactoryGirl.create(:storage)
-      test_collection_query(:data_stores, data_stores_url, Storage)
+      test_collection_query(:data_stores, api_data_stores_url, Storage)
     end
 
     it "query Events" do
       FactoryGirl.create(:miq_event_definition)
-      test_collection_query(:events, events_url, MiqEventDefinition)
+      test_collection_query(:events, api_events_url, MiqEventDefinition)
     end
 
     it "query Features" do
       FactoryGirl.create(:miq_product_feature, :identifier => "vm_auditing")
-      test_collection_query(:features, features_url, MiqProductFeature)
+      test_collection_query(:features, api_features_url, MiqProductFeature)
     end
 
     it "query Flavors" do
       FactoryGirl.create(:flavor)
-      test_collection_query(:flavors, flavors_url, Flavor)
+      test_collection_query(:flavors, api_flavors_url, Flavor)
     end
 
     it "query Groups" do
       expect(Tenant.exists?).to be_truthy
       FactoryGirl.create(:miq_group)
       api_basic_authorize collection_action_identifier(:groups, :read, :get)
-      run_get groups_url, :expand => 'resources'
+      run_get api_groups_url, :expand => 'resources'
       expect_query_result(:groups, MiqGroup.non_tenant_groups.count, MiqGroup.count)
       expect_result_resources_to_include_data('resources',
                                               'id' => MiqGroup.non_tenant_groups.select(:id).collect(&:compressed_id))
@@ -131,411 +131,411 @@ describe "Rest API Collections" do
 
     it "query Hosts" do
       FactoryGirl.create(:host)
-      test_collection_query(:hosts, hosts_url, Host, :guid)
+      test_collection_query(:hosts, api_hosts_url, Host, :guid)
     end
 
     it "query Pictures" do
       FactoryGirl.create(:picture)
-      test_collection_query(:pictures, pictures_url, Picture)
+      test_collection_query(:pictures, api_pictures_url, Picture)
     end
 
     it "query Policies" do
       FactoryGirl.create(:miq_policy)
-      test_collection_query(:policies, policies_url, MiqPolicy)
+      test_collection_query(:policies, api_policies_url, MiqPolicy)
     end
 
     it "query Policy Actions" do
       FactoryGirl.create(:miq_action)
-      test_collection_query(:policy_actions, policy_actions_url, MiqAction)
+      test_collection_query(:policy_actions, api_policy_actions_url, MiqAction)
     end
 
     it "query Policy Profiles" do
       FactoryGirl.create(:miq_policy_set)
-      test_collection_query(:policy_profiles, policy_profiles_url, MiqPolicySet)
+      test_collection_query(:policy_profiles, api_policy_profiles_url, MiqPolicySet)
     end
 
     it "query Providers" do
       FactoryGirl.create(:ext_management_system)
-      test_collection_query(:providers, providers_url, ExtManagementSystem, :guid)
+      test_collection_query(:providers, api_providers_url, ExtManagementSystem, :guid)
     end
 
     it "query Provision Dialogs" do
       FactoryGirl.create(:miq_dialog)
-      test_collection_query(:provision_dialogs, provision_dialogs_url, MiqDialog)
+      test_collection_query(:provision_dialogs, api_provision_dialogs_url, MiqDialog)
     end
 
     it "query Provision Requests" do
       FactoryGirl.create(:miq_provision_request, :source => template, :requester => @user)
-      test_collection_query(:provision_requests, provision_requests_url, MiqProvisionRequest)
+      test_collection_query(:provision_requests, api_provision_requests_url, MiqProvisionRequest)
     end
 
     it "query Rates" do
       FactoryGirl.build(:chargeback_rate_detail)
-      test_collection_query(:rates, rates_url, ChargebackRateDetail)
+      test_collection_query(:rates, api_rates_url, ChargebackRateDetail)
     end
 
     it "query Regions" do
       FactoryGirl.create(:miq_region)
-      test_collection_query(:regions, regions_url, MiqRegion)
+      test_collection_query(:regions, api_regions_url, MiqRegion)
     end
 
     it "query Reports" do
       FactoryGirl.create(:miq_report)
-      test_collection_query(:reports, reports_url, MiqReport)
+      test_collection_query(:reports, api_reports_url, MiqReport)
     end
 
     it "query Report Results" do
       FactoryGirl.create(:miq_report_result, :miq_group => @user.current_group)
-      test_collection_query(:results, results_url, MiqReportResult)
+      test_collection_query(:results, api_results_url, MiqReportResult)
     end
 
     it "query Request Tasks" do
       FactoryGirl.create(:miq_request_task)
-      test_collection_query(:request_tasks, request_tasks_url, MiqRequestTask)
+      test_collection_query(:request_tasks, api_request_tasks_url, MiqRequestTask)
     end
 
     it "query Requests" do
       FactoryGirl.create(:vm_migrate_request, :requester => @user)
-      test_collection_query(:requests, requests_url, MiqRequest)
+      test_collection_query(:requests, api_requests_url, MiqRequest)
     end
 
     it "query Resource Pools" do
       FactoryGirl.create(:resource_pool)
-      test_collection_query(:resource_pools, resource_pools_url, ResourcePool)
+      test_collection_query(:resource_pools, api_resource_pools_url, ResourcePool)
     end
 
     it "query Roles" do
       FactoryGirl.create(:miq_user_role)
-      test_collection_query(:roles, roles_url, MiqUserRole)
+      test_collection_query(:roles, api_roles_url, MiqUserRole)
     end
 
     it "query Security Groups" do
       FactoryGirl.create(:security_group)
-      test_collection_query(:security_groups, security_groups_url, SecurityGroup)
+      test_collection_query(:security_groups, api_security_groups_url, SecurityGroup)
     end
 
     it "query Servers" do
       miq_server # create resource
-      test_collection_query(:servers, servers_url, MiqServer, :guid)
+      test_collection_query(:servers, api_servers_url, MiqServer, :guid)
     end
 
     it "query Service Catalogs" do
       FactoryGirl.create(:service_template_catalog)
-      test_collection_query(:service_catalogs, service_catalogs_url, ServiceTemplateCatalog)
+      test_collection_query(:service_catalogs, api_service_catalogs_url, ServiceTemplateCatalog)
     end
 
     it "query Service Dialogs" do
       FactoryGirl.create(:dialog, :label => "ServiceDialog1")
-      test_collection_query(:service_dialogs, service_dialogs_url, Dialog)
+      test_collection_query(:service_dialogs, api_service_dialogs_url, Dialog)
     end
 
     it "query Service Requests" do
       FactoryGirl.create(:service_template_provision_request, :requester => @user)
-      test_collection_query(:service_requests, service_requests_url, ServiceTemplateProvisionRequest)
+      test_collection_query(:service_requests, api_service_requests_url, ServiceTemplateProvisionRequest)
     end
 
     it "query Service Templates" do
       FactoryGirl.create(:service_template)
-      test_collection_query(:service_templates, service_templates_url, ServiceTemplate, :guid)
+      test_collection_query(:service_templates, api_service_templates_url, ServiceTemplate, :guid)
     end
 
     it "query Services" do
       FactoryGirl.create(:service)
-      test_collection_query(:services, services_url, Service)
+      test_collection_query(:services, api_services_url, Service)
     end
 
     it "query Tags" do
       FactoryGirl.create(:classification_cost_center_with_tags)
-      test_collection_query(:tags, tags_url, Tag)
+      test_collection_query(:tags, api_tags_url, Tag)
     end
 
     it "query Tasks" do
       FactoryGirl.create(:miq_task)
-      test_collection_query(:tasks, tasks_url, MiqTask)
+      test_collection_query(:tasks, api_tasks_url, MiqTask)
     end
 
     it "query Templates" do
       template # create resource
-      test_collection_query(:templates, templates_url, MiqTemplate, :guid)
+      test_collection_query(:templates, api_templates_url, MiqTemplate, :guid)
     end
 
     it "query Tenants" do
       api_basic_authorize "rbac_tenant_view"
       Tenant.seed
-      test_collection_query(:tenants, tenants_url, Tenant)
+      test_collection_query(:tenants, api_tenants_url, Tenant)
     end
 
     it "query Users" do
       FactoryGirl.create(:user)
-      test_collection_query(:users, users_url, User)
+      test_collection_query(:users, api_users_url, User)
     end
 
     it "query Vms" do
       FactoryGirl.create(:vm_vmware)
-      test_collection_query(:vms, vms_url, Vm, :guid)
+      test_collection_query(:vms, api_vms_url, Vm, :guid)
     end
 
     it "query Zones" do
       FactoryGirl.create(:zone, :name => "api zone")
-      test_collection_query(:zones, zones_url, Zone)
+      test_collection_query(:zones, api_zones_url, Zone)
     end
 
     it "query ContainerDeployments" do
       FactoryGirl.create(:container_deployment)
-      test_collection_query(:container_deployments, container_deployments_url, ContainerDeployment)
+      test_collection_query(:container_deployments, api_container_deployments_url, ContainerDeployment)
     end
 
     it 'queries CloudNetworks' do
       FactoryGirl.create(:cloud_network)
-      test_collection_query(:cloud_networks, cloud_networks_url, CloudNetwork)
+      test_collection_query(:cloud_networks, api_cloud_networks_url, CloudNetwork)
     end
 
     it 'queries CloudSubnets' do
       FactoryGirl.create(:cloud_subnet)
-      test_collection_query(:cloud_subnets, cloud_subnets_url, CloudSubnet)
+      test_collection_query(:cloud_subnets, api_cloud_subnets_url, CloudSubnet)
     end
 
     it 'queries CloudTenants' do
       FactoryGirl.create(:cloud_tenant)
-      test_collection_query(:cloud_tenants, cloud_tenants_url, CloudTenant)
+      test_collection_query(:cloud_tenants, api_cloud_tenants_url, CloudTenant)
     end
 
     it 'query LoadBalancers' do
       FactoryGirl.create(:load_balancer)
-      test_collection_query(:load_balancers, load_balancers_url, LoadBalancer)
+      test_collection_query(:load_balancers, api_load_balancers_url, LoadBalancer)
     end
 
     it 'query Alerts' do
       FactoryGirl.create(:miq_alert_status)
-      test_collection_query(:alerts, alerts_url, MiqAlertStatus)
+      test_collection_query(:alerts, api_alerts_url, MiqAlertStatus)
     end
 
     it 'query Firmwares' do
       FactoryGirl.create(:firmware)
-      test_collection_query(:firmwares, firmwares_url, Firmware)
+      test_collection_query(:firmwares, api_firmwares_url, Firmware)
     end
 
     it 'query PhysicalServers' do
       FactoryGirl.create(:physical_server)
-      test_collection_query(:physical_servers, physical_servers_url, PhysicalServer)
+      test_collection_query(:physical_servers, api_physical_servers_url, PhysicalServer)
     end
 
     it 'query GuestDevices' do
       FactoryGirl.create(:guest_device)
-      test_collection_query(:guest_devices, guest_devices_url, GuestDevice)
+      test_collection_query(:guest_devices, api_guest_devices_url, GuestDevice)
     end
   end
 
   context "Collections Bulk Queries" do
     it 'bulk query MiqAeDomain' do
       FactoryGirl.create(:miq_ae_domain)
-      test_collection_bulk_query(:automate_domains, automate_domains_url, MiqAeDomain)
+      test_collection_bulk_query(:automate_domains, api_automate_domains_url, MiqAeDomain)
     end
 
     it "bulk query Availability Zones" do
       FactoryGirl.create(:availability_zone)
-      test_collection_bulk_query(:availability_zones, availability_zones_url, AvailabilityZone)
+      test_collection_bulk_query(:availability_zones, api_availability_zones_url, AvailabilityZone)
     end
 
     it "bulk query Blueprints" do
       FactoryGirl.create(:blueprint)
-      test_collection_bulk_query(:blueprints, blueprints_url, Blueprint)
+      test_collection_bulk_query(:blueprints, api_blueprints_url, Blueprint)
     end
 
     it "bulk query Categories" do
       FactoryGirl.create(:category)
-      test_collection_bulk_query(:categories, categories_url, Category)
+      test_collection_bulk_query(:categories, api_categories_url, Category)
     end
 
     it "bulk query Chargebacks" do
       FactoryGirl.create(:chargeback_rate)
-      test_collection_bulk_query(:chargebacks, chargebacks_url, ChargebackRate)
+      test_collection_bulk_query(:chargebacks, api_chargebacks_url, ChargebackRate)
     end
 
     it 'bulk query CloudNetworks' do
       FactoryGirl.create(:cloud_network)
-      test_collection_bulk_query(:cloud_networks, cloud_networks_url, CloudNetwork)
+      test_collection_bulk_query(:cloud_networks, api_cloud_networks_url, CloudNetwork)
     end
 
     it "bulk query Clusters" do
       FactoryGirl.create(:ems_cluster)
-      test_collection_bulk_query(:clusters, clusters_url, EmsCluster)
+      test_collection_bulk_query(:clusters, api_clusters_url, EmsCluster)
     end
 
     it "bulk query Conditions" do
       FactoryGirl.create(:condition)
-      test_collection_bulk_query(:conditions, conditions_url, Condition)
+      test_collection_bulk_query(:conditions, api_conditions_url, Condition)
     end
 
     it "bulk query Actions" do
       FactoryGirl.create(:miq_action)
-      test_collection_bulk_query(:actions, actions_url, MiqAction)
+      test_collection_bulk_query(:actions, api_actions_url, MiqAction)
     end
 
     it "bulk query ContainerDeployments" do
       FactoryGirl.create(:container_deployment)
-      test_collection_bulk_query(:container_deployments, container_deployments_url, ContainerDeployment)
+      test_collection_bulk_query(:container_deployments, api_container_deployments_url, ContainerDeployment)
     end
 
     it "bulk query Data Stores" do
       FactoryGirl.create(:storage)
-      test_collection_bulk_query(:data_stores, data_stores_url, Storage)
+      test_collection_bulk_query(:data_stores, api_data_stores_url, Storage)
     end
 
     it "bulk query Events" do
       FactoryGirl.create(:miq_event_definition)
-      test_collection_bulk_query(:events, events_url, MiqEventDefinition)
+      test_collection_bulk_query(:events, api_events_url, MiqEventDefinition)
     end
 
     it "bulk query Flavors" do
       FactoryGirl.create(:flavor)
-      test_collection_bulk_query(:flavors, flavors_url, Flavor)
+      test_collection_bulk_query(:flavors, api_flavors_url, Flavor)
     end
 
     it "bulk query FloatingIps" do
       FactoryGirl.create(:floating_ip)
-      test_collection_bulk_query(:floating_ips, floating_ips_url, FloatingIp)
+      test_collection_bulk_query(:floating_ips, api_floating_ips_url, FloatingIp)
     end
 
     it "bulk query Groups" do
       group = FactoryGirl.create(:miq_group)
-      test_collection_bulk_query(:groups, groups_url, MiqGroup, group.id)
+      test_collection_bulk_query(:groups, api_groups_url, MiqGroup, group.id)
     end
 
     it "bulk query Hosts" do
       FactoryGirl.create(:host)
-      test_collection_bulk_query(:hosts, hosts_url, Host)
+      test_collection_bulk_query(:hosts, api_hosts_url, Host)
     end
 
     it 'bulk query NetworkRouters' do
       FactoryGirl.create(:network_router)
-      test_collection_bulk_query(:network_routers, network_routers_url, NetworkRouter)
+      test_collection_bulk_query(:network_routers, api_network_routers_url, NetworkRouter)
     end
 
     it "bulk query Policies" do
       FactoryGirl.create(:miq_policy)
-      test_collection_bulk_query(:policies, policies_url, MiqPolicy)
+      test_collection_bulk_query(:policies, api_policies_url, MiqPolicy)
     end
 
     it "bulk query Policy Actions" do
       FactoryGirl.create(:miq_action)
-      test_collection_bulk_query(:policy_actions, policy_actions_url, MiqAction)
+      test_collection_bulk_query(:policy_actions, api_policy_actions_url, MiqAction)
     end
 
     it "bulk query Policy Profiles" do
       FactoryGirl.create(:miq_policy_set)
-      test_collection_bulk_query(:policy_profiles, policy_profiles_url, MiqPolicySet)
+      test_collection_bulk_query(:policy_profiles, api_policy_profiles_url, MiqPolicySet)
     end
 
     it "bulk query Providers" do
       FactoryGirl.create(:ext_management_system)
-      test_collection_bulk_query(:providers, providers_url, ExtManagementSystem)
+      test_collection_bulk_query(:providers, api_providers_url, ExtManagementSystem)
     end
 
     it "bulk query Provision Dialogs" do
       FactoryGirl.create(:miq_dialog)
-      test_collection_bulk_query(:provision_dialogs, provision_dialogs_url, MiqDialog)
+      test_collection_bulk_query(:provision_dialogs, api_provision_dialogs_url, MiqDialog)
     end
 
     it "bulk query Provision Requests" do
       FactoryGirl.create(:miq_provision_request, :source => template, :requester => @user)
-      test_collection_bulk_query(:provision_requests, provision_requests_url, MiqProvisionRequest)
+      test_collection_bulk_query(:provision_requests, api_provision_requests_url, MiqProvisionRequest)
     end
 
     it "bulk query Rates" do
       FactoryGirl.create(:chargeback_rate_detail, :chargeable_field => FactoryGirl.build(:chargeable_field))
-      test_collection_bulk_query(:rates, rates_url, ChargebackRateDetail)
+      test_collection_bulk_query(:rates, api_rates_url, ChargebackRateDetail)
     end
 
     it "bulk query Regions" do
       FactoryGirl.create(:miq_region)
-      test_collection_bulk_query(:regions, regions_url, MiqRegion)
+      test_collection_bulk_query(:regions, api_regions_url, MiqRegion)
     end
 
     it "bulk query Report Results" do
       FactoryGirl.create(:miq_report_result, :miq_group => @user.current_group)
-      test_collection_bulk_query(:results, results_url, MiqReportResult)
+      test_collection_bulk_query(:results, api_results_url, MiqReportResult)
     end
 
     it "bulk query Requests" do
       FactoryGirl.create(:vm_migrate_request, :requester => @user)
-      test_collection_bulk_query(:requests, requests_url, MiqRequest)
+      test_collection_bulk_query(:requests, api_requests_url, MiqRequest)
     end
 
     it "bulk query Resource Pools" do
       FactoryGirl.create(:resource_pool)
-      test_collection_bulk_query(:resource_pools, resource_pools_url, ResourcePool)
+      test_collection_bulk_query(:resource_pools, api_resource_pools_url, ResourcePool)
     end
 
     it "bulk query Roles" do
       FactoryGirl.create(:miq_user_role)
-      test_collection_bulk_query(:roles, roles_url, MiqUserRole)
+      test_collection_bulk_query(:roles, api_roles_url, MiqUserRole)
     end
 
     it "bulk query Security Groups" do
       FactoryGirl.create(:security_group)
-      test_collection_bulk_query(:security_groups, security_groups_url, SecurityGroup)
+      test_collection_bulk_query(:security_groups, api_security_groups_url, SecurityGroup)
     end
 
     it "bulk query Service Catalogs" do
       FactoryGirl.create(:service_template_catalog)
-      test_collection_bulk_query(:service_catalogs, service_catalogs_url, ServiceTemplateCatalog)
+      test_collection_bulk_query(:service_catalogs, api_service_catalogs_url, ServiceTemplateCatalog)
     end
 
     it "bulk query Service Dialogs" do
       FactoryGirl.create(:dialog, :label => "ServiceDialog1")
-      test_collection_bulk_query(:service_dialogs, service_dialogs_url, Dialog)
+      test_collection_bulk_query(:service_dialogs, api_service_dialogs_url, Dialog)
     end
 
     it "bulk query Service Orders" do
       FactoryGirl.create(:service_order, :user => @user)
-      test_collection_bulk_query(:service_orders, service_orders_url, ServiceOrder)
+      test_collection_bulk_query(:service_orders, api_service_orders_url, ServiceOrder)
     end
 
     it "bulk query Service Requests" do
       FactoryGirl.create(:service_template_provision_request, :requester => @user)
-      test_collection_bulk_query(:service_requests, service_requests_url, ServiceTemplateProvisionRequest)
+      test_collection_bulk_query(:service_requests, api_service_requests_url, ServiceTemplateProvisionRequest)
     end
 
     it "bulk query Service Templates" do
       FactoryGirl.create(:service_template)
-      test_collection_bulk_query(:service_templates, service_templates_url, ServiceTemplate)
+      test_collection_bulk_query(:service_templates, api_service_templates_url, ServiceTemplate)
     end
 
     it "bulk query Services" do
       FactoryGirl.create(:service)
-      test_collection_bulk_query(:services, services_url, Service)
+      test_collection_bulk_query(:services, api_services_url, Service)
     end
 
     it "bulk query Tags" do
       FactoryGirl.create(:classification_cost_center_with_tags)
-      test_collection_bulk_query(:tags, tags_url, Tag)
+      test_collection_bulk_query(:tags, api_tags_url, Tag)
     end
 
     it "bulk query Tasks" do
       FactoryGirl.create(:miq_task)
-      test_collection_bulk_query(:tasks, tasks_url, MiqTask)
+      test_collection_bulk_query(:tasks, api_tasks_url, MiqTask)
     end
 
     it "bulk query Templates" do
       template # create resource
-      test_collection_bulk_query(:templates, templates_url, MiqTemplate)
+      test_collection_bulk_query(:templates, api_templates_url, MiqTemplate)
     end
 
     it "bulk query Tenants" do
       api_basic_authorize "rbac_tenant_view"
       Tenant.seed
-      test_collection_bulk_query(:tenants, tenants_url, Tenant)
+      test_collection_bulk_query(:tenants, api_tenants_url, Tenant)
     end
 
     it "bulk query Users" do
       FactoryGirl.create(:user)
-      test_collection_bulk_query(:users, users_url, User)
+      test_collection_bulk_query(:users, api_users_url, User)
     end
 
     it "bulk query Vms" do
       FactoryGirl.create(:vm_vmware)
-      test_collection_bulk_query(:vms, vms_url, Vm)
+      test_collection_bulk_query(:vms, api_vms_url, Vm)
     end
 
     it "doing a bulk query renders actions for which the user is authorized" do
@@ -543,7 +543,7 @@ describe "Rest API Collections" do
       api_basic_authorize(collection_action_identifier(:vms, :query), action_identifier(:vms, :start))
 
       # HMMM
-      run_post(vms_url, gen_request(:query, [{"id" => vm.id}]))
+      run_post(api_vms_url, gen_request(:query, [{"id" => vm.id}]))
 
       expected = {
         "results" => [
@@ -552,7 +552,7 @@ describe "Rest API Collections" do
               a_hash_including(
                 "name"   => "start",
                 "method" => "post",
-                "href"   => a_string_matching(vms_url(vm.compressed_id))
+                "href"   => api_vm_url(nil, vm.compressed_id)
               )
             ]
           )
@@ -565,7 +565,7 @@ describe "Rest API Collections" do
       FactoryGirl.create(:vm_vmware)
       api_basic_authorize collection_action_identifier(:vms, :query)
 
-      run_post(vms_url, gen_request(:query, [{"guid" => "B999999D"}]))
+      run_post(api_vms_url, gen_request(:query, [{"guid" => "B999999D"}]))
 
       expect(response.parsed_body).to include_error_with_message("Invalid vms resource specified - guid=B999999D")
       expect(response).to have_http_status(:not_found)
@@ -573,42 +573,42 @@ describe "Rest API Collections" do
 
     it "bulk query Zones" do
       FactoryGirl.create(:zone, :name => "api zone")
-      test_collection_bulk_query(:zones, zones_url, Zone)
+      test_collection_bulk_query(:zones, api_zones_url, Zone)
     end
 
     it 'bulk query LoadBalancers' do
       FactoryGirl.create(:load_balancer)
-      test_collection_bulk_query(:load_balancers, load_balancers_url, LoadBalancer)
+      test_collection_bulk_query(:load_balancers, api_load_balancers_url, LoadBalancer)
     end
 
     it "bulk query CloudSubnets" do
       FactoryGirl.create(:cloud_subnet)
-      test_collection_bulk_query(:cloud_subnets, cloud_subnets_url, CloudSubnet)
+      test_collection_bulk_query(:cloud_subnets, api_cloud_subnets_url, CloudSubnet)
     end
 
     it 'bulk query CloudTenants' do
       FactoryGirl.create(:cloud_tenant)
-      test_collection_bulk_query(:cloud_tenants, cloud_tenants_url, CloudTenant)
+      test_collection_bulk_query(:cloud_tenants, api_cloud_tenants_url, CloudTenant)
     end
 
     it 'bulk query CloudVolumes' do
       FactoryGirl.create(:cloud_volume)
-      test_collection_bulk_query(:cloud_volumes, cloud_volumes_url, CloudVolume)
+      test_collection_bulk_query(:cloud_volumes, api_cloud_volumes_url, CloudVolume)
     end
 
     it 'bulk query Firmwares' do
       FactoryGirl.create(:firmware)
-      test_collection_bulk_query(:firmwares, firmwares_url, Firmware)
+      test_collection_bulk_query(:firmwares, api_firmwares_url, Firmware)
     end
 
     it 'bulk query PhysicalServers' do
       FactoryGirl.create(:physical_server)
-      test_collection_bulk_query(:physical_servers, physical_servers_url, PhysicalServer)
+      test_collection_bulk_query(:physical_servers, api_physical_servers_url, PhysicalServer)
     end
 
     it 'bulk query GuestDevices' do
       FactoryGirl.create(:guest_device)
-      test_collection_bulk_query(:guest_devices, guest_devices_url, GuestDevice)
+      test_collection_bulk_query(:guest_devices, api_guest_devices_url, GuestDevice)
     end
   end
 end

--- a/spec/requests/configuration_script_payloads_spec.rb
+++ b/spec/requests/configuration_script_payloads_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe 'Configuration Script Payloads API' do
       script_payload = FactoryGirl.create(:configuration_script_payload)
       api_basic_authorize collection_action_identifier(:configuration_script_payloads, :read, :get)
 
-      run_get(configuration_script_payloads_url)
+      run_get(api_configuration_script_payloads_url)
 
       expected = {
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'configuration_script_payloads',
         'resources' => [
-          hash_including('href' => a_string_matching(configuration_script_payloads_url(script_payload.compressed_id)))
+          hash_including('href' => api_configuration_script_payload_url(nil, script_payload.compressed_id))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -21,7 +21,7 @@ RSpec.describe 'Configuration Script Payloads API' do
     it 'forbids access to configuration script payloads without an appropriate role' do
       api_basic_authorize
 
-      run_get(configuration_script_payloads_url)
+      run_get(api_configuration_script_payloads_url)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -32,10 +32,10 @@ RSpec.describe 'Configuration Script Payloads API' do
       script_payload = FactoryGirl.create(:configuration_script_payload)
       api_basic_authorize action_identifier(:configuration_script_payloads, :read, :resource_actions, :get)
 
-      run_get(configuration_script_payloads_url(script_payload.id))
+      run_get(api_configuration_script_payload_url(nil, script_payload))
 
       expect(response.parsed_body)
-        .to include('href' => a_string_matching(configuration_script_payloads_url(script_payload.compressed_id)))
+        .to include('href' => api_configuration_script_payload_url(nil, script_payload.compressed_id))
       expect(response).to have_http_status(:ok)
     end
 
@@ -43,7 +43,7 @@ RSpec.describe 'Configuration Script Payloads API' do
       script_payload = FactoryGirl.create(:configuration_script_payload)
       api_basic_authorize
 
-      run_get(configuration_script_payloads_url(script_payload.id))
+      run_get(api_configuration_script_payload_url(nil, script_payload))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -55,7 +55,7 @@ RSpec.describe 'Configuration Script Payloads API' do
       playbook = FactoryGirl.create(:configuration_script_payload, :authentications => [authentication])
       api_basic_authorize subcollection_action_identifier(:configuration_script_payloads, :authentications, :read, :get)
 
-      run_get("#{configuration_script_payloads_url(playbook.id)}/authentications", :expand => 'resources')
+      run_get(api_configuration_script_payload_authentications_url(nil, playbook), :expand => 'resources')
 
       expected = {
         'resources' => [
@@ -84,7 +84,7 @@ RSpec.describe 'Configuration Script Payloads API' do
     it 'requires that the type support create_in_provider_queue' do
       api_basic_authorize subcollection_action_identifier(:configuration_script_payloads, :authentications, :create)
 
-      run_post("#{configuration_script_payloads_url(playbook.id)}/authentications", :type => 'Authentication')
+      run_post(api_configuration_script_payload_authentications_url(nil, playbook), :type => 'Authentication')
 
       expected = {
         'results' => [
@@ -98,7 +98,7 @@ RSpec.describe 'Configuration Script Payloads API' do
     it 'creates a new authentication with an appropriate role' do
       api_basic_authorize subcollection_action_identifier(:configuration_script_payloads, :authentications, :create)
 
-      run_post("#{configuration_script_payloads_url(playbook.id)}/authentications", params)
+      run_post(api_configuration_script_payload_authentications_url(nil, playbook), params)
 
       expected = {
         'results' => [a_hash_including(
@@ -114,7 +114,7 @@ RSpec.describe 'Configuration Script Payloads API' do
     it 'can create multiple authentications with an appropriate role' do
       api_basic_authorize subcollection_action_identifier(:configuration_script_payloads, :authentications, :create)
 
-      run_post("#{configuration_script_payloads_url(playbook.id)}/authentications", :resources => [params, params])
+      run_post(api_configuration_script_payload_authentications_url(nil, playbook), :resources => [params, params])
 
       expected = {
         'results' => [
@@ -137,7 +137,7 @@ RSpec.describe 'Configuration Script Payloads API' do
     it 'cannot create an authentication without appropriate role' do
       api_basic_authorize
 
-      run_post("#{configuration_script_payloads_url(playbook.id)}/authentications", :resources => [params])
+      run_post(api_configuration_script_payload_authentications_url(nil, playbook), :resources => [params])
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -149,7 +149,7 @@ RSpec.describe 'Configuration Script Payloads API' do
       playbook = FactoryGirl.create(:configuration_script_payload, :authentications => [authentication])
       api_basic_authorize subcollection_action_identifier(:configuration_script_payloads, :authentications, :read, :get)
 
-      run_get("#{configuration_script_payloads_url(playbook.id)}/authentications/#{authentication.id}")
+      run_get(api_configuration_script_payload_authentication_url(nil, playbook, authentication))
 
       expected = {
         'id' => authentication.compressed_id

--- a/spec/requests/configuration_script_sources_spec.rb
+++ b/spec/requests/configuration_script_sources_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe 'Configuration Script Sources API' do
       repository = FactoryGirl.create(:configuration_script_source)
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :read, :get)
 
-      run_get(configuration_script_sources_url)
+      run_get(api_configuration_script_sources_url)
 
       expected = {
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'configuration_script_sources',
-        'resources' => [hash_including('href' => a_string_matching(configuration_script_sources_url(repository.compressed_id)))]
+        'resources' => [hash_including('href' => api_configuration_script_source_url(nil, repository.compressed_id))]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -25,7 +25,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids access to configuration script sources without an appropriate role' do
       api_basic_authorize
 
-      run_get(configuration_script_sources_url)
+      run_get(api_configuration_script_sources_url)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -36,10 +36,10 @@ RSpec.describe 'Configuration Script Sources API' do
       repository = FactoryGirl.create(:configuration_script_source)
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :read, :get)
 
-      run_get(configuration_script_sources_url(repository.id))
+      run_get(api_configuration_script_source_url(nil, repository))
 
       expected = {
-        'href' => a_string_matching(configuration_script_sources_url(repository.compressed_id))
+        'href' => api_configuration_script_source_url(nil, repository.compressed_id)
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -49,7 +49,7 @@ RSpec.describe 'Configuration Script Sources API' do
       repository = FactoryGirl.create(:configuration_script_source)
       api_basic_authorize
 
-      run_get(configuration_script_sources_url(repository.id))
+      run_get(api_configuration_script_source_url(nil, repository))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -68,7 +68,7 @@ RSpec.describe 'Configuration Script Sources API' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :edit, :post)
       params2 = params.dup.merge(:id => config_script_src_2.id)
 
-      run_post(configuration_script_sources_url, :action => 'edit', :resources => [params, params2])
+      run_post(api_configuration_script_sources_url, :action => 'edit', :resources => [params, params2])
 
       expected = {
         'results' => [
@@ -91,7 +91,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids updating configuration_script_sources without an appropriate role' do
       api_basic_authorize
 
-      run_post(configuration_script_sources_url, :action => 'edit', :resources => [params])
+      run_post(api_configuration_script_sources_url, :action => 'edit', :resources => [params])
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -99,7 +99,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'will delete multiple configuration script source with an appropriate role' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :delete, :post)
 
-      run_post(configuration_script_sources_url, :action => 'delete', :resources => [{:id => config_script_src.id}, {:id => config_script_src_2.id}])
+      run_post(api_configuration_script_sources_url, :action => 'delete', :resources => [{:id => config_script_src.id}, {:id => config_script_src_2.id}])
 
       expected = {
         'results' => [
@@ -122,7 +122,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids delete without an appropriate role' do
       api_basic_authorize
 
-      run_post(configuration_script_sources_url, :action => 'delete', :resources => [{:id => config_script_src.id}])
+      run_post(api_configuration_script_sources_url, :action => 'delete', :resources => [{:id => config_script_src.id}])
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -130,7 +130,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'can refresh multiple configuration_script_source with an appropriate role' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :refresh, :post)
 
-      run_post(configuration_script_sources_url, :action => :refresh, :resources => [{ :id => config_script_src.id}, {:id => config_script_src_2.id}])
+      run_post(api_configuration_script_sources_url, :action => :refresh, :resources => [{ :id => config_script_src.id}, {:id => config_script_src_2.id}])
 
       expected = {
         'results' => [
@@ -166,7 +166,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'updates a configuration_script_source with an appropriate role' do
       api_basic_authorize action_identifier(:configuration_script_sources, :edit)
 
-      run_put(configuration_script_sources_url(config_script_src.id), :resource => params)
+      run_put(api_configuration_script_source_url(nil, config_script_src), :resource => params)
 
       expected = {
         'success' => true,
@@ -190,7 +190,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'updates a configuration_script_source with an appropriate role' do
       api_basic_authorize action_identifier(:configuration_script_sources, :edit)
 
-      run_patch(configuration_script_sources_url(config_script_src.id), [params])
+      run_patch(api_configuration_script_source_url(nil, config_script_src), [params])
 
       expected = {
         'success' => true,
@@ -213,7 +213,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'updates a configuration_script_source with an appropriate role' do
       api_basic_authorize action_identifier(:configuration_script_sources, :edit)
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => 'edit', :resource => params)
+      run_post(api_configuration_script_source_url(nil, config_script_src), :action => 'edit', :resource => params)
 
       expected = {
         'success' => true,
@@ -228,7 +228,7 @@ RSpec.describe 'Configuration Script Sources API' do
       config_script_src = FactoryGirl.create(:configuration_script_source)
       api_basic_authorize action_identifier(:configuration_script_sources, :edit)
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => 'edit', :resource => params)
+      run_post(api_configuration_script_source_url(nil, config_script_src), :action => 'edit', :resource => params)
 
       expected = {
         'success' => false,
@@ -241,7 +241,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids updating a configuration_script_source without an appropriate role' do
       api_basic_authorize
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => 'edit', :resource => params)
+      run_post(api_configuration_script_source_url(nil, config_script_src), :action => 'edit', :resource => params)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -249,7 +249,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids refresh without an appropriate role' do
       api_basic_authorize
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => 'refresh')
+      run_post(api_configuration_script_source_url(nil, config_script_src), :action => 'refresh')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -257,7 +257,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'can refresh a configuration_script_source with an appropriate role' do
       api_basic_authorize action_identifier(:configuration_script_sources, :refresh)
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => :refresh)
+      run_post(api_configuration_script_source_url(nil, config_script_src), :action => :refresh)
 
       expected = {
         'success'   => true,
@@ -273,7 +273,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'can delete a configuration_script_source with an appropriate role' do
       api_basic_authorize action_identifier(:configuration_script_sources, :delete)
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => 'delete')
+      run_post(api_configuration_script_source_url(nil, config_script_src), :action => 'delete')
 
       expected = {
         'success' => true,
@@ -288,7 +288,7 @@ RSpec.describe 'Configuration Script Sources API' do
       config_script_src = FactoryGirl.create(:configuration_script_source)
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :delete, :post)
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => 'delete', :resource => params)
+      run_post(api_configuration_script_source_url(nil, config_script_src), :action => 'delete', :resource => params)
 
       expected = {
         'success' => false,
@@ -301,14 +301,14 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids configuration script source delete without an appropriate role' do
       api_basic_authorize
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => 'delete')
+      run_post(api_configuration_script_source_url(nil, config_script_src), :action => 'delete')
 
       expect(response).to have_http_status(:forbidden)
     end
 
     let(:create_params) do
       {
-        :manager_resource => { :href => providers_url(manager.id) },
+        :manager_resource => { :href => api_provider_url(nil, manager) },
         :description      => 'Description',
         :name             => 'My Project',
         :related          => {}
@@ -327,7 +327,7 @@ RSpec.describe 'Configuration Script Sources API' do
           )
         ]
       }
-      run_post(configuration_script_sources_url, create_params)
+      run_post(api_configuration_script_sources_url, create_params)
 
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -346,7 +346,7 @@ RSpec.describe 'Configuration Script Sources API' do
           )
         ]
       }
-      run_post(configuration_script_sources_url, create_params)
+      run_post(api_configuration_script_sources_url, create_params)
 
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -369,7 +369,7 @@ RSpec.describe 'Configuration Script Sources API' do
           )
         ]
       }
-      run_post(configuration_script_sources_url, :resources => [create_params, create_params])
+      run_post(api_configuration_script_sources_url, :resources => [create_params, create_params])
 
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -378,7 +378,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'requires a manager_resource to be specified' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :create, :post)
 
-      run_post(configuration_script_sources_url, :resources => [create_params.except(:manager_resource)])
+      run_post(api_configuration_script_sources_url, :resources => [create_params.except(:manager_resource)])
 
       expected = {
         'results' => [{
@@ -392,9 +392,9 @@ RSpec.describe 'Configuration Script Sources API' do
 
     it 'requires a valid manager' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :create, :post)
-      create_params[:manager_resource] = { :href => users_url(10) }
+      create_params[:manager_resource] = { :href => api_user_url(nil, 10) }
 
-      run_post(configuration_script_sources_url, :resources => [create_params])
+      run_post(api_configuration_script_sources_url, :resources => [create_params])
 
       expected = {
         'results' => [{
@@ -409,7 +409,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids creation of new configuration script source without an appropriate role' do
       api_basic_authorize
 
-      run_post(configuration_script_sources_url, create_params)
+      run_post(api_configuration_script_sources_url, create_params)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -419,7 +419,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'can delete a configuration_script_source with an appropriate role' do
       api_basic_authorize action_identifier(:configuration_script_sources, :delete, :resource_actions, :delete)
 
-      run_delete(configuration_script_sources_url(config_script_src.id))
+      run_delete(api_configuration_script_source_url(nil, config_script_src))
 
       expect(response).to have_http_status(:no_content)
     end
@@ -427,7 +427,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids configuration_script_source delete without an appropriate role' do
       api_basic_authorize
 
-      run_delete(configuration_script_sources_url(config_script_src.id))
+      run_delete(api_configuration_script_source_url(nil, config_script_src))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -435,7 +435,6 @@ RSpec.describe 'Configuration Script Sources API' do
 
   describe 'GET /api/configuration_script_sources/:id/configuration_script_payloads' do
     let(:payload) { FactoryGirl.create(:configuration_script_payload) }
-    let(:url) { "#{configuration_script_sources_url(config_script_src.id)}/configuration_script_payloads" }
 
     before do
       config_script_src.configuration_script_payloads << payload
@@ -444,7 +443,7 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'forbids configuration_script_payload retrievel without an appropriate role' do
       api_basic_authorize
 
-      run_get(url)
+      run_get(api_configuration_script_source_configuration_script_payloads_url(nil, config_script_src))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -452,11 +451,11 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'lists all configuration_script_payloads belonging to a configuration_script_source' do
       api_basic_authorize subcollection_action_identifier(:configuration_script_sources, :configuration_script_payloads, :read, :get)
 
-      run_get(url)
+      run_get(api_configuration_script_source_configuration_script_payloads_url(nil, config_script_src))
 
       expected = {
         'resources' => [
-          {'href' => a_string_including("#{configuration_script_sources_url(config_script_src.compressed_id)}/configuration_script_payloads/#{payload.compressed_id}")}
+          {'href' => a_string_including(api_configuration_script_source_configuration_script_payload_url(nil, config_script_src.compressed_id, payload.compressed_id))}
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -466,18 +465,24 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'can filter on region_number' do
       api_basic_authorize subcollection_action_identifier(:configuration_script_sources, :configuration_script_payloads, :read, :get)
 
-      run_get url, :filter => ["region_number=#{payload.region_number}"]
+      run_get(
+        api_configuration_script_source_configuration_script_payloads_url(nil, config_script_src),
+        :filter => ["region_number=#{payload.region_number}"]
+      )
 
       expected = {
         'subcount'  => 1,
         'resources' => [
-          {'href' => a_string_including("#{configuration_script_sources_url(config_script_src.compressed_id)}/configuration_script_payloads/#{payload.compressed_id}")}
+          {'href' => a_string_including(api_configuration_script_source_configuration_script_payload_url(nil, config_script_src.compressed_id, payload.compressed_id))}
         ]
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
 
-      run_get url, :filter => ["region_number=#{payload.region_number + 1}"]
+      run_get(
+        api_configuration_script_source_configuration_script_payloads_url(nil, config_script_src),
+        :filter => ["region_number=#{payload.region_number + 1}"]
+      )
 
       expected = {
         'subcount'  => 0,

--- a/spec/requests/container_deployments_spec.rb
+++ b/spec/requests/container_deployments_spec.rb
@@ -1,6 +1,6 @@
 describe "Container Deployments API" do
   it "supports OPTIONS requests without authorization" do
-    run_options container_deployments_url
+    run_options api_container_deployments_url
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body["data"]).to be_empty
   end
@@ -8,7 +8,7 @@ describe "Container Deployments API" do
   it "supports collect-data with OPTIONS" do
     allow_any_instance_of(ContainerDeploymentService).to receive(:cloud_init_template_id).and_return(1)
     api_basic_authorize
-    run_options container_deployments_url
+    run_options api_container_deployments_url
     expect(response).to have_http_status(:ok)
     expect_hash_to_have_only_keys(response.parsed_body["data"], %w(deployment_types providers provision))
   end
@@ -16,7 +16,7 @@ describe "Container Deployments API" do
   it "creates container deployment with POST" do
     allow_any_instance_of(ContainerDeployment).to receive(:create_deployment).and_return(true)
     api_basic_authorize collection_action_identifier(:container_deployments, :create)
-    run_post(container_deployments_url, gen_request(:create, :example_data => true))
+    run_post(api_container_deployments_url, gen_request(:create, :example_data => true))
     expect(response).to have_http_status(:ok)
   end
 end

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -72,7 +72,7 @@ describe "Custom Actions API" do
       api_basic_authorize(action_identifier(:services, :edit),
                           action_identifier(:services, :read, :resource_actions, :get))
 
-      run_get services_url(svc1.id)
+      run_get api_service_url(nil, svc1)
 
       expect_result_to_have_keys(%w(id href actions))
       expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit add_resource remove_resource remove_all_resources))
@@ -88,7 +88,7 @@ describe "Custom Actions API" do
       api_basic_authorize(action_identifier(:services, :edit),
                           action_identifier(:services, :read, :resource_actions, :get))
 
-      run_get services_url(svc1.id)
+      run_get api_service_url(nil, svc1)
 
       expect_result_to_have_keys(%w(id href actions))
       expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3 add_resource remove_resource remove_all_resources))
@@ -98,7 +98,7 @@ describe "Custom Actions API" do
       api_basic_authorize(action_identifier(:services, :edit),
                           action_identifier(:services, :read, :resource_actions, :get))
 
-      run_get services_url(svc1.id), :attributes => "custom_actions"
+      run_get api_service_url(nil, svc1), :attributes => "custom_actions"
 
       expect_result_to_have_keys(%w(id href))
       expect_result_to_have_custom_actions_hash
@@ -108,7 +108,7 @@ describe "Custom Actions API" do
       api_basic_authorize(action_identifier(:services, :edit),
                           action_identifier(:services, :read, :resource_actions, :get))
 
-      run_get services_url(svc1.id), :attributes => "custom_action_buttons"
+      run_get api_service_url(nil, svc1), :attributes => "custom_action_buttons"
 
       expect_result_to_have_keys(%w(id href custom_action_buttons))
       expect(response.parsed_body["custom_action_buttons"].size).to eq(3)
@@ -124,7 +124,7 @@ describe "Custom Actions API" do
       api_basic_authorize(action_identifier(:service_templates, :edit),
                           action_identifier(:service_templates, :read, :resource_actions, :get))
 
-      run_get service_templates_url(template1.id)
+      run_get api_service_template_url(nil, template1)
 
       expect_result_to_have_keys(%w(id href actions))
       action_specs = response.parsed_body["actions"]
@@ -135,7 +135,7 @@ describe "Custom Actions API" do
     it "supports the custom_actions attribute" do
       api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
 
-      run_get service_templates_url(template1.id), :attributes => "custom_actions"
+      run_get api_service_template_url(nil, template1), :attributes => "custom_actions"
 
       expect_result_to_have_keys(%w(id href))
       expect_result_to_have_custom_actions_hash
@@ -144,7 +144,7 @@ describe "Custom Actions API" do
     it "supports the custom_action_buttons attribute" do
       api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
 
-      run_get service_templates_url(template1.id), :attributes => "custom_action_buttons"
+      run_get api_service_template_url(nil, template1), :attributes => "custom_action_buttons"
 
       expect_result_to_have_keys(%w(id href custom_action_buttons))
       expect(response.parsed_body["custom_action_buttons"].size).to eq(3)
@@ -160,17 +160,17 @@ describe "Custom Actions API" do
     it "accepts a custom action" do
       api_basic_authorize
 
-      run_post(services_url(svc1.id), gen_request(:button1, "button_key1" => "value", "button_key2" => "value"))
+      run_post(api_service_url(nil, svc1), gen_request(:button1, "button_key1" => "value", "button_key2" => "value"))
 
-      expect_single_action_result(:success => true, :message => /.*/, :href => services_url(svc1.compressed_id))
+      expect_single_action_result(:success => true, :message => /.*/, :href => api_service_url(nil, svc1.compressed_id))
     end
 
     it "accepts a custom action as case insensitive" do
       api_basic_authorize
 
-      run_post(services_url(svc1.id), gen_request(:BuTtOn1, "button_key1" => "value", "button_key2" => "value"))
+      run_post(api_service_url(nil, svc1), gen_request(:BuTtOn1, "button_key1" => "value", "button_key2" => "value"))
 
-      expect_single_action_result(:success => true, :message => /.*/, :href => services_url(svc1.compressed_id))
+      expect_single_action_result(:success => true, :message => /.*/, :href => api_service_url(nil, svc1.compressed_id))
     end
   end
 
@@ -187,7 +187,7 @@ describe "Custom Actions API" do
       service = FactoryGirl.create(:service, :service_template => FactoryGirl.create(:service_template))
       api_basic_authorize
 
-      run_post(services_url(service.id), "action" => "test button")
+      run_post(api_service_url(nil, service), "action" => "test button")
 
       expect(response.parsed_body).to include("success" => true, "message" => /Invoked custom action test button/)
     end
@@ -204,7 +204,7 @@ describe "Custom Actions API" do
       svc2      = FactoryGirl.create(:service, :name => "svc2", :service_template_id => template2.id)
       button2.resource_action = ra2
 
-      run_get services_url(svc2.id), :attributes => "custom_actions"
+      run_get api_service_url(nil, svc2), :attributes => "custom_actions"
 
       expected = {
         "custom_actions" => {

--- a/spec/requests/custom_attributes_spec.rb
+++ b/spec/requests/custom_attributes_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Custom Attributes API" do
       custom_attribute = FactoryGirl.create(:custom_attribute, :resource => vm)
       api_basic_authorize
 
-      run_get("#{vms_url(vm.id)}/custom_attributes/#{custom_attribute.id}")
+      run_get(api_vm_custom_attribute_url(nil, vm, custom_attribute))
 
       expected = {
         "actions" => a_collection_including(
@@ -24,7 +24,7 @@ RSpec.describe "Custom Attributes API" do
     api_basic_authorize
 
     expect do
-      run_delete("#{vms_url(vm.id)}/custom_attributes/#{custom_attribute.id}")
+      run_delete(api_vm_custom_attribute_url(nil, vm, custom_attribute))
     end.to change(CustomAttribute, :count).by(-1)
 
     expect(response).to have_http_status(:no_content)
@@ -33,12 +33,11 @@ RSpec.describe "Custom Attributes API" do
   it 'returns the correct href' do
     provider = FactoryGirl.create(:ext_management_system)
     custom_attribute = FactoryGirl.create(:custom_attribute, :resource => provider, :name => 'foo', :value => 'bar')
-    url = "#{providers_url(provider.id)}/custom_attributes/#{custom_attribute.id}"
     api_basic_authorize subcollection_action_identifier(:providers, :custom_attributes, :edit, :post)
 
-    run_post(url, :action => :edit, :name => 'name1')
+    run_post(api_provider_custom_attribute_url(nil, provider, custom_attribute), :action => :edit, :name => 'name1')
 
     expect(response).to have_http_status(:ok)
-    expect(response.parsed_body['href']).to include("#{providers_url(provider.compressed_id)}/custom_attributes/#{custom_attribute.compressed_id}")
+    expect(response.parsed_body['href']).to include(api_provider_custom_attribute_url(nil, provider.compressed_id, custom_attribute.compressed_id))
   end
 end

--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe "API entrypoint" do
         "version"     => Vmdb::Appliance.VERSION,
         "build"       => Vmdb::Appliance.BUILD,
         "appliance"   => MiqServer.my_server.name,
-        "server_href" => a_string_matching(servers_url(MiqServer.my_server.id)),
-        "zone_href"   => a_string_matching(zones_url(MiqServer.my_server.zone.id)),
-        "region_href" => a_string_matching(regions_url(MiqRegion.my_region.id))
+        "server_href" => api_server_url(nil, MiqServer.my_server),
+        "zone_href"   => api_zone_url(nil, MiqServer.my_server.zone),
+        "region_href" => api_region_url(nil, MiqRegion.my_region)
       )
     )
   end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -18,7 +18,7 @@ describe "Events API" do
     it "query invalid event" do
       api_basic_authorize action_identifier(:events, :read, :resource_actions, :get)
 
-      run_get events_url(999_999)
+      run_get api_event_url(nil, 999_999)
 
       expect(response).to have_http_status(:not_found)
     end
@@ -26,7 +26,7 @@ describe "Events API" do
     it "query events with no events defined" do
       api_basic_authorize collection_action_identifier(:events, :read, :get)
 
-      run_get events_url
+      run_get api_events_url
 
       expect_empty_query_result(:events)
     end
@@ -35,12 +35,12 @@ describe "Events API" do
       api_basic_authorize collection_action_identifier(:events, :read, :get)
       create_events(3)
 
-      run_get events_url
+      run_get api_events_url
 
       expect_query_result(:events, 3, 3)
       expect_result_resources_to_include_hrefs(
         "resources",
-        MiqEventDefinition.select(:id).collect { |med| /^.*#{events_url(med.compressed_id)}$/ }
+        MiqEventDefinition.select(:id).collect { |med| api_event_url(nil, med.compressed_id) }
       )
     end
 
@@ -48,7 +48,7 @@ describe "Events API" do
       api_basic_authorize collection_action_identifier(:events, :read, :get)
       create_events(3)
 
-      run_get events_url, :expand => "resources"
+      run_get api_events_url, :expand => "resources"
 
       expect_query_result(:events, 3, 3)
       expect_result_resources_to_include_data("resources", "guid" => miq_event_guid_list)
@@ -57,8 +57,6 @@ describe "Events API" do
 
   context "Event subcollection" do
     let(:policy)             { FactoryGirl.create(:miq_policy, :name => "Policy 1") }
-    let(:policy_url)         { policies_url(policy.id) }
-    let(:policy_events_url)  { "#{policy_url}/events" }
 
     def relate_events_to(policy)
       MiqEventDefinition.all.collect(&:id).each do |event_id|
@@ -69,7 +67,7 @@ describe "Events API" do
     it "query events with no events defined" do
       api_basic_authorize
 
-      run_get policy_events_url
+      run_get api_policy_events_url(nil, policy)
 
       expect_empty_query_result(:events)
     end
@@ -79,7 +77,7 @@ describe "Events API" do
       create_events(3)
       relate_events_to(policy)
 
-      run_get policy_events_url, :expand => "resources"
+      run_get api_policy_events_url(nil, policy), :expand => "resources"
 
       expect_query_result(:events, 3, 3)
       expect_result_resources_to_include_data("resources", "guid" => miq_event_guid_list)
@@ -90,7 +88,7 @@ describe "Events API" do
       create_events(3)
       relate_events_to(policy)
 
-      run_get policy_url, :expand => "events"
+      run_get api_policy_url(nil, policy), :expand => "events"
 
       expect_single_resource_query("name" => policy.name, "description" => policy.description, "guid" => policy.guid)
       expect_result_resources_to_include_data("events", "guid" => miq_event_guid_list)

--- a/spec/requests/firmwares_spec.rb
+++ b/spec/requests/firmwares_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "firmwares API" do
 
         api_basic_authorize action_identifier(:firmwares, :read, :resource_actions, :get)
 
-        run_get(firmwares_url(fw.id))
+        run_get(api_firmware_url(nil, fw))
 
         expect_single_resource_query("name"    => "UEFI",
                                      "version" => "D7E152CUS-2.11")
@@ -21,7 +21,7 @@ RSpec.describe "firmwares API" do
 
         api_basic_authorize
 
-        run_get(firmwares_url(fw.id))
+        run_get(api_firmware_url(nil, fw))
 
         expect(response).to have_http_status(:forbidden)
       end

--- a/spec/requests/floating_ips_spec.rb
+++ b/spec/requests/floating_ips_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe 'FloatingIp API' do
     it 'lists all cloud subnets with an appropriate role' do
       floating_ip = FactoryGirl.create(:floating_ip)
       api_basic_authorize collection_action_identifier(:floating_ips, :read, :get)
-      run_get(floating_ips_url)
+      run_get(api_floating_ips_url)
 
       expected = {
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'floating_ips',
         'resources' => [
-          hash_including('href' => a_string_matching(floating_ips_url(floating_ip.compressed_id)))
+          hash_including('href' => api_floating_ip_url(nil, floating_ip.compressed_id))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -20,7 +20,7 @@ RSpec.describe 'FloatingIp API' do
     it 'forbids access to cloud subnets without an appropriate role' do
       api_basic_authorize
 
-      run_get(floating_ips_url)
+      run_get(api_floating_ips_url)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -31,9 +31,9 @@ RSpec.describe 'FloatingIp API' do
       floating_ip = FactoryGirl.create(:floating_ip)
       api_basic_authorize action_identifier(:floating_ips, :read, :resource_actions, :get)
 
-      run_get(floating_ips_url(floating_ip.id))
+      run_get(api_floating_ip_url(nil, floating_ip))
 
-      expect(response.parsed_body).to include('href' => a_string_matching(floating_ips_url(floating_ip.compressed_id)))
+      expect(response.parsed_body).to include('href' => api_floating_ip_url(nil, floating_ip.compressed_id))
       expect(response).to have_http_status(:ok)
     end
 
@@ -41,7 +41,7 @@ RSpec.describe 'FloatingIp API' do
       floating_ip = FactoryGirl.create(:floating_ip)
       api_basic_authorize
 
-      run_get(floating_ips_url(floating_ip.id))
+      run_get(api_floating_ip_url(nil, floating_ip))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -50,7 +50,7 @@ RSpec.describe 'FloatingIp API' do
   describe 'POST /api/floating_ips' do
     it 'forbids access to floating ips without an appropriate role' do
       api_basic_authorize
-      run_post(floating_ips_url, gen_request(:query, ""))
+      run_post(api_floating_ips_url, gen_request(:query, ""))
       expect(response).to have_http_status(:forbidden)
     end
   end

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'does not list object definitions without an appropriate role' do
       api_basic_authorize
 
-      run_get(generic_object_definitions_url)
+      run_get(api_generic_object_definitions_url)
 
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'lists all generic object definitions with an appropriate role' do
       api_basic_authorize collection_action_identifier(:generic_object_definitions, :read, :get)
-      object_def_href = generic_object_definitions_url(object_def.compressed_id)
+      object_def_href = api_generic_object_definition_url(nil, object_def.compressed_id)
 
-      run_get(generic_object_definitions_url)
+      run_get(api_generic_object_definitions_url)
 
       expected = {
         'count'     => 1,
@@ -34,7 +34,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'does not let you query object definitions without an appropriate role' do
       api_basic_authorize
 
-      run_get(generic_object_definitions_url(object_def.compressed_id))
+      run_get(api_generic_object_definition_url(nil, object_def.compressed_id))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -42,7 +42,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'can query an object definition by its id' do
       api_basic_authorize action_identifier(:generic_object_definitions, :read, :resource_actions, :get)
 
-      run_get(generic_object_definitions_url(object_def.id))
+      run_get(api_generic_object_definition_url(nil, object_def))
 
       expected = {
         'id'   => object_def.compressed_id,
@@ -55,7 +55,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'can query an object definition by its name' do
       api_basic_authorize action_identifier(:generic_object_definitions, :read, :resource_actions, :get)
 
-      run_get(generic_object_definitions_url(object_def.name))
+      run_get(api_generic_object_definition_url(nil, object_def.name))
 
       expected = {
         'id'   => object_def.compressed_id,
@@ -68,7 +68,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'raises a record not found error if no object definition is found' do
       api_basic_authorize action_identifier(:generic_object_definitions, :read, :resource_actions, :get)
 
-      run_get(generic_object_definitions_url('bar'))
+      run_get(api_generic_object_definitions_url('bar'))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -96,7 +96,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           ]
         }
       }
-      run_post(generic_object_definitions_url, object_definition)
+      run_post(api_generic_object_definitions_url, object_definition)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['results'].first).to include(object_definition)
@@ -114,7 +114,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           }
         }
       }
-      run_post(generic_object_definitions_url, request)
+      run_post(api_generic_object_definitions_url, request)
 
       expected = {
         'error' => a_hash_including(
@@ -136,10 +136,10 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'resources' => [
           { 'name' => object_def.name, 'resource' => { 'name' => 'updated 1' } },
           { 'id' => object_def2.compressed_id, 'resource' => { 'name' => 'updated 2' }},
-          { 'href' => generic_object_definitions_url(object_def3.compressed_id), 'resource' => { 'name' => 'updated 3' }}
+          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id), 'resource' => { 'name' => 'updated 3' }}
         ]
       }
-      run_post(generic_object_definitions_url, request)
+      run_post(api_generic_object_definitions_url, request)
 
       expected = {
         'results' => a_collection_including(
@@ -176,7 +176,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           ]
         }
       }
-      run_post(generic_object_definitions_url(object_def.name), request)
+      run_post(api_generic_object_definition_url(nil, object_def.name), request)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(request.except('action'))
@@ -204,7 +204,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           ]
         }
       }
-      run_post(generic_object_definitions_url(object_def.compressed_id), request)
+      run_post(api_generic_object_definition_url(nil, object_def.compressed_id), request)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(request.except('action'))
@@ -221,7 +221,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           }
         }
       }
-      run_post(generic_object_definitions_url(object_def.compressed_id), request)
+      run_post(api_generic_object_definition_url(nil, object_def.compressed_id), request)
 
       expected = {
         'error' => a_hash_including(
@@ -236,7 +236,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'can delete an object definition by name' do
       api_basic_authorize action_identifier(:generic_object_definitions, :delete)
 
-      run_post(generic_object_definitions_url(object_def.name), :action => 'delete')
+      run_post(api_generic_object_definition_url(nil, object_def.name), :action => 'delete')
 
       expect(response).to have_http_status(:ok)
     end
@@ -244,7 +244,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'can delete an object definition by id' do
       api_basic_authorize action_identifier(:generic_object_definitions, :delete)
 
-      run_post(generic_object_definitions_url(object_def.compressed_id), :action => 'delete')
+      run_post(api_generic_object_definition_url(nil, object_def.compressed_id), :action => 'delete')
 
       expect(response).to have_http_status(:ok)
     end
@@ -253,7 +253,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
       api_basic_authorize action_identifier(:generic_object_definitions, :delete, :resource_actions, :delete)
       object_def.create_object(:name => 'foo object')
 
-      run_post(generic_object_definitions_url(object_def.name), :action => 'delete')
+      run_post(api_generic_object_definition_url(nil, object_def.name), :action => 'delete')
 
       expected = {
         'error' => a_hash_including(
@@ -275,10 +275,10 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'resources' => [
           { 'name' => object_def.name },
           { 'id' => object_def2.compressed_id},
-          { 'href' => generic_object_definitions_url(object_def3.compressed_id)}
+          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id)}
         ]
       }
-      run_post(generic_object_definitions_url, request)
+      run_post(api_generic_object_definitions_url, request)
 
       expected = {
         'results' => a_collection_including(
@@ -296,7 +296,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'can delete a generic_object_definition by id' do
       api_basic_authorize action_identifier(:generic_object_definitions, :delete, :resource_actions, :delete)
 
-      run_delete(generic_object_definitions_url(object_def.compressed_id))
+      run_delete(api_generic_object_definition_url(nil, object_def.compressed_id))
 
       expect(response).to have_http_status(:no_content)
     end
@@ -304,7 +304,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'can delete a generic_object_definition by name' do
       api_basic_authorize action_identifier(:generic_object_definitions, :delete, :resource_actions, :delete)
 
-      run_delete(generic_object_definitions_url(object_def.name))
+      run_delete(api_generic_object_definition_url(nil, object_def.name))
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -25,7 +25,7 @@ describe "Groups API" do
     it "rejects creation without appropriate role" do
       api_basic_authorize
 
-      run_post(groups_url, sample_group1)
+      run_post(api_groups_url, sample_group1)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -33,7 +33,7 @@ describe "Groups API" do
     it "rejects group creation with id specified" do
       api_basic_authorize collection_action_identifier(:groups, :create)
 
-      run_post(groups_url, "description" => "sample group", "id" => 100)
+      run_post(api_groups_url, "description" => "sample group", "id" => 100)
 
       expect_bad_request(/id or href should not be specified/i)
     end
@@ -41,7 +41,7 @@ describe "Groups API" do
     it "rejects group creation with invalid role specified" do
       api_basic_authorize collection_action_identifier(:groups, :create)
 
-      run_post(groups_url, "description" => "sample group", "role" => {"id" => 999_999})
+      run_post(api_groups_url, "description" => "sample group", "role" => {"id" => 999_999})
 
       expect(response).to have_http_status(:not_found)
     end
@@ -49,7 +49,7 @@ describe "Groups API" do
     it "rejects group creation with invalid tenant specified" do
       api_basic_authorize collection_action_identifier(:groups, :create)
 
-      run_post(groups_url, "description" => "sample group", "tenant" => {"id" => 999_999})
+      run_post(api_groups_url, "description" => "sample group", "tenant" => {"id" => 999_999})
 
       expect(response).to have_http_status(:not_found)
     end
@@ -57,7 +57,7 @@ describe "Groups API" do
     it "rejects group creation with invalid filters specified" do
       api_basic_authorize collection_action_identifier(:groups, :create)
 
-      run_post(groups_url, "description" => "sample group", "filters" => {"bogus" => %w(f1 f2)})
+      run_post(api_groups_url, "description" => "sample group", "filters" => {"bogus" => %w(f1 f2)})
 
       expect_bad_request(/Invalid filter/i)
     end
@@ -65,7 +65,7 @@ describe "Groups API" do
     it "supports single group creation" do
       api_basic_authorize collection_action_identifier(:groups, :create)
 
-      run_post(groups_url, sample_group1)
+      run_post(api_groups_url, sample_group1)
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -77,7 +77,7 @@ describe "Groups API" do
     it "supports single group creation via action" do
       api_basic_authorize collection_action_identifier(:groups, :create)
 
-      run_post(groups_url, gen_request(:create, sample_group1))
+      run_post(api_groups_url, gen_request(:create, sample_group1))
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -89,10 +89,10 @@ describe "Groups API" do
     it "supports single group creation via action with role and tenant specified" do
       api_basic_authorize collection_action_identifier(:groups, :create)
 
-      run_post(groups_url, gen_request(:create,
+      run_post(api_groups_url, gen_request(:create,
                                        "description" => "sample_group3",
                                        "role"        => {"name" => role3.name},
-                                       "tenant"      => {"href" => tenants_url(tenant3.id)}))
+                                       "tenant"      => {"href" => api_tenant_url(nil, tenant3)}))
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -117,7 +117,7 @@ describe "Groups API" do
                         "belongsto" => ["/managed/infra/1", "/managed/infra/2"],
                       }
       }
-      run_post(groups_url, gen_request(:create, sample_group))
+      run_post(api_groups_url, gen_request(:create, sample_group))
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -133,7 +133,7 @@ describe "Groups API" do
     it "supports multiple group creation" do
       api_basic_authorize collection_action_identifier(:groups, :create)
 
-      run_post(groups_url, gen_request(:create, [sample_group1, sample_group2]))
+      run_post(api_groups_url, gen_request(:create, [sample_group1, sample_group2]))
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -149,9 +149,9 @@ describe "Groups API" do
   describe "groups edit" do
     it "rejects group edits without appropriate role" do
       api_basic_authorize
-      run_post(groups_url, gen_request(:edit,
+      run_post(api_groups_url, gen_request(:edit,
                                        "description" => "updated_group",
-                                       "href"        => groups_url(group1.id)))
+                                       "href"        => api_group_url(nil, group1)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -159,7 +159,7 @@ describe "Groups API" do
     it "rejects group edits for invalid resources" do
       api_basic_authorize collection_action_identifier(:groups, :edit)
 
-      run_post(groups_url(999_999), gen_request(:edit, "description" => "updated_group"))
+      run_post(api_group_url(nil, 999_999), gen_request(:edit, "description" => "updated_group"))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -167,7 +167,7 @@ describe "Groups API" do
     it "supports single group edit" do
       api_basic_authorize collection_action_identifier(:groups, :edit)
 
-      run_post(groups_url(group1.id), gen_request(:edit, "description" => "updated_group"))
+      run_post(api_group_url(nil, group1), gen_request(:edit, "description" => "updated_group"))
 
       expect_single_resource_query("id"          => group1.compressed_id,
                                    "description" => "updated_group")
@@ -177,9 +177,9 @@ describe "Groups API" do
     it "supports multiple group edits" do
       api_basic_authorize collection_action_identifier(:groups, :edit)
 
-      run_post(groups_url, gen_request(:edit,
-                                       [{"href" => groups_url(group1.id), "description" => "updated_group1"},
-                                        {"href" => groups_url(group2.id), "description" => "updated_group2"}]))
+      run_post(api_groups_url, gen_request(:edit,
+                                           [{"href" => api_group_url(nil, group1), "description" => "updated_group1"},
+                                            {"href" => api_group_url(nil, group2), "description" => "updated_group2"}]))
 
       expect_results_to_match_hash("results",
                                    [{"id" => group1.compressed_id, "description" => "updated_group1"},
@@ -194,7 +194,7 @@ describe "Groups API" do
     it "rejects group deletion, by post action, without appropriate role" do
       api_basic_authorize
 
-      run_post(groups_url, gen_request(:delete, "description" => "group_description", "href" => groups_url(100)))
+      run_post(api_groups_url, gen_request(:delete, "description" => "group_description", "href" => api_group_url(nil, 100)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -202,7 +202,7 @@ describe "Groups API" do
     it "rejects group deletion without appropriate role" do
       api_basic_authorize
 
-      run_delete(groups_url(100))
+      run_delete(api_group_url(nil, 100))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -210,7 +210,7 @@ describe "Groups API" do
     it "rejects group deletes for invalid groups" do
       api_basic_authorize collection_action_identifier(:groups, :delete)
 
-      run_delete(groups_url(999_999))
+      run_delete(api_group_url(nil, 999_999))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -218,7 +218,7 @@ describe "Groups API" do
     it 'rejects a request to remove a default tenant group' do
       api_basic_authorize collection_action_identifier(:groups, :delete)
 
-      run_delete(groups_url(tenant3.default_miq_group_id))
+      run_delete(api_group_url(nil, tenant3.default_miq_group_id))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -227,7 +227,7 @@ describe "Groups API" do
       api_basic_authorize collection_action_identifier(:groups, :delete)
 
       g1_id = group1.id
-      run_delete(groups_url(g1_id))
+      run_delete(api_group_url(nil, g1_id))
 
       expect(response).to have_http_status(:no_content)
       expect(MiqGroup.exists?(g1_id)).to be_falsey
@@ -237,11 +237,11 @@ describe "Groups API" do
       api_basic_authorize collection_action_identifier(:groups, :delete)
 
       g1_id = group1.id
-      g1_url = groups_url(g1_id)
+      g1_url = api_group_url(nil, g1_id)
 
       run_post(g1_url, gen_request(:delete))
 
-      expect_single_action_result(:success => true, :message => "deleting", :href => groups_url(group1.compressed_id))
+      expect_single_action_result(:success => true, :message => "deleting", :href => api_group_url(nil, group1.compressed_id))
       expect(MiqGroup.exists?(g1_id)).to be_falsey
     end
 
@@ -249,12 +249,12 @@ describe "Groups API" do
       api_basic_authorize collection_action_identifier(:groups, :delete)
 
       g1_id, g2_id = group1.id, group2.id
-      g1_url, g2_url = groups_url(g1_id), groups_url(g2_id)
+      g1_url, g2_url = api_group_url(nil, g1_id), api_group_url(nil, g2_id)
 
-      run_post(groups_url, gen_request(:delete, [{"href" => g1_url}, {"href" => g2_url}]))
+      run_post(api_groups_url, gen_request(:delete, [{"href" => g1_url}, {"href" => g2_url}]))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [groups_url(group1.compressed_id), groups_url(group2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_group_url(nil, group1.compressed_id), api_group_url(nil, group2.compressed_id)])
       expect(MiqGroup.exists?(g1_id)).to be_falsey
       expect(MiqGroup.exists?(g2_id)).to be_falsey
     end
@@ -267,7 +267,7 @@ describe "Groups API" do
       Classification.classify(group, "department", "finance")
       api_basic_authorize
 
-      run_get("#{groups_url(group.id)}/tags")
+      run_get(api_group_tags_url(nil, group))
 
       expect(response.parsed_body).to include("subcount" => 1)
       expect(response).to have_http_status(:ok)
@@ -278,7 +278,7 @@ describe "Groups API" do
       FactoryGirl.create(:classification_department_with_tags)
       api_basic_authorize(subcollection_action_identifier(:groups, :tags, :assign))
 
-      run_post("#{groups_url(group.id)}/tags", :action => "assign", :category => "department", :name => "finance")
+      run_post(api_group_tags_url(nil, group), :action => "assign", :category => "department", :name => "finance")
 
       expected = {
         "results" => [
@@ -300,7 +300,7 @@ describe "Groups API" do
       Classification.classify(group, "department", "finance")
       api_basic_authorize(subcollection_action_identifier(:groups, :tags, :unassign))
 
-      run_post("#{groups_url(group.id)}/tags", :action => "unassign", :category => "department", :name => "finance")
+      run_post(api_group_tags_url(nil, group), :action => "unassign", :category => "department", :name => "finance")
 
       expected = {
         "results" => [

--- a/spec/requests/guest_devices_spec.rb
+++ b/spec/requests/guest_devices_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "guest devices API" do
 
         api_basic_authorize action_identifier(:guest_devices, :read, :resource_actions, :get)
 
-        run_get(guest_devices_url(device.id))
+        run_get(api_guest_device_url(nil, device))
 
         expect_single_resource_query("device_name" => "Broadcom 2-port 1GbE NIC Card",
                                      "device_type" => "ethernet",
@@ -23,7 +23,7 @@ RSpec.describe "guest devices API" do
 
         api_basic_authorize
 
-        run_get(guest_devices_url(device.id))
+        run_get(api_guest_device_url(nil, device))
 
         expect(response).to have_http_status(:forbidden)
       end

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Headers" do
     it "accepts JSON by default" do
       api_basic_authorize(collection_action_identifier(:groups, :create))
 
-      post groups_url, :params => '{"description": "foo"}', :headers => headers
+      post api_groups_url, :params => '{"description": "foo"}', :headers => headers
 
       expect(response).to have_http_status(:ok)
     end
@@ -47,7 +47,7 @@ RSpec.describe "Headers" do
     it "will accept JSON when set to application/json" do
       api_basic_authorize(collection_action_identifier(:groups, :create))
 
-      post(groups_url,
+      post(api_groups_url,
            :params  => '{"description": "foo"}',
            :headers => headers.merge("Content-Type" => "application/json"))
 
@@ -57,7 +57,7 @@ RSpec.describe "Headers" do
     it "will ignore the Content-Type" do
       api_basic_authorize(collection_action_identifier(:groups, :create))
 
-      post(groups_url,
+      post(api_groups_url,
            :params  => '{"description": "foo"}',
            :headers => headers.merge("Content-Type" => "application/xml"))
 

--- a/spec/requests/hosts_spec.rb
+++ b/spec/requests/hosts_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "hosts API" do
         options = {:credentials => {:authtype => "default", :password => "abc123"}}
 
         expect do
-          run_post hosts_url(host.id), gen_request(:edit, options)
+          run_post api_host_url(nil, host), gen_request(:edit, options)
         end.to change { host.reload.authentication_password(:default) }.to("abc123")
         expect(response).to have_http_status(:ok)
       end
@@ -18,7 +18,7 @@ RSpec.describe "hosts API" do
         options = {:credentials => {:password => "abc123"}}
 
         expect do
-          run_post hosts_url(host.id), gen_request(:edit, options)
+          run_post api_host_url(nil, host), gen_request(:edit, options)
         end.to change { host.reload.authentication_password(:default) }.to("abc123")
         expect(response).to have_http_status(:ok)
       end
@@ -29,7 +29,7 @@ RSpec.describe "hosts API" do
         options = {:name => "new name"}
 
         expect do
-          run_post hosts_url(host.id), gen_request(:edit, options)
+          run_post api_host_url(nil, host), gen_request(:edit, options)
         end.not_to change { host.reload.name }
         expect(response).to have_http_status(:bad_request)
       end
@@ -39,11 +39,11 @@ RSpec.describe "hosts API" do
         host2 = FactoryGirl.create(:host_with_authentication)
         api_basic_authorize action_identifier(:hosts, :edit)
         options = [
-          {:href => hosts_url(host1.id), :credentials => {:password => "abc123"}},
-          {:href => hosts_url(host2.id), :credentials => {:password => "def456"}}
+          {:href => api_host_url(nil, host1), :credentials => {:password => "abc123"}},
+          {:href => api_host_url(nil, host2), :credentials => {:password => "def456"}}
         ]
 
-        run_post hosts_url, gen_request(:edit, options)
+        run_post api_hosts_url, gen_request(:edit, options)
         expect(response).to have_http_status(:ok)
         expect(host1.reload.authentication_password(:default)).to eq("abc123")
         expect(host2.reload.authentication_password(:default)).to eq("def456")
@@ -58,7 +58,7 @@ RSpec.describe "hosts API" do
           {:id => host2.id, :credentials => {:password => "def456"}}
         ]
 
-        run_post hosts_url, gen_request(:edit, options)
+        run_post api_hosts_url, gen_request(:edit, options)
         expect(response).to have_http_status(:ok)
         expect(host1.reload.authentication_password(:default)).to eq("abc123")
         expect(host2.reload.authentication_password(:default)).to eq("def456")
@@ -72,7 +72,7 @@ RSpec.describe "hosts API" do
         options = {:credentials => {:authtype => "default", :password => "abc123"}}
 
         expect do
-          run_post hosts_url(host.id), gen_request(:edit, options)
+          run_post api_host_url(nil, host), gen_request(:edit, options)
         end.not_to change { host.reload.authentication_password(:default) }
         expect(response).to have_http_status(:forbidden)
       end
@@ -82,7 +82,7 @@ RSpec.describe "hosts API" do
       it 'returns hosts node_types' do
         expected_data = {"node_types" => Host.node_types.to_s}
 
-        run_options(hosts_url)
+        run_options(api_hosts_url)
         expect_options_results(:hosts, expected_data)
       end
     end

--- a/spec/requests/instances_spec.rb
+++ b/spec/requests/instances_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "Instances API" do
   let(:instance) { FactoryGirl.create(:vm_openstack, :ems_id => ems.id, :host => host) }
   let(:instance1) { FactoryGirl.create(:vm_openstack, :ems_id => ems.id, :host => host) }
   let(:instance2) { FactoryGirl.create(:vm_openstack, :ems_id => ems.id, :host => host) }
-  let(:instance_url) { instances_url(instance.id) }
-  let(:instance1_url) { instances_url(instance1.id) }
-  let(:instance2_url) { instances_url(instance2.id) }
-  let(:invalid_instance_url) { instances_url(999_999) }
+  let(:instance_url) { api_instance_url(nil, instance) }
+  let(:instance1_url) { api_instance_url(nil, instance1) }
+  let(:instance2_url) { api_instance_url(nil, instance2) }
+  let(:invalid_instance_url) { api_instance_url(nil, 999_999) }
   let(:instances_list) { [instance1_url, instance2_url] }
 
   context "Instance index" do
@@ -21,10 +21,10 @@ RSpec.describe "Instances API" do
       instance = FactoryGirl.create(:vm_openstack)
       _vm = FactoryGirl.create(:vm_vmware)
 
-      run_get(instances_url)
+      run_get(api_instances_url)
 
       expect_query_result(:instances, 1, 1)
-      expect_result_resources_to_include_hrefs("resources", [instances_url(instance.compressed_id)])
+      expect_result_resources_to_include_hrefs("resources", [api_instance_url(nil, instance.compressed_id)])
     end
   end
 
@@ -53,26 +53,26 @@ RSpec.describe "Instances API" do
       expect_single_action_result(
         :success => true,
         :message => /#{instance.id}.* terminating/i,
-        :href    => instances_url(instance.compressed_id)
+        :href    => api_instance_url(nil, instance.compressed_id)
       )
     end
 
     it "terminates multiple valid Instances" do
       api_basic_authorize collection_action_identifier(:instances, :terminate)
 
-      run_post(instances_url, gen_request(:terminate, [{"href" => instance1_url}, {"href" => instance2_url}]))
+      run_post(api_instances_url, gen_request(:terminate, [{"href" => instance1_url}, {"href" => instance2_url}]))
 
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
             "message" => a_string_matching(/#{instance1.id}.* terminating/i),
             "success" => true,
-            "href"    => a_string_matching(instances_url(instance1.compressed_id))
+            "href"    => api_instance_url(nil, instance1.compressed_id)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{instance2.id}.* terminating/i),
             "success" => true,
-            "href"    => a_string_matching(instances_url(instance2.compressed_id))
+            "href"    => api_instance_url(nil, instance2.compressed_id)
           )
         )
       }
@@ -104,7 +104,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:stop))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "stops a valid instance" do
@@ -112,16 +112,16 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:stop))
 
-      expect_single_action_result(:success => true, :message => "stopping", :href => instances_url(instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "stopping", :href => api_instance_url(nil, instance.compressed_id), :task => true)
     end
 
     it "stops multiple valid instances" do
       api_basic_authorize action_identifier(:instances, :stop)
 
-      run_post(instances_url, gen_request(:stop, nil, instance1_url, instance2_url))
+      run_post(api_instances_url, gen_request(:stop, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [instances_url(instance1.compressed_id), instances_url(instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
     end
   end
 
@@ -147,7 +147,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:start))
 
-      expect_single_action_result(:success => false, :message => "is powered on", :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is powered on", :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "starts an instance" do
@@ -156,17 +156,17 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => instances_url(instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "starting", :href => api_instance_url(nil, instance.compressed_id), :task => true)
     end
 
     it "starts multiple instances" do
       api_basic_authorize action_identifier(:instances, :start)
       update_raw_power_state("poweredOff", instance1, instance2)
 
-      run_post(instances_url, gen_request(:start, nil, instance1_url, instance2_url))
+      run_post(api_instances_url, gen_request(:start, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [instances_url(instance1.compressed_id), instances_url(instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
     end
   end
 
@@ -193,7 +193,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "fails to pause a paused instance" do
@@ -202,7 +202,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "pauses an instance" do
@@ -210,16 +210,16 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:pause))
 
-      expect_single_action_result(:success => true, :message => "pausing", :href => instances_url(instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "pausing", :href => api_instance_url(nil, instance.compressed_id), :task => true)
     end
 
     it "pauses multiple instances" do
       api_basic_authorize action_identifier(:instances, :pause)
 
-      run_post(instances_url, gen_request(:pause, nil, instance1_url, instance2_url))
+      run_post(api_instances_url, gen_request(:pause, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [instances_url(instance1.compressed_id), instances_url(instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
     end
   end
 
@@ -246,7 +246,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "cannot suspend a suspended instance" do
@@ -255,7 +255,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "suspends an instance" do
@@ -263,16 +263,16 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => true, :message => "suspending", :href => instances_url(instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "suspending", :href => api_instance_url(nil, instance.compressed_id), :task => true)
     end
 
     it "suspends multiple instances" do
       api_basic_authorize action_identifier(:instances, :suspend)
 
-      run_post(instances_url, gen_request(:suspend, nil, instance1_url, instance2_url))
+      run_post(api_instances_url, gen_request(:suspend, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [instances_url(instance1.compressed_id), instances_url(instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
     end
   end
 
@@ -299,7 +299,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "shelves a suspended instance" do
@@ -308,7 +308,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "shelves a paused instance" do
@@ -317,7 +317,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "cannot shelve a shelved instance" do
@@ -329,7 +329,7 @@ RSpec.describe "Instances API" do
       expect_single_action_result(
         :success => false,
         :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused",
-        :href    => instances_url(instance.compressed_id)
+        :href    => api_instance_url(nil, instance.compressed_id)
       )
     end
 
@@ -340,17 +340,17 @@ RSpec.describe "Instances API" do
 
       expect_single_action_result(:success => true,
                                   :message => "shelving",
-                                  :href    => instances_url(instance.compressed_id),
+                                  :href    => api_instance_url(nil, instance.compressed_id),
                                   :task    => true)
     end
 
     it "shelves multiple instances" do
       api_basic_authorize action_identifier(:instances, :shelve)
 
-      run_post(instances_url, gen_request(:shelve, nil, instance1_url, instance2_url))
+      run_post(api_instances_url, gen_request(:shelve, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [instances_url(instance1.compressed_id), instances_url(instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
     end
   end
 
@@ -377,7 +377,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "reboots a valid instance" do
@@ -385,16 +385,16 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => true, :message => "rebooting", :href => instances_url(instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "rebooting", :href => api_instance_url(nil, instance.compressed_id), :task => true)
     end
 
     it "reboots multiple valid instances" do
       api_basic_authorize action_identifier(:instances, :reboot_guest)
 
-      run_post(instances_url, gen_request(:reboot_guest, nil, instance1_url, instance2_url))
+      run_post(api_instances_url, gen_request(:reboot_guest, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [instances_url(instance1.compressed_id), instances_url(instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
     end
   end
 
@@ -421,7 +421,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:reset))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => instances_url(instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
     end
 
     it "resets a valid instance" do
@@ -429,16 +429,16 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:reset))
 
-      expect_single_action_result(:success => true, :message => "resetting", :href => instances_url(instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "resetting", :href => api_instance_url(nil, instance.compressed_id), :task => true)
     end
 
     it "resets multiple valid instances" do
       api_basic_authorize action_identifier(:instances, :reset)
 
-      run_post(instances_url, gen_request(:reset, nil, instance1_url, instance2_url))
+      run_post(api_instances_url, gen_request(:reset, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [instances_url(instance1.compressed_id), instances_url(instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
     end
   end
 
@@ -460,10 +460,10 @@ RSpec.describe "Instances API" do
       expected = {
         'name'      => 'load_balancers',
         'resources' => [
-          { 'href' => a_string_matching("#{instances_url(@vm.compressed_id)}/load_balancers/#{@load_balancer.compressed_id}") }
+          { 'href' => api_instance_load_balancer_url(nil, @vm.compressed_id, @load_balancer.compressed_id) }
         ]
       }
-      run_get("#{instances_url(@vm.id)}/load_balancers")
+      run_get(api_instance_load_balancers_url(nil, @vm))
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -472,14 +472,14 @@ RSpec.describe "Instances API" do
     it "will not show an instance's load balancers without the appropriate role" do
       api_basic_authorize
 
-      run_get("#{instances_url(@vm.id)}/load_balancers")
+      run_get(api_instance_load_balancers_url(nil, @vm))
 
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'queries a single load balancer on an instance' do
       api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :read, :get)
-      run_get("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}")
+      run_get(api_instance_load_balancer_url(nil, @vm, @load_balancer))
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => @load_balancer.compressed_id)
@@ -488,7 +488,7 @@ RSpec.describe "Instances API" do
     it "will not show an instance's load balancer without the appropriate role" do
       api_basic_authorize
 
-      run_get("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}")
+      run_get(api_instance_load_balancer_url(nil, @vm, @load_balancer))
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/load_balancers_spec.rb
+++ b/spec/requests/load_balancers_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe 'LoadBalancers API' do
         'subcount'  => 1,
         'name'      => 'load_balancers',
         'resources' => [
-          hash_including('href' => a_string_matching(load_balancers_url(load_balancer.compressed_id)))
+          hash_including('href' => api_load_balancer_url(nil, load_balancer.compressed_id))
         ]
       }
-      run_get(load_balancers_url)
+      run_get(api_load_balancers_url)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -21,7 +21,7 @@ RSpec.describe 'LoadBalancers API' do
     it 'forbids access to load balancers without an appropriate role' do
       api_basic_authorize
 
-      run_get(load_balancers_url)
+      run_get(api_load_balancers_url)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -32,9 +32,9 @@ RSpec.describe 'LoadBalancers API' do
       load_balancer = FactoryGirl.create(:load_balancer)
       api_basic_authorize action_identifier(:load_balancers, :read, :resource_actions, :get)
 
-      run_get(load_balancers_url(load_balancer.id))
+      run_get(api_load_balancer_url(nil, load_balancer))
 
-      expect(response.parsed_body).to include('href' => a_string_matching(load_balancers_url(load_balancer.compressed_id)))
+      expect(response.parsed_body).to include('href' => api_load_balancer_url(nil, load_balancer.compressed_id))
       expect(response).to have_http_status(:ok)
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'LoadBalancers API' do
       load_balancer = FactoryGirl.create(:load_balancer)
       api_basic_authorize
 
-      run_get(load_balancers_url(load_balancer.id))
+      run_get(api_load_balancer_url(nil, load_balancer))
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/logging_spec.rb
+++ b/spec/requests/logging_spec.rb
@@ -14,7 +14,7 @@ describe "Logging" do
     it "logs hashed details about the request" do
       api_basic_authorize collection_action_identifier(:users, :read, :get)
 
-      run_get users_url
+      run_get api_users_url
 
       @log.rewind
       request_log_line = @log.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
@@ -37,7 +37,7 @@ describe "Logging" do
     it "filters password attributes in nested parameters" do
       api_basic_authorize collection_action_identifier(:services, :create)
 
-      run_post(services_url, gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
+      run_post(api_services_url, gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
 
       expect(@log.string).to include(
         'Parameters:     {"action"=>"update", "controller"=>"api/services", "format"=>"json", ' \

--- a/spec/requests/metric_rollups_spec.rb
+++ b/spec/requests/metric_rollups_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'MetricRollups API' do
     it 'returns metric_rollups for a specific resource_type' do
       api_basic_authorize collection_action_identifier(:metric_rollups, :read, :get)
 
-      run_get metric_rollups_url, :resource_type => 'VmOrTemplate', :capture_interval => 'hourly', :start_date => Time.zone.today.to_s
+      run_get api_metric_rollups_url, :resource_type => 'VmOrTemplate', :capture_interval => 'hourly', :start_date => Time.zone.today.to_s
 
       expected = {
         'count'    => 3,
@@ -24,7 +24,7 @@ RSpec.describe 'MetricRollups API' do
       vm_metric = FactoryGirl.create(:metric_rollup_vm_hr, :resource => vm)
       api_basic_authorize collection_action_identifier(:metric_rollups, :read, :get)
 
-      run_get metric_rollups_url, :resource_type    => 'VmOrTemplate',
+      run_get api_metric_rollups_url, :resource_type    => 'VmOrTemplate',
                                   :resource_ids     => [vm.id],
                                   :capture_interval => 'hourly',
                                   :start_date       => Time.zone.today.to_s
@@ -33,7 +33,7 @@ RSpec.describe 'MetricRollups API' do
         'count'     => 4,
         'subcount'  => 1,
         'resources' => [
-          { 'href' => a_string_including(metric_rollups_url(vm_metric.compressed_id)) }
+          { 'href' => a_string_including(api_metric_rollup_url(nil, vm_metric.compressed_id)) }
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -46,7 +46,7 @@ RSpec.describe 'MetricRollups API' do
       vm_daily = FactoryGirl.create(:metric_rollup_vm_daily, :resource => vm)
       api_basic_authorize collection_action_identifier(:metric_rollups, :read, :get)
 
-      run_get metric_rollups_url, :resource_type    => 'VmOrTemplate',
+      run_get api_metric_rollups_url, :resource_type    => 'VmOrTemplate',
                                   :resource_ids     => [vm.id],
                                   :capture_interval => 'daily',
                                   :start_date       => Time.zone.today.to_s
@@ -55,7 +55,7 @@ RSpec.describe 'MetricRollups API' do
         'count'     => 5,
         'subcount'  => 1,
         'resources' => [
-          { 'href' => a_string_including(metric_rollups_url(vm_daily.compressed_id)) }
+          { 'href' => a_string_including(api_metric_rollup_url(nil, vm_daily.compressed_id)) }
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -65,7 +65,7 @@ RSpec.describe 'MetricRollups API' do
     it 'requires parameters' do
       api_basic_authorize collection_action_identifier(:metric_rollups, :read, :get)
 
-      run_get metric_rollups_url
+      run_get api_metric_rollups_url
 
       expected = {
         'error' => a_hash_including(
@@ -79,7 +79,7 @@ RSpec.describe 'MetricRollups API' do
     it 'pages the request by default' do
       api_basic_authorize collection_action_identifier(:metric_rollups, :read, :get)
 
-      run_get metric_rollups_url, :resource_type    => 'VmOrTemplate',
+      run_get api_metric_rollups_url, :resource_type    => 'VmOrTemplate',
                                   :capture_interval => 'daily',
                                   :start_date       => Time.zone.today.to_s
       expected = {
@@ -95,7 +95,7 @@ RSpec.describe 'MetricRollups API' do
     it 'validates that the capture interval is valid' do
       api_basic_authorize collection_action_identifier(:metric_rollups, :read, :get)
 
-      run_get metric_rollups_url, :resource_type    => 'VmOrTemplate',
+      run_get api_metric_rollups_url, :resource_type    => 'VmOrTemplate',
                                   :start_date       => Time.zone.today.to_s,
                                   :capture_interval => 'bad_interval'
 
@@ -114,7 +114,7 @@ RSpec.describe 'MetricRollups API' do
       FactoryGirl.create_list(:metric_rollup_vm_hr, 3, :resource => vm)
       api_basic_authorize collection_action_identifier(:metric_rollups, :read, :get)
 
-      run_get metric_rollups_url, :resource_type    => 'VmOrTemplate',
+      run_get api_metric_rollups_url, :resource_type    => 'VmOrTemplate',
                                   :resource_ids     => [vm.id],
                                   :capture_interval => 'hourly',
                                   :start_date       => Time.zone.today.to_s,

--- a/spec/requests/network_routers_spec.rb
+++ b/spec/requests/network_routers_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe 'NetworkRouters API' do
     it 'lists all cloud subnets with an appropriate role' do
       network_router = FactoryGirl.create(:network_router)
       api_basic_authorize collection_action_identifier(:network_routers, :read, :get)
-      run_get(network_routers_url)
+      run_get(api_network_routers_url)
 
       expected = {
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'network_routers',
         'resources' => [
-          hash_including('href' => a_string_matching(network_routers_url(network_router.compressed_id)))
+          hash_including('href' => api_network_router_url(nil, network_router.compressed_id))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -19,7 +19,7 @@ RSpec.describe 'NetworkRouters API' do
 
     it 'forbids access to cloud subnets without an appropriate role' do
       api_basic_authorize
-      run_get(network_routers_url)
+      run_get(api_network_routers_url)
       expect(response).to have_http_status(:forbidden)
     end
   end
@@ -28,15 +28,15 @@ RSpec.describe 'NetworkRouters API' do
     it 'will show a cloud subnet with an appropriate role' do
       network_router = FactoryGirl.create(:network_router)
       api_basic_authorize action_identifier(:network_routers, :read, :resource_actions, :get)
-      run_get(network_routers_url(network_router.id))
-      expect(response.parsed_body).to include('href' => a_string_matching(network_routers_url(network_router.compressed_id)))
+      run_get(api_network_router_url(nil, network_router))
+      expect(response.parsed_body).to include('href' => api_network_router_url(nil, network_router.compressed_id))
       expect(response).to have_http_status(:ok)
     end
 
     it 'forbids access to a cloud tenant without an appropriate role' do
       network_router = FactoryGirl.create(:network_router)
       api_basic_authorize
-      run_get(network_routers_url(network_router.id))
+      run_get(api_network_router_url(nil, network_router))
       expect(response).to have_http_status(:forbidden)
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe 'NetworkRouters API' do
   describe 'POST /api/network_routers' do
     it 'forbids access to network routers without an appropriate role' do
       api_basic_authorize
-      run_post(network_routers_url, gen_request(:query, ""))
+      run_post(api_network_routers_url, gen_request(:query, ""))
       expect(response).to have_http_status(:forbidden)
     end
   end

--- a/spec/requests/normalization_spec.rb
+++ b/spec/requests/normalization_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Normalization of objects API" do
     api_basic_authorize action_identifier(:hosts, :read, :resource_actions, :get)
     host = FactoryGirl.create(:host)
 
-    run_get(hosts_url(host.id))
+    run_get(api_host_url(nil, host))
 
     expect(response.parsed_body).to include("created_on" => host.created_on.iso8601)
   end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -3,14 +3,14 @@ describe 'Notifications API' do
   let(:notification) { FactoryGirl.create(:notification, :initiator => @user) }
   let(:foreign_notification) { FactoryGirl.create(:notification, :initiator => foreign_user) }
   let(:notification_recipient) { notification.notification_recipients.first }
-  let(:notification_url) { notifications_url(notification_recipient.id) }
-  let(:foreign_notification_url) { notifications_url(foreign_notification.notification_recipient_ids.first) }
+  let(:notification_url) { api_notification_url(nil, notification_recipient) }
+  let(:foreign_notification_url) { api_notification_url(nil, foreign_notification.notification_recipient_ids.first) }
 
   describe 'notification create' do
     it 'is not supported' do
       api_basic_authorize
 
-      run_post(notifications_url, gen_request(:create, :notification_id => 1, :user_id => 1))
+      run_post(api_notifications_url, gen_request(:create, :notification_id => 1, :user_id => 1))
       expect_bad_request(/Unsupported Action create/i)
     end
   end
@@ -36,7 +36,7 @@ describe 'Notifications API' do
     it 'is not supported' do
       api_basic_authorize
 
-      run_post(notifications_url, gen_request(:edit, :user_id => 1, :href => notification_url))
+      run_post(api_notifications_url, gen_request(:edit, :user_id => 1, :href => notification_url))
       expect_bad_request(/Unsupported Action edit/i)
     end
   end
@@ -48,7 +48,7 @@ describe 'Notifications API' do
 
         run_post(notification_url, gen_request(:delete))
         expect(response).to have_http_status(:ok)
-        expect_single_action_result(:success => true, :href => notifications_url(notification_recipient.compressed_id))
+        expect_single_action_result(:success => true, :href => api_notification_url(nil, notification_recipient.compressed_id))
         expect { notification_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -65,27 +65,27 @@ describe 'Notifications API' do
       it 'rejects on notification that is not owned by current user' do
         api_basic_authorize
 
-        run_post(notifications_url, gen_request(:delete, :href => foreign_notification_url))
+        run_post(api_notifications_url, gen_request(:delete, :href => foreign_notification_url))
         expect(response).to have_http_status(:not_found)
       end
 
       it 'deletes single' do
         api_basic_authorize
 
-        run_post(notifications_url, gen_request(:delete, :href => notification_url))
+        run_post(api_notifications_url, gen_request(:delete, :href => notification_url))
         expect(response).to have_http_status(:ok)
         expect_results_to_match_hash('results', [{'success' => true,
-                                                  'href'    => notifications_url(notification_recipient.compressed_id)}])
+                                                  'href'    => api_notification_url(nil, notification_recipient.compressed_id)}])
         expect { notification_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       let(:notification2) { FactoryGirl.create(:notification, :initiator => @user) }
       let(:notification2_recipient) { notification2.notification_recipients.first }
-      let(:notification2_url) { notifications_url(notification2_recipient.id) }
+      let(:notification2_url) { api_notification_url(nil, notification2_recipient) }
 
       it 'deletes multiple' do
         api_basic_authorize
-        run_post(notifications_url, gen_request(:delete, [{:href => notification_url}, {:href => notification2_url}]))
+        run_post(api_notifications_url, gen_request(:delete, [{:href => notification_url}, {:href => notification2_url}]))
         expect(response).to have_http_status(:ok)
         expect { notification_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { notification2_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -95,13 +95,13 @@ describe 'Notifications API' do
         let(:notification_id) { ApplicationRecord.compress_id(notification_recipient.id) }
         it 'deletes notifications specified by compressed id in href' do
           api_basic_authorize
-          run_post(notifications_url, gen_request(:delete, :href => notifications_url(notification_id)))
+          run_post(api_notifications_url, gen_request(:delete, :href => api_notification_url(nil, notification_id)))
           expect(response).to have_http_status(:ok)
         end
 
         it 'deletes notifications specified by compressed id' do
           api_basic_authorize
-          run_post(notifications_url, gen_request(:delete, :id => notification_id))
+          run_post(api_notifications_url, gen_request(:delete, :id => notification_id))
           expect(response).to have_http_status(:ok)
         end
       end
@@ -122,7 +122,7 @@ describe 'Notifications API' do
 
       expect(notification_recipient.seen).to be_falsey
       run_post(notification_url, gen_request(:mark_as_seen))
-      expect_single_action_result(:success => true, :href => notifications_url(notification_recipient.compressed_id))
+      expect_single_action_result(:success => true, :href => api_notification_url(nil, notification_recipient.compressed_id))
       expect(notification_recipient.reload.seen).to be_truthy
     end
   end

--- a/spec/requests/orchestration_template_spec.rb
+++ b/spec/requests/orchestration_template_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Orchestration Template API' do
       FactoryGirl.create(:orchestration_template_vnfd_with_content)
 
       api_basic_authorize collection_action_identifier(:orchestration_templates, :read, :get)
-      run_get(orchestration_templates_url)
+      run_get(api_orchestration_templates_url)
       expect_query_result(:orchestration_templates, 3, 3)
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe 'Orchestration Template API' do
     it 'rejects creation without appropriate role' do
       api_basic_authorize
 
-      run_post(orchestration_templates_url, request_body_hot)
+      run_post(api_orchestration_templates_url, request_body_hot)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -48,7 +48,7 @@ RSpec.describe 'Orchestration Template API' do
       api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
 
       expect do
-        run_post(orchestration_templates_url, request_body_hot)
+        run_post(api_orchestration_templates_url, request_body_hot)
       end.to change(OrchestrationTemplateHot, :count).by(1)
     end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Orchestration Template API' do
       api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
 
       expect do
-        run_post(orchestration_templates_url, request_body_cfn)
+        run_post(api_orchestration_templates_url, request_body_cfn)
       end.to change(OrchestrationTemplateCfn, :count).by(1)
     end
 
@@ -64,7 +64,7 @@ RSpec.describe 'Orchestration Template API' do
       api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
 
       expect do
-        run_post(orchestration_templates_url, request_body_vnfd)
+        run_post(api_orchestration_templates_url, request_body_vnfd)
       end.to change(OrchestrationTemplateVnfd, :count).by(1)
     end
 
@@ -72,14 +72,14 @@ RSpec.describe 'Orchestration Template API' do
       api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
 
       expect do
-        run_post(orchestration_templates_url, gen_request(:create, request_body_hot))
+        run_post(api_orchestration_templates_url, gen_request(:create, request_body_hot))
       end.to change(OrchestrationTemplateHot, :count).by(1)
     end
 
     it 'rejects a request with an id' do
       api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
 
-      run_post(orchestration_templates_url, request_body_hot.merge(:id => 1))
+      run_post(api_orchestration_templates_url, request_body_hot.merge(:id => 1))
 
       expect_bad_request(/Resource id or href should not be specified/)
     end
@@ -92,7 +92,7 @@ RSpec.describe 'Orchestration Template API' do
       api_basic_authorize collection_action_identifier(:orchestration_templates, :edit)
 
       edited_name = "Edited Hot Template"
-      run_post(orchestration_templates_url(hot.id), gen_request(:edit, :name => edited_name))
+      run_post(api_orchestration_template_url(nil, hot), gen_request(:edit, :name => edited_name))
 
       expect(hot.reload.name).to eq(edited_name)
     end
@@ -106,7 +106,7 @@ RSpec.describe 'Orchestration Template API' do
 
       api_basic_authorize collection_action_identifier(:orchestration_templates, :delete)
 
-      run_delete(orchestration_templates_url(cfn.id))
+      run_delete(api_orchestration_template_url(nil, cfn))
 
       expect(response).to have_http_status(:no_content)
       expect(OrchestrationTemplate.exists?(cfn.id)).to be_falsey
@@ -118,7 +118,7 @@ RSpec.describe 'Orchestration Template API' do
       cfn = FactoryGirl.create(:orchestration_template_vnfd_with_content)
       api_basic_authorize collection_action_identifier(:orchestration_templates, :delete)
       expect_any_instance_of(OrchestrationTemplateVnfd).to receive(:raw_destroy).with(no_args) # callback on the model
-      run_delete(orchestration_templates_url(cfn.id))
+      run_delete(api_orchestration_template_url(nil, cfn))
 
       expect(response).to have_http_status(:no_content)
       expect(OrchestrationTemplate.exists?(cfn.id)).to be_falsey
@@ -130,7 +130,7 @@ RSpec.describe 'Orchestration Template API' do
       cfn = FactoryGirl.create(:orchestration_template_cfn_with_content)
       hot = FactoryGirl.create(:orchestration_template_hot_with_content)
 
-      run_post(orchestration_templates_url,
+      run_post(api_orchestration_templates_url,
                gen_request(:delete, [{'id' => cfn.id}, {'id' => hot.id}]))
 
       expected = {
@@ -154,7 +154,7 @@ RSpec.describe 'Orchestration Template API' do
       new_content            = "{ 'Description': 'Test content 1' }\n"
 
       run_post(
-        orchestration_templates_url(orchestration_template.id),
+        api_orchestration_template_url(nil, orchestration_template),
         gen_request(:copy, :content => new_content)
       )
 
@@ -166,7 +166,7 @@ RSpec.describe 'Orchestration Template API' do
 
       orchestration_template = FactoryGirl.create(:orchestration_template_cfn)
 
-      run_post(orchestration_templates_url(orchestration_template.id), gen_request(:copy))
+      run_post(api_orchestration_template_url(nil, orchestration_template), gen_request(:copy))
 
       expect(response).to have_http_status(:bad_request)
     end
@@ -187,7 +187,7 @@ RSpec.describe 'Orchestration Template API' do
 
       expect do
         run_post(
-          orchestration_templates_url(orchestration_template.id),
+          api_orchestration_template_url(nil, orchestration_template),
           gen_request(:copy, :content => new_content)
         )
       end.to change(OrchestrationTemplateCfn, :count).by(1)
@@ -214,7 +214,7 @@ RSpec.describe 'Orchestration Template API' do
 
       expect do
         run_post(
-          orchestration_templates_url,
+          api_orchestration_templates_url,
           gen_request(
             :copy,
             [

--- a/spec/requests/physical_servers_spec.rb
+++ b/spec/requests/physical_servers_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server, :ems_ref => "A59D5B36821111E1A9F5E41F13ED4F6A")
 
         api_basic_authorize action_identifier(:physical_servers, :read, :resource_actions, :get)
-        run_get physical_servers_url(ps.id)
+        run_get api_physical_server_url(nil, ps)
 
         expect_single_resource_query("ems_ref" => "A59D5B36821111E1A9F5E41F13ED4F6A")
       end
@@ -18,7 +18,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :power_on, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:power_on))
+        run_post(api_physical_server_url(nil, ps), gen_request(:power_on))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -28,7 +28,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :power_off, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:power_off))
+        run_post(api_physical_server_url(nil, ps), gen_request(:power_off))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -38,7 +38,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :power_off_now, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:power_off_now))
+        run_post(api_physical_server_url(nil, ps), gen_request(:power_off_now))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -48,7 +48,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :restart, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:restart))
+        run_post(api_physical_server_url(nil, ps), gen_request(:restart))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -58,7 +58,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :restart_now, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:restart_now))
+        run_post(api_physical_server_url(nil, ps), gen_request(:restart_now))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -68,7 +68,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :restart_to_sys_setup, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:restart_to_sys_setup))
+        run_post(api_physical_server_url(nil, ps), gen_request(:restart_to_sys_setup))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -78,7 +78,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :restart_mgmt_controller, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:restart_mgmt_controller))
+        run_post(api_physical_server_url(nil, ps), gen_request(:restart_mgmt_controller))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -90,7 +90,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:power_on))
+        run_post(api_physical_server_url(nil, ps), gen_request(:power_on))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -100,7 +100,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:power_off))
+        run_post(api_physical_server_url(nil, ps), gen_request(:power_off))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -110,7 +110,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:power_off_now))
+        run_post(api_physical_server_url(nil, ps), gen_request(:power_off_now))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -120,7 +120,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:restart))
+        run_post(api_physical_server_url(nil, ps), gen_request(:restart))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -130,7 +130,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:restart_now))
+        run_post(api_physical_server_url(nil, ps), gen_request(:restart_now))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -140,7 +140,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:restart_to_sys_setup))
+        run_post(api_physical_server_url(nil, ps), gen_request(:restart_to_sys_setup))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -150,7 +150,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:restart_mgmt_controller))
+        run_post(api_physical_server_url(nil, ps), gen_request(:restart_mgmt_controller))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -164,7 +164,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :turn_on_loc_led, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:turn_on_loc_led))
+        run_post(api_physical_server_url(nil, ps), gen_request(:turn_on_loc_led))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -174,7 +174,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :turn_off_loc_led, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:turn_off_loc_led))
+        run_post(api_physical_server_url(nil, ps), gen_request(:turn_off_loc_led))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -184,7 +184,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize action_identifier(:physical_servers, :blink_loc_led, :resource_actions, :post)
-        run_post(physical_servers_url(ps.id), gen_request(:blink_loc_led))
+        run_post(api_physical_server_url(nil, ps), gen_request(:blink_loc_led))
 
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
@@ -196,7 +196,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:turn_on_loc_led))
+        run_post(api_physical_server_url(nil, ps), gen_request(:turn_on_loc_led))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -206,7 +206,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:turn_off_loc_led))
+        run_post(api_physical_server_url(nil, ps), gen_request(:turn_off_loc_led))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
@@ -216,7 +216,7 @@ RSpec.describe "physical_servers API" do
         ps = FactoryGirl.create(:physical_server)
 
         api_basic_authorize
-        run_post(physical_servers_url(ps.id), gen_request(:blink_loc_led))
+        run_post(api_physical_server_url(nil, ps), gen_request(:blink_loc_led))
 
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")

--- a/spec/requests/picture_spec.rb
+++ b/spec/requests/picture_spec.rb
@@ -36,7 +36,7 @@ describe "Pictures" do
     it "allows queries of the related picture and image_href" do
       api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
 
-      run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
+      run_get api_service_template_url(nil, template), :attributes => "picture,picture.image_href"
 
       expect_result_to_include_picture_href(template.compressed_id)
     end
@@ -46,7 +46,7 @@ describe "Pictures" do
     it "allows queries of the related picture and image_href" do
       api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
 
-      run_get services_url(service.id), :attributes => "picture,picture.image_href"
+      run_get api_service_url(nil, service), :attributes => "picture,picture.image_href"
 
       expect_result_to_include_picture_href(service.compressed_id)
     end
@@ -56,7 +56,7 @@ describe "Pictures" do
     it "allows queries of the related picture and image_href" do
       api_basic_authorize action_identifier(:service_requests, :read, :resource_actions, :get)
 
-      run_get service_requests_url(service_request.id), :attributes => "picture,picture.image_href"
+      run_get api_service_request_url(nil, service_request), :attributes => "picture,picture.image_href"
 
       expect_result_to_include_picture_href(service_request.compressed_id)
     end
@@ -82,7 +82,7 @@ describe "Pictures" do
     it 'rejects create without an appropriate role' do
       api_basic_authorize
 
-      run_post pictures_url, :extension => 'png', :content => content
+      run_post api_pictures_url, :extension => 'png', :content => content
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -95,7 +95,7 @@ describe "Pictures" do
       }
 
       expect do
-        run_post pictures_url, :extension => 'png', :content => content
+        run_post api_pictures_url, :extension => 'png', :content => content
       end.to change(Picture, :count).by(1)
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -109,7 +109,7 @@ describe "Pictures" do
       }
 
       expect do
-        run_post(pictures_url, gen_request(:create, [
+        run_post(api_pictures_url, gen_request(:create, [
                                              {:extension => 'png', :content => content},
                                              {:extension => 'jpg', :content => content}
                                            ]))
@@ -121,7 +121,7 @@ describe "Pictures" do
     it 'requires an extension' do
       api_basic_authorize collection_action_identifier(:pictures, :create)
 
-      run_post pictures_url, :content => content
+      run_post api_pictures_url, :content => content
 
       expected = {
         'error' => a_hash_including(
@@ -135,7 +135,7 @@ describe "Pictures" do
     it 'requires content' do
       api_basic_authorize collection_action_identifier(:pictures, :create)
 
-      run_post pictures_url, :extension => 'png'
+      run_post api_pictures_url, :extension => 'png'
 
       expected = {
         'error' => a_hash_including(
@@ -149,7 +149,7 @@ describe "Pictures" do
     it 'requires content with valid base64' do
       api_basic_authorize collection_action_identifier(:pictures, :create)
 
-      run_post pictures_url, :content => 'not base64', :extension => 'png'
+      run_post api_pictures_url, :content => 'not base64', :extension => 'png'
 
       expected = {
         'error' => a_hash_including(

--- a/spec/requests/policies_assignment_spec.rb
+++ b/spec/requests/policies_assignment_spec.rb
@@ -44,39 +44,39 @@ describe "Policies Assignment API" do
     ps2.add_member(p3)
   end
 
-  def test_policy_assign_no_role(object_policies_url)
+  def test_policy_assign_no_role(api_object_policies_url)
     api_basic_authorize
 
-    run_post(object_policies_url, gen_request(:assign))
+    run_post(api_object_policies_url, gen_request(:assign))
 
     expect(response).to have_http_status(:forbidden)
   end
 
-  def test_policy_assign_invalid_policy(object_policies_url, collection, subcollection)
+  def test_policy_assign_invalid_policy(api_object_policies_url, collection, subcollection)
     api_basic_authorize subcollection_action_identifier(collection, subcollection, :assign)
 
-    run_post(object_policies_url, gen_request(:assign, :href => "/api/#{subcollection}/999999"))
+    run_post(api_object_policies_url, gen_request(:assign, :href => "/api/#{subcollection}/999999"))
 
     expect(response).to have_http_status(:not_found)
   end
 
-  def test_policy_assign_invalid_policy_guid(object_url, object_policies_url, collection, subcollection)
+  def test_policy_assign_invalid_policy_guid(object_url, api_object_policies_url, collection, subcollection)
     api_basic_authorize subcollection_action_identifier(collection, subcollection, :assign)
 
-    run_post(object_policies_url, gen_request(:assign, :guid => "xyzzy"))
+    run_post(api_object_policies_url, gen_request(:assign, :guid => "xyzzy"))
 
     expect(response).to have_http_status(:ok)
     results_hash = [{"success" => false, "href" => object_url, "message" => /must specify a valid/i}]
     expect_results_to_match_hash("results", results_hash)
   end
 
-  def test_assign_multiple_policies(object_url, object_policies_url, collection, subcollection, options = {})
+  def test_assign_multiple_policies(object_url, api_object_policies_url, collection, subcollection, options = {})
     api_basic_authorize subcollection_action_identifier(collection, subcollection, :assign)
 
     object = options[:object]
     policies = options[:policies]
 
-    run_post(object_policies_url, gen_request(:assign, policies.collect { |p| {:guid => p.guid} }))
+    run_post(api_object_policies_url, gen_request(:assign, policies.collect { |p| {:guid => p.guid} }))
 
     expect_multiple_action_result(policies.size)
     sc_prefix = subcollection.to_s.singularize
@@ -88,38 +88,38 @@ describe "Policies Assignment API" do
     expect(object.get_policies.collect(&:guid)).to match_array(policies.collect(&:guid))
   end
 
-  def test_policy_unassign_no_role(object_policies_url)
+  def test_policy_unassign_no_role(api_object_policies_url)
     api_basic_authorize
 
-    run_post(object_policies_url, gen_request(:unassign))
+    run_post(api_object_policies_url, gen_request(:unassign))
 
     expect(response).to have_http_status(:forbidden)
   end
 
-  def test_policy_unassign_invalid_policy(object_policies_url, collection, subcollection)
+  def test_policy_unassign_invalid_policy(api_object_policies_url, collection, subcollection)
     api_basic_authorize subcollection_action_identifier(collection, subcollection, :unassign)
 
-    run_post(object_policies_url, gen_request(:unassign, :href => "/api/#{subcollection}/999999"))
+    run_post(api_object_policies_url, gen_request(:unassign, :href => "/api/#{subcollection}/999999"))
 
     expect(response).to have_http_status(:not_found)
   end
 
-  def test_policy_unassign_invalid_policy_guid(object_url, object_policies_url, collection, subcollection)
+  def test_policy_unassign_invalid_policy_guid(object_url, api_object_policies_url, collection, subcollection)
     api_basic_authorize subcollection_action_identifier(collection, subcollection, :unassign)
 
-    run_post(object_policies_url, gen_request(:unassign, :guid => "xyzzy"))
+    run_post(api_object_policies_url, gen_request(:unassign, :guid => "xyzzy"))
 
     expect(response).to have_http_status(:ok)
     results_hash = [{"success" => false, "href" => object_url, "message" => /must specify a valid/i}]
     expect_results_to_match_hash("results", results_hash)
   end
 
-  def test_unassign_multiple_policies(object_policies_url, collection, subcollection, options = {})
+  def test_unassign_multiple_policies(api_object_policies_url, collection, subcollection, options = {})
     api_basic_authorize subcollection_action_identifier(collection, subcollection, :unassign)
 
     object = options[:object]
     [p1, p2, p3].each { |p| object.add_policy(p) }
-    run_post(object_policies_url, gen_request(:unassign, [{:guid => p2.guid}, {:guid => p3.guid}]))
+    run_post(api_object_policies_url, gen_request(:unassign, [{:guid => p2.guid}, {:guid => p3.guid}]))
     object.reload
 
     expect_multiple_action_result(2)
@@ -127,12 +127,12 @@ describe "Policies Assignment API" do
     expect(object.get_policies.first.guid).to eq(p1.guid)
   end
 
-  def test_unassign_multiple_policy_profiles(object_policies_url, collection, subcollection, options = {})
+  def test_unassign_multiple_policy_profiles(api_object_policies_url, collection, subcollection, options = {})
     api_basic_authorize subcollection_action_identifier(collection, subcollection, :unassign)
 
     object = options[:object]
     [ps1, ps2].each { |ps| object.add_policy(ps) }
-    run_post(object_policies_url, gen_request(:unassign, [{:guid => ps2.guid}]))
+    run_post(api_object_policies_url, gen_request(:unassign, [{:guid => ps2.guid}]))
 
     expect_multiple_action_result(1)
     expect(object.get_policies.size).to eq(1)
@@ -140,12 +140,9 @@ describe "Policies Assignment API" do
   end
 
   context "Policy profile policies assignment" do
-    let(:policy_profile_url)            { policy_profiles_url(ps2.id) }
-    let(:policy_profile_policies_url)   { "#{policy_profile_url}/policies" }
-
     it "adds Policies to a Policy Profile" do
-      test_assign_multiple_policies(policy_profiles_url(ps2.compressed_id),
-                                    policy_profile_policies_url,
+      test_assign_multiple_policies(api_policy_profile_url(nil, ps2.compressed_id),
+                                    api_policy_profile_policies_url(nil, ps2),
                                     :policy_profiles,
                                     :policies,
                                     :object   => ps2,
@@ -153,30 +150,26 @@ describe "Policies Assignment API" do
     end
 
     it "removes Policies from a Policy Profile" do
-      test_unassign_multiple_policies(policy_profile_policies_url, :policy_profiles, :policies, :object => ps2)
+      test_unassign_multiple_policies(api_policy_profile_policies_url(nil, ps2), :policy_profiles, :policies, :object => ps2)
     end
   end
 
   context "Provider policies subcollection assignment" do
-    let(:provider_url)                  { providers_url(provider.id) }
-    let(:provider_policies_url)         { "#{provider_url}/policies" }
-    let(:provider_policy_profiles_url)  { "#{provider_url}/policy_profiles" }
-
     it "assign Provider policy without approriate role" do
-      test_policy_assign_no_role(provider_policies_url)
+      test_policy_assign_no_role(api_provider_policies_url(nil, provider))
     end
 
     it "assign Provider policy with invalid href" do
-      test_policy_assign_invalid_policy(provider_policies_url, :providers, :policies)
+      test_policy_assign_invalid_policy(api_provider_policies_url(nil, provider), :providers, :policies)
     end
 
     it "assign Provider policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(providers_url(provider.compressed_id), provider_policies_url, :providers, :policies)
+      test_policy_assign_invalid_policy_guid(api_provider_url(nil, provider.compressed_id), api_provider_policies_url(nil, provider), :providers, :policies)
     end
 
     it "assign Provider multiple policies" do
-      test_assign_multiple_policies(providers_url(provider.compressed_id),
-                                    provider_policies_url,
+      test_assign_multiple_policies(api_provider_url(nil, provider.compressed_id),
+                                    api_provider_policies_url(nil, provider),
                                     :providers,
                                     :policies,
                                     :object   => provider,
@@ -184,42 +177,38 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Provider policy without approriate role" do
-      test_policy_unassign_no_role(provider_policies_url)
+      test_policy_unassign_no_role(api_provider_policies_url(nil, provider))
     end
 
     it "unassign Provider policy with invalid href" do
-      test_policy_unassign_invalid_policy(provider_policies_url, :providers, :policies)
+      test_policy_unassign_invalid_policy(api_provider_policies_url(nil, provider), :providers, :policies)
     end
 
     it "unassign Provider policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(providers_url(provider.compressed_id), provider_policies_url, :providers, :policies)
+      test_policy_unassign_invalid_policy_guid(api_provider_url(nil, provider.compressed_id), api_provider_policies_url(nil, provider), :providers, :policies)
     end
 
     it "unassign Provider multiple policies" do
-      test_unassign_multiple_policies(provider_policies_url, :providers, :policies, :object => provider)
+      test_unassign_multiple_policies(api_provider_policies_url(nil, provider), :providers, :policies, :object => provider)
     end
   end
 
   context "Provider policy profiles subcollection assignment" do
-    let(:provider_url)                  { providers_url(provider.id) }
-    let(:provider_policies_url)         { "#{provider_url}/policies" }
-    let(:provider_policy_profiles_url)  { "#{provider_url}/policy_profiles" }
-
     it "assign Provider policy profile without approriate role" do
-      test_policy_assign_no_role(provider_policy_profiles_url)
+      test_policy_assign_no_role(api_provider_policy_profiles_url(nil, provider))
     end
 
     it "assign Provider policy profile with invalid href" do
-      test_policy_assign_invalid_policy(provider_policy_profiles_url, :providers, :policy_profiles)
+      test_policy_assign_invalid_policy(api_provider_policy_profiles_url(nil, provider), :providers, :policy_profiles)
     end
 
     it "assign Provider policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(providers_url(provider.compressed_id), provider_policy_profiles_url, :providers, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_provider_url(nil, provider.compressed_id), api_provider_policy_profiles_url(nil, provider), :providers, :policy_profiles)
     end
 
     it "assign Provider multiple policy profiles" do
-      test_assign_multiple_policies(providers_url(provider.compressed_id),
-                                    provider_policy_profiles_url,
+      test_assign_multiple_policies(api_provider_url(nil, provider.compressed_id),
+                                    api_provider_policy_profiles_url(nil, provider),
                                     :providers,
                                     :policy_profiles,
                                     :object   => provider,
@@ -227,22 +216,22 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Provider policy profile without approriate role" do
-      test_policy_unassign_no_role(provider_policy_profiles_url)
+      test_policy_unassign_no_role(api_provider_policy_profiles_url(nil, provider))
     end
 
     it "unassign Provider policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(provider_policy_profiles_url, :providers, :policy_profiles)
+      test_policy_unassign_invalid_policy(api_provider_policy_profiles_url(nil, provider), :providers, :policy_profiles)
     end
 
     it "unassign Provider policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(providers_url(provider.compressed_id),
-                                               provider_policy_profiles_url,
+      test_policy_unassign_invalid_policy_guid(api_provider_url(nil, provider.compressed_id),
+                                               api_provider_policy_profiles_url(nil, provider),
                                                :providers,
                                                :policy_profiles)
     end
 
     it "unassign Provider multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(provider_policy_profiles_url,
+      test_unassign_multiple_policy_profiles(api_provider_policy_profiles_url(nil, provider),
                                              :providers,
                                              :policy_profiles,
                                              :object => provider)
@@ -250,25 +239,21 @@ describe "Policies Assignment API" do
   end
 
   context "Host policies subcollection assignments" do
-    let(:host_url)                  { hosts_url(host.id) }
-    let(:host_policies_url)         { "#{host_url}/policies" }
-    let(:host_policy_profiles_url)  { "#{host_url}/policy_profiles" }
-
     it "assign Host policy without approriate role" do
-      test_policy_assign_no_role(host_policies_url)
+      test_policy_assign_no_role(api_host_policies_url(nil, host))
     end
 
     it "assign Host policy with invalid href" do
-      test_policy_assign_invalid_policy(host_policies_url, :hosts, :policies)
+      test_policy_assign_invalid_policy(api_host_policies_url(nil, host), :hosts, :policies)
     end
 
     it "assign Host policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(hosts_url(host.compressed_id), host_policies_url, :hosts, :policies)
+      test_policy_assign_invalid_policy_guid(api_host_url(nil, host.compressed_id), api_host_policies_url(nil, host), :hosts, :policies)
     end
 
     it "assign Host multiple policies" do
-      test_assign_multiple_policies(hosts_url(host.compressed_id),
-                                    host_policies_url,
+      test_assign_multiple_policies(api_host_url(nil, host.compressed_id),
+                                    api_host_policies_url(nil, host),
                                     :hosts,
                                     :policies,
                                     :object   => host,
@@ -276,42 +261,38 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Host policy without approriate role" do
-      test_policy_unassign_no_role(host_policies_url)
+      test_policy_unassign_no_role(api_host_policies_url(nil, host))
     end
 
     it "unassign Host policy with invalid href" do
-      test_policy_unassign_invalid_policy(host_policies_url, :hosts, :policies)
+      test_policy_unassign_invalid_policy(api_host_policies_url(nil, host), :hosts, :policies)
     end
 
     it "unassign Host policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(hosts_url(host.compressed_id), host_policies_url, :hosts, :policies)
+      test_policy_unassign_invalid_policy_guid(api_host_url(nil, host.compressed_id), api_host_policies_url(nil, host), :hosts, :policies)
     end
 
     it "unassign Host multiple policies" do
-      test_unassign_multiple_policies(host_policies_url, :hosts, :policies, :object => host)
+      test_unassign_multiple_policies(api_host_policies_url(nil, host), :hosts, :policies, :object => host)
     end
   end
 
   context "Host policy profiles subcollection assignments" do
-    let(:host_url)                  { hosts_url(host.id) }
-    let(:host_policies_url)         { "#{host_url}/policies" }
-    let(:host_policy_profiles_url)  { "#{host_url}/policy_profiles" }
-
     it "assign Host policy profile without approriate role" do
-      test_policy_assign_no_role(host_policy_profiles_url)
+      test_policy_assign_no_role(api_host_policy_profiles_url(nil, host))
     end
 
     it "assign Host policy profile with invalid href" do
-      test_policy_assign_invalid_policy(host_policy_profiles_url, :hosts, :policy_profiles)
+      test_policy_assign_invalid_policy(api_host_policy_profiles_url(nil, host), :hosts, :policy_profiles)
     end
 
     it "assign Host policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(hosts_url(host.compressed_id), host_policy_profiles_url, :hosts, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_host_url(nil, host.compressed_id), api_host_policy_profiles_url(nil, host), :hosts, :policy_profiles)
     end
 
     it "assign Host multiple policy profiles" do
-      test_assign_multiple_policies(hosts_url(host.compressed_id),
-                                    host_policy_profiles_url,
+      test_assign_multiple_policies(api_host_url(nil, host.compressed_id),
+                                    api_host_policy_profiles_url(nil, host),
                                     :hosts,
                                     :policy_profiles,
                                     :object   => host,
@@ -319,22 +300,22 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Host policy profile without approriate role" do
-      test_policy_unassign_no_role(host_policy_profiles_url)
+      test_policy_unassign_no_role(api_host_policy_profiles_url(nil, host))
     end
 
     it "unassign Host policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(host_policy_profiles_url, :hosts, :policy_profiles)
+      test_policy_unassign_invalid_policy(api_host_policy_profiles_url(nil, host), :hosts, :policy_profiles)
     end
 
     it "unassign Host policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(hosts_url(host.compressed_id),
-                                               host_policy_profiles_url,
+      test_policy_unassign_invalid_policy_guid(api_host_url(nil, host.compressed_id),
+                                               api_host_policy_profiles_url(nil, host),
                                                :hosts,
                                                :policy_profiles)
     end
 
     it "unassign Host multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(host_policy_profiles_url,
+      test_unassign_multiple_policy_profiles(api_host_policy_profiles_url(nil, host),
                                              :hosts,
                                              :policy_profiles,
                                              :object => host)
@@ -342,25 +323,21 @@ describe "Policies Assignment API" do
   end
 
   context "Resource Pool policies subcollection assignments" do
-    let(:rp_url)                  { resource_pools_url(rp.id) }
-    let(:rp_policies_url)         { "#{rp_url}/policies" }
-    let(:rp_policy_profiles_url)  { "#{rp_url}/policy_profiles" }
-
     it "assign Resource Pool policy without appropriate role" do
-      test_policy_assign_no_role(rp_policies_url)
+      test_policy_assign_no_role(api_resource_pool_policies_url(nil, rp))
     end
 
     it "assign Resource Pool policy with invalid href" do
-      test_policy_assign_invalid_policy(rp_policies_url, :resource_pools, :policies)
+      test_policy_assign_invalid_policy(api_resource_pool_policies_url(nil, rp), :resource_pools, :policies)
     end
 
     it "assign Resource Pool policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(resource_pools_url(rp.compressed_id), rp_policies_url, :resource_pools, :policies)
+      test_policy_assign_invalid_policy_guid(api_resource_pool_url(nil, rp.compressed_id), api_resource_pool_policies_url(nil, rp), :resource_pools, :policies)
     end
 
     it "assign Resource Pool multiple policies" do
-      test_assign_multiple_policies(resource_pools_url(rp.compressed_id),
-                                    rp_policies_url,
+      test_assign_multiple_policies(api_resource_pool_url(nil, rp.compressed_id),
+                                    api_resource_pool_policies_url(nil, rp),
                                     :resource_pools,
                                     :policies,
                                     :object   => rp,
@@ -368,42 +345,38 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Resource Pool policy without approriate role" do
-      test_policy_unassign_no_role(rp_policies_url)
+      test_policy_unassign_no_role(api_resource_pool_policies_url(nil, rp))
     end
 
     it "unassign Resource Pool policy with invalid href" do
-      test_policy_unassign_invalid_policy(rp_policies_url, :resource_pools, :policies)
+      test_policy_unassign_invalid_policy(api_resource_pool_policies_url(nil, rp), :resource_pools, :policies)
     end
 
     it "unassign Resource Pool policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(resource_pools_url(rp.compressed_id), rp_policies_url, :resource_pools, :policies)
+      test_policy_unassign_invalid_policy_guid(api_resource_pool_url(nil, rp.compressed_id), api_resource_pool_policies_url(nil, rp), :resource_pools, :policies)
     end
 
     it "unassign Resource Pool multiple policies" do
-      test_unassign_multiple_policies(rp_policies_url, :resource_pools, :policies, :object => rp)
+      test_unassign_multiple_policies(api_resource_pool_policies_url(nil, rp), :resource_pools, :policies, :object => rp)
     end
   end
 
   context "Resource Pool policy profiles subcollection assignments" do
-    let(:rp_url)                  { resource_pools_url(rp.id) }
-    let(:rp_policies_url)         { "#{rp_url}/policies" }
-    let(:rp_policy_profiles_url)  { "#{rp_url}/policy_profiles" }
-
     it "assign Resource Pool policy profile without approriate role" do
-      test_policy_assign_no_role(rp_policy_profiles_url)
+      test_policy_assign_no_role(api_resource_pool_policy_profiles_url(nil, rp))
     end
 
     it "assign Resource Pool policy profile with invalid href" do
-      test_policy_assign_invalid_policy(rp_policy_profiles_url, :resource_pools, :policy_profiles)
+      test_policy_assign_invalid_policy(api_resource_pool_policy_profiles_url(nil, rp), :resource_pools, :policy_profiles)
     end
 
     it "assign Resource Pool policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(resource_pools_url(rp.compressed_id), rp_policy_profiles_url, :resource_pools, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_resource_pool_url(nil, rp.compressed_id), api_resource_pool_policy_profiles_url(nil, rp), :resource_pools, :policy_profiles)
     end
 
     it "assign Resource Pool multiple policy profiles" do
-      test_assign_multiple_policies(resource_pools_url(rp.compressed_id),
-                                    rp_policy_profiles_url,
+      test_assign_multiple_policies(api_resource_pool_url(nil, rp.compressed_id),
+                                    api_resource_pool_policy_profiles_url(nil, rp),
                                     :resource_pools,
                                     :policy_profiles,
                                     :object   => rp,
@@ -411,22 +384,22 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Resource Pool policy profile without approriate role" do
-      test_policy_unassign_no_role(rp_policy_profiles_url)
+      test_policy_unassign_no_role(api_resource_pool_policy_profiles_url(nil, rp))
     end
 
     it "unassign Resource Pool policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(rp_policy_profiles_url, :resource_pools, :policy_profiles)
+      test_policy_unassign_invalid_policy(api_resource_pool_policy_profiles_url(nil, rp), :resource_pools, :policy_profiles)
     end
 
     it "unassign Resource Pool policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(resource_pools_url(rp.compressed_id),
-                                               rp_policy_profiles_url,
+      test_policy_unassign_invalid_policy_guid(api_resource_pool_url(nil, rp.compressed_id),
+                                               api_resource_pool_policy_profiles_url(nil, rp),
                                                :resource_pools,
                                                :policy_profiles)
     end
 
     it "unassign Resource Pool multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(rp_policy_profiles_url,
+      test_unassign_multiple_policy_profiles(api_resource_pool_policy_profiles_url(nil, rp),
                                              :resource_pools,
                                              :policy_profiles,
                                              :object => rp)
@@ -434,25 +407,21 @@ describe "Policies Assignment API" do
   end
 
   context "Cluster policies subcollection assignments" do
-    let(:cluster_url)                 { clusters_url(cluster.id) }
-    let(:cluster_policies_url)        { "#{cluster_url}/policies" }
-    let(:cluster_policy_profiles_url) { "#{cluster_url}/policy_profiles" }
-
     it "assign Cluster policy without approriate role" do
-      test_policy_assign_no_role(cluster_policies_url)
+      test_policy_assign_no_role(api_cluster_policies_url(nil, cluster))
     end
 
     it "assign Cluster policy with invalid href" do
-      test_policy_assign_invalid_policy(cluster_policies_url, :clusters, :policies)
+      test_policy_assign_invalid_policy(api_cluster_policies_url(nil, cluster), :clusters, :policies)
     end
 
     it "assign Cluster policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(clusters_url(cluster.compressed_id), cluster_policies_url, :clusters, :policies)
+      test_policy_assign_invalid_policy_guid(api_cluster_url(nil, cluster.compressed_id), api_cluster_policies_url(nil, cluster), :clusters, :policies)
     end
 
     it "assign Cluster multiple policies" do
-      test_assign_multiple_policies(clusters_url(cluster.compressed_id),
-                                    cluster_policies_url,
+      test_assign_multiple_policies(api_cluster_url(nil, cluster.compressed_id),
+                                    api_cluster_policies_url(nil, cluster),
                                     :clusters,
                                     :policies,
                                     :object   => cluster,
@@ -460,42 +429,38 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Cluster policy without approriate role" do
-      test_policy_unassign_no_role(cluster_policies_url)
+      test_policy_unassign_no_role(api_cluster_policies_url(nil, cluster))
     end
 
     it "unassign Cluster policy with invalid href" do
-      test_policy_unassign_invalid_policy(cluster_policies_url, :clusters, :policies)
+      test_policy_unassign_invalid_policy(api_cluster_policies_url(nil, cluster), :clusters, :policies)
     end
 
     it "unassign Cluster policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(clusters_url(cluster.compressed_id), cluster_policies_url, :clusters, :policies)
+      test_policy_unassign_invalid_policy_guid(api_cluster_url(nil, cluster.compressed_id), api_cluster_policies_url(nil, cluster), :clusters, :policies)
     end
 
     it "unassign Cluster multiple policies" do
-      test_unassign_multiple_policies(cluster_policies_url, :clusters, :policies, :object => cluster)
+      test_unassign_multiple_policies(api_cluster_policies_url(nil, cluster), :clusters, :policies, :object => cluster)
     end
   end
 
   context "Cluster policy profiles subcollection assignments" do
-    let(:cluster_url)                 { clusters_url(cluster.id) }
-    let(:cluster_policies_url)        { "#{cluster_url}/policies" }
-    let(:cluster_policy_profiles_url) { "#{cluster_url}/policy_profiles" }
-
     it "assign Cluster policy profile without approriate role" do
-      test_policy_assign_no_role(cluster_policy_profiles_url)
+      test_policy_assign_no_role(api_cluster_policy_profiles_url(nil, cluster))
     end
 
     it "assign Cluster policy profile with invalid href" do
-      test_policy_assign_invalid_policy(cluster_policy_profiles_url, :clusters, :policy_profiles)
+      test_policy_assign_invalid_policy(api_cluster_policy_profiles_url(nil, cluster), :clusters, :policy_profiles)
     end
 
     it "assign Cluster policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(clusters_url(cluster.compressed_id), cluster_policy_profiles_url, :clusters, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_cluster_url(nil, cluster.compressed_id), api_cluster_policy_profiles_url(nil, cluster), :clusters, :policy_profiles)
     end
 
     it "assign Cluster multiple policy profiles" do
-      test_assign_multiple_policies(clusters_url(cluster.compressed_id),
-                                    cluster_policy_profiles_url,
+      test_assign_multiple_policies(api_cluster_url(nil, cluster.compressed_id),
+                                    api_cluster_policy_profiles_url(nil, cluster),
                                     :clusters,
                                     :policy_profiles,
                                     :object   => cluster,
@@ -503,22 +468,22 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Cluster policy profile without approriate role" do
-      test_policy_unassign_no_role(cluster_policy_profiles_url)
+      test_policy_unassign_no_role(api_cluster_policy_profiles_url(nil, cluster))
     end
 
     it "unassign Cluster policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(cluster_policy_profiles_url, :clusters, :policy_profiles)
+      test_policy_unassign_invalid_policy(api_cluster_policy_profiles_url(nil, cluster), :clusters, :policy_profiles)
     end
 
     it "unassign Cluster policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(clusters_url(cluster.compressed_id),
-                                               cluster_policy_profiles_url,
+      test_policy_unassign_invalid_policy_guid(api_cluster_url(nil, cluster.compressed_id),
+                                               api_cluster_policy_profiles_url(nil, cluster),
                                                :clusters,
                                                :policy_profiles)
     end
 
     it "unassign Cluster multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(cluster_policy_profiles_url,
+      test_unassign_multiple_policy_profiles(api_cluster_policy_profiles_url(nil, cluster),
                                              :clusters,
                                              :policy_profiles,
                                              :object => cluster)
@@ -526,25 +491,21 @@ describe "Policies Assignment API" do
   end
 
   context "Vms policies subcollection assignments" do
-    let(:vm_url)                  { vms_url(vm.id) }
-    let(:vm_policies_url)         { "#{vm_url}/policies" }
-    let(:vm_policy_profiles_url)  { "#{vm_url}/policy_profiles" }
-
     it "assign Vm policy without approriate role" do
-      test_policy_assign_no_role(vm_policies_url)
+      test_policy_assign_no_role(api_vm_policies_url(nil, vm))
     end
 
     it "assign Vm policy with invalid href" do
-      test_policy_assign_invalid_policy(vm_policies_url, :vms, :policies)
+      test_policy_assign_invalid_policy(api_vm_policies_url(nil, vm), :vms, :policies)
     end
 
     it "assign Vm policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(vms_url(vm.compressed_id), vm_policies_url, :vms, :policies)
+      test_policy_assign_invalid_policy_guid(api_vm_url(nil, vm.compressed_id), api_vm_policies_url(nil, vm), :vms, :policies)
     end
 
     it "assign Vm multiple policies" do
-      test_assign_multiple_policies(vms_url(vm.compressed_id),
-                                    vm_policies_url,
+      test_assign_multiple_policies(api_vm_url(nil, vm.compressed_id),
+                                    api_vm_policies_url(nil, vm),
                                     :vms,
                                     :policies,
                                     :object   => vm,
@@ -552,42 +513,38 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Vm policy without approriate role" do
-      test_policy_unassign_no_role(vm_policies_url)
+      test_policy_unassign_no_role(api_vm_policies_url(nil, vm))
     end
 
     it "unassign Vm policy with invalid href" do
-      test_policy_unassign_invalid_policy(vm_policies_url, :vms, :policies)
+      test_policy_unassign_invalid_policy(api_vm_policies_url(nil, vm), :vms, :policies)
     end
 
     it "unassign Vm policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(vms_url(vm.compressed_id), vm_policies_url, :vms, :policies)
+      test_policy_unassign_invalid_policy_guid(api_vm_url(nil, vm.compressed_id), api_vm_policies_url(nil, vm), :vms, :policies)
     end
 
     it "unassign Vm multiple policies" do
-      test_unassign_multiple_policies(vm_policies_url, :vms, :policies, :object => vm)
+      test_unassign_multiple_policies(api_vm_policies_url(nil, vm), :vms, :policies, :object => vm)
     end
   end
 
   context "Vms policy profiles subcollection assignments" do
-    let(:vm_url)                  { vms_url(vm.id) }
-    let(:vm_policies_url)         { "#{vm_url}/policies" }
-    let(:vm_policy_profiles_url)  { "#{vm_url}/policy_profiles" }
-
     it "assign Vm policy profile without approriate role" do
-      test_policy_assign_no_role(vm_policy_profiles_url)
+      test_policy_assign_no_role(api_vm_policy_profiles_url(nil, vm))
     end
 
     it "assign Vm policy profile with invalid href" do
-      test_policy_assign_invalid_policy(vm_policy_profiles_url, :vms, :policy_profiles)
+      test_policy_assign_invalid_policy(api_vm_policy_profiles_url(nil, vm), :vms, :policy_profiles)
     end
 
     it "assign Vm policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(vms_url(vm.compressed_id), vm_policy_profiles_url, :vms, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_vm_url(nil, vm.compressed_id), api_vm_policy_profiles_url(nil, vm), :vms, :policy_profiles)
     end
 
     it "assign Vm multiple policy profiles" do
-      test_assign_multiple_policies(vms_url(vm.compressed_id),
-                                    vm_policy_profiles_url,
+      test_assign_multiple_policies(api_vm_url(nil, vm.compressed_id),
+                                    api_vm_policy_profiles_url(nil, vm),
                                     :vms,
                                     :policy_profiles,
                                     :object   => vm,
@@ -595,22 +552,22 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Vm policy profile without approriate role" do
-      test_policy_unassign_no_role(vm_policy_profiles_url)
+      test_policy_unassign_no_role(api_vm_policy_profiles_url(nil, vm))
     end
 
     it "unassign Vm policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(vm_policy_profiles_url, :vms, :policy_profiles)
+      test_policy_unassign_invalid_policy(api_vm_policy_profiles_url(nil, vm), :vms, :policy_profiles)
     end
 
     it "unassign Vm policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(vms_url(vm.compressed_id),
-                                               vm_policy_profiles_url,
+      test_policy_unassign_invalid_policy_guid(api_vm_url(nil, vm.compressed_id),
+                                               api_vm_policy_profiles_url(nil, vm),
                                                :vms,
                                                :policy_profiles)
     end
 
     it "unassign Vm multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(vm_policy_profiles_url,
+      test_unassign_multiple_policy_profiles(api_vm_policy_profiles_url(nil, vm),
                                              :vms,
                                              :policy_profiles,
                                              :object => vm)
@@ -618,25 +575,21 @@ describe "Policies Assignment API" do
   end
 
   context "Template policies subcollection assignments" do
-    let(:template_url)                  { templates_url(template.id) }
-    let(:template_policies_url)         { "#{template_url}/policies" }
-    let(:template_policy_profiles_url)  { "#{template_url}/policy_profiles" }
-
     it "assign Template policy without approriate role" do
-      test_policy_assign_no_role(template_policies_url)
+      test_policy_assign_no_role(api_template_policies_url(nil, template))
     end
 
     it "assign Template policy with invalid href" do
-      test_policy_assign_invalid_policy(template_policies_url, :templates, :policies)
+      test_policy_assign_invalid_policy(api_template_policies_url(nil, template), :templates, :policies)
     end
 
     it "assign Template policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(templates_url(template.compressed_id), template_policies_url, :templates, :policies)
+      test_policy_assign_invalid_policy_guid(api_template_url(nil, template.compressed_id), api_template_policies_url(nil, template), :templates, :policies)
     end
 
     it "assign Template multiple policies" do
-      test_assign_multiple_policies(templates_url(template.compressed_id),
-                                    template_policies_url,
+      test_assign_multiple_policies(api_template_url(nil, template.compressed_id),
+                                    api_template_policies_url(nil, template),
                                     :templates,
                                     :policies,
                                     :object   => template,
@@ -644,42 +597,38 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Template policy without approriate role" do
-      test_policy_unassign_no_role(template_policies_url)
+      test_policy_unassign_no_role(api_template_policies_url(nil, template))
     end
 
     it "unassign Template policy with invalid href" do
-      test_policy_unassign_invalid_policy(template_policies_url, :templates, :policies)
+      test_policy_unassign_invalid_policy(api_template_policies_url(nil, template), :templates, :policies)
     end
 
     it "unassign Template policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(templates_url(template.compressed_id), template_policies_url, :templates, :policies)
+      test_policy_unassign_invalid_policy_guid(api_template_url(nil, template.compressed_id), api_template_policies_url(nil, template), :templates, :policies)
     end
 
     it "unassign Template multiple policies" do
-      test_unassign_multiple_policies(template_policies_url, :templates, :policies, :object => template)
+      test_unassign_multiple_policies(api_template_policies_url(nil, template), :templates, :policies, :object => template)
     end
   end
 
   context "Template policies subcollection assignments" do
-    let(:template_url)                  { templates_url(template.id) }
-    let(:template_policies_url)         { "#{template_url}/policies" }
-    let(:template_policy_profiles_url)  { "#{template_url}/policy_profiles" }
-
     it "assign Template policy profile without approriate role" do
-      test_policy_assign_no_role(template_policy_profiles_url)
+      test_policy_assign_no_role(api_template_policy_profiles_url(nil, template))
     end
 
     it "assign Template policy profile with invalid href" do
-      test_policy_assign_invalid_policy(template_policy_profiles_url, :templates, :policy_profiles)
+      test_policy_assign_invalid_policy(api_template_policy_profiles_url(nil, template), :templates, :policy_profiles)
     end
 
     it "assign Template policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(templates_url(template.compressed_id), template_policy_profiles_url, :templates, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_template_url(nil, template.compressed_id), api_template_policy_profiles_url(nil, template), :templates, :policy_profiles)
     end
 
     it "assign Template multiple policy profiles" do
-      test_assign_multiple_policies(templates_url(template.compressed_id),
-                                    template_policy_profiles_url,
+      test_assign_multiple_policies(api_template_url(nil, template.compressed_id),
+                                    api_template_policy_profiles_url(nil, template),
                                     :templates,
                                     :policy_profiles,
                                     :object   => template,
@@ -687,22 +636,22 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Template policy profile without approriate role" do
-      test_policy_unassign_no_role(template_policy_profiles_url)
+      test_policy_unassign_no_role(api_template_policy_profiles_url(nil, template))
     end
 
     it "unassign Template policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(template_policy_profiles_url, :templates, :policy_profiles)
+      test_policy_unassign_invalid_policy(api_template_policy_profiles_url(nil, template), :templates, :policy_profiles)
     end
 
     it "unassign Template policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(templates_url(template.compressed_id),
-                                               template_policy_profiles_url,
+      test_policy_unassign_invalid_policy_guid(api_template_url(nil, template.compressed_id),
+                                               api_template_policy_profiles_url(nil, template),
                                                :templates,
                                                :policy_profiles)
     end
 
     it "unassign Template multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(template_policy_profiles_url,
+      test_unassign_multiple_policy_profiles(api_template_policy_profiles_url(nil, template),
                                              :templates,
                                              :policy_profiles,
                                              :object => template)

--- a/spec/requests/policy_actions_spec.rb
+++ b/spec/requests/policy_actions_spec.rb
@@ -20,7 +20,7 @@ describe "Policy Actions API" do
     it "query invalid action" do
       api_basic_authorize action_identifier(:policy_actions, :read, :resource_actions, :get)
 
-      run_get policy_actions_url(999_999)
+      run_get api_policy_action_url(nil, 999_999)
 
       expect(response).to have_http_status(:not_found)
     end
@@ -28,7 +28,7 @@ describe "Policy Actions API" do
     it "query policy actions with no actions defined" do
       api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
 
-      run_get policy_actions_url
+      run_get api_policy_actions_url
 
       expect_empty_query_result(:policy_actions)
     end
@@ -37,12 +37,12 @@ describe "Policy Actions API" do
       api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
       create_actions(4)
 
-      run_get policy_actions_url
+      run_get api_policy_actions_url
 
       expect_query_result(:policy_actions, 4, 4)
       expect_result_resources_to_include_hrefs(
         "resources",
-        MiqAction.select(:id).collect { |ma| /^.*#{policy_actions_url(ma.compressed_id)}$/ }
+        MiqAction.select(:id).collect { |ma| api_policy_action_url(nil, ma.compressed_id) }
       )
     end
 
@@ -50,7 +50,7 @@ describe "Policy Actions API" do
       api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
       create_actions(4)
 
-      run_get policy_actions_url, :expand => "resources"
+      run_get api_policy_actions_url, :expand => "resources"
 
       expect_query_result(:policy_actions, 4, 4)
       expect_result_resources_to_include_data("resources", "guid" => miq_action_guid_list)
@@ -59,8 +59,6 @@ describe "Policy Actions API" do
 
   context "Policy Action subcollection" do
     let(:policy)             { FactoryGirl.create(:miq_policy, :name => "Policy 1") }
-    let(:policy_url)         { policies_url(policy.id) }
-    let(:policy_actions_url) { "#{policy_url}/policy_actions" }
 
     def relate_actions_to(policy)
       MiqAction.all.collect(&:id).each do |action_id|
@@ -71,7 +69,7 @@ describe "Policy Actions API" do
     it "query policy actions with no actions defined" do
       api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
 
-      run_get policy_actions_url
+      run_get api_policy_policy_actions_url(nil, policy)
 
       expect_empty_query_result(:policy_actions)
     end
@@ -81,7 +79,7 @@ describe "Policy Actions API" do
       create_actions(4)
       relate_actions_to(policy)
 
-      run_get policy_actions_url, :expand => "resources"
+      run_get api_policy_policy_actions_url(nil, policy), :expand => "resources"
 
       expect_query_result(:policy_actions, 4, 4)
       expect_result_resources_to_include_data("resources", "guid" => miq_action_guid_list)
@@ -92,7 +90,7 @@ describe "Policy Actions API" do
       create_actions(4)
       relate_actions_to(policy)
 
-      run_get policy_url, :expand => "policy_actions"
+      run_get api_policy_url(nil, policy), :expand => "policy_actions"
 
       expect_single_resource_query("name" => policy.name, "description" => policy.description, "guid" => policy.guid)
       expect_result_resources_to_include_data("policy_actions", "guid" => miq_action_guid_list)

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -87,7 +87,7 @@ describe "Provision Requests API" do
         }
       )
 
-      run_post(provision_requests_url, body)
+      run_post(api_provision_requests_url, body)
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
@@ -119,7 +119,7 @@ describe "Provision Requests API" do
         }
       )
 
-      run_post(provision_requests_url, body)
+      run_post(api_provision_requests_url, body)
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
@@ -148,7 +148,7 @@ describe "Provision Requests API" do
         }
       )
 
-      run_post(provision_requests_url, body)
+      run_post(api_provision_requests_url, body)
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
@@ -208,13 +208,13 @@ describe "Provision Requests API" do
       provision_request2 = FactoryGirl.create(:miq_provision_request, :requester => @user)
       api_basic_authorize collection_action_identifier(:provision_requests, :read, :get)
 
-      run_get provision_requests_url
+      run_get api_provision_requests_url
 
       expected = {
         "count"     => 2,
         "subcount"  => 1,
         "resources" => a_collection_containing_exactly(
-          "href" => a_string_matching(provision_requests_url(provision_request2.compressed_id)),
+          "href" => api_provision_request_url(nil, provision_request2.compressed_id),
         )
       }
       expect(response).to have_http_status(:ok)
@@ -228,14 +228,14 @@ describe "Provision Requests API" do
       provision_request2 = FactoryGirl.create(:miq_provision_request, :requester => @user)
       api_basic_authorize collection_action_identifier(:provision_requests, :read, :get)
 
-      run_get provision_requests_url
+      run_get api_provision_requests_url
 
       expected = {
         "count"     => 2,
         "subcount"  => 2,
         "resources" => a_collection_containing_exactly(
-          {"href" => a_string_matching(provision_requests_url(provision_request1.compressed_id))},
-          {"href" => a_string_matching(provision_requests_url(provision_request2.compressed_id))},
+          {"href" => api_provision_request_url(nil, provision_request1.compressed_id)},
+          {"href" => api_provision_request_url(nil, provision_request2.compressed_id)},
         )
       }
       expect(response).to have_http_status(:ok)
@@ -247,7 +247,7 @@ describe "Provision Requests API" do
       provision_request = FactoryGirl.create(:miq_provision_request, :requester => other_user)
       api_basic_authorize action_identifier(:provision_requests, :read, :resource_actions, :get)
 
-      run_get provision_requests_url(provision_request.id)
+      run_get api_provision_request_url(nil, provision_request)
 
       expect(response).to have_http_status(:not_found)
     end
@@ -258,11 +258,11 @@ describe "Provision Requests API" do
       provision_request = FactoryGirl.create(:miq_provision_request, :requester => other_user)
       api_basic_authorize action_identifier(:provision_requests, :read, :resource_actions, :get)
 
-      run_get provision_requests_url(provision_request.id)
+      run_get api_provision_request_url(nil, provision_request)
 
       expected = {
         "id"   => provision_request.compressed_id,
-        "href" => a_string_matching(provision_requests_url(provision_request.compressed_id))
+        "href" => api_provision_request_url(nil, provision_request.compressed_id)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -271,7 +271,7 @@ describe "Provision Requests API" do
     it "rejects requests without appropriate role" do
       api_basic_authorize
 
-      run_post(provision_requests_url, single_provision_request)
+      run_post(api_provision_requests_url, single_provision_request)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -280,7 +280,7 @@ describe "Provision Requests API" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
       dialog  # Create the Provisioning dialog
-      run_post(provision_requests_url, single_provision_request)
+      run_post(api_provision_requests_url, single_provision_request)
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -294,7 +294,7 @@ describe "Provision Requests API" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
       dialog  # Create the Provisioning dialog
-      run_post(provision_requests_url, gen_request(:create, single_provision_request))
+      run_post(api_provision_requests_url, gen_request(:create, single_provision_request))
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -308,7 +308,7 @@ describe "Provision Requests API" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
       dialog  # Create the Provisioning dialog
-      run_post(provision_requests_url, gen_request(:create, [single_provision_request, single_provision_request]))
+      run_post(api_provision_requests_url, gen_request(:create, [single_provision_request, single_provision_request]))
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -324,7 +324,7 @@ describe "Provision Requests API" do
         provision_request = FactoryGirl.create(:miq_provision_request, :requester => @user, :options => {:foo => "bar"})
         api_basic_authorize
 
-        run_post(provision_requests_url(provision_request.id), :action => "edit", :options => {:baz => "qux"})
+        run_post(api_provision_request_url(nil, provision_request), :action => "edit", :options => {:baz => "qux"})
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -333,7 +333,7 @@ describe "Provision Requests API" do
         provision_request = FactoryGirl.create(:miq_provision_request, :requester => @user, :options => {:foo => "bar"})
         api_basic_authorize(action_identifier(:provision_requests, :edit))
 
-        run_post(provision_requests_url(provision_request.id), :action => "edit", :options => {:baz => "qux"})
+        run_post(api_provision_request_url(nil, provision_request), :action => "edit", :options => {:baz => "qux"})
 
         expected = {
           "id"      => provision_request.compressed_id,
@@ -351,7 +351,7 @@ describe "Provision Requests API" do
         api_basic_authorize collection_action_identifier(:service_requests, :edit)
 
         run_post(
-          provision_requests_url,
+          api_provision_requests_url,
           :action    => "edit",
           :resources => [
             {:id => provision_request.id, :options => {:baz => "qux"}},
@@ -377,8 +377,8 @@ describe "Provision Requests API" do
     let(:provreqbody)   { {:requester => user, :source_type => 'VmOrTemplate', :source_id => template.id} }
     let(:provreq1)      { FactoryGirl.create(:miq_provision_request, provreqbody) }
     let(:provreq2)      { FactoryGirl.create(:miq_provision_request, provreqbody) }
-    let(:provreq1_url)  { provision_requests_url(provreq1.id) }
-    let(:provreq2_url)  { provision_requests_url(provreq2.id) }
+    let(:provreq1_url)  { api_provision_request_url(nil, provreq1) }
+    let(:provreq2_url)  { api_provision_request_url(nil, provreq2) }
 
     before do
       @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :role => "administrator")
@@ -390,7 +390,7 @@ describe "Provision Requests API" do
       run_post(provreq1_url, gen_request(:approve))
 
       expected_msg = "Provision request #{provreq1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => provision_requests_url(provreq1.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_provision_request_url(nil, provreq1.compressed_id))
     end
 
     it "supports denying a request" do
@@ -399,25 +399,25 @@ describe "Provision Requests API" do
       run_post(provreq2_url, gen_request(:deny))
 
       expected_msg = "Provision request #{provreq2.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => provision_requests_url(provreq2.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_provision_request_url(nil, provreq2.compressed_id))
     end
 
     it "supports approving multiple requests" do
       api_basic_authorize collection_action_identifier(:provision_requests, :approve)
 
-      run_post(provision_requests_url, gen_request(:approve, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
+      run_post(api_provision_requests_url, gen_request(:approve, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
 
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/Provision request #{provreq1.id} approved/i),
             "success" => true,
-            "href"    => a_string_matching(provision_requests_url(provreq1.compressed_id))
+            "href"    => api_provision_request_url(nil, provreq1.compressed_id)
           },
           {
             "message" => a_string_matching(/Provision request #{provreq2.id} approved/i),
             "success" => true,
-            "href"    => a_string_matching(provision_requests_url(provreq2.compressed_id))
+            "href"    => api_provision_request_url(nil, provreq2.compressed_id)
           }
         )
       }
@@ -428,19 +428,19 @@ describe "Provision Requests API" do
     it "supports denying multiple requests" do
       api_basic_authorize collection_action_identifier(:provision_requests, :approve)
 
-      run_post(provision_requests_url, gen_request(:deny, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
+      run_post(api_provision_requests_url, gen_request(:deny, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
 
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/Provision request #{provreq1.id} denied/i),
             "success" => true,
-            "href"    => a_string_matching(provision_requests_url(provreq1.compressed_id))
+            "href"    => api_provision_request_url(nil, provreq1.compressed_id)
           },
           {
             "message" => a_string_matching(/Provision request #{provreq2.id} denied/i),
             "success" => true,
-            "href"    => a_string_matching(provision_requests_url(provreq2.compressed_id))
+            "href"    => api_provision_request_url(nil, provreq2.compressed_id)
           }
         )
       }
@@ -456,20 +456,20 @@ describe "Provision Requests API" do
       FactoryGirl.create(:miq_request_task, :miq_request_id => provision_request.id)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      run_get("#{provision_requests_url(provision_request.id)}/tasks")
+      run_get("#{api_provision_request_url(nil, provision_request)}/tasks")
 
       expect(response).to have_http_status(:moved_permanently)
-      expect(response.redirect_url).to include("#{provision_requests_url(provision_request.id)}/request_tasks")
+      expect(response.redirect_url).to include("#{api_provision_request_url(nil, provision_request)}/request_tasks")
     end
 
     it 'redirects to request_tasks subresources' do
       task = FactoryGirl.create(:miq_request_task, :miq_request_id => provision_request.id)
       api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
 
-      run_get("#{provision_requests_url(provision_request.id)}/tasks/#{task.id}")
+      run_get("#{api_provision_request_url(nil, provision_request)}/tasks/#{task.id}")
 
       expect(response).to have_http_status(:moved_permanently)
-      expect(response.redirect_url).to include("#{provision_requests_url(provision_request.id)}/request_tasks/#{task.id}")
+      expect(response.redirect_url).to include("#{api_provision_request_url(nil, provision_request)}/request_tasks/#{task.id}")
     end
   end
 end

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -21,7 +21,7 @@ describe "Querying" do
     it "supports offset" do
       create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :offset => 2
+      run_get api_vms_url, :offset => 2
 
       expect_query_result(:vms, 1, 3)
     end
@@ -29,7 +29,7 @@ describe "Querying" do
     it "supports limit" do
       create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :limit => 2
+      run_get api_vms_url, :limit => 2
 
       expect_query_result(:vms, 2, 3)
     end
@@ -37,7 +37,7 @@ describe "Querying" do
     it "supports offset and limit" do
       create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :offset => 1, :limit => 1
+      run_get api_vms_url, :offset => 1, :limit => 1
 
       expect_query_result(:vms, 1, 3)
     end
@@ -45,17 +45,17 @@ describe "Querying" do
     it "supports paging via offset and limit" do
       create_vms_by_name %w(aa bb cc dd ee)
 
-      run_get vms_url, :offset => 0, :limit => 2, :sort_by => "name", :expand => "resources"
+      run_get api_vms_url, :offset => 0, :limit => 2, :sort_by => "name", :expand => "resources"
 
       expect_query_result(:vms, 2, 5)
       expect_result_resources_to_match_hash([{"name" => "aa"}, {"name" => "bb"}])
 
-      run_get vms_url, :offset => 2, :limit => 2, :sort_by => "name", :expand => "resources"
+      run_get api_vms_url, :offset => 2, :limit => 2, :sort_by => "name", :expand => "resources"
 
       expect_query_result(:vms, 2, 5)
       expect_result_resources_to_match_hash([{"name" => "cc"}, {"name" => "dd"}])
 
-      run_get vms_url, :offset => 4, :limit => 2, :sort_by => "name", :expand => "resources"
+      run_get api_vms_url, :offset => 4, :limit => 2, :sort_by => "name", :expand => "resources"
 
       expect_query_result(:vms, 1, 5)
       expect_result_resources_to_match_hash([{"name" => "ee"}])
@@ -64,7 +64,7 @@ describe "Querying" do
     it 'raises a BadRequestError for attributes that do not exist' do
       api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
 
-      run_get(vms_url(vm1.id), :attributes => 'not_an_attribute')
+      run_get(api_vm_url(nil, vm1), :attributes => 'not_an_attribute')
 
       expected = {
         'error' => a_hash_including(
@@ -79,7 +79,7 @@ describe "Querying" do
     it "returns correct paging links" do
       create_vms_by_name %w(bb ff aa cc ee gg dd)
 
-      run_get vms_url, :offset => 0, :limit => 2, :sort_by => "name", :expand => "resources"
+      run_get api_vms_url, :offset => 0, :limit => 2, :sort_by => "name", :expand => "resources"
 
       expect_query_result(:vms, 2, 7)
       expect_result_resources_to_match_hash([{"name" => "aa"}, {"name" => "bb"}])
@@ -109,7 +109,7 @@ describe "Querying" do
       expect_query_result(:vms, 2, 7)
       expect_result_resources_to_match_hash([{"name" => "ee"}, {"name" => "ff"}])
 
-      run_get vms_url, :offset => 4, :limit => 3, :sort_by => "name", :expand => "resources"
+      run_get api_vms_url, :offset => 4, :limit => 3, :sort_by => "name", :expand => "resources"
 
       expect_query_result(:vms, 3, 7)
       expect_result_resources_to_match_hash([{"name" => "ee"}, {"name" => "ff"}, {"name" => "gg"}])
@@ -119,7 +119,7 @@ describe "Querying" do
     it "only returns paging links if both offset and limit are specified" do
       create_vms_by_name %w(aa bb)
 
-      run_get vms_url, :offset => 0, :expand => :resources
+      run_get api_vms_url, :offset => 0, :expand => :resources
 
       expect(response.parsed_body.keys).to eq(%w(name count subcount resources actions))
     end
@@ -127,19 +127,19 @@ describe "Querying" do
     it "returns the correct page count" do
       create_vms_by_name %w(aa bb cc dd)
 
-      run_get vms_url, :offset => 0, :limit => 2
+      run_get api_vms_url, :offset => 0, :limit => 2
 
       expect(response.parsed_body['pages']).to eq(2)
 
-      run_get vms_url, :offset => 0, :limit => 3
+      run_get api_vms_url, :offset => 0, :limit => 3
 
       expect(response.parsed_body['pages']).to eq(2)
 
-      run_get vms_url, :offset => 0, :limit => 4
+      run_get api_vms_url, :offset => 0, :limit => 4
       expect(response.parsed_body['subquery_count']).to be_nil
       expect(response.parsed_body['pages']).to eq(1)
 
-      run_get vms_url, :offset => 0, :limit => 4, :filter => ["name='aa'", "or name='bb'"]
+      run_get api_vms_url, :offset => 0, :limit => 4, :filter => ["name='aa'", "or name='bb'"]
       expect(response.parsed_body['subquery_count']).to eq(2)
       expect(response.parsed_body['pages']).to eq(1)
     end
@@ -147,7 +147,7 @@ describe "Querying" do
     it "returns the correct pages if filters are specified" do
       create_vms_by_name %w(aa bb cc)
 
-      run_get vms_url, :sort_by => "name", :filter => ["name='aa'", "or name='bb'"], :expand => "resources", :offset => 0, :limit => 1
+      run_get api_vms_url, :sort_by => "name", :filter => ["name='aa'", "or name='bb'"], :expand => "resources", :offset => 0, :limit => 1
 
       expect_query_result(:vms, 1, 3)
       expect_result_resources_to_match_hash([{"name" => "aa"}])
@@ -164,7 +164,7 @@ describe "Querying" do
     it "returns the correct subquery_count" do
       create_vms_by_name %w(aa bb cc dd)
 
-      run_get vms_url, :sort_by => "name", :filter => ["name='aa'", "or name='bb'", "or name='dd'"], :expand => "resources", :offset => 0, :limit => 1
+      run_get api_vms_url, :sort_by => "name", :filter => ["name='aa'", "or name='bb'", "or name='dd'"], :expand => "resources", :offset => 0, :limit => 1
 
       expect(response.parsed_body["subquery_count"]).to eq(3)
       expect_query_result(:vms, 1, 4)
@@ -177,7 +177,7 @@ describe "Querying" do
     it "supports ascending order" do
       create_vms_by_name %w(cc aa bb)
 
-      run_get vms_url, :sort_by => "name", :sort_order => "asc", :expand => "resources"
+      run_get api_vms_url, :sort_by => "name", :sort_order => "asc", :expand => "resources"
 
       expect_query_result(:vms, 3, 3)
       expect_result_resources_to_match_hash([{"name" => "aa"}, {"name" => "bb"}, {"name" => "cc"}])
@@ -186,7 +186,7 @@ describe "Querying" do
     it "supports decending order" do
       create_vms_by_name %w(cc aa bb)
 
-      run_get vms_url, :sort_by => "name", :sort_order => "desc", :expand => "resources"
+      run_get api_vms_url, :sort_by => "name", :sort_order => "desc", :expand => "resources"
 
       expect_query_result(:vms, 3, 3)
       expect_result_resources_to_match_hash([{"name" => "cc"}, {"name" => "bb"}, {"name" => "aa"}])
@@ -195,7 +195,7 @@ describe "Querying" do
     it "supports case insensitive ordering" do
       create_vms_by_name %w(B c a)
 
-      run_get vms_url, :sort_by => "name", :sort_order => "asc", :sort_options => "ignore_case", :expand => "resources"
+      run_get api_vms_url, :sort_by => "name", :sort_order => "asc", :sort_options => "ignore_case", :expand => "resources"
 
       expect_query_result(:vms, 3, 3)
       expect_result_resources_to_match_hash([{"name" => "a"}, {"name" => "B"}, {"name" => "c"}])
@@ -205,7 +205,7 @@ describe "Querying" do
       FactoryGirl.create(:vm_vmware, :vendor => "vmware", :name => "vmware_vm")
       FactoryGirl.create(:vm_redhat, :vendor => "redhat", :name => "redhat_vm")
 
-      run_get vms_url, :sort_by => "vendor", :sort_order => "asc", :expand => "resources"
+      run_get api_vms_url, :sort_by => "vendor", :sort_order => "asc", :expand => "resources"
 
       expect_query_result(:vms, 2, 2)
       expect_result_resources_to_match_hash([{"name" => "redhat_vm"}, {"name" => "vmware_vm"}])
@@ -219,7 +219,7 @@ describe "Querying" do
       FactoryGirl.create(:vm, :name => 'vm_bar', :host => host_bar)
       FactoryGirl.create(:vm, :name => 'vm_zap', :host => host_zap)
 
-      run_get vms_url, :sort_by => 'host_name', :sort_order => 'desc', :expand => 'resources'
+      run_get api_vms_url, :sort_by => 'host_name', :sort_order => 'desc', :expand => 'resources'
 
       expect_query_result(:vms, 3, 3)
       expect_result_resources_to_match_hash([{'name' => 'vm_zap'}, {'name' => 'vm_foo'}, {'name' => 'vm_bar'}])
@@ -228,7 +228,7 @@ describe "Querying" do
     it 'does not support non sql friendly virtual attributes' do
       FactoryGirl.create(:vm)
 
-      run_get vms_url, :sort_by => 'aggressive_recommended_mem', :sort_order => 'asc'
+      run_get api_vms_url, :sort_by => 'aggressive_recommended_mem', :sort_order => 'asc'
 
       expected = {
         'error' => a_hash_including(
@@ -246,7 +246,7 @@ describe "Querying" do
       FactoryGirl.create(:classification_tag, :name => 'finance', :parent => dept)
       Classification.classify(svc1, 'department', 'finance')
 
-      run_get services_url, :sort_by => 'created_at', :filter => ['tags.name=/managed/department/finance'],
+      run_get api_services_url, :sort_by => 'created_at', :filter => ['tags.name=/managed/department/finance'],
               :sort_order => 'asc', :limit => 20, :offset => 0
 
       expect(response).to have_http_status(:ok)
@@ -260,7 +260,7 @@ describe "Querying" do
     it "supports attribute equality test using double quotes" do
       _vm1, vm2 = create_vms_by_name(%w(aa bb))
 
-      run_get vms_url, :expand => "resources", :filter => ['name="bb"']
+      run_get api_vms_url, :expand => "resources", :filter => ['name="bb"']
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm2.name, "guid" => vm2.guid}])
@@ -269,7 +269,7 @@ describe "Querying" do
     it "supports attribute equality test using single quotes" do
       vm1, _vm2 = create_vms_by_name(%w(aa bb))
 
-      run_get vms_url, :expand => "resources", :filter => ["name='aa'"]
+      run_get api_vms_url, :expand => "resources", :filter => ["name='aa'"]
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm1.name, "guid" => vm1.guid}])
@@ -278,7 +278,7 @@ describe "Querying" do
     it "supports attribute pattern matching via %" do
       vm1, _vm2, vm3 = create_vms_by_name(%w(aa_B2 bb aa_A1))
 
-      run_get vms_url, :expand => "resources", :filter => ["name='aa%'"], :sort_by => "name"
+      run_get api_vms_url, :expand => "resources", :filter => ["name='aa%'"], :sort_by => "name"
 
       expect_query_result(:vms, 2, 3)
       expect_result_resources_to_match_hash([{"name" => vm3.name, "guid" => vm3.guid},
@@ -288,7 +288,7 @@ describe "Querying" do
     it "supports attribute pattern matching via *" do
       vm1, _vm2, vm3 = create_vms_by_name(%w(aa_B2 bb aa_A1))
 
-      run_get vms_url, :expand => "resources", :filter => ["name='aa*'"], :sort_by => "name"
+      run_get api_vms_url, :expand => "resources", :filter => ["name='aa*'"], :sort_by => "name"
 
       expect_query_result(:vms, 2, 3)
       expect_result_resources_to_match_hash([{"name" => vm3.name, "guid" => vm3.guid},
@@ -298,7 +298,7 @@ describe "Querying" do
     it "supports inequality test via !=" do
       vm1, _vm2, vm3 = create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :expand => "resources", :filter => ["name!='b%'"], :sort_by => "name"
+      run_get api_vms_url, :expand => "resources", :filter => ["name!='b%'"], :sort_by => "name"
 
       expect_query_result(:vms, 2, 3)
       expect_result_resources_to_match_hash([{"name" => vm1.name, "guid" => vm1.guid},
@@ -309,7 +309,7 @@ describe "Querying" do
       vm1, vm2 = create_vms_by_name(%w(aa bb))
       vm2.update_attributes!(:retired => true)
 
-      run_get vms_url, :expand => "resources", :filter => ["retired=NULL"]
+      run_get api_vms_url, :expand => "resources", :filter => ["retired=NULL"]
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm1.name, "guid" => vm1.guid}])
@@ -319,7 +319,7 @@ describe "Querying" do
       _vm1, vm2 = create_vms_by_name(%w(aa bb))
       vm2.update_attributes!(:retired => true)
 
-      run_get vms_url, :expand => "resources", :filter => ["retired!=nil"]
+      run_get api_vms_url, :expand => "resources", :filter => ["retired!=nil"]
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm2.name, "guid" => vm2.guid}])
@@ -328,7 +328,7 @@ describe "Querying" do
     it "supports numerical less than comparison via <" do
       vm1, vm2, vm3 = create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :expand => "resources", :filter => ["id < #{vm3.id}"], :sort_by => "name"
+      run_get api_vms_url, :expand => "resources", :filter => ["id < #{vm3.id}"], :sort_by => "name"
 
       expect_query_result(:vms, 2, 3)
       expect_result_resources_to_match_hash([{"name" => vm1.name, "guid" => vm1.guid},
@@ -338,7 +338,7 @@ describe "Querying" do
     it "supports numerical less than or equal comparison via <=" do
       vm1, vm2, _vm3 = create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :expand => "resources", :filter => ["id <= #{vm2.id}"], :sort_by => "name"
+      run_get api_vms_url, :expand => "resources", :filter => ["id <= #{vm2.id}"], :sort_by => "name"
 
       expect_query_result(:vms, 2, 3)
       expect_result_resources_to_match_hash([{"name" => vm1.name, "guid" => vm1.guid},
@@ -348,7 +348,7 @@ describe "Querying" do
     it "support greater than numerical comparison via >" do
       vm1, vm2 = create_vms_by_name(%w(aa bb))
 
-      run_get vms_url, :expand => "resources", :filter => ["id > #{vm1.id}"], :sort_by => "name"
+      run_get api_vms_url, :expand => "resources", :filter => ["id > #{vm1.id}"], :sort_by => "name"
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm2.name, "guid" => vm2.guid}])
@@ -357,7 +357,7 @@ describe "Querying" do
     it "supports greater or equal than numerical comparison via >=" do
       _vm1, vm2, vm3 = create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :expand => "resources", :filter => ["id >= #{vm2.id}"], :sort_by => "name"
+      run_get api_vms_url, :expand => "resources", :filter => ["id >= #{vm2.id}"], :sort_by => "name"
 
       expect_query_result(:vms, 2, 3)
       expect_result_resources_to_match_hash([{"name" => vm2.name, "guid" => vm2.guid},
@@ -367,7 +367,7 @@ describe "Querying" do
     it "supports compound logical OR comparisons" do
       vm1, vm2, vm3 = create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :expand  => "resources",
+      run_get api_vms_url, :expand  => "resources",
                        :filter  => ["id = #{vm1.id}", "or id > #{vm2.id}"],
                        :sort_by => "name"
 
@@ -379,7 +379,7 @@ describe "Querying" do
     it "supports multiple logical AND comparisons" do
       vm1, _vm2 = create_vms_by_name(%w(aa bb))
 
-      run_get vms_url, :expand => "resources",
+      run_get api_vms_url, :expand => "resources",
                        :filter => ["id = #{vm1.id}", "name = #{vm1.name}"]
 
       expect_query_result(:vms, 1, 2)
@@ -389,7 +389,7 @@ describe "Querying" do
     it "supports multiple comparisons with both AND and OR" do
       vm1, vm2, vm3 = create_vms_by_name(%w(aa bb cc))
 
-      run_get vms_url, :expand  => "resources",
+      run_get api_vms_url, :expand  => "resources",
                        :filter  => ["id = #{vm1.id}", "name = #{vm1.name}", "or id > #{vm2.id}"],
                        :sort_by => "name"
 
@@ -404,7 +404,7 @@ describe "Querying" do
       vm1 = FactoryGirl.create(:vm_vmware, :name => "baz", :host => host1)
       _vm2 = FactoryGirl.create(:vm_vmware, :name => "qux", :host => host2)
 
-      run_get vms_url, :expand => "resources",
+      run_get api_vms_url, :expand => "resources",
                        :filter => ["host.name='foo'"]
 
       expect_query_result(:vms, 1, 2)
@@ -417,7 +417,7 @@ describe "Querying" do
       vm1 = FactoryGirl.create(:vm_vmware, :name => "baz", :host => host1)
       _vm2 = FactoryGirl.create(:vm_vmware, :name => "qux", :host => host2)
 
-      run_get vms_url, :expand => "resources",
+      run_get api_vms_url, :expand => "resources",
               :filter => ["host.name='foo'"], :offset => 0, :limit => 1
 
       expect_query_result(:vms, 1, 2)
@@ -425,7 +425,7 @@ describe "Querying" do
     end
 
     it "does not support filtering by attributes of associations' associations" do
-      run_get vms_url, :expand => "resources", :filter => ["host.hardware.memory_mb>1024"]
+      run_get api_vms_url, :expand => "resources", :filter => ["host.hardware.memory_mb>1024"]
 
       expect_bad_request(/Filtering of attributes with more than one association away is not supported/)
     end
@@ -436,7 +436,7 @@ describe "Querying" do
       vm_a = FactoryGirl.create(:vm, :host => host_a)
       _vm_b = FactoryGirl.create(:vm, :host => host_b)
 
-      run_get(vms_url, :filter => ["host_name='aa'"], :expand => "resources")
+      run_get(api_vms_url, :filter => ["host_name='aa'"], :expand => "resources")
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm_a.name, "guid" => vm_a.guid}])
@@ -448,7 +448,7 @@ describe "Querying" do
       vm_a = FactoryGirl.create(:vm, :host => host_a)
       _vm_b = FactoryGirl.create(:vm, :host => host_b)
 
-      run_get(vms_url, :filter => ["host_name='a%'"], :expand => "resources")
+      run_get(api_vms_url, :filter => ["host_name='a%'"], :expand => "resources")
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm_a.name, "guid" => vm_a.guid}])
@@ -461,7 +461,7 @@ describe "Querying" do
       _vm = FactoryGirl.create(:vm, :host => host, :ext_management_system => ems)
       archived_vm = FactoryGirl.create(:vm)
 
-      run_get(vms_url, :filter => ["archived=true"], :expand => "resources")
+      run_get(api_vms_url, :filter => ["archived=true"], :expand => "resources")
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => archived_vm.name, "guid" => archived_vm.guid}])
@@ -473,7 +473,7 @@ describe "Querying" do
       _vm_1 = FactoryGirl.create(:vm, :hardware => hardware_1)
       vm_2 = FactoryGirl.create(:vm, :hardware => hardware_2)
 
-      run_get(vms_url, :filter => ["num_cpu > 4"], :expand => "resources")
+      run_get(api_vms_url, :filter => ["num_cpu > 4"], :expand => "resources")
 
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm_2.name, "guid" => vm_2.guid}])
@@ -484,9 +484,9 @@ describe "Querying" do
       vm_2 = FactoryGirl.create(:vm, :retires_on => "2016-01-02", :vendor => "vmware")
       _vm_3 = FactoryGirl.create(:vm, :retires_on => "2016-01-02", :vendor => "openstack")
 
-      run_get(vms_url, :filter => ["retires_on = 2016-01-02", "vendor_display = VMware"])
+      run_get(api_vms_url, :filter => ["retires_on = 2016-01-02", "vendor_display = VMware"])
 
-      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.compressed_id))}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -496,9 +496,9 @@ describe "Querying" do
       vm_2 = FactoryGirl.create(:vm, :retires_on => "2016-01-02", :vendor => "vmware")
       _vm_3 = FactoryGirl.create(:vm, :retires_on => "2016-01-03", :vendor => "openstack")
 
-      run_get(vms_url, :filter => ["retires_on > 2016-01-01", "vendor_display = VMware"])
+      run_get(api_vms_url, :filter => ["retires_on > 2016-01-01", "vendor_display = VMware"])
 
-      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.compressed_id))}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -508,9 +508,9 @@ describe "Querying" do
       vm_2 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T08:00:00Z", :vendor => "vmware")
       _vm_3 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T08:00:00Z", :vendor => "openstack")
 
-      run_get(vms_url, :filter => ["last_scan_on > 2016-01-01T07:59:59Z", "vendor_display = VMware"])
+      run_get(api_vms_url, :filter => ["last_scan_on > 2016-01-01T07:59:59Z", "vendor_display = VMware"])
 
-      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.compressed_id))}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -520,9 +520,9 @@ describe "Querying" do
       vm_2 = FactoryGirl.create(:vm, :retires_on => "2016-01-02", :vendor => "vmware")
       _vm_3 = FactoryGirl.create(:vm, :retires_on => "2016-01-03", :vendor => "vmware")
 
-      run_get(vms_url, :filter => ["retires_on < 2016-01-03", "vendor_display = VMware"])
+      run_get(api_vms_url, :filter => ["retires_on < 2016-01-03", "vendor_display = VMware"])
 
-      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.compressed_id))}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -532,36 +532,36 @@ describe "Querying" do
       vm_2 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T07:59:59Z", :vendor => "vmware")
       _vm_3 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T08:00:00Z", :vendor => "vmware")
 
-      run_get(vms_url, :filter => ["last_scan_on < 2016-01-01T08:00:00Z", "vendor_display = VMware"])
+      run_get(api_vms_url, :filter => ["last_scan_on < 2016-01-01T08:00:00Z", "vendor_display = VMware"])
 
-      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.compressed_id))}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
 
     it "does not support filtering with <= with datetimes" do
-      run_get(vms_url, :filter => ["retires_on <= 2016-01-03"])
+      run_get(api_vms_url, :filter => ["retires_on <= 2016-01-03"])
 
       expect(response.parsed_body).to include_error_with_message("Unsupported operator for datetime: <=")
       expect(response).to have_http_status(:bad_request)
     end
 
     it "does not support filtering with >= with datetimes" do
-      run_get(vms_url, :filter => ["retires_on >= 2016-01-03"])
+      run_get(api_vms_url, :filter => ["retires_on >= 2016-01-03"])
 
       expect(response.parsed_body).to include_error_with_message("Unsupported operator for datetime: >=")
       expect(response).to have_http_status(:bad_request)
     end
 
     it "does not support filtering with != with datetimes" do
-      run_get(vms_url, :filter => ["retires_on != 2016-01-03"])
+      run_get(api_vms_url, :filter => ["retires_on != 2016-01-03"])
 
       expect(response.parsed_body).to include_error_with_message("Unsupported operator for datetime: !=")
       expect(response).to have_http_status(:bad_request)
     end
 
     it "will handle poorly formed datetimes in the filter" do
-      run_get(vms_url, :filter => ["retires_on > foobar"])
+      run_get(api_vms_url, :filter => ["retires_on > foobar"])
 
       expect(response.parsed_body).to include_error_with_message("Bad format for datetime: foobar")
       expect(response).to have_http_status(:bad_request)
@@ -572,7 +572,7 @@ describe "Querying" do
       service << FactoryGirl.create(:vm_vmware, :name => "foo")
       service << FactoryGirl.create(:vm_vmware, :name => "bar")
 
-      run_get("#{services_url(service.id)}/vms", :filter => ["name=foo"])
+      run_get(api_service_vms_url(nil, service), :filter => ["name=foo"])
 
       expect(response.parsed_body).to include_error_with_message("Filtering is not supported on vms subcollection")
       expect(response).to have_http_status(:bad_request)
@@ -583,12 +583,12 @@ describe "Querying" do
       _tag_2 = FactoryGirl.create(:tag, :name => "/managed/bar")
       api_basic_authorize collection_action_identifier(:tags, :read, :get)
 
-      run_get(tags_url, :filter => ["name='*/foo'"])
+      run_get(api_tags_url, :filter => ["name='*/foo'"])
 
       expected = {
         "count"     => 2,
         "subcount"  => 1,
-        "resources" => [{"href" => a_string_matching(tags_url(tag_1.compressed_id))}]
+        "resources" => [{"href" => api_tag_url(nil, tag_1.compressed_id)}]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -597,7 +597,7 @@ describe "Querying" do
     it "supports filtering by compressed id" do
       vm1, _vm2 = create_vms_by_name(%w(aa bb))
 
-      run_get vms_url, :expand => "resources",
+      run_get api_vms_url, :expand => "resources",
                        :filter => ["id = #{ApplicationRecord.compress_id(vm1.id)}"]
 
       expect_query_result(:vms, 1, 2)
@@ -607,7 +607,7 @@ describe "Querying" do
     it "supports filtering by compressed id as string" do
       _vm1, vm2 = create_vms_by_name(%w(aa bb))
 
-      run_get vms_url, :expand => "resources",
+      run_get api_vms_url, :expand => "resources",
                        :filter => ["id = '#{ApplicationRecord.compress_id(vm2.id)}'"]
 
       expect_query_result(:vms, 1, 2)
@@ -629,7 +629,7 @@ describe "Querying" do
                                :ext_management_system => ems2,
                                :raw_power_state       => "poweredOff")
 
-      run_get vms_url, :expand => "resources",
+      run_get api_vms_url, :expand => "resources",
                        :filter => ["ems_id = #{ApplicationRecord.compress_id(ems2.id)}"]
 
       expect_query_result(:vms, 1, 2)
@@ -637,7 +637,7 @@ describe "Querying" do
     end
 
     it "returns a bad request if trying to filter on invalid attributes" do
-      run_get(vms_url, :filter => ["destroy=true"])
+      run_get(api_vms_url, :filter => ["destroy=true"])
 
       expected = {
         "error" => a_hash_including(
@@ -655,7 +655,7 @@ describe "Querying" do
       api_basic_authorize collection_action_identifier(:vms, :read, :get)
       vm = create_vms_by_name(%w(aa)).first
 
-      run_get vms_url, :expand => "resources", :attributes => "href_slug,name,vendor"
+      run_get api_vms_url, :expand => "resources", :attributes => "href_slug,name,vendor"
 
       expected = {
         "name"      => "vms",
@@ -664,7 +664,7 @@ describe "Querying" do
         "resources" => [
           {
             "id"        => vm.compressed_id,
-            "href"      => a_string_matching(vms_url(vm.compressed_id)),
+            "href"      => api_vm_url(nil, vm.compressed_id),
             "href_slug" => "vms/#{vm.compressed_id}",
             "name"      => "aa",
             "vendor"    => anything
@@ -686,7 +686,7 @@ describe "Querying" do
       Classification.classify(vm1, "department", "finance")
       Classification.classify(vm3, "department", "finance")
 
-      run_get vms_url, :expand => "resources", :by_tag => "/department/finance"
+      run_get api_vms_url, :expand => "resources", :by_tag => "/department/finance"
 
       expect_query_result(:vms, 2, 3)
       expect_result_resources_to_include_data("resources", "name" => [vm1.name, vm3.name])
@@ -705,7 +705,7 @@ describe "Querying" do
       Classification.classify(vm1, "cc", "cc01")
       Classification.classify(vm3, "department", "finance")
 
-      run_get vms_url, :expand => "resources", :by_tag => "/department/finance,/cc/cc01"
+      run_get api_vms_url, :expand => "resources", :by_tag => "/department/finance,/cc/cc01"
 
       expect_query_result(:vms, 1, 3)
       expect_result_resources_to_include_data("resources", "name" => [vm1.name])
@@ -716,13 +716,13 @@ describe "Querying" do
     before { api_basic_authorize collection_action_identifier(:vms, :read, :get) }
 
     it "and sorted by name succeeeds with unreferenced class" do
-      run_get vms_url, :sort_by => "name", :expand => "resources"
+      run_get api_vms_url, :sort_by => "name", :expand => "resources"
 
       expect_query_result(:vms, 0, 0)
     end
 
     it "by invalid attribute" do
-      run_get vms_url, :sort_by => "bad_attribute", :expand => "resources"
+      run_get api_vms_url, :sort_by => "bad_attribute", :expand => "resources"
 
       expect_bad_request("bad_attribute is not a valid attribute")
     end
@@ -730,7 +730,7 @@ describe "Querying" do
     it "is supported without expanding resources" do
       create_vms_by_name(%w(aa bb))
 
-      run_get vms_url
+      run_get api_vms_url
 
       expected = {
         "name"      => "vms",
@@ -745,7 +745,7 @@ describe "Querying" do
     it "supports expanding resources" do
       create_vms_by_name(%w(aa bb))
 
-      run_get vms_url, :expand => "resources"
+      run_get api_vms_url, :expand => "resources"
 
       expect_query_result(:vms, 2, 2)
       expect_result_resources_to_include_keys("resources", %w(id href guid name vendor))
@@ -755,7 +755,7 @@ describe "Querying" do
       vm1 = create_vms_by_name(%w(aa)).first
       FactoryGirl.create(:guest_application, :vm_or_template_id => vm1.id, :name => "LibreOffice")
 
-      run_get vms_url, :expand => "resources,software"
+      run_get api_vms_url, :expand => "resources,software"
 
       expect_query_result(:vms, 1, 1)
       expect_result_resources_to_include_keys("resources", %w(id href guid name vendor software))
@@ -764,7 +764,7 @@ describe "Querying" do
     it "supports suppressing resources" do
       FactoryGirl.create(:vm)
 
-      run_get(vms_url, :hide => "resources")
+      run_get(api_vms_url, :hide => "resources")
 
       expect(response.parsed_body).not_to include("resources")
       expect(response).to have_http_status(:ok)
@@ -775,7 +775,7 @@ describe "Querying" do
     it "does not return actions if not entitled" do
       api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
 
-      run_get vms_url(vm1.id)
+      run_get api_vm_url(nil, vm1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to_not have_key("actions")
@@ -784,7 +784,7 @@ describe "Querying" do
     it "returns actions if authorized" do
       api_basic_authorize action_identifier(:vms, :edit), action_identifier(:vms, :read, :resource_actions, :get)
 
-      run_get vms_url(vm1.id)
+      run_get api_vm_url(nil, vm1)
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor actions))
@@ -793,7 +793,7 @@ describe "Querying" do
     it "returns correct actions if authorized as such" do
       api_basic_authorize action_identifier(:vms, :suspend), action_identifier(:vms, :read, :resource_actions, :get)
 
-      run_get vms_url(vm1.id)
+      run_get api_vm_url(nil, vm1)
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor actions))
@@ -807,7 +807,7 @@ describe "Querying" do
                           action_identifier(:vms, :start),
                           action_identifier(:vms, :stop))
 
-      run_get(vms_url)
+      run_get(api_vms_url)
 
       actions = response.parsed_body['actions']
       expect(actions.size).to eq(3)
@@ -822,7 +822,7 @@ describe "Querying" do
       vm = FactoryGirl.create(:vm)
       FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-      run_get("#{vms_url(vm.id)}/snapshots")
+      run_get(api_vm_snapshots_url(nil, vm))
 
       actions = response.parsed_body['actions']
       expect(actions.size).to eq(2)
@@ -838,7 +838,7 @@ describe "Querying" do
       vm = FactoryGirl.create(:vm)
       snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-      run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+      run_get(api_vm_snapshot_url(nil, vm, snapshot))
 
       actions = response.parsed_body['actions']
       expect(actions.size).to eq(2)
@@ -854,7 +854,7 @@ describe "Querying" do
 
       blueprint = FactoryGirl.create(:blueprint)
 
-      run_get(blueprints_url(blueprint.id))
+      run_get(api_blueprint_url(nil, blueprint))
 
       actions = response.parsed_body['actions']
       expect(actions.size).to eq(4)
@@ -867,7 +867,7 @@ describe "Querying" do
                           action_identifier(:vms, :stop),
                           action_identifier(:vms, :read, :resource_actions, :get))
 
-      run_get vms_url(vm1.id)
+      run_get api_vm_url(nil, vm1)
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor actions))
@@ -877,7 +877,7 @@ describe "Querying" do
     it "returns actions if asked for with physical attributes" do
       api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
 
-      run_get vms_url(vm1.id), :attributes => "name,vendor,actions"
+      run_get api_vm_url(nil, vm1), :attributes => "name,vendor,actions"
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_only_keys(%w(id href name vendor actions))
@@ -886,7 +886,7 @@ describe "Querying" do
     it "does not return actions if asking for a physical attribute" do
       api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
 
-      run_get vms_url(vm1.id), :attributes => "name"
+      run_get api_vm_url(nil, vm1), :attributes => "name"
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_only_keys(%w(id href name))
@@ -895,7 +895,7 @@ describe "Querying" do
     it "does return actions if asking for virtual attributes" do
       api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
 
-      run_get vms_url(vm1.id), :attributes => "disconnected"
+      run_get api_vm_url(nil, vm1), :attributes => "disconnected"
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(id href name vendor disconnected actions))
@@ -904,7 +904,7 @@ describe "Querying" do
     it "does not return actions if asking for physical and virtual attributes" do
       api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
 
-      run_get vms_url(vm1.id), :attributes => "name,disconnected"
+      run_get api_vm_url(nil, vm1), :attributes => "name,disconnected"
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_only_keys(%w(id href name disconnected))
@@ -913,7 +913,7 @@ describe "Querying" do
 
   describe 'OPTIONS /api/vms' do
     it 'returns the options information' do
-      run_options(vms_url)
+      run_options(api_vms_url)
       expect_options_results(:vms)
     end
   end
@@ -922,7 +922,7 @@ describe "Querying" do
     before { api_basic_authorize collection_action_identifier(:vms, :read, :get) }
 
     it "fail with invalid collection_class specified" do
-      run_get vms_url, :collection_class => "BogusClass"
+      run_get api_vms_url, :collection_class => "BogusClass"
 
       expect_bad_request("Invalid collection_class BogusClass specified for the vms collection")
     end
@@ -930,7 +930,7 @@ describe "Querying" do
     it "succeed with collection_class matching the collection class" do
       create_vms_by_name(%w(aa bb))
 
-      run_get vms_url, :collection_class => "Vm"
+      run_get api_vms_url, :collection_class => "Vm"
 
       expect_query_result(:vms, 2, 2)
     end
@@ -940,7 +940,7 @@ describe "Querying" do
       FactoryGirl.create(:vm_vmware_cloud, :name => "bb")
       FactoryGirl.create(:vm_vmware_cloud, :name => "cc")
 
-      run_get vms_url, :expand => "resources", :collection_class => "Vm"
+      run_get api_vms_url, :expand => "resources", :collection_class => "Vm"
 
       expect_query_result(:vms, 3, 3)
       expect(response.parsed_body["resources"].collect { |vm| vm["name"] }).to match_array(%w(aa bb cc))
@@ -951,7 +951,7 @@ describe "Querying" do
       FactoryGirl.create(:vm_vmware_cloud, :name => "bb")
       vmcc = FactoryGirl.create(:vm_vmware_cloud, :name => "cc")
 
-      run_get vms_url, :expand => "resources", :collection_class => vmcc.class.name
+      run_get api_vms_url, :expand => "resources", :collection_class => vmcc.class.name
 
       expect_query_result(:vms, 2, 2)
       expect(response.parsed_body["resources"].collect { |vm| vm["name"] }).to match_array(%w(bb cc))

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -12,7 +12,7 @@ describe "Regions API" do
   it "forbids access to regions without an appropriate role" do
     api_basic_authorize
 
-    run_get(regions_url)
+    run_get(api_regions_url)
 
     expect(response).to have_http_status(:forbidden)
   end
@@ -22,7 +22,7 @@ describe "Regions API" do
 
     region = FactoryGirl.create(:miq_region, :region => "2")
 
-    run_get(regions_url(region.id))
+    run_get(api_region_url(nil, region))
 
     expect(response).to have_http_status(:forbidden)
   end
@@ -32,11 +32,11 @@ describe "Regions API" do
 
     region = FactoryGirl.create(:miq_region, :region => "2")
 
-    run_get(regions_url(region.id))
+    run_get(api_region_url(nil, region))
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href" => a_string_matching(regions_url(region.compressed_id)),
+      "href" => api_region_url(nil, region.compressed_id),
       "id"   => region.compressed_id
     )
   end

--- a/spec/requests/service_catalogs_spec.rb
+++ b/spec/requests/service_catalogs_spec.rb
@@ -19,9 +19,12 @@
 # - Refresh dialog fields       /api/service_catalogs/:id/service_templates/:id action "refresh_dialog_fields"
 #
 describe "Service Catalogs API" do
-  def sc_templates_url(id, st_id = nil)
-    st_base = "#{service_catalogs_url(id)}/service_templates"
-    st_id ? "#{st_base}/#{st_id}" : st_base
+  def sc_template_url(id, st_id = nil)
+    if st_id
+      api_service_catalog_service_template_url(nil, id, st_id)
+    else
+      api_service_catalog_service_templates_url(nil, id)
+    end
   end
 
   describe "Service Catalog Index" do
@@ -29,7 +32,7 @@ describe "Service Catalogs API" do
       FactoryGirl.create(:service_template_catalog)
       api_basic_authorize collection_action_identifier(:service_catalogs, :read, :get)
 
-      run_get service_catalogs_url, :expand => 'resources', :attributes => 'name'
+      run_get api_service_catalogs_url, :expand => 'resources', :attributes => 'name'
 
       expect(response).to have_http_status(:ok)
       response.parsed_body['resources'].each { |res| expect_hash_to_have_only_keys(res, %w(href id name)) }
@@ -40,7 +43,7 @@ describe "Service Catalogs API" do
     it "rejects resource creation without appropriate role" do
       api_basic_authorize
 
-      run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
+      run_post(api_service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -48,7 +51,7 @@ describe "Service Catalogs API" do
     it "rejects resource creation via create action without appropriate role" do
       api_basic_authorize
 
-      run_post(service_catalogs_url, "name" => "sample service catalog")
+      run_post(api_service_catalogs_url, "name" => "sample service catalog")
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -56,7 +59,7 @@ describe "Service Catalogs API" do
     it "rejects resource creation with id specified" do
       api_basic_authorize collection_action_identifier(:service_catalogs, :add)
 
-      run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog", "id" => 100))
+      run_post(api_service_catalogs_url, gen_request(:add, "name" => "sample service catalog", "id" => 100))
 
       expect_bad_request(/id or href should not be specified/i)
     end
@@ -64,7 +67,7 @@ describe "Service Catalogs API" do
     it "supports single resource creation" do
       api_basic_authorize collection_action_identifier(:service_catalogs, :add)
 
-      run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
+      run_post(api_service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
 
       expect(response).to have_http_status(:ok)
       expected = {
@@ -85,7 +88,7 @@ describe "Service Catalogs API" do
     it "supports single resource creation via create action" do
       api_basic_authorize collection_action_identifier(:service_catalogs, :add)
 
-      run_post(service_catalogs_url, "name" => "sample service catalog")
+      run_post(api_service_catalogs_url, "name" => "sample service catalog")
 
       expect(response).to have_http_status(:ok)
       expected = {
@@ -106,7 +109,7 @@ describe "Service Catalogs API" do
     it "supports multiple resource creation" do
       api_basic_authorize collection_action_identifier(:service_catalogs, :add)
 
-      run_post(service_catalogs_url, gen_request(:add, [{"name" => "sc1"}, {"name" => "sc2"}]))
+      run_post(api_service_catalogs_url, gen_request(:add, [{"name" => "sc1"}, {"name" => "sc2"}]))
 
       expect(response).to have_http_status(:ok)
       expected = {
@@ -130,12 +133,12 @@ describe "Service Catalogs API" do
       st1 = FactoryGirl.create(:service_template)
       st2 = FactoryGirl.create(:service_template)
 
-      run_post(service_catalogs_url, gen_request(:add,
+      run_post(api_service_catalogs_url, gen_request(:add,
                                                  "name"              => "sc",
                                                  "description"       => "sc description",
                                                  "service_templates" => [
-                                                   {"href" => service_templates_url(st1.id)},
-                                                   {"href" => service_templates_url(st2.id)}
+                                                   {"href" => api_service_template_url(nil, st1)},
+                                                   {"href" => api_service_template_url(nil, st2)}
                                                  ]))
 
       expect(response).to have_http_status(:ok)
@@ -152,7 +155,7 @@ describe "Service Catalogs API" do
     it "rejects resource edits without appropriate role" do
       api_basic_authorize
 
-      run_post(service_catalogs_url, gen_request(:edit, "name" => "sc1", "href" => service_catalogs_url(999_999)))
+      run_post(api_service_catalogs_url, gen_request(:edit, "name" => "sc1", "href" => api_service_catalog_url(nil, 999_999)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -160,7 +163,7 @@ describe "Service Catalogs API" do
     it "rejects edits for invalid resources" do
       api_basic_authorize collection_action_identifier(:service_catalogs, :edit)
 
-      run_post(service_catalogs_url(999_999), gen_request(:edit, "description" => "updated sc description"))
+      run_post(api_service_catalog_url(nil, 999_999), gen_request(:edit, "description" => "updated sc description"))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -170,7 +173,7 @@ describe "Service Catalogs API" do
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
 
-      run_post(service_catalogs_url(sc.id), gen_request(:edit, "description" => "updated sc description"))
+      run_post(api_service_catalog_url(nil, sc), gen_request(:edit, "description" => "updated sc description"))
 
       expected = {
         "service_templates" => a_hash_including(
@@ -197,9 +200,9 @@ describe "Service Catalogs API" do
       sc1 = FactoryGirl.create(:service_template_catalog, :name => "sc1", :description => "sc1 description")
       sc2 = FactoryGirl.create(:service_template_catalog, :name => "sc2", :description => "sc2 description")
 
-      run_post(service_catalogs_url, gen_request(:edit,
-                                                 [{"href" => service_catalogs_url(sc1.id), "name" => "sc1 updated"},
-                                                  {"href" => service_catalogs_url(sc2.id), "name" => "sc2 updated"}]))
+      run_post(api_service_catalogs_url, gen_request(:edit,
+                                                     [{"href" => api_service_catalog_url(nil, sc1), "name" => "sc1 updated"},
+                                                      {"href" => api_service_catalog_url(nil, sc2), "name" => "sc2 updated"}]))
 
       expect_results_to_match_hash("results",
                                    [{"id" => sc1.compressed_id, "name" => "sc1 updated", "description" => "sc1 description"},
@@ -214,7 +217,7 @@ describe "Service Catalogs API" do
     it "rejects deletion without appropriate role" do
       api_basic_authorize
 
-      run_post(service_catalogs_url, gen_request(:delete, "name" => "sc1", "href" => service_catalogs_url(100)))
+      run_post(api_service_catalogs_url, gen_request(:delete, "name" => "sc1", "href" => api_service_catalog_url(nil, 100)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -222,7 +225,7 @@ describe "Service Catalogs API" do
     it "rejects resource deletion without appropriate role" do
       api_basic_authorize
 
-      run_delete(service_catalogs_url(100))
+      run_delete(api_service_catalog_url(nil, 100))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -230,7 +233,7 @@ describe "Service Catalogs API" do
     it "rejects resource deletes for invalid resources" do
       api_basic_authorize collection_action_identifier(:service_catalogs, :delete)
 
-      run_delete(service_catalogs_url(999_999))
+      run_delete(api_service_catalog_url(nil, 999_999))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -240,7 +243,7 @@ describe "Service Catalogs API" do
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
 
-      run_delete(service_catalogs_url(sc.id))
+      run_delete(api_service_catalog_url(nil, sc))
 
       expect(response).to have_http_status(:no_content)
       expect { sc.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -251,9 +254,9 @@ describe "Service Catalogs API" do
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
 
-      run_post(service_catalogs_url(sc.id), gen_request(:delete))
+      run_post(api_service_catalog_url(nil, sc), gen_request(:delete))
 
-      expect_single_action_result(:success => true, :message => "deleting", :href => service_catalogs_url(sc.compressed_id))
+      expect_single_action_result(:success => true, :message => "deleting", :href => api_service_catalog_url(nil, sc.compressed_id))
       expect { sc.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -263,11 +266,11 @@ describe "Service Catalogs API" do
       sc1 = FactoryGirl.create(:service_template_catalog, :name => "sc1", :description => "sc1 description")
       sc2 = FactoryGirl.create(:service_template_catalog, :name => "sc2", :description => "sc2 description")
 
-      run_post(service_catalogs_url, gen_request(:delete,
-                                                 [{"href" => service_catalogs_url(sc1.id)},
-                                                  {"href" => service_catalogs_url(sc2.id)}]))
+      run_post(api_service_catalogs_url, gen_request(:delete,
+                                                     [{"href" => api_service_catalog_url(nil, sc1)},
+                                                      {"href" => api_service_catalog_url(nil, sc2)}]))
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [service_catalogs_url(sc1.compressed_id), service_catalogs_url(sc2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_service_catalog_url(nil, sc1.compressed_id), api_service_catalog_url(nil, sc2.compressed_id)])
 
       expect { sc1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { sc2.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -278,7 +281,7 @@ describe "Service Catalogs API" do
     it "rejects assign requests without appropriate role" do
       api_basic_authorize
 
-      run_post(sc_templates_url(100), gen_request(:assign, "href" => service_templates_url(1)))
+      run_post(sc_template_url(100), gen_request(:assign, "href" => api_service_template_url(nil, 1)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -286,7 +289,7 @@ describe "Service Catalogs API" do
     it "rejects unassign requests without appropriate role" do
       api_basic_authorize
 
-      run_post(sc_templates_url(100), gen_request(:unassign, "href" => service_templates_url(1)))
+      run_post(sc_template_url(100), gen_request(:unassign, "href" => api_service_template_url(nil, 1)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -296,10 +299,10 @@ describe "Service Catalogs API" do
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
 
-      run_post(sc_templates_url(sc.id), gen_request(:assign, "href" => service_templates_url(999_999)))
+      run_post(sc_template_url(sc.id), gen_request(:assign, "href" => api_service_template_url(nil, 999_999)))
 
       expect(response).to have_http_status(:ok)
-      expect_results_to_match_hash("results", [{"success" => false, "href" => service_catalogs_url(sc.compressed_id)}])
+      expect_results_to_match_hash("results", [{"success" => false, "href" => api_service_catalog_url(nil, sc.compressed_id)}])
     end
 
     it "supports assign requests" do
@@ -308,14 +311,14 @@ describe "Service Catalogs API" do
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
       st = FactoryGirl.create(:service_template)
 
-      run_post(sc_templates_url(sc.id), gen_request(:assign, "href" => service_templates_url(st.compressed_id)))
+      run_post(sc_template_url(sc.id), gen_request(:assign, "href" => api_service_template_url(nil, st.compressed_id)))
 
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
                                    [{"success"               => true,
-                                     "href"                  => service_catalogs_url(sc.compressed_id),
+                                     "href"                  => api_service_catalog_url(nil, sc.compressed_id),
                                      "service_template_id"   => st.compressed_id,
-                                     "service_template_href" => /^.*#{service_templates_url(st.compressed_id)}$/,
+                                     "service_template_href" => /^.*#{api_service_template_url(nil, st.compressed_id)}$/,
                                      "message"               => /assigning/i}])
       expect(sc.reload.service_templates.pluck(:id)).to eq([st.id])
     end
@@ -328,14 +331,14 @@ describe "Service Catalogs API" do
       st2 = FactoryGirl.create(:service_template)
       sc.service_templates = [st1, st2]
 
-      run_post(sc_templates_url(sc.id), gen_request(:unassign, "href" => service_templates_url(st1.id)))
+      run_post(sc_template_url(sc.id), gen_request(:unassign, "href" => api_service_template_url(nil, st1)))
 
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
                                    [{"success"               => true,
-                                     "href"                  => service_catalogs_url(sc.compressed_id),
+                                     "href"                  => api_service_catalog_url(nil, sc.compressed_id),
                                      "service_template_id"   => st1.compressed_id,
-                                     "service_template_href" => /^.*#{service_templates_url(st1.compressed_id)}$/,
+                                     "service_template_href" => /^.*#{api_service_template_url(nil, st1.compressed_id)}$/,
                                      "message"               => /unassigning/i}])
       expect(sc.reload.service_templates.pluck(:id)).to eq([st2.id])
     end
@@ -376,7 +379,7 @@ describe "Service Catalogs API" do
       st1.display = false
       st1.save
 
-      run_get sc_templates_url(sc.id, st1.id)
+      run_get sc_template_url(sc.id, st1.id)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to_not include_actions("order")
@@ -389,7 +392,7 @@ describe "Service Catalogs API" do
       init_st(st1, ra1)
       sc.service_templates = [st1]
 
-      run_get sc_templates_url(sc.id, st1.id)
+      run_get sc_template_url(sc.id, st1.id)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include_actions("order")
@@ -398,7 +401,7 @@ describe "Service Catalogs API" do
     it "rejects order requests without appropriate role" do
       api_basic_authorize
 
-      run_post(sc_templates_url(100), gen_request(:order, "href" => service_templates_url(1)))
+      run_post(sc_template_url(100), gen_request(:order, "href" => api_service_template_url(nil, 1)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -409,7 +412,7 @@ describe "Service Catalogs API" do
       init_st(st1, ra1)
       sc.service_templates = [st1]
 
-      run_post(sc_templates_url(sc.id, st1.id), gen_request(:order))
+      run_post(sc_template_url(sc.id, st1.id), gen_request(:order))
 
       expect_single_resource_query(order_request.merge("href" => /service_requests/))
     end
@@ -421,7 +424,7 @@ describe "Service Catalogs API" do
       init_st(st1, ra1)
       sc.service_templates = [st1]
 
-      run_post(sc_templates_url(sc.id, st1.id), gen_request(:order, "text1" => "value1"))
+      run_post(sc_template_url(sc.id, st1.id), gen_request(:order, "text1" => "value1"))
 
       expect_single_resource_query(order_request)
     end
@@ -433,7 +436,7 @@ describe "Service Catalogs API" do
       init_st(st1, ra1)
       sc.service_templates = [st1]
 
-      run_post(sc_templates_url(sc.id, st1.id), gen_request(:order))
+      run_post(sc_template_url(sc.id, st1.id), gen_request(:order))
 
       expect_bad_request("Failed to order")
     end
@@ -445,8 +448,8 @@ describe "Service Catalogs API" do
       init_st(st2, ra2)
       sc.service_templates = [st1, st2]
 
-      run_post(sc_templates_url(sc.id), gen_request(:order, [{"href" => service_templates_url(st1.id)},
-                                                             {"href" => service_templates_url(st2.id)}]))
+      run_post(sc_template_url(sc.id), gen_request(:order, [{"href" => api_service_template_url(nil, st1)},
+                                                            {"href" => api_service_template_url(nil, st2)}]))
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [order_request, order_request])
     end
@@ -476,7 +479,7 @@ describe "Service Catalogs API" do
     it "rejects refresh dialog fields requests without appropriate role" do
       api_basic_authorize
 
-      run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(test1)))
+      run_post(sc_template_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(test1)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -485,7 +488,7 @@ describe "Service Catalogs API" do
       api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :refresh_dialog_fields)
       sc.service_templates = [st1]
 
-      run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields))
+      run_post(sc_template_url(sc.id, st1.id), gen_request(:refresh_dialog_fields))
 
       expect_single_action_result(:success => false, :message => /must specify fields/i)
     end
@@ -494,7 +497,7 @@ describe "Service Catalogs API" do
       api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :refresh_dialog_fields)
       init_st_dialog
 
-      run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(bad_field)))
+      run_post(sc_template_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(bad_field)))
 
       expect_single_action_result(:success => false, :message => /unknown dialog field bad_field/i)
     end
@@ -503,7 +506,7 @@ describe "Service Catalogs API" do
       api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :refresh_dialog_fields)
       init_st_dialog
 
-      run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
+      run_post(sc_template_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
 
       expected = {
         "success"               => true,

--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -47,14 +47,14 @@ describe "Service Requests API" do
     end
 
     it "can return the provision_dialog" do
-      run_get service_requests_url(service_request.id), :attributes => "provision_dialog"
+      run_get api_service_request_url(nil, service_request), :attributes => "provision_dialog"
 
       expect_result_to_have_provision_dialog
     end
 
     it "can return the request's user.email" do
       @user.update_attributes!(:email => "admin@api.net")
-      run_get service_requests_url(service_request.id), :attributes => "user.email"
+      run_get api_service_request_url(nil, service_request), :attributes => "user.email"
 
       expect_result_to_have_user_email(@user.email)
     end
@@ -67,14 +67,14 @@ describe "Service Requests API" do
     end
 
     it "can return the provision_dialog" do
-      run_get services_url(service.id), :attributes => "provision_dialog"
+      run_get api_service_url(nil, service), :attributes => "provision_dialog"
 
       expect_result_to_have_provision_dialog
     end
 
     it "can return the request's user.email" do
       @user.update_attributes!(:email => "admin@api.net")
-      run_get services_url(service.id), :attributes => "user.email"
+      run_get api_service_url(nil, service), :attributes => "user.email"
 
       expect_result_to_have_user_email(@user.email)
     end
@@ -93,8 +93,8 @@ describe "Service Requests API" do
                          :source_id   => template.id,
                          :source_type => template.class.name)
     end
-    let(:svcreq1_url)  { service_requests_url(svcreq1.id) }
-    let(:svcreq2_url)  { service_requests_url(svcreq2.id) }
+    let(:svcreq1_url)  { api_service_request_url(nil, svcreq1) }
+    let(:svcreq2_url)  { api_service_request_url(nil, svcreq2) }
 
     it "supports approving a request" do
       api_basic_authorize collection_action_identifier(:service_requests, :approve)
@@ -102,7 +102,7 @@ describe "Service Requests API" do
       run_post(svcreq1_url, gen_request(:approve, :reason => "approve reason"))
 
       expected_msg = "Service request #{svcreq1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => service_requests_url(svcreq1.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_service_request_url(nil, svcreq1.compressed_id))
     end
 
     it "supports denying a request" do
@@ -111,13 +111,13 @@ describe "Service Requests API" do
       run_post(svcreq2_url, gen_request(:deny, :reason => "deny reason"))
 
       expected_msg = "Service request #{svcreq2.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => service_requests_url(svcreq2.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_service_request_url(nil, svcreq2.compressed_id))
     end
 
     it "supports approving multiple requests" do
       api_basic_authorize collection_action_identifier(:service_requests, :approve)
 
-      run_post(service_requests_url, gen_request(:approve, [{"href" => svcreq1_url, "reason" => "approve reason"},
+      run_post(api_service_requests_url, gen_request(:approve, [{"href" => svcreq1_url, "reason" => "approve reason"},
                                                             {"href" => svcreq2_url, "reason" => "approve reason"}]))
 
       expected = {
@@ -125,12 +125,12 @@ describe "Service Requests API" do
           {
             "message" => a_string_matching(/Service request #{svcreq1.id} approved/i),
             "success" => true,
-            "href"    => a_string_matching(service_requests_url(svcreq1.compressed_id))
+            "href"    => api_service_request_url(nil, svcreq1.compressed_id)
           },
           {
             "message" => a_string_matching(/Service request #{svcreq2.id} approved/i),
             "success" => true,
-            "href"    => a_string_matching(service_requests_url(svcreq2.compressed_id))
+            "href"    => api_service_request_url(nil, svcreq2.compressed_id)
           }
         )
       }
@@ -141,7 +141,7 @@ describe "Service Requests API" do
     it "supports denying multiple requests" do
       api_basic_authorize collection_action_identifier(:service_requests, :approve)
 
-      run_post(service_requests_url, gen_request(:deny, [{"href" => svcreq1_url, "reason" => "deny reason"},
+      run_post(api_service_requests_url, gen_request(:deny, [{"href" => svcreq1_url, "reason" => "deny reason"},
                                                          {"href" => svcreq2_url, "reason" => "deny reason"}]))
 
       expected = {
@@ -149,12 +149,12 @@ describe "Service Requests API" do
           {
             "message" => a_string_matching(/Service request #{svcreq1.id} denied/i),
             "success" => true,
-            "href"    => a_string_matching(service_requests_url(svcreq1.compressed_id))
+            "href"    => api_service_request_url(nil, svcreq1.compressed_id)
           },
           {
             "message" => a_string_matching(/Service request #{svcreq2.id} denied/i),
             "success" => true,
-            "href"    => a_string_matching(service_requests_url(svcreq2.compressed_id))
+            "href"    => api_service_request_url(nil, svcreq2.compressed_id)
           }
         )
       }
@@ -167,7 +167,7 @@ describe "Service Requests API" do
     it "is forbidden for a user without appropriate role" do
       api_basic_authorize
 
-      run_get service_requests_url
+      run_get api_service_requests_url
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -180,7 +180,7 @@ describe "Service Requests API" do
                          :source_type => template.class.name)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      run_get service_requests_url
+      run_get api_service_requests_url
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include("name" => "service_requests", "count" => 1, "subcount" => 0)
@@ -194,7 +194,7 @@ describe "Service Requests API" do
                                            :source_type => template.class.name)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      run_get service_requests_url(service_request.id)
+      run_get api_service_request_url(nil, service_request)
 
       expected = {
         "error" => a_hash_including(
@@ -212,7 +212,7 @@ describe "Service Requests API" do
                                             :source_type => template.class.name)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      run_get service_requests_url
+      run_get api_service_requests_url
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include("name" => "service_requests", "count" => 1, "subcount" => 1)
@@ -225,11 +225,11 @@ describe "Service Requests API" do
                                            :source_type => template.class.name)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      run_get service_requests_url(service_request.id)
+      run_get api_service_request_url(nil, service_request)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include("id"   => service_request.compressed_id,
-                                              "href" => a_string_matching(service_requests_url(service_request.compressed_id)))
+                                              "href" => api_service_request_url(nil, service_request.compressed_id))
     end
 
     it "lists all the service requests if you are admin" do
@@ -245,14 +245,14 @@ describe "Service Requests API" do
                                              :source_type => template.class.name)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      run_get service_requests_url
+      run_get api_service_requests_url
 
       expected = {
         "count"     => 2,
         "subcount"  => 2,
         "resources" => a_collection_containing_exactly(
-          {"href" => a_string_matching(service_requests_url(service_request_1.compressed_id))},
-          {"href" => a_string_matching(service_requests_url(service_request_2.compressed_id))},
+          {"href" => api_service_request_url(nil, service_request_1.compressed_id)},
+          {"href" => api_service_request_url(nil, service_request_2.compressed_id)},
         )
       }
       expect(response).to have_http_status(:ok)
@@ -268,11 +268,11 @@ describe "Service Requests API" do
                                            :source_type => template.class.name)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      run_get service_requests_url(service_request.id)
+      run_get api_service_request_url(nil, service_request)
 
       expected = {
         "id"   => service_request.compressed_id,
-        "href" => a_string_matching(service_requests_url(service_request.compressed_id))
+        "href" => api_service_request_url(nil, service_request.compressed_id)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -283,7 +283,7 @@ describe "Service Requests API" do
     it 'forbids deletion without an appropriate role' do
       api_basic_authorize
 
-      run_post(service_requests_url(service_request.id), :action => 'delete')
+      run_post(api_service_request_url(nil, service_request), :action => 'delete')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -291,7 +291,7 @@ describe "Service Requests API" do
     it 'can delete a single service request resource' do
       api_basic_authorize collection_action_identifier(:service_requests, :delete)
 
-      run_post(service_requests_url(service_request.id), :action => 'delete')
+      run_post(api_service_request_url(nil, service_request), :action => 'delete')
 
       expected = {
         'success' => true,
@@ -309,7 +309,7 @@ describe "Service Requests API" do
                                              :source_type => template.class.name)
       api_basic_authorize collection_action_identifier(:service_requests, :delete)
 
-      run_post(service_requests_url, :action => 'delete', :resources => [
+      run_post(api_service_requests_url, :action => 'delete', :resources => [
                  { :id => service_request.id }, { :id => service_request_2.id }
                ])
 
@@ -329,7 +329,7 @@ describe "Service Requests API" do
     it 'can delete a service request via DELETE' do
       api_basic_authorize collection_action_identifier(:service_requests, :delete)
 
-      run_delete(service_requests_url(service_request.id))
+      run_delete(api_service_request_url(nil, service_request))
 
       expect(response).to have_http_status(:no_content)
     end
@@ -337,7 +337,7 @@ describe "Service Requests API" do
     it 'forbids service request DELETE without an appropriate role' do
       api_basic_authorize
 
-      run_delete(service_requests_url(service_request.id))
+      run_delete(api_service_request_url(nil, service_request))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -350,7 +350,7 @@ describe "Service Requests API" do
       api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
 
       expect do
-        run_post(service_requests_url(service_request.id), :action => 'add_approver', :user_id => user.id)
+        run_post(api_service_request_url(nil, service_request), :action => 'add_approver', :user_id => user.id)
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => service_request.compressed_id)
@@ -373,7 +373,7 @@ describe "Service Requests API" do
         )
       }
       expect do
-        run_post(service_requests_url, :action => 'add_approver', :resources => [
+        run_post(api_service_requests_url, :action => 'add_approver', :resources => [
                    { :id => service_request.id, :user_id => user.id },
                    { :id => service_request_2.id, :user_id => user.id }
                  ])
@@ -385,7 +385,7 @@ describe "Service Requests API" do
     it 'forbids adding an approver without an appropriate role' do
       api_basic_authorize
 
-      run_post(service_requests_url, :action => 'add_approver')
+      run_post(api_service_requests_url, :action => 'add_approver')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -396,7 +396,7 @@ describe "Service Requests API" do
       api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
 
       expect do
-        run_post(service_requests_url(service_request.id), :action => 'add_approver', :user => { :id => user.id})
+        run_post(api_service_request_url(nil, service_request), :action => 'add_approver', :user => { :id => user.id })
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => service_request.compressed_id)
@@ -408,8 +408,8 @@ describe "Service Requests API" do
       api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
 
       expect do
-        run_post(service_requests_url(service_request.id),
-                 :action => 'add_approver', :user => { :href => users_url(user.id)})
+        run_post(api_service_request_url(nil, service_request),
+                 :action => 'add_approver', :user => { :href => api_user_url(nil, user)})
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => service_request.compressed_id)
@@ -424,7 +424,7 @@ describe "Service Requests API" do
           'message' => 'Cannot add approver - Must specify a valid user_id or user'
         )
       }
-      run_post(service_requests_url(service_request.id), :action => 'add_approver')
+      run_post(api_service_request_url(nil, service_request), :action => 'add_approver')
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:bad_request)
     end
@@ -437,7 +437,7 @@ describe "Service Requests API" do
       api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
 
       expect do
-        run_post(service_requests_url(service_request.id), :action => 'remove_approver', :user_id => user.id)
+        run_post(api_service_request_url(nil, service_request), :action => 'remove_approver', :user_id => user.id)
       end.to change(MiqApproval, :count).by(-1)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => service_request.compressed_id)
@@ -461,7 +461,7 @@ describe "Service Requests API" do
       }
       expect do
         run_post(
-          service_requests_url,
+          api_service_requests_url,
           :action    => 'remove_approver',
           :resources => [
             { :id => service_request.id, :user_id => user.id },
@@ -476,7 +476,7 @@ describe "Service Requests API" do
     it 'forbids adding an approver without an appropriate role' do
       api_basic_authorize
 
-      run_post(service_requests_url, :action => 'remove_approver')
+      run_post(api_service_requests_url, :action => 'remove_approver')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -487,9 +487,9 @@ describe "Service Requests API" do
       api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
 
       expect do
-        run_post(service_requests_url(service_request.id),
+        run_post(api_service_request_url(nil, service_request),
                  :action => 'remove_approver',
-                 :user   => { :href => users_url(user.id)})
+                 :user   => { :href => api_user_url(nil, user)})
       end.to change(MiqApproval, :count).by(-1)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => service_request.compressed_id)
@@ -504,7 +504,7 @@ describe "Service Requests API" do
           'message' => 'Cannot remove approver - Must specify a valid user_id or user'
         )
       }
-      run_post(service_requests_url(service_request.id), :action => 'remove_approver')
+      run_post(api_service_request_url(nil, service_request), :action => 'remove_approver')
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:bad_request)
     end
@@ -514,7 +514,7 @@ describe "Service Requests API" do
       service_request.miq_approvals << FactoryGirl.create(:miq_approval)
       api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
 
-      run_post(service_requests_url(service_request.id), :action => 'remove_approver', :user_id => user.id)
+      run_post(api_service_request_url(nil, service_request), :action => 'remove_approver', :user_id => user.id)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => service_request.compressed_id)
     end
@@ -527,7 +527,7 @@ describe "Service Requests API" do
                                            :options   => {:foo => "bar"})
       api_basic_authorize
 
-      run_post(service_requests_url(service_request.id), :action => "edit", :options => {:baz => "qux"})
+      run_post(api_service_request_url(nil, service_request), :action => "edit", :options => {:baz => "qux"})
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -538,7 +538,7 @@ describe "Service Requests API" do
                                            :options   => {:foo => "bar"})
       api_basic_authorize(action_identifier(:service_requests, :edit))
 
-      run_post(service_requests_url(service_request.id), :action => "edit", :options => {:baz => "qux"})
+      run_post(api_service_request_url(nil, service_request), :action => "edit", :options => {:baz => "qux"})
 
       expected = {
         "id"      => service_request.compressed_id,
@@ -556,7 +556,7 @@ describe "Service Requests API" do
       api_basic_authorize collection_action_identifier(:service_requests, :edit)
 
       run_post(
-        service_requests_url,
+        api_service_requests_url,
         :action    => "edit",
         :resources => [
           {:id => service_request.id, :options => {:baz => "qux"}},
@@ -580,20 +580,20 @@ describe "Service Requests API" do
       FactoryGirl.create(:miq_request_task, :miq_request_id => service_request.id)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      run_get("#{service_requests_url(service_request.id)}/tasks")
+      run_get("#{api_service_request_url(nil, service_request)}/tasks")
 
       expect(response).to have_http_status(:moved_permanently)
-      expect(response.redirect_url).to include("#{service_requests_url(service_request.id)}/request_tasks")
+      expect(response.redirect_url).to include("#{api_service_request_url(nil, service_request)}/request_tasks")
     end
 
     it 'redirects to request_tasks subresources' do
       task = FactoryGirl.create(:miq_request_task, :miq_request_id => service_request.id)
       api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
 
-      run_get("#{service_requests_url(service_request.id)}/tasks/#{task.id}")
+      run_get("#{api_service_request_url(nil, service_request)}/tasks/#{task.id}")
 
       expect(response).to have_http_status(:moved_permanently)
-      expect(response.redirect_url).to include("#{service_requests_url(service_request.id)}/request_tasks/#{task.id}")
+      expect(response.redirect_url).to include("#{api_service_request_url(nil, service_request)}/request_tasks/#{task.id}")
     end
   end
 end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -34,7 +34,7 @@ describe "Services API" do
     it "rejects requests without appropriate role" do
       api_basic_authorize
 
-      run_post(services_url, gen_request(:create, "name" => "svc_new_1"))
+      run_post(api_services_url, gen_request(:create, "name" => "svc_new_1"))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -43,7 +43,7 @@ describe "Services API" do
       api_basic_authorize collection_action_identifier(:services, :create)
 
       expect do
-        run_post(services_url, gen_request(:create, "name" => "svc_new_1"))
+        run_post(api_services_url, gen_request(:create, "name" => "svc_new_1"))
       end.to change(Service, :count).by(1)
 
       expect(response).to have_http_status(:ok)
@@ -54,7 +54,7 @@ describe "Services API" do
       api_basic_authorize collection_action_identifier(:services, :create)
 
       expect do
-        run_post(services_url, gen_request(:create,
+        run_post(api_services_url, gen_request(:create,
                                            [{"name" => "svc_new_1"},
                                             {"name" => "svc_new_2"}]))
       end.to change(Service, :count).by(2)
@@ -73,13 +73,13 @@ describe "Services API" do
         'resource' => {
           'type'                   => 'ServiceOrchestration',
           'name'                   => 'svc_new',
-          'parent_service'         => { 'href' => services_url(svc1.id)},
-          'orchestration_template' => { 'href' => orchestration_templates_url(orchestration_template.compressed_id) },
-          'orchestration_manager'  => { 'href' => providers_url(ems.compressed_id) }
+          'parent_service'         => { 'href' => api_service_url(nil, svc1)},
+          'orchestration_template' => { 'href' => api_orchestration_template_url(nil, orchestration_template.compressed_id) },
+          'orchestration_manager'  => { 'href' => api_provider_url(nil, ems.compressed_id) }
         }
       }
       expect do
-        run_post(services_url, request)
+        run_post(api_services_url, request)
       end.to change(Service, :count).by(1)
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"name" => "svc_new"}])
@@ -99,7 +99,7 @@ describe "Services API" do
         }
       }
       expect do
-        run_post(services_url, request)
+        run_post(api_services_url, request)
       end.to change(Service, :count).by(1)
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"name" => "svc_new"}])
@@ -110,7 +110,7 @@ describe "Services API" do
     it "rejects requests without appropriate role" do
       api_basic_authorize
 
-      run_post(services_url(svc.id), gen_request(:edit, "name" => "sample service"))
+      run_post(api_service_url(nil, svc), gen_request(:edit, "name" => "sample service"))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -118,9 +118,9 @@ describe "Services API" do
     it "supports edits of single resource" do
       api_basic_authorize collection_action_identifier(:services, :edit)
 
-      run_post(services_url(svc.id), gen_request(:edit, "name" => "updated svc1"))
+      run_post(api_service_url(nil, svc), gen_request(:edit, "name" => "updated svc1"))
 
-      expect_single_resource_query("id" => svc.compressed_id, "href" => services_url(svc.compressed_id), "name" => "updated svc1")
+      expect_single_resource_query("id" => svc.compressed_id, "href" => api_service_url(nil, svc.compressed_id), "name" => "updated svc1")
       expect(svc.reload.name).to eq("updated svc1")
     end
 
@@ -130,12 +130,12 @@ describe "Services API" do
       resource = {
         'action'   => 'edit',
         'resource' => {
-          'parent_service'         => { 'href' => services_url(svc1.id) },
-          'orchestration_template' => { 'href' => orchestration_templates_url(orchestration_template.compressed_id) },
-          'orchestration_manager'  => { 'href' => providers_url(ems.compressed_id) }
+          'parent_service'         => { 'href' => api_service_url(nil, svc1) },
+          'orchestration_template' => { 'href' => api_orchestration_template_url(nil, orchestration_template.compressed_id) },
+          'orchestration_manager'  => { 'href' => api_provider_url(nil, ems.compressed_id) }
         }
       }
-      run_post(services_url(svc_orchestration.id), resource)
+      run_post(api_service_url(nil, svc_orchestration), resource)
 
       expected = {
         'id'       => svc_orchestration.compressed_id,
@@ -159,7 +159,7 @@ describe "Services API" do
           'orchestration_manager'  => { 'id' => ems.id }
         }
       }
-      run_post(services_url(svc_orchestration.id), resource)
+      run_post(api_service_url(nil, svc_orchestration), resource)
 
       expected = {
         'id'       => svc_orchestration.compressed_id,
@@ -175,18 +175,18 @@ describe "Services API" do
     it "supports edits of single resource via PUT" do
       api_basic_authorize collection_action_identifier(:services, :edit)
 
-      run_put(services_url(svc.id), "name" => "updated svc1")
+      run_put(api_service_url(nil, svc), "name" => "updated svc1")
 
-      expect_single_resource_query("id" => svc.compressed_id, "href" => services_url(svc.compressed_id), "name" => "updated svc1")
+      expect_single_resource_query("id" => svc.compressed_id, "href" => api_service_url(nil, svc.compressed_id), "name" => "updated svc1")
       expect(svc.reload.name).to eq("updated svc1")
     end
 
     it "supports edits of single resource via PATCH" do
       api_basic_authorize collection_action_identifier(:services, :edit)
 
-      run_patch(services_url(svc.id), [{"action" => "edit",   "path" => "name",        "value" => "updated svc1"},
-                                       {"action" => "remove", "path" => "description"},
-                                       {"action" => "add",    "path" => "display",     "value" => true}])
+      run_patch(api_service_url(nil, svc), [{"action" => "edit",   "path" => "name", "value" => "updated svc1"},
+                                            {"action" => "remove", "path" => "description"},
+                                            {"action" => "add",    "path" => "display", "value" => true}])
 
       expect_single_resource_query("id" => svc.compressed_id, "name" => "updated svc1", "display" => true)
       expect(svc.reload.name).to eq("updated svc1")
@@ -197,9 +197,9 @@ describe "Services API" do
     it "supports edits of multiple resources" do
       api_basic_authorize collection_action_identifier(:services, :edit)
 
-      run_post(services_url, gen_request(:edit,
-                                         [{"href" => services_url(svc1.id), "name" => "updated svc1"},
-                                          {"href" => services_url(svc2.id), "name" => "updated svc2"}]))
+      run_post(api_services_url, gen_request(:edit,
+                                             [{"href" => api_service_url(nil, svc1), "name" => "updated svc1"},
+                                              {"href" => api_service_url(nil, svc2), "name" => "updated svc2"}]))
 
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
@@ -214,7 +214,7 @@ describe "Services API" do
     it "rejects POST delete requests without appropriate role" do
       api_basic_authorize
 
-      run_post(services_url, gen_request(:delete, "href" => services_url(100)))
+      run_post(api_services_url, gen_request(:delete, "href" => api_service_url(nil, 100)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -222,7 +222,7 @@ describe "Services API" do
     it "rejects DELETE requests without appropriate role" do
       api_basic_authorize
 
-      run_delete(services_url(100))
+      run_delete(api_service_url(nil, 100))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -230,7 +230,7 @@ describe "Services API" do
     it "rejects requests for invalid resources" do
       api_basic_authorize collection_action_identifier(:services, :delete)
 
-      run_delete(services_url(999_999))
+      run_delete(api_service_url(nil, 999_999))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -238,7 +238,7 @@ describe "Services API" do
     it "supports single resource deletes" do
       api_basic_authorize collection_action_identifier(:services, :delete)
 
-      run_delete(services_url(svc.id))
+      run_delete(api_service_url(nil, svc))
 
       expect(response).to have_http_status(:no_content)
       expect { svc.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -249,13 +249,13 @@ describe "Services API" do
       api_basic_authorize(action_identifier(:services, :delete))
 
       expect do
-        run_post(services_url(service.id), :action => "delete")
+        run_post(api_service_url(nil, service), :action => "delete")
       end.to change(Service, :count).by(-1)
 
       expected = {
         "success" => true,
         "message" => "services id: #{service.id} deleting",
-        "href"    => a_string_matching(services_url(service.compressed_id))
+        "href"    => api_service_url(nil, service.compressed_id)
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -266,7 +266,7 @@ describe "Services API" do
       api_basic_authorize
 
       expect do
-        run_post(services_url(service.id), :action => "delete")
+        run_post(api_service_url(nil, service), :action => "delete")
       end.not_to change(Service, :count)
 
       expect(response).to have_http_status(:forbidden)
@@ -275,12 +275,12 @@ describe "Services API" do
     it "supports multiple resource deletes" do
       api_basic_authorize collection_action_identifier(:services, :delete)
 
-      run_post(services_url, gen_request(:delete,
-                                         [{"href" => services_url(svc1.id)},
-                                          {"href" => services_url(svc2.id)}]))
+      run_post(api_services_url, gen_request(:delete,
+                                             [{"href" => api_service_url(nil, svc1)},
+                                              {"href" => api_service_url(nil, svc2)}]))
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results",
-                                               [services_url(svc1.compressed_id), services_url(svc2.compressed_id)])
+                                               [api_service_url(nil, svc1.compressed_id), api_service_url(nil, svc2.compressed_id)])
       expect { svc1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { svc2.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
@@ -294,7 +294,7 @@ describe "Services API" do
     it "rejects requests without appropriate role" do
       api_basic_authorize
 
-      run_post(services_url(100), gen_request(:retire))
+      run_post(api_service_url(nil, 100), gen_request(:retire))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -302,7 +302,7 @@ describe "Services API" do
     it "rejects multiple requests without appropriate role" do
       api_basic_authorize
 
-      run_post(services_url, gen_request(:retire, [{"href" => services_url(1)}, {"href" => services_url(2)}]))
+      run_post(api_services_url, gen_request(:retire, [{"href" => api_service_url(nil, 1)}, {"href" => api_service_url(nil, 2)}]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -312,9 +312,9 @@ describe "Services API" do
 
       expect(MiqEvent).to receive(:raise_evm_event).once
 
-      run_post(services_url(svc.id), gen_request(:retire))
+      run_post(api_service_url(nil, svc), gen_request(:retire))
 
-      expect_single_resource_query("id" => svc.compressed_id, "href" => services_url(svc.compressed_id))
+      expect_single_resource_query("id" => svc.compressed_id, "href" => api_service_url(nil, svc.compressed_id))
     end
 
     it "supports single service retirement in future" do
@@ -322,7 +322,7 @@ describe "Services API" do
 
       ret_date = format_retirement_date(Time.now + 5.days)
 
-      run_post(services_url(svc.id), gen_request(:retire, "date" => ret_date, "warn" => 2))
+      run_post(api_service_url(nil, svc), gen_request(:retire, "date" => ret_date, "warn" => 2))
 
       expect_single_resource_query("id" => svc.compressed_id, "retires_on" => ret_date, "retirement_warn" => 2)
       expect(format_retirement_date(svc.reload.retires_on)).to eq(ret_date)
@@ -334,9 +334,9 @@ describe "Services API" do
 
       expect(MiqEvent).to receive(:raise_evm_event).twice
 
-      run_post(services_url, gen_request(:retire,
-                                         [{"href" => services_url(svc1.id)},
-                                          {"href" => services_url(svc2.id)}]))
+      run_post(api_services_url, gen_request(:retire,
+                                             [{"href" => api_service_url(nil, svc1)},
+                                              {"href" => api_service_url(nil, svc2)}]))
 
       expect_results_to_match_hash("results", [{"id" => svc1.compressed_id}, {"id" => svc2.compressed_id}])
     end
@@ -346,9 +346,9 @@ describe "Services API" do
 
       ret_date = format_retirement_date(Time.now + 2.days)
 
-      run_post(services_url, gen_request(:retire,
-                                         [{"href" => services_url(svc1.id), "date" => ret_date, "warn" => 3},
-                                          {"href" => services_url(svc2.id), "date" => ret_date, "warn" => 5}]))
+      run_post(api_services_url, gen_request(:retire,
+                                             [{"href" => api_service_url(nil, svc1), "date" => ret_date, "warn" => 3},
+                                              {"href" => api_service_url(nil, svc2), "date" => ret_date, "warn" => 5}]))
 
       expect_results_to_match_hash("results",
                                    [{"id" => svc1.compressed_id, "retires_on" => ret_date, "retirement_warn" => 3},
@@ -371,7 +371,7 @@ describe "Services API" do
     it "rejects requests without appropriate role" do
       api_basic_authorize
 
-      run_post(services_url(100), gen_request(:reconfigure))
+      run_post(api_service_url(nil, 100), gen_request(:reconfigure))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -381,7 +381,7 @@ describe "Services API" do
                           action_identifier(:services, :retire),
                           action_identifier(:services, :reconfigure))
 
-      run_get services_url(svc1.id)
+      run_get api_service_url(nil, svc1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to declare_actions("retire")
@@ -396,7 +396,7 @@ describe "Services API" do
       svc1.service_template_id = st1.id
       svc1.save
 
-      run_get services_url(svc1.id)
+      run_get api_service_url(nil, svc1)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to declare_actions("retire", "reconfigure")
@@ -410,9 +410,9 @@ describe "Services API" do
       svc1.service_template_id = st1.id
       svc1.save
 
-      run_post(services_url(svc1.id), gen_request(:reconfigure, "text1" => "updated_text"))
+      run_post(api_service_url(nil, svc1), gen_request(:reconfigure, "text1" => "updated_text"))
 
-      expect_single_action_result(:success => true, :message => /reconfiguring/i, :href => services_url(svc1.compressed_id))
+      expect_single_action_result(:success => true, :message => /reconfiguring/i, :href => api_service_url(nil, svc1.compressed_id))
     end
   end
 
@@ -432,22 +432,22 @@ describe "Services API" do
     end
 
     def expect_svc_with_vms
-      expect_single_resource_query("href" => services_url(svc1.compressed_id))
+      expect_single_resource_query("href" => api_service_url(nil, svc1.compressed_id))
       expect_result_resources_to_include_hrefs("vms",
-                                               ["#{services_url(svc1.compressed_id)}/vms/#{vm1.compressed_id}", "#{services_url(svc1.compressed_id)}/vms/#{vm2.compressed_id}"])
+                                               [api_service_vm_url(nil, svc1.compressed_id, vm1.compressed_id), api_service_vm_url(nil, svc1.compressed_id, vm2.compressed_id)])
     end
 
     it "can query vms as subcollection" do
-      run_get "#{services_url(svc1.id)}/vms"
+      run_get(api_service_vms_url(nil, svc1))
 
       expect_query_result(:vms, 2, 2)
       expect_result_resources_to_include_hrefs("resources",
-                                               ["#{services_url(svc1.compressed_id)}/vms/#{vm1.compressed_id}",
-                                                "#{services_url(svc1.compressed_id)}/vms/#{vm2.compressed_id}"])
+                                               [api_service_vm_url(nil, svc1.compressed_id, vm1.compressed_id),
+                                                api_service_vm_url(nil, svc1.compressed_id, vm2.compressed_id)])
     end
 
     it "supports expansion of virtual attributes" do
-      run_get services_url, :expand => "resources", :attributes => "power_states"
+      run_get api_services_url, :expand => "resources", :attributes => "power_states"
 
       expected = {
         "resources" => [
@@ -459,13 +459,13 @@ describe "Services API" do
     end
 
     it "can query vms as subcollection via expand" do
-      run_get services_url(svc1.id), :expand => "vms"
+      run_get api_service_url(nil, svc1), :expand => "vms"
 
       expect_svc_with_vms
     end
 
     it "can query vms as subcollection via expand with additional virtual attributes" do
-      run_get services_url(svc1.id), :expand => "vms", :attributes => "vms.cpu_total_cores"
+      run_get api_service_url(nil, svc1), :expand => "vms", :attributes => "vms.cpu_total_cores"
 
       expect_svc_with_vms
       expect_results_to_match_hash("vms", [{"id" => vm1.compressed_id, "cpu_total_cores" => 2},
@@ -473,7 +473,7 @@ describe "Services API" do
     end
 
     it "can query vms as subcollection via decorators with additional decorators" do
-      run_get services_url(svc1.id), :expand => "vms", :attributes => "", :decorators => "vms.supports_console?"
+      run_get api_service_url(nil, svc1), :expand => "vms", :attributes => "", :decorators => "vms.supports_console?"
 
       expect_svc_with_vms
       expect_results_to_match_hash("vms", [{"id" => vm1.compressed_id, "supports_console?" => true},
@@ -481,7 +481,7 @@ describe "Services API" do
     end
 
     it "cannot query vms via both virtual attribute and subcollection" do
-      run_get services_url(svc1.id), :expand => "vms", :attributes => "vms"
+      run_get api_service_url(nil, svc1), :expand => "vms", :attributes => "vms"
 
       expect_bad_request("Cannot expand subcollection vms by name and virtual attribute")
     end
@@ -493,10 +493,10 @@ describe "Services API" do
         service = FactoryGirl.create(:service)
         api_basic_authorize(action_identifier(:services, :start))
 
-        run_post(services_url(service.id), :action => "start")
+        run_post(api_service_url(nil, service), :action => "start")
 
         expected = {
-          "href"    => a_string_matching(services_url(service.compressed_id)),
+          "href"    => api_service_url(nil, service.compressed_id),
           "success" => true,
           "message" => a_string_matching("starting")
         }
@@ -508,7 +508,7 @@ describe "Services API" do
         service_1, service_2 = FactoryGirl.create_list(:service, 2)
         api_basic_authorize(collection_action_identifier(:services, :start))
 
-        run_post(services_url, :action => "start", :resources => [{:id => service_1.id}, {:id => service_2.id}])
+        run_post(api_services_url, :action => "start", :resources => [{:id => service_1.id}, {:id => service_2.id}])
 
         expected = {
           "results" => a_collection_containing_exactly(
@@ -516,12 +516,12 @@ describe "Services API" do
                              "message"   => a_string_matching("starting"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => a_string_matching(services_url(service_1.compressed_id))),
+                             "href"      => api_service_url(nil, service_1.compressed_id)),
             a_hash_including("success"   => true,
                              "message"   => a_string_matching("starting"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => a_string_matching(services_url(service_2.compressed_id))),
+                             "href"      => api_service_url(nil, service_2.compressed_id)),
           )
         }
         expect(response.parsed_body).to include(expected)
@@ -532,7 +532,7 @@ describe "Services API" do
         service = FactoryGirl.create(:service)
         api_basic_authorize
 
-        run_post(services_url(service.id), :action => "start")
+        run_post(api_service_url(nil, service), :action => "start")
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -543,10 +543,10 @@ describe "Services API" do
         service = FactoryGirl.create(:service)
         api_basic_authorize(action_identifier(:services, :stop))
 
-        run_post(services_url(service.id), :action => "stop")
+        run_post(api_service_url(nil, service), :action => "stop")
 
         expected = {
-          "href"    => a_string_matching(services_url(service.compressed_id)),
+          "href"    => api_service_url(nil, service.compressed_id),
           "success" => true,
           "message" => a_string_matching("stopping")
         }
@@ -558,7 +558,7 @@ describe "Services API" do
         service_1, service_2 = FactoryGirl.create_list(:service, 2)
         api_basic_authorize(collection_action_identifier(:services, :stop))
 
-        run_post(services_url, :action => "stop", :resources => [{:id => service_1.id}, {:id => service_2.id}])
+        run_post(api_services_url, :action => "stop", :resources => [{:id => service_1.id}, {:id => service_2.id}])
 
         expected = {
           "results" => a_collection_containing_exactly(
@@ -566,12 +566,12 @@ describe "Services API" do
                              "message"   => a_string_matching("stopping"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => a_string_matching(services_url(service_1.compressed_id))),
+                             "href"      => api_service_url(nil, service_1.compressed_id)),
             a_hash_including("success"   => true,
                              "message"   => a_string_matching("stopping"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => a_string_matching(services_url(service_2.compressed_id))),
+                             "href"      => api_service_url(nil, service_2.compressed_id)),
           )
         }
         expect(response.parsed_body).to include(expected)
@@ -582,7 +582,7 @@ describe "Services API" do
         service = FactoryGirl.create(:service)
         api_basic_authorize
 
-        run_post(services_url(service.id), :action => "stop")
+        run_post(api_service_url(nil, service), :action => "stop")
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -593,10 +593,10 @@ describe "Services API" do
         service = FactoryGirl.create(:service)
         api_basic_authorize(action_identifier(:services, :suspend))
 
-        run_post(services_url(service.id), :action => "suspend")
+        run_post(api_service_url(nil, service), :action => "suspend")
 
         expected = {
-          "href"    => a_string_matching(services_url(service.compressed_id)),
+          "href"    => api_service_url(nil, service.compressed_id),
           "success" => true,
           "message" => a_string_matching("suspending")
         }
@@ -608,7 +608,7 @@ describe "Services API" do
         service_1, service_2 = FactoryGirl.create_list(:service, 2)
         api_basic_authorize(collection_action_identifier(:services, :suspend))
 
-        run_post(services_url, :action => "suspend", :resources => [{:id => service_1.id}, {:id => service_2.id}])
+        run_post(api_services_url, :action => "suspend", :resources => [{:id => service_1.id}, {:id => service_2.id}])
 
         expected = {
           "results" => a_collection_containing_exactly(
@@ -616,12 +616,12 @@ describe "Services API" do
                              "message"   => a_string_matching("suspending"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => a_string_matching(services_url(service_1.compressed_id))),
+                             "href"      => api_service_url(nil, service_1.compressed_id)),
             a_hash_including("success"   => true,
                              "message"   => a_string_matching("suspending"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => a_string_matching(services_url(service_2.compressed_id))),
+                             "href"      => api_service_url(nil, service_2.compressed_id)),
           )
         }
         expect(response.parsed_body).to include(expected)
@@ -632,7 +632,7 @@ describe "Services API" do
         service = FactoryGirl.create(:service)
         api_basic_authorize
 
-        run_post(services_url(service.id), :action => "suspend")
+        run_post(api_service_url(nil, service), :action => "suspend")
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -649,7 +649,7 @@ describe "Services API" do
     it 'can query orchestration stacks as a subcollection' do
       api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
 
-      run_get("#{services_url(svc.id)}/orchestration_stacks", :expand => 'resources')
+      run_get(api_service_orchestration_stacks_url(nil, svc), :expand => 'resources')
 
       expected = {
         'resources' => [
@@ -663,7 +663,7 @@ describe "Services API" do
     it 'can query a specific orchestration stack' do
       api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
 
-      run_get("#{services_url(svc.id)}/orchestration_stacks/#{os.id}")
+      run_get(api_service_orchestration_stack_url(nil, svc, os))
 
       expected = {'id' => os.compressed_id}
       expect(response).to have_http_status(:ok)
@@ -674,7 +674,7 @@ describe "Services API" do
       api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
 
       allow_any_instance_of(OrchestrationStack).to receive(:stdout).with(nil).and_return("default text stdout")
-      run_get("#{services_url(svc.id)}/orchestration_stacks/#{os.id}", :attributes => "stdout")
+      run_get(api_service_orchestration_stack_url(nil, svc, os), :attributes => "stdout")
 
       expected = {
         'id'     => os.compressed_id,
@@ -688,7 +688,7 @@ describe "Services API" do
       api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
 
       allow_any_instance_of(OrchestrationStack).to receive(:stdout).with("json").and_return("json stdout")
-      run_get("#{services_url(svc.id)}/orchestration_stacks/#{os.id}", :attributes => "stdout", :format_attributes => "stdout=json")
+      run_get(api_service_orchestration_stack_url(nil, svc, os), :attributes => "stdout", :format_attributes => "stdout=json")
 
       expected = {
         'id'     => os.compressed_id,
@@ -701,7 +701,7 @@ describe "Services API" do
     it 'will not return orchestration stacks without an appropriate role' do
       api_basic_authorize
 
-      run_get("#{services_url(svc.id)}/orchestration_stacks")
+      run_get(api_service_orchestration_stacks_url(nil, svc))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -716,12 +716,12 @@ describe "Services API" do
       request = {
         'action'    => 'add_resource',
         'resources' => [
-          { 'href' => services_url(svc.compressed_id), 'resource' => {'href' => vms_url(vm1.id)} },
-          { 'href' => services_url(svc1.id), 'resource' => {'href' => vms_url(vm2.id)} }
+          { 'href' => api_service_url(nil, svc.compressed_id), 'resource' => {'href' => api_vm_url(nil, vm1)} },
+          { 'href' => api_service_url(nil, svc1), 'resource' => {'href' => api_vm_url(nil, vm2)} }
         ]
       }
 
-      run_post(services_url, request)
+      run_post(api_services_url, request)
 
       expected = {
         'results' => [
@@ -742,12 +742,12 @@ describe "Services API" do
       request = {
         'action'    => 'add_resource',
         'resources' => [
-          { 'href' => services_url(svc.compressed_id), 'resource' => {'href' => vms_url(vm1.id)} },
-          { 'href' => services_url(svc1.id), 'resource' => {'href' => users_url(user.compressed_id)} }
+          { 'href' => api_service_url(nil, svc.compressed_id), 'resource' => {'href' => api_vm_url(nil, vm1)} },
+          { 'href' => api_service_url(nil, svc1), 'resource' => {'href' => api_user_url(nil, user.compressed_id)} }
         ]
       }
 
-      run_post(services_url, request)
+      run_post(api_services_url, request)
 
       expected = {
         'results' => [
@@ -768,7 +768,7 @@ describe "Services API" do
         'resource' => { 'resource' => { 'href' => '1' } }
       }
 
-      run_post(services_url(svc.id), request)
+      run_post(api_service_url(nil, svc), request)
 
       expected = { 'success' => false, 'message' => "Invalid resource href specified 1"}
 
@@ -781,10 +781,10 @@ describe "Services API" do
       api_basic_authorize(collection_action_identifier(:services, :add_resource))
       request = {
         'action'   => 'add_resource',
-        'resource' => { 'resource' => { 'href' => users_url(user.compressed_id) } }
+        'resource' => { 'resource' => { 'href' => api_user_url(nil, user.compressed_id) } }
       }
 
-      run_post(services_url(svc.id), request)
+      run_post(api_service_url(nil, svc), request)
 
       expected = { 'success' => false, 'message' => "Cannot assign users to Service id:#{svc.id} name:'#{svc.name}'"}
 
@@ -799,7 +799,7 @@ describe "Services API" do
         'resource' => { 'resource' => {} }
       }
 
-      run_post(services_url(svc.id), request)
+      run_post(api_service_url(nil, svc), request)
 
       expected = { 'success' => false, 'message' => "Must specify a resource reference"}
 
@@ -811,10 +811,10 @@ describe "Services API" do
       api_basic_authorize(collection_action_identifier(:services, :add_resource))
       request = {
         'action'   => 'add_resource',
-        'resource' => { 'resource' => {'href' => vms_url(vm1.id)} }
+        'resource' => { 'resource' => {'href' => api_vm_url(nil, vm1)} }
       }
 
-      run_post(services_url(svc.id), request)
+      run_post(api_service_url(nil, svc), request)
 
       expected = { 'success' => true, 'message' => "Assigned resource vms id:#{vm1.id} to Service id:#{svc.id} name:'#{svc.name}'"}
 
@@ -826,7 +826,7 @@ describe "Services API" do
     it 'cannot add multiple vms to multiple services by href without an appropriate role' do
       api_basic_authorize
 
-      run_post(services_url, 'action' => 'add_resource')
+      run_post(api_services_url, 'action' => 'add_resource')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -844,7 +844,7 @@ describe "Services API" do
     it 'cannot remove vms from services without an appropriate role' do
       api_basic_authorize
 
-      run_post(services_url, 'action' => 'remove_resource')
+      run_post(api_services_url, 'action' => 'remove_resource')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -854,12 +854,12 @@ describe "Services API" do
       request = {
         'action'    => 'remove_resource',
         'resources' => [
-          { 'href' => services_url(svc.compressed_id), 'resource' => { 'href' => vms_url(vm1.id)} },
-          { 'href' => services_url(svc1.id), 'resource' => { 'href' => vms_url(vm2.id)} }
+          { 'href' => api_service_url(nil, svc.compressed_id), 'resource' => { 'href' => api_vm_url(nil, vm1)} },
+          { 'href' => api_service_url(nil, svc1), 'resource' => { 'href' => api_vm_url(nil, vm2)} }
         ]
       }
 
-      run_post(services_url, request)
+      run_post(api_services_url, request)
 
       expected = {
         'results' => [
@@ -878,11 +878,11 @@ describe "Services API" do
       request = {
         'action'    => 'remove_resource',
         'resources' => [
-          { 'href' => services_url, 'resource' => { 'href' => vms_url(vm1.id)} }
+          { 'href' => api_services_url, 'resource' => { 'href' => api_vm_url(nil, vm1)} }
         ]
       }
 
-      run_post(services_url, request)
+      run_post(api_services_url, request)
 
       expected = {
         'results' => [
@@ -898,11 +898,11 @@ describe "Services API" do
       request = {
         'action'    => 'remove_resource',
         'resources' => [
-          { 'href' => services_url(svc.compressed_id), 'resource' => {} }
+          { 'href' => api_service_url(nil, svc.compressed_id), 'resource' => {} }
         ]
       }
 
-      run_post(services_url, request)
+      run_post(api_services_url, request)
 
       expected = {
         'results' => [
@@ -916,7 +916,7 @@ describe "Services API" do
     it 'cannot remove a vm from a service without an appropriate role' do
       api_basic_authorize
 
-      run_post(services_url(svc.id), 'action' => 'remove_resource')
+      run_post(api_service_url(nil, svc), 'action' => 'remove_resource')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -925,10 +925,10 @@ describe "Services API" do
       api_basic_authorize collection_action_identifier(:services, :remove_resource)
       request = {
         'action'   => 'remove_resource',
-        'resource' => { 'resource' => {'href' => vms_url(vm1.id)} }
+        'resource' => { 'resource' => {'href' => api_vm_url(nil, vm1)} }
       }
 
-      run_post(services_url(svc.id), request)
+      run_post(api_service_url(nil, svc), request)
 
       expected = {
         'success' => true,
@@ -954,7 +954,7 @@ describe "Services API" do
     it 'cannot remove all resources without an appropriate role' do
       api_basic_authorize
 
-      run_post(services_url, 'action' => 'remove_all_resources')
+      run_post(api_services_url, 'action' => 'remove_all_resources')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -964,12 +964,12 @@ describe "Services API" do
       request = {
         'action'    => 'remove_all_resources',
         'resources' => [
-          { 'href' => services_url(svc.compressed_id) },
-          { 'href' => services_url(svc1.id) }
+          { 'href' => api_service_url(nil, svc.compressed_id) },
+          { 'href' => api_service_url(nil, svc1) }
         ]
       }
 
-      run_post(services_url, request)
+      run_post(api_services_url, request)
 
       expected = {
         'results' => [
@@ -986,7 +986,7 @@ describe "Services API" do
     it 'cannot remove all resources without an appropriate role' do
       api_basic_authorize
 
-      run_post(services_url(svc.id), :action => 'remove_all_resources')
+      run_post(api_service_url(nil, svc), :action => 'remove_all_resources')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -994,7 +994,7 @@ describe "Services API" do
     it 'can remove all resources from a service' do
       api_basic_authorize collection_action_identifier(:services, :remove_all_resources)
 
-      run_post(services_url(svc.id), :action => 'remove_all_resources')
+      run_post(api_service_url(nil, svc), :action => 'remove_all_resources')
 
       expected = {
         'success' => true, 'message' => "Removed all resources from Service id:#{svc.id} name:'#{svc.name}'"
@@ -1007,7 +1007,7 @@ describe "Services API" do
   end
 
   describe "Metric Rollups subcollection" do
-    let(:url) { "#{services_url(svc.id)}/metric_rollups" }
+    let(:url) { api_service_metric_rollups_url(nil, svc) }
 
     before do
       FactoryGirl.create_list(:metric_rollup_vm_hr, 3, :resource => svc)

--- a/spec/requests/set_ownership_spec.rb
+++ b/spec/requests/set_ownership_spec.rb
@@ -19,7 +19,7 @@ describe "Set Ownership" do
     it "to an invalid service" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
+      run_post(api_service_url(nil, 999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -27,7 +27,7 @@ describe "Set Ownership" do
     it "without appropriate action role" do
       api_basic_authorize
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"id" => 1}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -35,7 +35,7 @@ describe "Set Ownership" do
     it "with missing owner or group" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership))
 
       expect_bad_request("Must specify an owner or group")
     end
@@ -43,65 +43,65 @@ describe "Set Ownership" do
     it "with invalid owner" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
-      expect_single_action_result(:success => false, :message => /.*/, :href => services_url(svc.compressed_id))
+      expect_single_action_result(:success => false, :message => /.*/, :href => api_service_url(nil, svc.compressed_id))
     end
 
     it "to a service" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(svc, services_url(svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
     end
 
     it "by owner name to a service" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
-      expect_set_ownership_success(svc, services_url(svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
     end
 
     it "by owner href to a service" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"href" => users_url(@user.id)}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "owner" => {"href" => api_user_url(nil, @user)}))
 
-      expect_set_ownership_success(svc, services_url(svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
     end
 
     it "by owner id to a service" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
-      expect_set_ownership_success(svc, services_url(svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
     end
 
     it "by group id to a service" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "group" => {"id" => @group.id}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
-      expect_set_ownership_success(svc, services_url(svc.compressed_id), nil, @group)
+      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), nil, @group)
     end
 
     it "by group description to a service" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "group" => {"description" => @group.description}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "group" => {"description" => @group.description}))
 
-      expect_set_ownership_success(svc, services_url(svc.compressed_id), nil, @group)
+      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), nil, @group)
     end
 
     it "with owner and group to a service" do
       api_basic_authorize action_identifier(:services, :set_ownership)
 
-      run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
+      run_post(api_service_url(nil, svc), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(svc, services_url(svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
     end
 
     it "to multiple services" do
@@ -110,11 +110,11 @@ describe "Set Ownership" do
       svc1 = FactoryGirl.create(:service, :name => "svc1", :description => "svc1 description")
       svc2 = FactoryGirl.create(:service, :name => "svc2", :description => "svc2 description")
 
-      svc_urls = [services_url(svc1.id), services_url(svc2.id)]
-      run_post(services_url, gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *svc_urls))
+      svc_urls = [api_service_url(nil, svc1), api_service_url(nil, svc2)]
+      run_post(api_services_url, gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *svc_urls))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [services_url(svc1.compressed_id), services_url(svc2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_service_url(nil, svc1.compressed_id), api_service_url(nil, svc2.compressed_id)])
       expect(svc1.reload.evm_owner).to eq(@user)
       expect(svc2.reload.evm_owner).to eq(@user)
     end
@@ -126,7 +126,7 @@ describe "Set Ownership" do
     it "to an invalid vm" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
+      run_post(api_vm_url(nil, 999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -134,7 +134,7 @@ describe "Set Ownership" do
     it "without appropriate action role" do
       api_basic_authorize
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"id" => 1}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -142,7 +142,7 @@ describe "Set Ownership" do
     it "with missing owner or group" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership))
 
       expect_bad_request("Must specify an owner or group")
     end
@@ -150,65 +150,65 @@ describe "Set Ownership" do
     it "with invalid owner" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
-      expect_single_action_result(:success => false, :message => /.*/, :href => vms_url(vm.compressed_id))
+      expect_single_action_result(:success => false, :message => /.*/, :href => api_vm_url(nil, vm.compressed_id))
     end
 
     it "to a vm" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(vm, vms_url(vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
     end
 
     it "by owner name to a vm" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
-      expect_set_ownership_success(vm, vms_url(vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
     end
 
     it "by owner href to a vm" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"href" => users_url(@user.id)}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "owner" => {"href" => api_user_url(nil, @user)}))
 
-      expect_set_ownership_success(vm, vms_url(vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
     end
 
     it "by owner id to a vm" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
-      expect_set_ownership_success(vm, vms_url(vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
     end
 
     it "by group id to a vm" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "group" => {"id" => @group.id}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
-      expect_set_ownership_success(vm, vms_url(vm.compressed_id), nil, @group)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), nil, @group)
     end
 
     it "by group description to a vm" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "group" => {"description" => @group.description}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "group" => {"description" => @group.description}))
 
-      expect_set_ownership_success(vm, vms_url(vm.compressed_id), nil, @group)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), nil, @group)
     end
 
     it "with owner and group to a vm" do
       api_basic_authorize action_identifier(:vms, :set_ownership)
 
-      run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
+      run_post(api_vm_url(nil, vm), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(vm, vms_url(vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
     end
 
     it "to multiple vms" do
@@ -217,11 +217,11 @@ describe "Set Ownership" do
       vm1 = FactoryGirl.create(:vm, :name => "vm1", :description => "vm1 description")
       vm2 = FactoryGirl.create(:vm, :name => "vm2", :description => "vm2 description")
 
-      vm_urls = [vms_url(vm1.id), vms_url(vm2.id)]
-      run_post(vms_url, gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *vm_urls))
+      vm_urls = [api_vm_url(nil, vm1), api_vm_url(nil, vm2)]
+      run_post(api_vms_url, gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *vm_urls))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [vms_url(vm1.compressed_id), vms_url(vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1.compressed_id), api_vm_url(nil, vm2.compressed_id)])
       expect(vm1.reload.evm_owner).to eq(@user)
       expect(vm2.reload.evm_owner).to eq(@user)
     end
@@ -233,7 +233,7 @@ describe "Set Ownership" do
     it "to an invalid template" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
+      run_post(api_template_url(nil, 999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -241,7 +241,7 @@ describe "Set Ownership" do
     it "without appropriate action role" do
       api_basic_authorize
 
-      run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"id" => 1}))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -249,7 +249,7 @@ describe "Set Ownership" do
     it "with missing owner or group" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id), gen_request(:set_ownership))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership))
 
       expect_bad_request("Must specify an owner or group")
     end
@@ -257,66 +257,66 @@ describe "Set Ownership" do
     it "with invalid owner" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
-      expect_single_action_result(:success => false, :message => /.*/, :href => templates_url(template.compressed_id))
+      expect_single_action_result(:success => false, :message => /.*/, :href => api_template_url(nil, template.compressed_id))
     end
 
     it "to a template" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(template, templates_url(template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
     end
 
     it "by owner name to a template" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
-      expect_set_ownership_success(template, templates_url(template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
     end
 
     it "by owner href to a template" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"href" => users_url(@user.id)}))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership, "owner" => {"href" => api_user_url(nil, @user)}))
 
-      expect_set_ownership_success(template, templates_url(template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
     end
 
     it "by owner id to a template" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
-      expect_set_ownership_success(template, templates_url(template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
     end
 
     it "by group id to a template" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id), gen_request(:set_ownership, "group" => {"id" => @group.id}))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
-      expect_set_ownership_success(template, templates_url(template.compressed_id), nil, @group)
+      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), nil, @group)
     end
 
     it "by group description to a template" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id),
+      run_post(api_template_url(nil, template),
                gen_request(:set_ownership, "group" => {"description" => @group.description}))
 
-      expect_set_ownership_success(template, templates_url(template.compressed_id), nil, @group)
+      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), nil, @group)
     end
 
     it "with owner and group to a template" do
       api_basic_authorize action_identifier(:templates, :set_ownership)
 
-      run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
+      run_post(api_template_url(nil, template), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(template, templates_url(template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
     end
 
     it "to multiple templates" do
@@ -325,11 +325,11 @@ describe "Set Ownership" do
       template1 = FactoryGirl.create(:template_vmware, :name => "template1")
       template2 = FactoryGirl.create(:template_vmware, :name => "template2")
 
-      template_urls = [templates_url(template1.id), templates_url(template2.id)]
-      run_post(templates_url, gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *template_urls))
+      template_urls = [api_template_url(nil, template1), api_template_url(nil, template2)]
+      run_post(api_templates_url, gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *template_urls))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [templates_url(template1.compressed_id), templates_url(template2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_template_url(nil, template1.compressed_id), api_template_url(nil, template2.compressed_id)])
       expect(template1.reload.evm_owner).to eq(@user)
       expect(template2.reload.evm_owner).to eq(@user)
     end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -8,7 +8,7 @@ describe "Settings API" do
     it "tests queries of all exposed settings" do
       api_basic_authorize action_identifier(:settings, :read, :collection_actions, :get)
 
-      run_get settings_url
+      run_get api_settings_url
 
       expect_result_to_have_only_keys(api_settings)
     end
@@ -17,7 +17,7 @@ describe "Settings API" do
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
       category = api_settings.first
-      run_get settings_url(category)
+      run_get api_setting_url(nil, category)
 
       expect_result_to_have_only_keys(category)
     end
@@ -26,7 +26,7 @@ describe "Settings API" do
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
       category = api_settings.first
-      run_get settings_url(category)
+      run_get api_setting_url(nil, category)
 
       expect(response.parsed_body[category]).to eq(Settings[category].to_hash.stringify_keys)
     end
@@ -34,7 +34,7 @@ describe "Settings API" do
     it "rejects query for an invalid setting category " do
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
-      run_get settings_url("invalid_setting")
+      run_get api_setting_url(nil, "invalid_setting")
 
       expect(response).to have_http_status(:not_found)
     end
@@ -94,7 +94,7 @@ describe "Settings API" do
       stub_api_settings_categories(%w(product authentication server))
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
-      run_get settings_url
+      run_get api_settings_url
 
       expect(response.parsed_body).to match(
         "product"        => sample_settings["product"],
@@ -107,7 +107,7 @@ describe "Settings API" do
       stub_api_settings_categories(%w(product server/role))
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
-      run_get settings_url
+      run_get api_settings_url
 
       expect(response.parsed_body).to match(
         "product" => sample_settings["product"],
@@ -119,7 +119,7 @@ describe "Settings API" do
       stub_api_settings_categories(%w(product server/role server/worker_monitor/sync_interval))
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
-      run_get settings_url
+      run_get api_settings_url
 
       expect(response.parsed_body).to match(
         "product" => sample_settings["product"],
@@ -134,7 +134,7 @@ describe "Settings API" do
       stub_api_settings_categories(%w(product server/role server/worker_monitor authentication))
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
-      run_get settings_url
+      run_get api_settings_url
 
       expect(response.parsed_body).to match(
         "product"        => sample_settings["product"],

--- a/spec/requests/snapshots_spec.rb
+++ b/spec/requests/snapshots_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe "Snapshots API" do
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
         _other_snapshot = FactoryGirl.create(:snapshot)
 
-        run_get("#{vms_url(vm.id)}/snapshots")
+        run_get(api_vm_snapshots_url(nil, vm))
 
         expected = {
           "count"     => 2,
           "name"      => "snapshots",
           "subcount"  => 1,
           "resources" => [
-            {"href" => a_string_matching("#{vms_url(vm.compressed_id)}/snapshots/#{snapshot.compressed_id}")}
+            {"href" => api_vm_snapshot_url(nil, vm.compressed_id, snapshot.compressed_id)}
           ]
         }
         expect(response.parsed_body).to include(expected)
@@ -26,7 +26,7 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
         FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-        run_get("#{vms_url(vm.id)}/snapshots")
+        run_get(api_vm_snapshots_url(nil, vm))
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -39,11 +39,11 @@ RSpec.describe "Snapshots API" do
         create_time = Time.zone.parse("2017-01-11T00:00:00Z")
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm, :create_time => create_time)
 
-        run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+        run_get(api_vm_snapshot_url(nil, vm, snapshot))
 
         expected = {
           "create_time"       => create_time.iso8601,
-          "href"              => a_string_matching("#{vms_url(vm.compressed_id)}/snapshots/#{snapshot.compressed_id}"),
+          "href"              => api_vm_snapshot_url(nil, vm.compressed_id, snapshot.compressed_id),
           "id"                => snapshot.compressed_id,
           "vm_or_template_id" => vm.compressed_id
         }
@@ -56,7 +56,7 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-        run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+        run_get(api_vm_snapshot_url(nil, vm, snapshot))
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -69,7 +69,7 @@ RSpec.describe "Snapshots API" do
         host = FactoryGirl.create(:host, :ext_management_system => ems)
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
 
-        run_post("#{vms_url(vm.id)}/snapshots", :name => "Alice's snapshot")
+        run_post(api_vm_snapshots_url(nil, vm), :name => "Alice's snapshot")
 
         expected = {
           "results" => [
@@ -77,7 +77,7 @@ RSpec.describe "Snapshots API" do
               "success"   => true,
               "message"   => "Creating snapshot Alice's snapshot for Virtual Machine id:#{vm.id} name:'Alice's VM'",
               "task_id"   => anything,
-              "task_href" => a_string_matching(tasks_url)
+              "task_href" => a_string_matching(api_tasks_url)
             )
           ]
         }
@@ -89,7 +89,7 @@ RSpec.describe "Snapshots API" do
         api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :create))
         vm = FactoryGirl.create(:vm_vmware)
 
-        run_post("#{vms_url(vm.id)}/snapshots", :name => "Alice's snapsnot")
+        run_post(api_vm_snapshots_url(nil, vm), :name => "Alice's snapsnot")
 
         expected = {
           "results" => [
@@ -109,7 +109,7 @@ RSpec.describe "Snapshots API" do
         host = FactoryGirl.create(:host, :ext_management_system => ems)
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
 
-        run_post("#{vms_url(vm.id)}/snapshots", :description => "Alice's snapshot")
+        run_post(api_vm_snapshots_url(nil, vm), :description => "Alice's snapshot")
 
         expected = {
           "results" => [
@@ -127,7 +127,7 @@ RSpec.describe "Snapshots API" do
         api_basic_authorize
         vm = FactoryGirl.create(:vm_vmware)
 
-        run_post("#{vms_url(vm.id)}/snapshots", :description => "Alice's snapshot")
+        run_post(api_vm_snapshots_url(nil, vm), :description => "Alice's snapshot")
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -141,12 +141,12 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
         snapshot = FactoryGirl.create(:snapshot, :name => "Alice's snapshot", :vm_or_template => vm)
 
-        run_post("#{vms_url(vm.id)}/snapshots/#{snapshot.id}", :action => "revert")
+        run_post(api_vm_snapshot_url(nil, vm, snapshot), :action => "revert")
 
         expected = {
           "message"   => "Reverting to snapshot Alice's snapshot for Virtual Machine id:#{vm.id} name:'Alice's VM'",
           "success"   => true,
-          "task_href" => a_string_matching(tasks_url),
+          "task_href" => a_string_matching(api_tasks_url),
           "task_id"   => anything
         }
         expect(response.parsed_body).to include(expected)
@@ -158,7 +158,7 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-        run_post("#{vms_url(vm.id)}/snapshots/#{snapshot.id}", :action => "revert")
+        run_post(api_vm_snapshot_url(nil, vm, snapshot), :action => "revert")
 
         expected = {
           "success" => false,
@@ -173,7 +173,7 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-        run_post("#{vms_url(vm.id)}/snapshots/#{snapshot.id}", :action => "revert")
+        run_post(api_vm_snapshot_url(nil, vm, snapshot), :action => "revert")
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -187,12 +187,12 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
         snapshot = FactoryGirl.create(:snapshot, :name => "Alice's snapshot", :vm_or_template => vm)
 
-        run_post("#{vms_url(vm.id)}/snapshots/#{snapshot.id}", :action => "delete")
+        run_post(api_vm_snapshot_url(nil, vm, snapshot), :action => "delete")
 
         expected = {
           "message"   => "Deleting snapshot Alice's snapshot for Virtual Machine id:#{vm.id} name:'Alice's VM'",
           "success"   => true,
-          "task_href" => a_string_matching(tasks_url),
+          "task_href" => a_string_matching(api_tasks_url),
           "task_id"   => anything
         }
         expect(response.parsed_body).to include(expected)
@@ -204,7 +204,7 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-        run_post("#{vms_url(vm.id)}/snapshots/#{snapshot.id}", :action => "delete")
+        run_post(api_vm_snapshot_url(nil, vm, snapshot), :action => "delete")
 
         expected = {
           "success" => false,
@@ -219,7 +219,7 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-        run_post("#{vms_url(vm.id)}/snapshots/#{snapshot.id}", :action => "delete")
+        run_post(api_vm_snapshot_url(nil, vm, snapshot), :action => "delete")
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -228,7 +228,7 @@ RSpec.describe "Snapshots API" do
         api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :post))
         vm = FactoryGirl.create(:vm_vmware)
 
-        run_post("#{vms_url(vm.id)}/snapshots/0", :action => "delete")
+        run_post(api_vm_snapshot_url(nil, vm, 0), :action => "delete")
 
         expected = {
           "error" => a_hash_including(
@@ -252,11 +252,11 @@ RSpec.describe "Snapshots API" do
         snapshot2 = FactoryGirl.create(:snapshot, :name => "Bob's snapshot", :vm_or_template => vm)
 
         run_post(
-          "#{vms_url(vm.id)}/snapshots",
+          api_vm_snapshots_url(nil, vm),
           :action    => "delete",
           :resources => [
-            {:href => "#{vms_url(vm.id)}/snapshots/#{snapshot1.id}"},
-            {:href => "#{vms_url(vm.id)}/snapshots/#{snapshot2.id}"}
+            {:href => api_vm_snapshot_url(nil, vm, snapshot1)},
+            {:href => api_vm_snapshot_url(nil, vm, snapshot2)}
           ]
         )
 
@@ -265,13 +265,13 @@ RSpec.describe "Snapshots API" do
             a_hash_including(
               "message"   => "Deleting snapshot Alice's snapshot for Virtual Machine id:#{vm.id} name:'Alice and Bob's VM'",
               "success"   => true,
-              "task_href" => a_string_matching(tasks_url),
+              "task_href" => a_string_matching(api_tasks_url),
               "task_id"   => anything
             ),
             a_hash_including(
               "message"   => "Deleting snapshot Bob's snapshot for Virtual Machine id:#{vm.id} name:'Alice and Bob's VM'",
               "success"   => true,
-              "task_href" => a_string_matching(tasks_url),
+              "task_href" => a_string_matching(api_tasks_url),
               "task_id"   => anything
             )
           )
@@ -285,10 +285,10 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
 
         run_post(
-          "#{vms_url(vm.id)}/snapshots",
+          api_vm_snapshots_url(nil, vm),
           :action    => "delete",
           :resources => [
-            {:href => "#{vms_url(vm.id)}/snapshots/0"}
+            {:href => api_vm_snapshot_url(nil, vm, 0)}
           ]
         )
 
@@ -310,7 +310,7 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-        run_delete("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+        run_delete(api_vm_snapshot_url(nil, vm, snapshot))
 
         expect(response).to have_http_status(:no_content)
       end
@@ -320,7 +320,7 @@ RSpec.describe "Snapshots API" do
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-        run_delete("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+        run_delete(api_vm_snapshot_url(nil, vm, snapshot))
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -329,7 +329,7 @@ RSpec.describe "Snapshots API" do
         api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :delete))
         vm = FactoryGirl.create(:vm_vmware)
 
-        run_delete("#{vms_url(vm.id)}/snapshots/0", :action => "delete")
+        run_delete(api_vm_snapshot_url(nil, vm, 0), :action => "delete")
 
         expected = {
           "error" => a_hash_including(
@@ -352,14 +352,14 @@ RSpec.describe "Snapshots API" do
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
         _other_snapshot = FactoryGirl.create(:snapshot)
 
-        run_get("#{instances_url(instance.id)}/snapshots")
+        run_get(api_instance_snapshots_url(nil, instance))
 
         expected = {
           "count"     => 2,
           "name"      => "snapshots",
           "subcount"  => 1,
           "resources" => [
-            {"href" => a_string_matching("#{instances_url(instance.compressed_id)}/snapshots/#{snapshot.compressed_id}")}
+            {"href" => api_instance_snapshot_url(nil, instance.compressed_id, snapshot.compressed_id)}
           ]
         }
         expect(response.parsed_body).to include(expected)
@@ -371,7 +371,7 @@ RSpec.describe "Snapshots API" do
         instance = FactoryGirl.create(:vm_openstack)
         _snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
 
-        run_get("#{instances_url(instance.id)}/snapshots")
+        run_get(api_instance_snapshots_url(nil, instance))
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -384,11 +384,11 @@ RSpec.describe "Snapshots API" do
         create_time = Time.zone.parse("2017-01-11T00:00:00Z")
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance, :create_time => create_time)
 
-        run_get("#{instances_url(instance.id)}/snapshots/#{snapshot.id}")
+        run_get(api_instance_snapshot_url(nil, instance, snapshot))
 
         expected = {
           "create_time"       => create_time.iso8601,
-          "href"              => a_string_matching("#{instances_url(instance.compressed_id)}/snapshots/#{snapshot.compressed_id}"),
+          "href"              => api_instance_snapshot_url(nil, instance.compressed_id, snapshot.compressed_id),
           "id"                => snapshot.compressed_id,
           "vm_or_template_id" => instance.compressed_id
         }
@@ -401,7 +401,7 @@ RSpec.describe "Snapshots API" do
         instance = FactoryGirl.create(:vm_openstack)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
 
-        run_get("#{instances_url(instance.id)}/snapshots/#{snapshot.id}")
+        run_get(api_instance_snapshot_url(nil, instance, snapshot))
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -414,7 +414,7 @@ RSpec.describe "Snapshots API" do
         host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => ems)
         instance = FactoryGirl.create(:vm_openstack, :name => "Alice's Instance", :ext_management_system => ems, :host => host)
 
-        run_post("#{instances_url(instance.id)}/snapshots", :name => "Alice's snapshot")
+        run_post(api_instance_snapshots_url(nil, instance), :name => "Alice's snapshot")
 
         expected = {
           "results" => [
@@ -422,7 +422,7 @@ RSpec.describe "Snapshots API" do
               "success"   => true,
               "message"   => "Creating snapshot Alice's snapshot for Instance id:#{instance.id} name:'Alice's Instance'",
               "task_id"   => anything,
-              "task_href" => a_string_matching(tasks_url)
+              "task_href" => a_string_matching(api_tasks_url)
             )
           ]
         }
@@ -434,7 +434,7 @@ RSpec.describe "Snapshots API" do
         api_basic_authorize(subcollection_action_identifier(:instances, :snapshots, :create))
         instance = FactoryGirl.create(:vm_openstack)
 
-        run_post("#{instances_url(instance.id)}/snapshots", :name => "Alice's snapsnot")
+        run_post(api_instance_snapshots_url(nil, instance), :name => "Alice's snapsnot")
 
         expected = {
           "results" => [
@@ -454,7 +454,7 @@ RSpec.describe "Snapshots API" do
         host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => ems)
         instance = FactoryGirl.create(:vm_openstack, :name => "Alice's Instance", :ext_management_system => ems, :host => host)
 
-        run_post("#{instances_url(instance.id)}/snapshots", :description => "Alice's snapshot")
+        run_post(api_instance_snapshots_url(nil, instance), :description => "Alice's snapshot")
 
         expected = {
           "results" => [
@@ -472,7 +472,7 @@ RSpec.describe "Snapshots API" do
         api_basic_authorize
         instance = FactoryGirl.create(:vm_openstack)
 
-        run_post("#{instances_url(instance.id)}/snapshots", :description => "Alice's snapshot")
+        run_post(api_instance_snapshots_url(nil, instance), :description => "Alice's snapshot")
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -487,12 +487,12 @@ RSpec.describe "Snapshots API" do
         instance = FactoryGirl.create(:vm_openstack, :name => "Alice's Instance", :ext_management_system => ems, :host => host)
         snapshot = FactoryGirl.create(:snapshot, :name => "Alice's snapshot", :vm_or_template => instance)
 
-        run_post("#{instances_url(instance.id)}/snapshots/#{snapshot.id}", :action => "delete")
+        run_post(api_instance_snapshot_url(nil, instance, snapshot), :action => "delete")
 
         expected = {
           "message"   => "Deleting snapshot Alice's snapshot for Instance id:#{instance.id} name:'Alice's Instance'",
           "success"   => true,
-          "task_href" => a_string_matching(tasks_url),
+          "task_href" => a_string_matching(api_tasks_url),
           "task_id"   => anything
         }
         expect(response.parsed_body).to include(expected)
@@ -504,7 +504,7 @@ RSpec.describe "Snapshots API" do
         instance = FactoryGirl.create(:vm_openstack)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
 
-        run_post("#{instances_url(instance.id)}/snapshots/#{snapshot.id}", :action => "delete")
+        run_post(api_instance_snapshot_url(nil, instance, snapshot), :action => "delete")
 
         expected = {
           "success" => false,
@@ -519,7 +519,7 @@ RSpec.describe "Snapshots API" do
         instance = FactoryGirl.create(:vm_openstack)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
 
-        run_post("#{instances_url(instance.id)}/snapshots/#{snapshot.id}", :action => "delete")
+        run_post(api_instance_snapshot_url(nil, instance, snapshot), :action => "delete")
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -536,11 +536,11 @@ RSpec.describe "Snapshots API" do
         snapshot2 = FactoryGirl.create(:snapshot, :name => "Bob's snapshot", :vm_or_template => instance)
 
         run_post(
-          "#{instances_url(instance.id)}/snapshots",
+          api_instance_snapshots_url(nil, instance),
           :action    => "delete",
           :resources => [
-            {:href => "#{instances_url(instance.id)}/snapshots/#{snapshot1.id}"},
-            {:href => "#{instances_url(instance.id)}/snapshots/#{snapshot2.id}"}
+            {:href => api_instance_snapshot_url(nil, instance, snapshot1)},
+            {:href => api_instance_snapshot_url(nil, instance, snapshot2)}
           ]
         )
 
@@ -549,13 +549,13 @@ RSpec.describe "Snapshots API" do
             a_hash_including(
               "message"   => "Deleting snapshot Alice's snapshot for Instance id:#{instance.id} name:'Alice and Bob's Instance'",
               "success"   => true,
-              "task_href" => a_string_matching(tasks_url),
+              "task_href" => a_string_matching(api_tasks_url),
               "task_id"   => anything
             ),
             a_hash_including(
               "message"   => "Deleting snapshot Bob's snapshot for Instance id:#{instance.id} name:'Alice and Bob's Instance'",
               "success"   => true,
-              "task_href" => a_string_matching(tasks_url),
+              "task_href" => a_string_matching(api_tasks_url),
               "task_id"   => anything
             )
           )
@@ -571,7 +571,7 @@ RSpec.describe "Snapshots API" do
         instance = FactoryGirl.create(:vm_openstack)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
 
-        run_delete("#{instances_url(instance.id)}/snapshots/#{snapshot.id}")
+        run_delete(api_instance_snapshot_url(nil, instance, snapshot))
 
         expect(response).to have_http_status(:no_content)
       end
@@ -581,7 +581,7 @@ RSpec.describe "Snapshots API" do
         instance = FactoryGirl.create(:vm_openstack)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
 
-        run_delete("#{instances_url(instance.id)}/snapshots/#{snapshot.id}")
+        run_delete(api_instance_snapshot_url(nil, instance, snapshot))
 
         expect(response).to have_http_status(:forbidden)
       end

--- a/spec/requests/tag_collections_spec.rb
+++ b/spec/requests/tag_collections_spec.rb
@@ -32,14 +32,12 @@ describe "Tag Collections API" do
 
   context "Provider Tag subcollection" do
     let(:provider)          { ems }
-    let(:provider_url)      { providers_url(provider.id) }
-    let(:provider_tags_url) { "#{provider_url}/tags" }
 
     it "query all tags of a Provider and verify tag category and names" do
       api_basic_authorize
       classify_resource(provider)
 
-      run_get provider_tags_url, :expand => "resources"
+      run_get api_provider_tags_url(nil, provider), :expand => "resources"
 
       expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => tag_paths)
@@ -48,7 +46,7 @@ describe "Tag Collections API" do
     it "does not assign a tag to a Provider without appropriate role" do
       api_basic_authorize
 
-      run_post(provider_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_provider_tags_url(nil, provider), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -56,15 +54,15 @@ describe "Tag Collections API" do
     it "assigns a tag to a Provider" do
       api_basic_authorize subcollection_action_identifier(:providers, :tags, :assign)
 
-      run_post(provider_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_provider_tags_url(nil, provider), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(providers_url(provider.compressed_id)))
+      expect_tagging_result(tag1_results(api_provider_url(nil, provider.compressed_id)))
     end
 
     it "does not unassign a tag from a Provider without appropriate role" do
       api_basic_authorize
 
-      run_post(provider_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_provider_tags_url(nil, provider), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -73,22 +71,19 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:providers, :tags, :unassign)
       classify_resource(provider)
 
-      run_post(provider_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_provider_tags_url(nil, provider), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(providers_url(provider.compressed_id)))
+      expect_tagging_result(tag1_results(api_provider_url(nil, provider.compressed_id)))
       expect_resource_has_tags(provider, tag2[:path])
     end
   end
 
   context "Host Tag subcollection" do
-    let(:host_url)      { hosts_url(host.id) }
-    let(:host_tags_url) { "#{host_url}/tags" }
-
     it "query all tags of a Host and verify tag category and names" do
       api_basic_authorize
       classify_resource(host)
 
-      run_get host_tags_url, :expand => "resources"
+      run_get api_host_tags_url(nil, host), :expand => "resources"
 
       expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => tag_paths)
@@ -97,7 +92,7 @@ describe "Tag Collections API" do
     it "does not assign a tag to a Host without appropriate role" do
       api_basic_authorize
 
-      run_post(host_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_host_tags_url(nil, host), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -105,15 +100,15 @@ describe "Tag Collections API" do
     it "assigns a tag to a Host" do
       api_basic_authorize subcollection_action_identifier(:hosts, :tags, :assign)
 
-      run_post(host_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_host_tags_url(nil, host), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(hosts_url(host.compressed_id)))
+      expect_tagging_result(tag1_results(api_host_url(nil, host.compressed_id)))
     end
 
     it "does not unassign a tag from a Host without appropriate role" do
       api_basic_authorize
 
-      run_post(host_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_host_tags_url(nil, host), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -122,23 +117,21 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:hosts, :tags, :unassign)
       classify_resource(host)
 
-      run_post(host_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_host_tags_url(nil, host), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(hosts_url(host.compressed_id)))
+      expect_tagging_result(tag1_results(api_host_url(nil, host.compressed_id)))
       expect_resource_has_tags(host, tag2[:path])
     end
   end
 
   context "Data Store Tag subcollection" do
     let(:ds)          { FactoryGirl.create(:storage, :name => "Storage 1", :store_type => "VMFS") }
-    let(:ds_url)      { data_stores_url(ds.id) }
-    let(:ds_tags_url) { "#{ds_url}/tags" }
 
     it "query all tags of a Data Store and verify tag category and names" do
       api_basic_authorize
       classify_resource(ds)
 
-      run_get ds_tags_url, :expand => "resources"
+      run_get api_data_store_tags_url(nil, ds), :expand => "resources"
 
       expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => tag_paths)
@@ -147,7 +140,7 @@ describe "Tag Collections API" do
     it "does not assign a tag to a Data Store without appropriate role" do
       api_basic_authorize
 
-      run_post(ds_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_data_store_tags_url(nil, ds), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -155,15 +148,15 @@ describe "Tag Collections API" do
     it "assigns a tag to a Data Store" do
       api_basic_authorize subcollection_action_identifier(:data_stores, :tags, :assign)
 
-      run_post(ds_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_data_store_tags_url(nil, ds), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(data_stores_url(ds.compressed_id)))
+      expect_tagging_result(tag1_results(api_data_store_url(nil, ds.compressed_id)))
     end
 
     it "does not unassign a tag from a Data Store without appropriate role" do
       api_basic_authorize
 
-      run_post(ds_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_data_store_tags_url(nil, ds), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -172,23 +165,21 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:data_stores, :tags, :unassign)
       classify_resource(ds)
 
-      run_post(ds_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_data_store_tags_url(nil, ds), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(data_stores_url(ds.compressed_id)))
+      expect_tagging_result(tag1_results(api_data_store_url(nil, ds.compressed_id)))
       expect_resource_has_tags(ds, tag2[:path])
     end
   end
 
   context "Resource Pool Tag subcollection" do
     let(:rp)          { FactoryGirl.create(:resource_pool, :name => "Resource Pool 1") }
-    let(:rp_url)      { resource_pools_url(rp.id) }
-    let(:rp_tags_url) { "#{rp_url}/tags" }
 
     it "query all tags of a Resource Pool and verify tag category and names" do
       api_basic_authorize
       classify_resource(rp)
 
-      run_get rp_tags_url, :expand => "resources"
+      run_get api_resource_pool_tags_url(nil, rp), :expand => "resources"
 
       expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => tag_paths)
@@ -197,7 +188,7 @@ describe "Tag Collections API" do
     it "does not assign a tag to a Resource Pool without appropriate role" do
       api_basic_authorize
 
-      run_post(rp_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_resource_pool_tags_url(nil, rp), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -205,15 +196,15 @@ describe "Tag Collections API" do
     it "assigns a tag to a Resource Pool" do
       api_basic_authorize subcollection_action_identifier(:resource_pools, :tags, :assign)
 
-      run_post(rp_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_resource_pool_tags_url(nil, rp), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(resource_pools_url(rp.compressed_id)))
+      expect_tagging_result(tag1_results(api_resource_pool_url(nil, rp.compressed_id)))
     end
 
     it "does not unassign a tag from a Resource Pool without appropriate role" do
       api_basic_authorize
 
-      run_post(rp_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_resource_pool_tags_url(nil, rp), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -222,9 +213,9 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:resource_pools, :tags, :unassign)
       classify_resource(rp)
 
-      run_post(rp_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_resource_pool_tags_url(nil, rp), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(resource_pools_url(rp.compressed_id)))
+      expect_tagging_result(tag1_results(api_resource_pool_url(nil, rp.compressed_id)))
       expect_resource_has_tags(rp, tag2[:path])
     end
   end
@@ -238,14 +229,11 @@ describe "Tag Collections API" do
                          :vms                   => [])
     end
 
-    let(:cluster_url)      { clusters_url(cluster.id) }
-    let(:cluster_tags_url) { "#{cluster_url}/tags" }
-
     it "query all tags of a Cluster and verify tag category and names" do
       api_basic_authorize
       classify_resource(cluster)
 
-      run_get cluster_tags_url, :expand => "resources"
+      run_get api_cluster_tags_url(nil, cluster), :expand => "resources"
 
       expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => tag_paths)
@@ -254,7 +242,7 @@ describe "Tag Collections API" do
     it "does not assign a tag to a Cluster without appropriate role" do
       api_basic_authorize
 
-      run_post(cluster_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_cluster_tags_url(nil, cluster), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -262,15 +250,15 @@ describe "Tag Collections API" do
     it "assigns a tag to a Cluster" do
       api_basic_authorize subcollection_action_identifier(:clusters, :tags, :assign)
 
-      run_post(cluster_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_cluster_tags_url(nil, cluster), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(clusters_url(cluster.compressed_id)))
+      expect_tagging_result(tag1_results(api_cluster_url(nil, cluster.compressed_id)))
     end
 
     it "does not unassign a tag from a Cluster without appropriate role" do
       api_basic_authorize
 
-      run_post(cluster_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_cluster_tags_url(nil, cluster), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -279,23 +267,21 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:clusters, :tags, :unassign)
       classify_resource(cluster)
 
-      run_post(cluster_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_cluster_tags_url(nil, cluster), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(clusters_url(cluster.compressed_id)))
+      expect_tagging_result(tag1_results(api_cluster_url(nil, cluster.compressed_id)))
       expect_resource_has_tags(cluster, tag2[:path])
     end
   end
 
   context "Service Tag subcollection" do
     let(:service)          { FactoryGirl.create(:service) }
-    let(:service_url)      { services_url(service.id) }
-    let(:service_tags_url) { "#{service_url}/tags" }
 
     it "query all tags of a Service and verify tag category and names" do
       api_basic_authorize
       classify_resource(service)
 
-      run_get service_tags_url, :expand => "resources"
+      run_get api_service_tags_url(nil, service), :expand => "resources"
 
       expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => tag_paths)
@@ -304,7 +290,7 @@ describe "Tag Collections API" do
     it "does not assign a tag to a Service without appropriate role" do
       api_basic_authorize
 
-      run_post(service_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_service_tags_url(nil, service), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -312,15 +298,15 @@ describe "Tag Collections API" do
     it "assigns a tag to a Service" do
       api_basic_authorize subcollection_action_identifier(:services, :tags, :assign)
 
-      run_post(service_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_service_tags_url(nil, service), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(services_url(service.compressed_id)))
+      expect_tagging_result(tag1_results(api_service_url(nil, service.compressed_id)))
     end
 
     it "does not unassign a tag from a Service without appropriate role" do
       api_basic_authorize
 
-      run_post(service_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_service_tags_url(nil, service), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -329,23 +315,21 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:services, :tags, :unassign)
       classify_resource(service)
 
-      run_post(service_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_service_tags_url(nil, service), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(services_url(service.compressed_id)))
+      expect_tagging_result(tag1_results(api_service_url(nil, service.compressed_id)))
       expect_resource_has_tags(service, tag2[:path])
     end
   end
 
   context "Service Template Tag subcollection" do
     let(:service_template)          { FactoryGirl.create(:service_template) }
-    let(:service_template_url)      { service_templates_url(service_template.id) }
-    let(:service_template_tags_url) { "#{service_template_url}/tags" }
 
     it "query all tags of a Service Template and verify tag category and names" do
       api_basic_authorize
       classify_resource(service_template)
 
-      run_get service_template_tags_url, :expand => "resources"
+      run_get api_service_template_tags_url(nil, service_template), :expand => "resources"
 
       expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => tag_paths)
@@ -354,7 +338,7 @@ describe "Tag Collections API" do
     it "does not assign a tag to a Service Template without appropriate role" do
       api_basic_authorize
 
-      run_post(service_template_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_service_template_tags_url(nil, service_template), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -362,15 +346,15 @@ describe "Tag Collections API" do
     it "assigns a tag to a Service Template" do
       api_basic_authorize subcollection_action_identifier(:service_templates, :tags, :assign)
 
-      run_post(service_template_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_service_template_tags_url(nil, service_template), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(service_templates_url(service_template.compressed_id)))
+      expect_tagging_result(tag1_results(api_service_template_url(nil, service_template.compressed_id)))
     end
 
     it "does not unassign a tag from a Service Template without appropriate role" do
       api_basic_authorize
 
-      run_post(service_template_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_service_template_tags_url(nil, service_template), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -379,23 +363,21 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:service_templates, :tags, :unassign)
       classify_resource(service_template)
 
-      run_post(service_template_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_service_template_tags_url(nil, service_template), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(service_templates_url(service_template.compressed_id)))
+      expect_tagging_result(tag1_results(api_service_template_url(nil, service_template.compressed_id)))
       expect_resource_has_tags(service_template, tag2[:path])
     end
   end
 
   context "Tenant Tag subcollection" do
     let(:tenant)          { FactoryGirl.create(:tenant, :name => "Tenant A", :description => "Tenant A Description") }
-    let(:tenant_url)      { tenants_url(tenant.id) }
-    let(:tenant_tags_url) { "#{tenant_url}/tags" }
 
     it "query all tags of a Tenant and verify tag category and names" do
       api_basic_authorize
       classify_resource(tenant)
 
-      run_get tenant_tags_url, :expand => "resources"
+      run_get api_tenant_tags_url(nil, tenant), :expand => "resources"
 
       expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => tag_paths)
@@ -404,7 +386,7 @@ describe "Tag Collections API" do
     it "does not assign a tag to a Tenant without appropriate role" do
       api_basic_authorize
 
-      run_post(tenant_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_tenant_tags_url(nil, tenant), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -412,15 +394,15 @@ describe "Tag Collections API" do
     it "assigns a tag to a Tenant" do
       api_basic_authorize subcollection_action_identifier(:tenants, :tags, :assign)
 
-      run_post(tenant_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_tenant_tags_url(nil, tenant), gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(tenants_url(tenant.compressed_id)))
+      expect_tagging_result(tag1_results(api_tenant_url(nil, tenant.compressed_id)))
     end
 
     it "does not unassign a tag from a Tenant without appropriate role" do
       api_basic_authorize
 
-      run_post(tenant_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_tenant_tags_url(nil, tenant), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -429,9 +411,9 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:tenants, :tags, :unassign)
       classify_resource(tenant)
 
-      run_post(tenant_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+      run_post(api_tenant_tags_url(nil, tenant), gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(tenants_url(tenant.compressed_id)))
+      expect_tagging_result(tag1_results(api_tenant_url(nil, tenant.compressed_id)))
       expect_resource_has_tags(tenant, tag2[:path])
     end
   end
@@ -441,7 +423,7 @@ describe "Tag Collections API" do
       api_basic_authorize
       blueprint = FactoryGirl.create(:blueprint)
 
-      run_get("#{blueprints_url(blueprint.id)}/tags")
+      run_get(api_blueprint_tags_url(nil, blueprint))
 
       expect(response).to have_http_status(:ok)
     end
@@ -450,7 +432,7 @@ describe "Tag Collections API" do
       api_basic_authorize subcollection_action_identifier(:blueprints, :tags, :assign)
       blueprint = FactoryGirl.create(:blueprint)
 
-      run_post("#{blueprints_url(blueprint.id)}/tags",
+      run_post(api_blueprint_tags_url(nil, blueprint),
                :action   => "assign",
                :category => tag1[:category],
                :name     => tag1[:name])
@@ -463,7 +445,7 @@ describe "Tag Collections API" do
       blueprint = FactoryGirl.create(:blueprint)
       classify_resource(blueprint)
 
-      run_post("#{blueprints_url(blueprint.id)}/tags",
+      run_post(api_blueprint_tags_url(nil, blueprint),
                :action   => "unassign",
                :category => tag1[:category],
                :name     => tag1[:name])
@@ -475,7 +457,7 @@ describe "Tag Collections API" do
       api_basic_authorize
       blueprint = FactoryGirl.create(:blueprint)
 
-      run_post("#{blueprints_url(blueprint.id)}/tags",
+      run_post(api_blueprint_tags_url(nil, blueprint),
                :action   => "assign",
                :category => tag1[:category],
                :name     => tag1[:name])
@@ -488,7 +470,7 @@ describe "Tag Collections API" do
       blueprint = FactoryGirl.create(:blueprint)
       classify_resource(blueprint)
 
-      run_post("#{blueprints_url(blueprint.id)}/tags",
+      run_post(api_blueprint_tags_url(nil, blueprint),
                :action   => "unassign",
                :category => tag1[:category],
                :name     => tag1[:name])
@@ -512,7 +494,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
@@ -533,21 +515,21 @@ describe "Tag Collections API" do
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
-          { 'href' => vms_url(vm1.id), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
-          { 'href' => vms_url(vm2.id), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
+          { 'href' => api_vm_url(nil, vm1), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
+          { 'href' => api_vm_url(nil, vm2), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(vms_url(vm1.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm1.compressed_id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(vms_url(vm2.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm2.compressed_id)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -569,17 +551,17 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
           a_hash_including('success' => false, 'message' => a_string_including("Couldn't find Vm")),
           a_hash_including('success'      => false,
-                           'href'         => a_string_including(vms_url(vm2.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm2.compressed_id)),
                            'tag_category' => bad_tag[:category],
                            'tag_name'     => bad_tag[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(vms_url(vm2.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm2.compressed_id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name])
         ]
@@ -591,7 +573,7 @@ describe "Tag Collections API" do
     it 'fails without an appropriate role' do
       api_basic_authorize
 
-      run_post(vms_url, :action => 'assign_tags')
+      run_post(api_vms_url, :action => 'assign_tags')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -601,21 +583,21 @@ describe "Tag Collections API" do
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
-          { 'id' => vm1.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag1[:path]).id)}] },
-          { 'id' => vm2.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag2[:path]).id)}] }
+          { 'id' => vm1.id, 'tags' => [{'href' => api_tag_url(nil, Tag.find_by(:name => tag1[:path]))}] },
+          { 'id' => vm2.id, 'tags' => [{'href' => api_tag_url(nil, Tag.find_by(:name => tag2[:path]))}] }
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(vms_url(vm1.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm1.compressed_id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(vms_url(vm2.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm2.compressed_id)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -634,7 +616,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
@@ -666,7 +648,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
@@ -687,12 +669,12 @@ describe "Tag Collections API" do
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
-          { 'href' => services_url(service1.id), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
-          { 'href' => services_url(service2.id), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
+          { 'href' => api_service_url(nil, service1), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
+          { 'href' => api_service_url(nil, service2), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
@@ -721,7 +703,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
@@ -741,7 +723,7 @@ describe "Tag Collections API" do
     it 'fails without an appropriate role' do
       api_basic_authorize
 
-      run_post(services_url, :action => 'assign_tags')
+      run_post(api_services_url, :action => 'assign_tags')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -751,12 +733,12 @@ describe "Tag Collections API" do
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
-          { 'id' => service1.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag1[:path]).id)}] },
-          { 'id' => service2.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag2[:path]).id)}] }
+          { 'id' => service1.id, 'tags' => [{'href' => api_tag_url(nil, Tag.find_by(:name => tag1[:path]))}] },
+          { 'id' => service2.id, 'tags' => [{'href' => api_tag_url(nil, Tag.find_by(:name => tag2[:path]))}] }
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
@@ -782,7 +764,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
@@ -819,16 +801,16 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(services_url(service1.compressed_id)),
+                           'href'         => a_string_including(api_service_url(nil, service1.compressed_id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(services_url(service2.compressed_id)),
+                           'href'         => a_string_including(api_service_url(nil, service2.compressed_id)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -842,21 +824,21 @@ describe "Tag Collections API" do
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
-          { 'href' => services_url(service1.id), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
-          { 'href' => services_url(service2.id), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
+          { 'href' => api_service_url(nil, service1), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
+          { 'href' => api_service_url(nil, service2), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(services_url(service1.compressed_id)),
+                           'href'         => a_string_including(api_service_url(nil, service1.compressed_id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(services_url(service2.compressed_id)),
+                           'href'         => a_string_including(api_service_url(nil, service2.compressed_id)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -878,7 +860,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
@@ -899,7 +881,7 @@ describe "Tag Collections API" do
     it 'fails without an appropriate role' do
       api_basic_authorize
 
-      run_post(services_url, :action => 'unassign_tags')
+      run_post(api_services_url, :action => 'unassign_tags')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -909,12 +891,12 @@ describe "Tag Collections API" do
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
-          { 'id' => service1.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag1[:path]).id)}] },
-          { 'id' => service2.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag2[:path]).id)}] }
+          { 'id' => service1.id, 'tags' => [{'href' => api_tag_url(nil, Tag.find_by(:name => tag1[:path]))}] },
+          { 'id' => service2.id, 'tags' => [{'href' => api_tag_url(nil, Tag.find_by(:name => tag2[:path]))}] }
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
@@ -940,7 +922,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(services_url, request_body)
+      run_post(api_services_url, request_body)
 
       expected = {
         'results' => [
@@ -977,7 +959,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
@@ -998,12 +980,12 @@ describe "Tag Collections API" do
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
-          { 'href' => vms_url(vm1.id), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
-          { 'href' => vms_url(vm2.id), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
+          { 'href' => api_vm_url(nil, vm1), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
+          { 'href' => api_vm_url(nil, vm2), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
@@ -1032,7 +1014,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
@@ -1053,7 +1035,7 @@ describe "Tag Collections API" do
     it 'fails without an appropriate role' do
       api_basic_authorize
 
-      run_post(vms_url, :action => 'unassign_tags')
+      run_post(api_vms_url, :action => 'unassign_tags')
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -1063,12 +1045,12 @@ describe "Tag Collections API" do
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
-          { 'id' => vm1.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag1[:path]).id)}] },
-          { 'id' => vm2.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag2[:path]).id)}] }
+          { 'id' => vm1.id, 'tags' => [{'href' => api_tag_url(nil, Tag.find_by(:name => tag1[:path]))}] },
+          { 'id' => vm2.id, 'tags' => [{'href' => api_tag_url(nil, Tag.find_by(:name => tag2[:path]))}] }
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [
@@ -1094,7 +1076,7 @@ describe "Tag Collections API" do
         ]
       }
 
-      run_post(vms_url, request_body)
+      run_post(api_vms_url, request_body)
 
       expected = {
         'results' => [

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -4,7 +4,7 @@
 describe "Tags API" do
   let(:tag1)         { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
   let(:tag2)         { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }
-  let(:invalid_tag_url) { tags_url(999_999) }
+  let(:invalid_tag_url) { api_tag_url(nil, 999_999) }
 
   before(:each) do
     FactoryGirl.create(:classification_department_with_tags)
@@ -15,7 +15,7 @@ describe "Tags API" do
     it "query all tags" do
       api_basic_authorize collection_action_identifier(:tags, :read, :get)
 
-      run_get tags_url
+      run_get api_tags_url
 
       expect_query_result(:tags, Tag.count)
     end
@@ -24,15 +24,15 @@ describe "Tags API" do
       it "can create a tag with category by href" do
         api_basic_authorize collection_action_identifier(:tags, :create)
         category = FactoryGirl.create(:category)
-        options = {:name => "test_tag", :description => "Test Tag", :category => {:href => categories_url(category.id)}}
+        options = {:name => "test_tag", :description => "Test Tag", :category => {:href => api_category_url(nil, category)}}
 
-        expect { run_post tags_url, options }.to change(Tag, :count).by(1)
+        expect { run_post api_tags_url, options }.to change(Tag, :count).by(1)
 
         result = response.parsed_body["results"].first
         tag = Tag.find(ApplicationRecord.uncompress_id(result["id"]))
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
-        expect(result["href"]).to include(tags_url(tag.compressed_id))
+        expect(result["href"]).to include(api_tag_url(nil, tag.compressed_id))
         expect(response).to have_http_status(:ok)
       end
 
@@ -41,7 +41,7 @@ describe "Tags API" do
         category = FactoryGirl.create(:category)
 
         expect do
-          run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:id => category.id}
+          run_post api_tags_url, :name => "test_tag", :description => "Test Tag", :category => {:id => category.id}
         end.to change(Tag, :count).by(1)
 
         tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
@@ -56,7 +56,7 @@ describe "Tags API" do
         category = FactoryGirl.create(:category)
 
         expect do
-          run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:name => category.name}
+          run_post api_tags_url, :name => "test_tag", :description => "Test Tag", :category => {:name => category.name}
         end.to change(Tag, :count).by(1)
 
         tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
@@ -71,7 +71,7 @@ describe "Tags API" do
         category = FactoryGirl.create(:category)
 
         expect do
-          run_post "#{categories_url(category.id)}/tags", :name => "test_tag", :description => "Test Tag"
+          run_post(api_category_tags_url(nil, category), :name => "test_tag", :description => "Test Tag")
         end.to change(Tag, :count).by(1)
         tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
         tag_category = Category.find(tag.category.id)
@@ -83,7 +83,7 @@ describe "Tags API" do
       it "returns bad request when the category doesn't exist" do
         api_basic_authorize collection_action_identifier(:tags, :create)
 
-        run_post tags_url, :name => "test_tag", :description => "Test Tag"
+        run_post api_tags_url, :name => "test_tag", :description => "Test Tag"
 
         expect(response).to have_http_status(:bad_request)
       end
@@ -95,7 +95,7 @@ describe "Tags API" do
         tag = classification.tag
 
         expect do
-          run_post tags_url(tag.id), gen_request(:edit, :name => "new_name")
+          run_post api_tag_url(nil, tag), gen_request(:edit, :name => "new_name")
         end.to change { classification.reload.tag.name }.to("#{category.tag.name}/new_name")
         expect(response.parsed_body["name"]).to eq("#{category.tag.name}/new_name")
         expect(response).to have_http_status(:ok)
@@ -108,7 +108,7 @@ describe "Tags API" do
         tag = classification.tag
 
         expect do
-          run_post tags_url(tag.id), gen_request(:edit, :description => "New Description")
+          run_post api_tag_url(nil, tag), gen_request(:edit, :description => "New Description")
         end.to change { tag.reload.classification.description }.to("New Description")
 
         expect(response).to have_http_status(:ok)
@@ -119,7 +119,7 @@ describe "Tags API" do
         classification = FactoryGirl.create(:classification_tag)
         tag = classification.tag
 
-        expect { run_post tags_url(tag.id), :action => :delete }.to change(Tag, :count).by(-1)
+        expect { run_post api_tag_url(nil, tag), :action => :delete }.to change(Tag, :count).by(-1)
         expect { classification.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect(response).to have_http_status(:ok)
       end
@@ -129,7 +129,7 @@ describe "Tags API" do
         classification = FactoryGirl.create(:classification_tag)
         tag = classification.tag
 
-        expect { run_delete tags_url(tag.id) }.to change(Tag, :count).by(-1)
+        expect { run_delete api_tag_url(nil, tag) }.to change(Tag, :count).by(-1)
         expect { classification.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect(response).to have_http_status(:no_content)
       end
@@ -140,7 +140,7 @@ describe "Tags API" do
         tag_id = classification.tag.id
         classification.destroy!
 
-        run_delete tags_url(tag_id)
+        run_delete api_tag_url(nil, tag_id)
 
         expect(response).to have_http_status(:not_found)
       end
@@ -151,7 +151,7 @@ describe "Tags API" do
         tag_id = classification.tag.id
         classification.destroy!
 
-        run_post tags_url(tag_id), :action => :delete
+        run_post api_tag_url(nil, tag_id), :action => :delete
 
         expect(response).to have_http_status(:not_found)
       end
@@ -165,7 +165,7 @@ describe "Tags API" do
         tag2 = classification2.tag
 
         expect do
-          run_post "#{categories_url(category.id)}/tags", gen_request(:delete, [{:id => tag1.id}, {:id => tag2.id}])
+          run_post(api_category_tags_url(nil, category.id), gen_request(:delete, [{:id => tag1.id}, {:id => tag2.id}]))
         end.to change(Tag, :count).by(-2)
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -189,7 +189,7 @@ describe "Tags API" do
         body = gen_request(:delete, [{:name => tag1.name}, {:name => tag2.name}])
 
         expect do
-          run_post "#{categories_url(category.id)}/tags", body
+          run_post(api_category_tags_url(nil, category), body)
         end.to change(Tag, :count).by(-2)
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -209,7 +209,7 @@ describe "Tags API" do
         api_basic_authorize
 
         expect do
-          run_post tags_url, :name => "test_tag", :description => "Test Tag"
+          run_post api_tags_url, :name => "test_tag", :description => "Test Tag"
         end.not_to change(Tag, :count)
 
         expect(response).to have_http_status(:forbidden)
@@ -220,7 +220,7 @@ describe "Tags API" do
         tag = Tag.create(:name => "Old name")
 
         expect do
-          run_post tags_url(tag.id), gen_request(:edit, :name => "New name")
+          run_post api_tag_url(nil, tag), gen_request(:edit, :name => "New name")
         end.not_to change { tag.reload.name }
 
         expect(response).to have_http_status(:forbidden)
@@ -230,7 +230,7 @@ describe "Tags API" do
         api_basic_authorize
         tag = Tag.create(:name => "Test tag")
 
-        expect { run_post tags_url(tag.id), :action => :delete }.not_to change(Tag, :count)
+        expect { run_post api_tag_url(nil, tag), :action => :delete }.not_to change(Tag, :count)
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -239,7 +239,7 @@ describe "Tags API" do
         api_basic_authorize
         tag = Tag.create(:name => "Test tag")
 
-        expect { run_delete tags_url(tag.id) }.not_to change(Tag, :count)
+        expect { run_delete api_tag_url(nil, tag) }.not_to change(Tag, :count)
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -256,7 +256,7 @@ describe "Tags API" do
     it "query tags with expanded resources" do
       api_basic_authorize collection_action_identifier(:tags, :read, :get)
 
-      run_get tags_url, :expand => "resources"
+      run_get api_tags_url, :expand => "resources"
 
       expect_query_result(:tags, Tag.count, Tag.count)
       expect_result_resources_to_include_keys("resources", %w(id name))
@@ -267,10 +267,10 @@ describe "Tags API" do
 
       tag = Tag.last
       attr_list = "category.name,category.description,classification.name,classification.description"
-      run_get tags_url(tag.id), :attributes => attr_list
+      run_get api_tag_url(nil, tag), :attributes => attr_list
 
       expect_single_resource_query(
-        "href"           => tags_url(tag.compressed_id),
+        "href"           => api_tag_url(nil, tag.compressed_id),
         "id"             => tag.compressed_id,
         "name"           => tag.name,
         "category"       => {"name" => tag.category.name,       "description" => tag.category.description},
@@ -282,10 +282,10 @@ describe "Tags API" do
       api_basic_authorize action_identifier(:tags, :read, :resource_actions, :get)
 
       tag = Tag.last
-      run_get tags_url(tag.id), :attributes => "categorization"
+      run_get api_tag_url(nil, tag), :attributes => "categorization"
 
       expect_single_resource_query(
-        "href"           => tags_url(tag.compressed_id),
+        "href"           => api_tag_url(nil, tag.compressed_id),
         "id"             => tag.compressed_id,
         "name"           => tag.name,
         "categorization" => {
@@ -300,7 +300,7 @@ describe "Tags API" do
     it "query all tags with categorization" do
       api_basic_authorize action_identifier(:tags, :read, :resource_actions, :get)
 
-      run_get tags_url, :expand => "resources", :attributes => "categorization"
+      run_get api_tags_url, :expand => "resources", :attributes => "categorization"
 
       expect_query_result(:tags, Tag.count, Tag.count)
       expect_result_resources_to_include_keys("resources", %w(id name categorization))

--- a/spec/requests/templates_spec.rb
+++ b/spec/requests/templates_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe "Templates API" do
       template = FactoryGirl.create(:template)
 
       expect do
-        run_post(templates_url(template.id), :action => "delete")
+        run_post(api_template_url(nil, template), :action => "delete")
       end.to change(MiqTemplate, :count).by(-1)
 
       expected = {
-        "href"    => a_string_matching(templates_url(template.compressed_id)),
+        "href"    => api_template_url(nil, template.compressed_id),
         "message" => "templates id: #{template.id} deleting",
         "success" => true
       }
@@ -22,7 +22,7 @@ RSpec.describe "Templates API" do
       template = FactoryGirl.create(:template)
 
       expect do
-        run_post(templates_url(template.id), :action => "delete")
+        run_post(api_template_url(nil, template), :action => "delete")
       end.not_to change(MiqTemplate, :count)
 
       expect(response).to have_http_status(:forbidden)
@@ -36,7 +36,7 @@ RSpec.describe "Templates API" do
       Classification.classify(template, "department", "finance")
       api_basic_authorize
 
-      run_get("#{templates_url(template.id)}/tags")
+      run_get(api_template_tags_url(nil, template))
 
       expect(response.parsed_body).to include("subcount" => 1)
       expect(response).to have_http_status(:ok)
@@ -47,7 +47,7 @@ RSpec.describe "Templates API" do
       FactoryGirl.create(:classification_department_with_tags)
       api_basic_authorize(subcollection_action_identifier(:templates, :tags, :assign))
 
-      run_post("#{templates_url(template.id)}/tags", :action => "assign", :category => "department", :name => "finance")
+      run_post(api_template_tags_url(nil, template), :action => "assign", :category => "department", :name => "finance")
 
       expected = {
         "results" => [
@@ -69,7 +69,7 @@ RSpec.describe "Templates API" do
       Classification.classify(template, "department", "finance")
       api_basic_authorize(subcollection_action_identifier(:templates, :tags, :unassign))
 
-      run_post("#{templates_url(template.id)}/tags",
+      run_post(api_template_tags_url(nil, template),
                :action   => "unassign",
                :category => "department",
                :name     => "finance")

--- a/spec/requests/tenant_quotas_spec.rb
+++ b/spec/requests/tenant_quotas_spec.rb
@@ -45,7 +45,7 @@ describe "tenant quotas API" do
 
       expected = {
         'results' => [
-          a_hash_including('href' => a_string_including("#{tenants_url(tenant.compressed_id)}/quotas/"))
+          a_hash_including('href' => a_string_including(api_tenant_quotas_url(nil, tenant.compressed_id)))
         ]
       }
       expect do

--- a/spec/requests/tenants_spec.rb
+++ b/spec/requests/tenants_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe "tenants API" do
     tenant_1 = FactoryGirl.create(:tenant, :parent => root_tenant)
     tenant_2 = FactoryGirl.create(:tenant, :parent => root_tenant)
 
-    run_get tenants_url
+    run_get api_tenants_url
 
     expect_result_resources_to_include_hrefs(
       "resources",
       [
-        tenants_url(root_tenant.compressed_id),
-        tenants_url(tenant_1.compressed_id),
-        tenants_url(tenant_2.compressed_id)
+        api_tenant_url(nil, root_tenant.compressed_id),
+        api_tenant_url(nil, tenant_1.compressed_id),
+        api_tenant_url(nil, tenant_2.compressed_id)
       ]
     )
 
@@ -29,11 +29,11 @@ RSpec.describe "tenants API" do
       :description => "Tenant for this test"
     )
 
-    run_get tenants_url(tenant.id)
+    run_get api_tenant_url(nil, tenant)
 
     expect_result_to_match_hash(
       response.parsed_body,
-      "href"        => tenants_url(tenant.compressed_id),
+      "href"        => api_tenant_url(nil, tenant.compressed_id),
       "id"          => tenant.compressed_id,
       "name"        => "Test Tenant",
       "description" => "Tenant for this test"
@@ -46,7 +46,7 @@ RSpec.describe "tenants API" do
       api_basic_authorize collection_action_identifier(:tenants, :create)
 
       expect do
-        run_post tenants_url, :parent => {:id => root_tenant.id}
+        run_post api_tenants_url, :parent => {:id => root_tenant.id}
       end.to change(Tenant, :count).by(1)
 
       expect(response).to have_http_status(:ok)
@@ -57,7 +57,7 @@ RSpec.describe "tenants API" do
       invalid_tenant = FactoryGirl.create(:tenant, :parent => root_tenant).destroy
 
       expect do
-        run_post tenants_url, :parent => {:id => invalid_tenant.id}
+        run_post api_tenants_url, :parent => {:id => invalid_tenant.id}
       end.not_to change(Tenant, :count)
 
       expect(response).to have_http_status(:not_found)
@@ -73,7 +73,7 @@ RSpec.describe "tenants API" do
       )
       options = {:name => "New Tenant name", :description => "New Tenant description"}
 
-      run_post tenants_url(tenant.id), gen_request(:edit, options)
+      run_post api_tenant_url(nil, tenant), gen_request(:edit, options)
 
       expect(response).to have_http_status(:ok)
       tenant.reload
@@ -91,7 +91,7 @@ RSpec.describe "tenants API" do
       )
       options = {:name => "New Tenant name", :description => "New Tenant description"}
 
-      run_put tenants_url(tenant.id), options
+      run_put api_tenant_url(nil, tenant), options
 
       expect(response).to have_http_status(:ok)
       tenant.reload
@@ -108,10 +108,10 @@ RSpec.describe "tenants API" do
 
       it "shows properties from configuration settings" do
         api_basic_authorize action_identifier(:tenants, :read, :resource_actions, :get)
-        run_get tenants_url(root_tenant.id)
+        run_get api_tenant_url(nil, root_tenant)
 
         expect_result_to_match_hash(response.parsed_body,
-                                    "href" => tenants_url(root_tenant.compressed_id),
+                                    "href" => api_tenant_url(nil, root_tenant.compressed_id),
                                     "id"   => root_tenant.compressed_id,
                                     "name" => ::Settings.server.company,
                                    )
@@ -132,11 +132,11 @@ RSpec.describe "tenants API" do
         :name   => "Test Tenant 2"
       )
       options = [
-        {"href" => tenants_url(tenant_1.id), "name" => "Updated Test Tenant 1"},
-        {"href" => tenants_url(tenant_2.id), "name" => "Updated Test Tenant 2"}
+        {"href" => api_tenant_url(nil, tenant_1), "name" => "Updated Test Tenant 1"},
+        {"href" => api_tenant_url(nil, tenant_2), "name" => "Updated Test Tenant 2"}
       ]
 
-      run_post tenants_url, gen_request(:edit, options)
+      run_post api_tenants_url, gen_request(:edit, options)
 
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash(
@@ -152,7 +152,7 @@ RSpec.describe "tenants API" do
       api_basic_authorize action_identifier(:tenants, :delete)
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
-      expect { run_post tenants_url(tenant.id), gen_request(:delete) }.to change(Tenant, :count).by(-1)
+      expect { run_post api_tenant_url(nil, tenant), gen_request(:delete) }.to change(Tenant, :count).by(-1)
       expect(response).to have_http_status(:ok)
     end
 
@@ -160,7 +160,7 @@ RSpec.describe "tenants API" do
       api_basic_authorize action_identifier(:tenants, :delete)
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
-      expect { run_delete tenants_url(tenant.id) }.to change(Tenant, :count).by(-1)
+      expect { run_delete api_tenant_url(nil, tenant) }.to change(Tenant, :count).by(-1)
       expect(response).to have_http_status(:no_content)
     end
 
@@ -169,12 +169,12 @@ RSpec.describe "tenants API" do
       tenant_1 = FactoryGirl.create(:tenant, :parent => root_tenant)
       tenant_2 = FactoryGirl.create(:tenant, :parent => root_tenant)
       options = [
-        {"href" => tenants_url(tenant_1.id)},
-        {"href" => tenants_url(tenant_2.id)}
+        {"href" => api_tenant_url(nil, tenant_1)},
+        {"href" => api_tenant_url(nil, tenant_2)}
       ]
 
       expect do
-        run_post tenants_url, gen_request(:delete, options)
+        run_post api_tenants_url, gen_request(:delete, options)
       end.to change(Tenant, :count).by(-2)
       expect(response).to have_http_status(:ok)
     end
@@ -185,7 +185,7 @@ RSpec.describe "tenants API" do
       api_basic_authorize
 
       expect do
-        run_post tenants_url, :parent => {:id => root_tenant.id}
+        run_post api_tenants_url, :parent => {:id => root_tenant.id}
       end.not_to change(Tenant, :count)
 
       expect(response).to have_http_status(:forbidden)
@@ -201,7 +201,7 @@ RSpec.describe "tenants API" do
       )
       options = {:name => "New Tenant name", :description => "New Tenant description"}
 
-      run_post tenants_url(tenant.id), gen_request(:edit, options)
+      run_post api_tenant_url(nil, tenant), gen_request(:edit, options)
 
       expect(response).to have_http_status(:forbidden)
       tenant.reload
@@ -219,7 +219,7 @@ RSpec.describe "tenants API" do
       )
       options = {:name => "New Tenant name", :description => "New Tenant description"}
 
-      run_put tenants_url(tenant.id), options
+      run_put api_tenant_url(nil, tenant), options
 
       expect(response).to have_http_status(:forbidden)
       tenant.reload
@@ -240,11 +240,11 @@ RSpec.describe "tenants API" do
         :name   => "Test Tenant 2"
       )
       options = [
-        {"href" => tenants_url(tenant_1.id), "name" => "Updated Test Tenant 1"},
-        {"href" => tenants_url(tenant_2.id), "name" => "Updated Test Tenant 2"}
+        {"href" => api_tenant_url(nil, tenant_1), "name" => "Updated Test Tenant 1"},
+        {"href" => api_tenant_url(nil, tenant_2), "name" => "Updated Test Tenant 2"}
       ]
 
-      run_post tenants_url, gen_request(:edit, options)
+      run_post api_tenants_url, gen_request(:edit, options)
 
       expect(response).to have_http_status(:forbidden)
       expect(tenant_1.reload.name).to eq("Test Tenant 1")
@@ -255,7 +255,7 @@ RSpec.describe "tenants API" do
       api_basic_authorize
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
-      expect { run_post tenants_url(tenant.id), gen_request(:delete) }.not_to change(Tenant, :count)
+      expect { run_post api_tenant_url(nil, tenant), gen_request(:delete) }.not_to change(Tenant, :count)
       expect(response).to have_http_status(:forbidden)
     end
 
@@ -263,7 +263,7 @@ RSpec.describe "tenants API" do
       api_basic_authorize
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
-      expect { run_delete tenants_url(tenant.id) }.not_to change(Tenant, :count)
+      expect { run_delete api_tenant_url(nil, tenant) }.not_to change(Tenant, :count)
       expect(response).to have_http_status(:forbidden)
     end
 
@@ -272,12 +272,12 @@ RSpec.describe "tenants API" do
       tenant_1 = FactoryGirl.create(:tenant, :parent => root_tenant)
       tenant_2 = FactoryGirl.create(:tenant, :parent => root_tenant)
       options = [
-        {"href" => tenants_url(tenant_1.id)},
-        {"href" => tenants_url(tenant_2.id)}
+        {"href" => api_tenant_url(nil, tenant_1)},
+        {"href" => api_tenant_url(nil, tenant_2)}
       ]
 
       expect do
-        run_post tenants_url, gen_request(:delete, options)
+        run_post api_tenants_url, gen_request(:delete, options)
       end.not_to change(Tenant, :count)
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "users API" do
       api_basic_authorize action_identifier(:users, :edit)
 
       expect do
-        run_post users_url(@user.id), gen_request(:edit, :password => "new_password")
+        run_post api_user_url(nil, @user), gen_request(:edit, :password => "new_password")
       end.to change { @user.reload.password_digest }
 
       expect(response).to have_http_status(:ok)
@@ -41,7 +41,7 @@ RSpec.describe "users API" do
       user = FactoryGirl.create(:user)
 
       expect do
-        run_post users_url(user.id), gen_request(:edit, :password => "new_password")
+        run_post api_user_url(nil, user), gen_request(:edit, :password => "new_password")
       end.to change { user.reload.password_digest }
 
       expect(response).to have_http_status(:ok)
@@ -53,7 +53,7 @@ RSpec.describe "users API" do
       api_basic_authorize
 
       expect do
-        run_post users_url(@user.id), gen_request(:edit, :password => "new_password")
+        run_post api_user_url(nil, @user), gen_request(:edit, :password => "new_password")
       end.to change { @user.reload.password_digest }
 
       expect(response).to have_http_status(:ok)
@@ -63,7 +63,7 @@ RSpec.describe "users API" do
       api_basic_authorize action_identifier(:users, :edit)
 
       expect do
-        run_post users_url(@user.id), gen_request(:edit, :email => "tom@cartoons.com")
+        run_post api_user_url(nil, @user), gen_request(:edit, :email => "tom@cartoons.com")
       end.to change { @user.reload.email }
 
       expect(response).to have_http_status(:ok)
@@ -73,7 +73,7 @@ RSpec.describe "users API" do
       api_basic_authorize action_identifier(:users, :edit)
 
       expect do
-        run_post users_url(@user.id), gen_request(:edit, :settings => {:cartoon => {:tom_jerry => 'y'}})
+        run_post api_user_url(nil, @user), gen_request(:edit, :settings => {:cartoon => {:tom_jerry => 'y'}})
       end.to change { @user.reload.settings }
 
       expect(response).to have_http_status(:ok)
@@ -83,7 +83,7 @@ RSpec.describe "users API" do
       api_basic_authorize
 
       expect do
-        run_post users_url(@user.id), gen_request(:edit, :name => "updated_name")
+        run_post api_user_url(nil, @user), gen_request(:edit, :name => "updated_name")
       end.not_to change { @user.reload.name }
 
       expect(response).to have_http_status(:bad_request)
@@ -94,7 +94,7 @@ RSpec.describe "users API" do
       user = FactoryGirl.create(:user)
 
       expect do
-        run_post users_url(user.id), gen_request(:edit, :password => "new_password")
+        run_post api_user_url(nil, user), gen_request(:edit, :password => "new_password")
       end.not_to change { user.reload.password_digest }
 
       expect(response).to have_http_status(:forbidden)
@@ -105,7 +105,7 @@ RSpec.describe "users API" do
       user = FactoryGirl.create(:user, :settings => {:locale => "en"})
 
       expect do
-        run_post users_url(user.id), gen_request(:edit, :settings => {:locale => "ja"})
+        run_post api_user_url(nil, user), gen_request(:edit, :settings => {:locale => "ja"})
       end.not_to change { user.reload.settings }
 
       expect(response).to have_http_status(:forbidden)
@@ -116,7 +116,7 @@ RSpec.describe "users API" do
     it "rejects creation without appropriate role" do
       api_basic_authorize
 
-      run_post(users_url, sample_user1)
+      run_post(api_users_url, sample_user1)
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -124,7 +124,7 @@ RSpec.describe "users API" do
     it "rejects user creation with id specified" do
       api_basic_authorize collection_action_identifier(:users, :create)
 
-      run_post(users_url, "userid" => "userid1", "id" => 100)
+      run_post(api_users_url, "userid" => "userid1", "id" => 100)
 
       expect_bad_request(/id or href should not be specified/i)
     end
@@ -132,7 +132,7 @@ RSpec.describe "users API" do
     it "rejects user creation with invalid group specified" do
       api_basic_authorize collection_action_identifier(:users, :create)
 
-      run_post(users_url, sample_user2.merge("group" => {"id" => 999_999}))
+      run_post(api_users_url, sample_user2.merge("group" => {"id" => 999_999}))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -140,7 +140,7 @@ RSpec.describe "users API" do
     it "rejects user creation with missing attribute" do
       api_basic_authorize collection_action_identifier(:users, :create)
 
-      run_post(users_url, sample_user2.except(:userid))
+      run_post(api_users_url, sample_user2.except(:userid))
 
       expect_bad_request(/Missing attribute/i)
     end
@@ -148,7 +148,7 @@ RSpec.describe "users API" do
     it "supports single user creation" do
       api_basic_authorize collection_action_identifier(:users, :create)
 
-      run_post(users_url, sample_user1)
+      run_post(api_users_url, sample_user1)
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -160,7 +160,7 @@ RSpec.describe "users API" do
     it "supports single user creation via action" do
       api_basic_authorize collection_action_identifier(:users, :create)
 
-      run_post(users_url, gen_request(:create, sample_user1))
+      run_post(api_users_url, gen_request(:create, sample_user1))
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -172,7 +172,7 @@ RSpec.describe "users API" do
     it "supports multiple user creation" do
       api_basic_authorize collection_action_identifier(:users, :create)
 
-      run_post(users_url, gen_request(:create, [sample_user1, sample_user2]))
+      run_post(api_users_url, gen_request(:create, [sample_user1, sample_user2]))
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
@@ -190,7 +190,7 @@ RSpec.describe "users API" do
     it "rejects user edits without appropriate role" do
       api_basic_authorize
 
-      run_post(users_url, gen_request(:edit, "name" => "updated name", "href" => users_url(user1.id)))
+      run_post(api_users_url, gen_request(:edit, "name" => "updated name", "href" => api_user_url(nil, user1)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -198,7 +198,7 @@ RSpec.describe "users API" do
     it "rejects user edits for invalid resources" do
       api_basic_authorize collection_action_identifier(:users, :edit)
 
-      run_post(users_url(999_999), gen_request(:edit, "name" => "updated name"))
+      run_post(api_user_url(nil, 999_999), gen_request(:edit, "name" => "updated name"))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -206,7 +206,7 @@ RSpec.describe "users API" do
     it "supports single user edit" do
       api_basic_authorize collection_action_identifier(:users, :edit)
 
-      run_post(users_url(user1.id), gen_request(:edit, "name" => "updated name"))
+      run_post(api_user_url(nil, user1), gen_request(:edit, "name" => "updated name"))
 
       expect_single_resource_query("id" => user1.compressed_id, "name" => "updated name")
       expect(user1.reload.name).to eq("updated name")
@@ -215,7 +215,7 @@ RSpec.describe "users API" do
     it "supports single user edit of other attributes including group change" do
       api_basic_authorize collection_action_identifier(:users, :edit)
 
-      run_post(users_url(user1.id), gen_request(:edit,
+      run_post(api_user_url(nil, user1), gen_request(:edit,
                                                 "email" => "user1@email.com",
                                                 "group" => {"description" => group2.description}))
 
@@ -227,9 +227,9 @@ RSpec.describe "users API" do
     it "supports multiple user edits" do
       api_basic_authorize collection_action_identifier(:users, :edit)
 
-      run_post(users_url, gen_request(:edit,
-                                      [{"href" => users_url(user1.id), "first_name" => "John"},
-                                       {"href" => users_url(user2.id), "first_name" => "Jane"}]))
+      run_post(api_users_url, gen_request(:edit,
+                                          [{"href" => api_user_url(nil, user1), "first_name" => "John"},
+                                           {"href" => api_user_url(nil, user2), "first_name" => "Jane"}]))
 
       expect_results_to_match_hash("results",
                                    [{"id" => user1.compressed_id, "first_name" => "John"},
@@ -244,7 +244,7 @@ RSpec.describe "users API" do
     it "rejects user deletion, by post action, without appropriate role" do
       api_basic_authorize
 
-      run_post(users_url, gen_request(:delete, "href" => users_url(100)))
+      run_post(api_users_url, gen_request(:delete, "href" => api_user_url(nil, 100)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -252,7 +252,7 @@ RSpec.describe "users API" do
     it "rejects user deletion without appropriate role" do
       api_basic_authorize
 
-      run_delete(users_url(100))
+      run_delete(api_user_url(nil, 100))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -260,7 +260,7 @@ RSpec.describe "users API" do
     it "rejects user deletes for invalid users" do
       api_basic_authorize collection_action_identifier(:users, :delete)
 
-      run_delete(users_url(999_999))
+      run_delete(api_user_url(nil, 999_999))
 
       expect(response).to have_http_status(:not_found)
     end
@@ -268,7 +268,7 @@ RSpec.describe "users API" do
     it "rejects user delete of requesting user via action" do
       api_basic_authorize collection_action_identifier(:users, :delete)
 
-      run_post(users_url, gen_request(:delete, "href" => users_url(@user.id)))
+      run_post(api_users_url, gen_request(:delete, "href" => api_user_url(nil, @user)))
 
       expect_bad_request("Cannot delete user of current request")
     end
@@ -276,7 +276,7 @@ RSpec.describe "users API" do
     it "rejects user delete of requesting user" do
       api_basic_authorize collection_action_identifier(:users, :delete)
 
-      run_delete(users_url(@user.id))
+      run_delete(api_user_url(nil, @user))
 
       expect_bad_request("Cannot delete user of current request")
     end
@@ -285,7 +285,7 @@ RSpec.describe "users API" do
       api_basic_authorize collection_action_identifier(:users, :delete)
 
       user1_id = user1.id
-      run_delete(users_url(user1_id))
+      run_delete(api_user_url(nil, user1_id))
 
       expect(response).to have_http_status(:no_content)
       expect(User.exists?(user1_id)).to be_falsey
@@ -295,11 +295,11 @@ RSpec.describe "users API" do
       api_basic_authorize collection_action_identifier(:users, :delete)
 
       user1_id = user1.id
-      user1_url = users_url(user1_id)
+      user1_url = api_user_url(nil, user1_id)
 
       run_post(user1_url, gen_request(:delete))
 
-      expect_single_action_result(:success => true, :message => "deleting", :href => users_url(user1.compressed_id))
+      expect_single_action_result(:success => true, :message => "deleting", :href => api_user_url(nil, user1.compressed_id))
       expect(User.exists?(user1_id)).to be_falsey
     end
 
@@ -307,12 +307,12 @@ RSpec.describe "users API" do
       api_basic_authorize collection_action_identifier(:users, :delete)
 
       user1_id, user2_id = user1.id, user2.id
-      user1_url, user2_url = users_url(user1_id), users_url(user2_id)
+      user1_url, user2_url = api_user_url(nil, user1_id), api_user_url(nil, user2_id)
 
-      run_post(users_url, gen_request(:delete, [{"href" => user1_url}, {"href" => user2_url}]))
+      run_post(api_users_url, gen_request(:delete, [{"href" => user1_url}, {"href" => user2_url}]))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [users_url(user1.compressed_id), users_url(user2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_user_url(nil, user1.compressed_id), api_user_url(nil, user2.compressed_id)])
       expect(User.exists?(user1_id)).to be_falsey
       expect(User.exists?(user2_id)).to be_falsey
     end
@@ -325,7 +325,7 @@ RSpec.describe "users API" do
       Classification.classify(user, "department", "finance")
       api_basic_authorize
 
-      run_get("#{users_url(user.id)}/tags")
+      run_get(api_user_tags_url(nil, user))
 
       expect(response.parsed_body).to include("subcount" => 1)
       expect(response).to have_http_status(:ok)
@@ -336,7 +336,7 @@ RSpec.describe "users API" do
       FactoryGirl.create(:classification_department_with_tags)
       api_basic_authorize(subcollection_action_identifier(:users, :tags, :assign))
 
-      run_post("#{users_url(user.id)}/tags", :action => "assign", :category => "department", :name => "finance")
+      run_post(api_user_tags_url(nil, user), :action => "assign", :category => "department", :name => "finance")
 
       expected = {
         "results" => [
@@ -358,7 +358,7 @@ RSpec.describe "users API" do
       Classification.classify(user, "department", "finance")
       api_basic_authorize(subcollection_action_identifier(:users, :tags, :unassign))
 
-      run_post("#{users_url(user.id)}/tags", :action => "unassign", :category => "department", :name => "finance")
+      run_post(api_user_tags_url(nil, user), :action => "unassign", :category => "department", :name => "finance")
 
       expected = {
         "results" => [

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -68,17 +68,6 @@ module Spec
         define_user
       end
 
-      def auth_url
-        "#{api_config(:entrypoint)}/auth"
-      end
-
-      (Api::ApiConfig.collections.keys - [:auth]).each do |collection|
-        define_method("#{collection}_url".to_sym) do |id = nil|
-          path = "#{api_config(:entrypoint)}/#{collection}"
-          id.nil? ? path : "#{path}/#{id}"
-        end
-      end
-
       def api_basic_authorize(*identifiers)
         update_user_role(@role, *identifiers)
         basic_authorize api_config(:user), api_config(:password)


### PR DESCRIPTION
Follow up to #23 

This enables us to:

* delete the custom metaprogramming in api_helper.rb which offered a
  similar but limited implementation.
* take advantage of the default behavior when passed an object which
  is to form a URL from the object's id, meaning the id can be omitted
  for terseness.
* avoid having to do  fuzzy matching when comparing hrefs, because
  where our methods provided only the path, Rails' gives us the full
  URL
* avoid doing our own string concatenation for subcollection routes,
  e.g.:
  ```ruby
  # before
  "#{blueprints_url(blueprint.id)}/tags/#{tag.id}"
  # after
  api_blueprint_tag_url(nil, blueprint, tag)
* possibly leverage some of these helpers on the production side

This won't stay fresh for long, so ask me to rebase prior to merging.

@miq-bot add-label test, technical debt
@miq-bot assign @abellotti