### PR TITLE
OPTIONS - Generic Object Definition

### DIFF
--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -25,14 +25,26 @@ module Api
       raise BadRequestError, "Failed to delete generic object definition - #{err}"
     end
 
+    def self.allowed_association_types
+      GenericObjectDefinition::ALLOWED_ASSOCIATION_TYPES.collect do |association_type|
+        [Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :plural => false), association_type]
+      end.sort
+    end
+
+    def self.allowed_types
+      GenericObjectDefinition::TYPE_MAP.keys.collect do |type|
+        [Dictionary.gettext(type.to_s, :type => :data_type, :notfound => :titleize, :plural => false), type.to_s]
+      end.sort
+    end
+
     def options
       render_options(:generic_object_definitions, build_generic_object_definition_options)
     end
 
     def build_generic_object_definition_options
       {
-        :allowed_association_types => allowed_association_types,
-        :allowed_types             => allowed_types
+        :allowed_association_types => GenericObjectDefinitionsController.allowed_association_types,
+        :allowed_types             => GenericObjectDefinitionsController.allowed_types
       }
     end
     private
@@ -44,18 +56,6 @@ module Api
         go_def = klass.find_by!(:name => id)
         filter_resource(go_def, type, klass)
       end
-    end
-
-    def allowed_association_types
-      GenericObjectDefinition::ALLOWED_ASSOCIATION_TYPES.collect do |association_type|
-        [Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :plural => false), association_type]
-      end.sort
-    end
-
-    def allowed_types
-      GenericObjectDefinition::TYPE_MAP.keys.collect do |type|
-        [Dictionary.gettext(type.to_s, :type => :data_type, :notfound => :titleize, :plural => false), type]
-      end.sort
     end
   end
 end

--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -25,6 +25,16 @@ module Api
       raise BadRequestError, "Failed to delete generic object definition - #{err}"
     end
 
+    def options
+      render_options(:generic_object_definitions, build_generic_object_definition_options)
+    end
+
+    def build_generic_object_definition_options
+      {
+        :allowed_association_types => allowed_association_types,
+        :allowed_types             => allowed_types
+      }
+    end
     private
 
     def resource_search(id, type, klass)
@@ -34,6 +44,18 @@ module Api
         go_def = klass.find_by!(:name => id)
         filter_resource(go_def, type, klass)
       end
+    end
+
+    def allowed_association_types
+      GenericObjectDefinition::ALLOWED_ASSOCIATION_TYPES.collect do |association_type|
+        [Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :plural => false), association_type]
+      end.sort
+    end
+
+    def allowed_types
+      GenericObjectDefinition::TYPE_MAP.keys.collect do |type|
+        [Dictionary.gettext(type.to_s, :type => :data_type, :notfound => :titleize, :plural => false), type]
+      end.sort
     end
   end
 end

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -328,4 +328,28 @@ RSpec.describe 'GenericObjectDefinitions API' do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  describe 'OPTIONS /api/generic_object_definitions' do
+    it 'returns allowed association types and data types' do
+      run_options(generic_object_definitions_url)
+
+      expected_data = {'allowed_association_types' => allowed_association_types,
+                       'allowed_types'             => allowed_types}
+
+      expect_options_results(:generic_object_definitions, expected_data)
+    end
+  end
+
+  def allowed_association_types
+    GenericObjectDefinition::ALLOWED_ASSOCIATION_TYPES.collect do |association_type|
+      [Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :plural => false), association_type]
+    end.sort
+  end
+
+  def allowed_types
+    GenericObjectDefinition::TYPE_MAP.keys.collect do |type|
+      type_str = type.to_s
+      [Dictionary.gettext(type_str, :type => :data_type, :notfound => :titleize, :plural => false), type_str]
+    end.sort
+  end
 end

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
 
   describe 'OPTIONS /api/generic_object_definitions' do
     it 'returns allowed association types and data types' do
-      run_options(generic_object_definitions_url)
+      run_options(api_generic_object_definitions_url)
 
       expected_data = {'allowed_association_types' => allowed_association_types,
                        'allowed_types'             => allowed_types}

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -333,23 +333,10 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'returns allowed association types and data types' do
       run_options(api_generic_object_definitions_url)
 
-      expected_data = {'allowed_association_types' => allowed_association_types,
-                       'allowed_types'             => allowed_types}
+      expected_data = {'allowed_association_types' => Api::GenericObjectDefinitionsController.allowed_association_types,
+                       'allowed_types'             => Api::GenericObjectDefinitionsController.allowed_types}
 
       expect_options_results(:generic_object_definitions, expected_data)
     end
-  end
-
-  def allowed_association_types
-    GenericObjectDefinition::ALLOWED_ASSOCIATION_TYPES.collect do |association_type|
-      [Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :plural => false), association_type]
-    end.sort
-  end
-
-  def allowed_types
-    GenericObjectDefinition::TYPE_MAP.keys.collect do |type|
-      type_str = type.to_s
-      [Dictionary.gettext(type_str, :type => :data_type, :notfound => :titleize, :plural => false), type_str]
-    end.sort
   end
 end


### PR DESCRIPTION
We need support for `OPTIONS /api/generic_object_definitions` so that the Generic Object Definitions UI populates the dropdowns with the allowed `association types` and allowed `data types`


Requires https://github.com/ManageIQ/manageiq/pull/15922 to be merged first for the new Dictionary entries added for the allowed data types.