### PR TITLE
Remove notify_email from additional attributes

### DIFF
--- a/app/controllers/api/alert_definitions_controller.rb
+++ b/app/controllers/api/alert_definitions_controller.rb
@@ -29,7 +29,7 @@ module Api
     private
 
     def set_additional_attributes
-      @additional_attributes = %w(expression notify_email)
+      @additional_attributes = %w(expression)
     end
   end
 end


### PR DESCRIPTION
This was added when debugging `set_additional_attributes`' not doing
the thing I expected for `#create` actions, and was left erroneously.

🙈 

@miq-bot assign @abellotti 