### PR TITLE
Allow current group update 

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -48,17 +48,6 @@ module Api
       super
     end
 
-    def add_miq_groups_resource(type, id, data)
-      user = resource_search(id, type, collection_class(type))
-      data["miq_groups"].each do |group|
-        miq_group = parse_fetch_group(group)
-        user.miq_groups << miq_group if miq_group
-      end
-      user
-    rescue => err
-      raise BadRequestError, "Cannot add to miq_groups - #{err}"
-    end
-
     private
 
     def update_target_is_api_user?
@@ -66,8 +55,15 @@ module Api
     end
 
     def parse_set_group(data)
-      group = parse_fetch_group(data.delete("group"))
-      data["miq_groups"] = Array(group) if group
+      groups = if data.key?("group")
+                 group = parse_fetch_group(data.delete("group"))
+                 Array(group) if group
+               elsif data.key?("miq_groups")
+                 data["miq_groups"].collect do |miq_group|
+                   parse_fetch_group(miq_group)
+                 end
+               end
+      data["miq_groups"] = groups if groups
     end
 
     def parse_set_current_group(data)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2427,6 +2427,8 @@
         :identifier: rbac_user_edit
       - :name: delete
         :identifier: rbac_user_delete
+      - :name: add_miq_groups
+        :identifier: rbac_user_edit
     :resource_actions:
       :get:
       - :name: read
@@ -2436,6 +2438,8 @@
         :identifier: rbac_user_edit
       - :name: delete
         :identifier: rbac_user_delete
+      - :name: add_miq_groups
+        :identifier: rbac_user_edit
       :delete:
       - :name: delete
         :identifier: rbac_user_delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -2427,8 +2427,6 @@
         :identifier: rbac_user_edit
       - :name: delete
         :identifier: rbac_user_delete
-      - :name: add_miq_groups
-        :identifier: rbac_user_edit
     :resource_actions:
       :get:
       - :name: read
@@ -2438,8 +2436,6 @@
         :identifier: rbac_user_edit
       - :name: delete
         :identifier: rbac_user_delete
-      - :name: add_miq_groups
-        :identifier: rbac_user_edit
       :delete:
       - :name: delete
         :identifier: rbac_user_delete


### PR DESCRIPTION
This PR allows editing a users current group via:

```
{
   "action": "edit", 
  "current_group": { "href": "api/groups/:compressed_id" }
}
```

and also allows for editing of all `miq_groups` via edit. By passing an array of groups, the new `miq_groups` will be set.

```
{
   "action": "edit",
   "miq_groups": [ { "href": "/api/groups/:compressed_id" }. { "id": ":compressed_id" } ]
}
```

@miq-bot add_label enhancement
cc: @AllenBW 