### PR TITLE
Fix generic object definition spec

### DIFF
--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'name'        => 'LoadBalancer Updated',
         'description' => 'LoadBalancer description Updated'
       }
-      run_put(generic_object_definitions_url(object_def.name), request)
+      run_put(api_generic_object_definition_url(nil, object_def.name), request)
 
       expected = {
         'name'        => 'LoadBalancer Updated',


### PR DESCRIPTION
This went red with the collision of #38 and #40 - updated to use the
new helper.


@miq-bot add-label bug
@miq-bot assign @abellotti 