### PR TITLE
Fix bin/update

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -11,4 +11,4 @@ else
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
-ManageIQ::Environment.manageiq_plugin_setup
+ManageIQ::Environment.manageiq_plugin_update


### PR DESCRIPTION
Fixing `bin/update` from using `setup` to `update` 😄 

@miq-bot assign @Fryguy 
@miq-bot add_label bug 

cc: @imtayadeway 