### PR TITLE
Add an Uncompressor

### DIFF
--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -94,7 +94,7 @@ module Api
         def json_body
           @json_body ||= begin
                            body = @request.body.read if @request.body
-                           body.blank? ? {} : JSON.parse(body)
+                           Uncompressor.uncompress(body.blank? ? {} : JSON.parse(body))
                          end
         end
 

--- a/lib/api/uncompressor.rb
+++ b/lib/api/uncompressor.rb
@@ -1,0 +1,24 @@
+module Api
+  class Uncompressor
+    ID_MATCHER = /(\Aid\z|_id\z)/
+
+    def self.uncompress(body)
+      return body unless body.kind_of?(Hash)
+      body.each_with_object({}) do |(k, v), result|
+        result[k] =
+          case v
+          when Array
+            v.collect(&method(:uncompress))
+          when Hash
+            uncompress(v)
+          else
+            if k =~ ID_MATCHER
+              ApplicationRecord.uncompress_id(v)
+            else
+              v
+            end
+          end
+      end
+    end
+  end
+end

--- a/spec/lib/api/uncompressor_spec.rb
+++ b/spec/lib/api/uncompressor_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Api::Uncompressor do
+  describe ".uncompress" do
+    it "converts compressed ids into uncompressed ids" do
+      actual = described_class.uncompress(:id => "1r1")
+      expected = {:id => 1_000_000_000_001}
+      expect(actual).to eq(expected)
+    end
+
+    it "will detect foreign key ids and uncompress them" do
+      actual = described_class.uncompress(:vm_or_template_id => "1r1")
+      expected = {:vm_or_template_id => 1_000_000_000_001}
+      expect(actual).to eq(expected)
+    end
+
+    it "will uncompress ids nested in arrays" do
+      actual = described_class.uncompress(:dialog_tabs => [{:id => "1r1"}])
+      expected = {:dialog_tabs => [{:id => 1_000_000_000_001}]}
+      expect(actual).to eq(expected)
+    end
+
+    it "will uncompress ids nested in hashes" do
+      actual = described_class.uncompress(:content => {:dialog_tabs => [{:id => "1r1"}]})
+      expected = {:content => {:dialog_tabs => [{:id => 1_000_000_000_001}]}}
+      expect(actual).to eq(expected)
+    end
+
+    it "will leave non-id attributes as-is" do
+      actual = described_class.uncompress(:foo => "bar")
+      expected = {:foo => "bar"}
+      expect(actual).to eq(expected)
+    end
+
+    it "will preserve the input" do
+      body = {:id => "1r1"}
+      expect { described_class.uncompress(body) }.not_to change { body }
+    end
+
+    it "can handle unexpected input" do
+      actual = described_class.uncompress(true)
+      expected = true
+      expect(actual).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
### The problem
Since we're accepting incoming compressed ids in place of actual ids, they will occasionally be passed to things that aren't expecting them, and definitely shouldn't. We don't want to update every method that deals with an id somewhere to uncompress it. (see Dialogs/Dialog Fields)

### The solution
I've added an `Uncompressor` service which gets executed when the body is parsed. It will traverse the body, looking for things to uncompress, and will uncompress them. This seems like the right place to do it, since it only needs to happen once and nothing else will need to know about compressed ids 

/cc @jntullo @eclarizio 
@miq-bot add-label enhancement, technical debt
@miq-bot assign @abellotti 