### PR TITLE
Fix broken alert definition specs

### DIFF
--- a/spec/requests/alert_definitions_spec.rb
+++ b/spec/requests/alert_definitions_spec.rb
@@ -65,11 +65,11 @@ describe "Alerts Definitions API" do
 
   it "creates an alert definition" do
     sample_alert_definition = {
-      "description" => "Test Alert Definition",
-      "db"          => "ContainerNode",
-      "expression"  => { "eval_method" => "dwh_generic", "mode" => "internal", "options" => {} },
-      "options"     => { "notifications" => {"delay_next_evaluation" => 600, "evm_event" => {} } },
-      "enabled"     => true
+      "description"     => "Test Alert Definition",
+      "db"              => "ContainerNode",
+      "hash_expression" => { "eval_method" => "dwh_generic", "mode" => "internal", "options" => {} },
+      "options"         => { "notifications" => {"delay_next_evaluation" => 600, "evm_event" => {} } },
+      "enabled"         => true
     }
     api_basic_authorize collection_action_identifier(:alert_definitions, :create)
     run_post(alert_definitions_url, sample_alert_definition)
@@ -116,11 +116,11 @@ describe "Alerts Definitions API" do
 
   it "edits an alert definition" do
     sample_alert_definition = {
-      :description => "Test Alert Definition",
-      :db          => "ContainerNode",
-      :expression  => { :eval_method => "mw_heap_used", :mode => "internal", :options => {} },
-      :options     => { :notifications => {:delay_next_evaluation => 0, :evm_event => {} } },
-      :enabled     => true
+      :description     => "Test Alert Definition",
+      :db              => "ContainerNode",
+      :hash_expression => { :eval_method => "mw_heap_used", :mode => "internal", :options => {} },
+      :options         => { :notifications => {:delay_next_evaluation => 0, :evm_event => {} } },
+      :enabled         => true
     }
     updated_options = { :notifications => {:delay_next_evaluation => 60, :evm_event => {} } }
     api_basic_authorize action_identifier(:alert_definitions, :edit, :resource_actions, :post)


### PR DESCRIPTION
`MiqAlert#expression` became `#hash_expression` and `#miq_expession`
in https://github.com/ManageIQ/manageiq-schema/pull/49 - so these
tests needed to be updated.

@miq-bot add-label test
@miq-bot assign @abellotti 