### PR TITLE
Load developer bundler stuff in the Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 /tmp/
 
 /spec/manageiq
+
+# ignore included plugins in bundler.d
+bundler.d/*

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,6 @@ else
   exit 1
 end
 
+# Load other additional Gemfiles
+#   Developers can create a file ending in .rb under bundler.d/ to specify additional development dependencies
+Dir.glob(File.join(__dir__, 'bundler.d/*.rb')).each { |f| eval_gemfile(File.expand_path(f, __dir__)) }


### PR DESCRIPTION
Creates a bundler.d folder, gitignore its contents and load them at
the end of the Gemfile, as we do in the main repo.

/cc @jntullo 
@miq-bot assign @abellotti 