### PR TITLE
Express ids as uncompressed strings

### DIFF
--- a/app/controllers/api/base_controller/action.rb
+++ b/app/controllers/api/base_controller/action.rb
@@ -8,7 +8,7 @@ module Api
 
         result = yield(klass) if block_given?
 
-        add_href_to_result(result, type, compress_if_numeric_id(id)) unless options[:skip_href]
+        add_href_to_result(result, type, id) unless options[:skip_href]
         log_result(result)
         result
       end

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -187,7 +187,7 @@ module Api
                  rescue => err
                    action_result(false, "#{err} - #{resource.errors.full_messages.join(', ')}")
                  end
-        add_href_to_result(result, type, ApplicationRecord.compress_id(id))
+        add_href_to_result(result, type, id)
         log_result(result)
         result
       end
@@ -204,7 +204,7 @@ module Api
                  rescue => err
                    action_result(false, err.to_s)
                  end
-        add_href_to_result(result, type, resource.compressed_id)
+        add_href_to_result(result, type, resource.id)
         log_result(result)
         result
       end
@@ -218,7 +218,7 @@ module Api
                  rescue => err
                    action_result(false, err.to_s)
                  end
-        add_href_to_result(result, type, resource.compressed_id)
+        add_href_to_result(result, type, resource.id)
         log_result(result)
         result
       end

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -10,7 +10,7 @@ module Api
         attrs = normalize_select_attributes(obj, opts)
         result = {}
 
-        href = new_href(compress_path(type), compress_if_numeric_id(obj["id"]), obj["href"])
+        href = new_href(type, obj["id"], obj["href"])
         if href.present?
           result["href"] = href
           attrs -= ["href"]
@@ -32,7 +32,7 @@ module Api
         elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
         elsif attr == "id" || attr.to_s.ends_with?("_id")
-          ApplicationRecord.compress_id(value)
+          value.to_s
         elsif Api.time_attribute?(attr)
           normalize_time(value)
         elsif Api.url_attribute?(attr)
@@ -78,7 +78,7 @@ module Api
       end
 
       def subcollection_href(type, value)
-        normalize_url("#{@req.collection}/#{ApplicationRecord.compress_id(@req.c_id)}/#{type}/#{value}")
+        normalize_url("#{@req.collection}/#{@req.c_id}/#{type}/#{value}")
       end
 
       def collection_href(type, value)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -48,7 +48,7 @@ module Api
               if opts[:expand_resources]
                 add_hash json, resource_to_jbuilder(type, reftype, resource, opts).attributes!
               else
-                json.href normalize_href(compress_path(reftype), ApplicationRecord.compress_id(resource["id"]))
+                json.href normalize_href(reftype, resource["id"])
               end
             end
           end
@@ -405,7 +405,7 @@ module Api
               if @req.expand?(sc) || scr["id"].nil?
                 add_child js, normalize_hash(sctype, scr)
               else
-                js.child! { |jsc| jsc.href normalize_href(sctype, ApplicationRecord.compress_id(scr["id"])) }
+                js.child! { |jsc| jsc.href normalize_href(sctype, scr["id"]) }
               end
             end
           end
@@ -481,22 +481,6 @@ module Api
       def render_options(resource, data = {})
         klass = collection_class(resource)
         render :json => OptionsSerializer.new(klass, data).serialize
-      end
-
-      def compress_path(path)
-        if path.to_s.split("/").size > 1
-          path.to_s.split("/").tap { |e| e[1] = ApplicationRecord.compress_id(e[1]) if e[1] =~ /\A[0-9]+\z/ }.join("/")
-        else
-          path
-        end
-      end
-
-      def compress_if_numeric_id(id)
-        if id.to_s =~ /\A[0-9]+\z/
-          ApplicationRecord.compress_id(id)
-        else
-          id
-        end
       end
     end
   end

--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -9,7 +9,7 @@ module Api
         res[:result]  = options[:result] unless options[:result].nil?
         add_task_to_result(res, options[:task_id]) if options[:task_id].present?
         add_tasks_to_result(res, options[:task_ids]) if options[:task_ids].present?
-        add_parent_href_to_result(res, ApplicationRecord.compress_id(options[:parent_id])) if options[:parent_id].present?
+        add_parent_href_to_result(res, options[:parent_id]) if options[:parent_id].present?
         res
       end
 
@@ -20,27 +20,27 @@ module Api
 
       def add_parent_href_to_result(hash, parent_id = nil)
         return if hash[:href].present?
-        hash[:href] = "#{@req.api_prefix}/#{@req.collection}/#{parent_id ? parent_id : ApplicationRecord.compress_id(@req.c_id)}"
+        hash[:href] = "#{@req.api_prefix}/#{@req.collection}/#{parent_id ? parent_id : @req.c_id}"
         hash
       end
 
       def add_task_to_result(hash, task_id)
-        hash[:task_id]   = ApplicationRecord.compress_id(task_id)
-        hash[:task_href] = task_href(ApplicationRecord.compress_id(task_id))
+        hash[:task_id]   = task_id.to_s
+        hash[:task_href] = task_href(task_id)
         hash
       end
 
       def add_tasks_to_result(hash, task_ids)
         add_task_to_result(hash, task_ids.first)
         hash[:tasks] = task_ids.collect do |task_id|
-          { :id => ApplicationRecord.compress_id(task_id), :href => task_href(ApplicationRecord.compress_id(task_id)) }
+          { :id => task_id.to_s, :href => task_href(task_id) }
         end
       end
 
       def add_tag_to_result(hash, tag_spec)
         hash[:tag_category] = tag_spec[:category] if tag_spec[:category].present?
         hash[:tag_name]     = tag_spec[:name] if tag_spec[:name].present?
-        hash[:tag_href]     = "#{@req.api_prefix}/tags/#{ApplicationRecord.compress_id(tag_spec[:id])}" if tag_spec[:id].present?
+        hash[:tag_href]     = "#{@req.api_prefix}/tags/#{tag_spec[:id]}" if tag_spec[:id].present?
         hash
       end
 
@@ -52,7 +52,7 @@ module Api
         return hash if object.blank?
         ctype_pref = ctype.to_s.singularize
         hash["#{ctype_pref}_id".to_sym]   = object.id
-        hash["#{ctype_pref}_href".to_sym] = "#{@req.api_prefix}/#{ctype}/#{object.compressed_id}"
+        hash["#{ctype_pref}_href".to_sym] = "#{@req.api_prefix}/#{ctype}/#{object.id}"
         hash
       end
 

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -30,7 +30,7 @@ module Api
       res = {:success => success}
       res[:message] = message if message.present?
       add_parent_href_to_result(res)
-      add_report_result_to_result(res, ApplicationRecord.compress_id(options[:report_result_id])) if options[:report_result_id].present?
+      add_report_result_to_result(res, options[:report_result_id]) if options[:report_result_id].present?
       add_task_to_result(res, options[:task_id]) if options[:task_id].present?
       res
     end
@@ -60,8 +60,8 @@ module Api
       desc = "scheduling of report #{report.id}"
       schedule = report.add_schedule fetch_schedule_data(data)
       res = action_result(true, desc)
-      add_report_schedule_to_result(res, schedule.compressed_id, report.compressed_id)
-      add_href_to_result(res, type, ApplicationRecord.compress_id(id))
+      add_report_schedule_to_result(res, schedule.id, report.id)
+      add_href_to_result(res, type, id)
       res
     rescue => err
       action_result(false, err.to_s)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -195,7 +195,7 @@ module Api
                rescue => err
                  action_result(false, err.to_s)
                end
-      add_href_to_result(result, type, svc.compressed_id)
+      add_href_to_result(result, type, svc.id)
       log_result(result)
       result
     end

--- a/spec/requests/actions_spec.rb
+++ b/spec/requests/actions_spec.rb
@@ -27,7 +27,7 @@ describe "Actions API" do
 
       expect(response).to have_http_status(:ok)
 
-      action_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      action_id = response.parsed_body["results"].first["id"]
 
       expect(MiqAction.exists?(action_id)).to be_truthy
     end

--- a/spec/requests/alert_definitions_spec.rb
+++ b/spec/requests/alert_definitions_spec.rb
@@ -24,10 +24,10 @@ describe "Alerts Definitions API" do
       "subcount"  => 2,
       "resources" => a_collection_containing_exactly(
         {
-          "href" => api_alert_definition_url(nil, alert_definitions[0].compressed_id)
+          "href" => api_alert_definition_url(nil, alert_definitions[0])
         },
         {
-          "href" => api_alert_definition_url(nil, alert_definitions[1].compressed_id)
+          "href" => api_alert_definition_url(nil, alert_definitions[1])
         }
       )
     )
@@ -49,8 +49,8 @@ describe "Alerts Definitions API" do
     get(api_alert_definition_url(nil, alert_definition))
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href"        => api_alert_definition_url(nil, alert_definition.compressed_id),
-      "id"          => alert_definition.compressed_id,
+      "href"        => api_alert_definition_url(nil, alert_definition),
+      "id"          => alert_definition.id.to_s,
       "description" => alert_definition.description,
       "guid"        => alert_definition.guid,
       "expression"  => {"exp" => {"=" => {"field" => "Vm-name", "value" => "foo"}}, "context_type" => nil}
@@ -78,7 +78,7 @@ describe "Alerts Definitions API" do
     api_basic_authorize collection_action_identifier(:alert_definitions, :create)
     post(api_alert_definitions_url, :params => sample_alert_definition)
     expect(response).to have_http_status(:ok)
-    alert_definition = MiqAlert.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
+    alert_definition = MiqAlert.find(response.parsed_body["results"].first["id"])
     expect(alert_definition).to be_truthy
     expect(alert_definition.expression.class).to eq(MiqExpression)
     expect(alert_definition.expression.exp).to eq(sample_alert_definition["expression"])
@@ -98,7 +98,7 @@ describe "Alerts Definitions API" do
     expect(response).to have_http_status(:ok)
     expect_single_action_result(:success => true,
                                 :message => "alert_definitions id: #{alert_definition.id} deleting",
-                                :href    => api_alert_definition_url(nil, alert_definition.compressed_id))
+                                :href    => api_alert_definition_url(nil, alert_definition))
   end
 
   it "deletes an alert definition via DELETE" do
@@ -196,8 +196,8 @@ describe "Alerts Definition Profiles API" do
     expect_query_result(:alert_definition_profiles, 2, 2)
     expect_result_resources_to_include_hrefs(
       "resources",
-      [api_alert_definition_profile_url(nil, alert_definition_profiles.first.compressed_id),
-       api_alert_definition_profile_url(nil, alert_definition_profiles.second.compressed_id)]
+      [api_alert_definition_profile_url(nil, alert_definition_profiles.first),
+       api_alert_definition_profile_url(nil, alert_definition_profiles.second)]
     )
   end
 
@@ -208,7 +208,7 @@ describe "Alerts Definition Profiles API" do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href"        => api_alert_definition_profile_url(nil, alert_definition_profile.compressed_id),
+      "href"        => api_alert_definition_profile_url(nil, alert_definition_profile),
       "description" => alert_definition_profile.description,
       "guid"        => alert_definition_profile.guid
     )
@@ -224,8 +224,8 @@ describe "Alerts Definition Profiles API" do
     expect(response).to have_http_status(:ok)
     expect_result_resources_to_include_hrefs(
       "resources",
-      [api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile.compressed_id, alert_definitions.first.compressed_id),
-       api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile.compressed_id, alert_definitions.first.compressed_id)]
+      [api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile, alert_definitions.first),
+       api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile, alert_definitions.first)]
     )
   end
 
@@ -255,7 +255,7 @@ describe "Alerts Definition Profiles API" do
     post(api_alert_definition_profiles_url, :params => sample_alert_definition_profile)
 
     expect(response).to have_http_status(:ok)
-    id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+    id = response.parsed_body["results"].first["id"]
     alert_definition_profile = MiqAlertSet.find(id)
     expect(alert_definition_profile).to be_truthy
     expect(response.parsed_body["results"].first).to include(
@@ -272,7 +272,7 @@ describe "Alerts Definition Profiles API" do
     expect(response).to have_http_status(:ok)
     expect_single_action_result(:success => true,
                                 :message => "alert_definition_profiles id: #{alert_definition_profile.id} deleting",
-                                :href    => api_alert_definition_profile_url(nil, alert_definition_profile.compressed_id))
+                                :href    => api_alert_definition_profile_url(nil, alert_definition_profile))
   end
 
   it "deletes an alert definition profile via DELETE" do

--- a/spec/requests/alerts_spec.rb
+++ b/spec/requests/alerts_spec.rb
@@ -16,10 +16,10 @@ describe "Alerts API" do
       "subcount"  => 2,
       "resources" => [
         {
-          "href" => api_alert_url(nil, alert_statuses[0].compressed_id)
+          "href" => api_alert_url(nil, alert_statuses[0])
         },
         {
-          "href" => api_alert_url(nil, alert_statuses[1].compressed_id)
+          "href" => api_alert_url(nil, alert_statuses[1])
         }
       ]
     )
@@ -38,8 +38,8 @@ describe "Alerts API" do
     get(api_alert_url(nil, alert_status))
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href" => api_alert_url(nil, alert_status.compressed_id),
-      "id"   => alert_status.compressed_id
+      "href" => api_alert_url(nil, alert_status),
+      "id"   => alert_status.id.to_s
     )
   end
 
@@ -49,7 +49,7 @@ describe "Alerts API" do
     let(:expected_assignee) do
       {
         'results' => a_collection_containing_exactly(
-          a_hash_including("assignee_id" => assignee.compressed_id)
+          a_hash_including("assignee_id" => assignee.id.to_s)
         )
       }
     end
@@ -80,7 +80,7 @@ describe "Alerts API" do
         "subcount"  => 1,
         "resources" => [
           {
-            "href" => api_alert_alert_action_url(nil, alert.compressed_id, alert_action.compressed_id)
+            "href" => api_alert_alert_action_url(nil, alert, alert_action)
           }
         ]
       )
@@ -126,7 +126,7 @@ describe "Alerts API" do
       expect(response).to have_http_status(:ok)
       expected = {
         "results" => [
-          a_hash_including(attributes.merge("user_id" => User.current_user.compressed_id))
+          a_hash_including(attributes.merge("user_id" => User.current_user.id.to_s))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -136,7 +136,7 @@ describe "Alerts API" do
     it "create an assignment alert action reference by id" do
       attributes = {
         "action_type" => "assign",
-        "assignee"    => { "id" => assignee.compressed_id }
+        "assignee"    => { "id" => assignee.id.to_s }
       }
       api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :create, :post)
       post(api_alert_alert_actions_url(nil, alert), :params => attributes)
@@ -147,7 +147,7 @@ describe "Alerts API" do
     it "create an assignment alert action reference by href" do
       attributes = {
         "action_type" => "assign",
-        "assignee"    => { "href" => api_user_url(nil, assignee.compressed_id) }
+        "assignee"    => { "href" => api_user_url(nil, assignee) }
       }
       api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :create, :post)
       post(api_alert_alert_actions_url(nil, alert), :params => attributes)
@@ -178,10 +178,10 @@ describe "Alerts API" do
       get(api_alert_alert_action_url(nil, alert, alert_action))
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
-        "href"        => api_alert_alert_action_url(nil, alert.compressed_id, alert_action.compressed_id),
-        "id"          => alert_action.compressed_id,
+        "href"        => api_alert_alert_action_url(nil, alert, alert_action),
+        "id"          => alert_action.id.to_s,
         "action_type" => alert_action.action_type,
-        "user_id"     => user.compressed_id,
+        "user_id"     => user.id.to_s,
         "comment"     => alert_action.comment,
       )
     end

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Authentications API' do
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'authentications',
-        'resources' => [hash_including('href' => api_authentication_url(nil, auth.compressed_id))]
+        'resources' => [hash_including('href' => api_authentication_url(nil, auth))]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -36,7 +36,7 @@ RSpec.describe 'Authentications API' do
       get(api_authentication_url(nil, auth))
 
       expected = {
-        'href' => api_authentication_url(nil, auth.compressed_id)
+        'href' => api_authentication_url(nil, auth)
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)

--- a/spec/requests/automate_domains_spec.rb
+++ b/spec/requests/automate_domains_spec.rb
@@ -45,7 +45,7 @@ describe "Automate Domains API" do
         expect_single_action_result(
           :success => true,
           :message => a_string_matching(/Refreshing Automate Domain .* from git repository/),
-          :href    => api_automate_domain_url(nil, git_domain.compressed_id)
+          :href    => api_automate_domain_url(nil, git_domain)
         )
       end
 

--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -38,7 +38,7 @@ describe "Automation Requests API" do
         "count"     => 2,
         "subcount"  => 1,
         "resources" => a_collection_containing_exactly(
-          "href" => api_automation_request_url(nil, automation_request2.compressed_id),
+          "href" => api_automation_request_url(nil, automation_request2),
         )
       }
       expect(response).to have_http_status(:ok)
@@ -58,8 +58,8 @@ describe "Automation Requests API" do
         "count"     => 2,
         "subcount"  => 2,
         "resources" => a_collection_containing_exactly(
-          {"href" => api_automation_request_url(nil, automation_request1.compressed_id)},
-          {"href" => api_automation_request_url(nil, automation_request2.compressed_id)},
+          {"href" => api_automation_request_url(nil, automation_request1)},
+          {"href" => api_automation_request_url(nil, automation_request2)},
         )
       }
       expect(response).to have_http_status(:ok)
@@ -85,8 +85,8 @@ describe "Automation Requests API" do
       get api_automation_request_url(nil, automation_request)
 
       expected = {
-        "id"   => automation_request.compressed_id,
-        "href" => api_automation_request_url(nil, automation_request.compressed_id)
+        "id"   => automation_request.id.to_s,
+        "href" => api_automation_request_url(nil, automation_request)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -101,7 +101,7 @@ describe "Automation Requests API" do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      task_id = response.parsed_body["results"].first["id"]
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -114,7 +114,7 @@ describe "Automation Requests API" do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      task_id = response.parsed_body["results"].first["id"]
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -127,7 +127,7 @@ describe "Automation Requests API" do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = response.parsed_body["results"].collect { |r| ApplicationRecord.uncompress_id(r["id"]) }
+      task_id1, task_id2 = response.parsed_body["results"].collect { |r| r["id"] }
       expect(AutomationRequest.exists?(task_id1)).to be_truthy
       expect(AutomationRequest.exists?(task_id2)).to be_truthy
     end
@@ -150,7 +150,7 @@ describe "Automation Requests API" do
       post(api_automation_request_url(nil, automation_request), :params => { :action => "edit", :options => {:baz => "qux"} })
 
       expected = {
-        "id"      => automation_request.compressed_id,
+        "id"      => automation_request.id.to_s,
         "options" => a_hash_including("foo" => "bar", "baz" => "qux")
       }
       expect(response).to have_http_status(:ok)
@@ -200,7 +200,7 @@ describe "Automation Requests API" do
       post(request1_url, :params => gen_request(:approve, :reason => "approve reason"))
 
       expected_msg = "Automation request #{request1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => api_automation_request_url(nil, request1.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_automation_request_url(nil, request1))
     end
 
     it "supports denying a request" do
@@ -209,7 +209,7 @@ describe "Automation Requests API" do
       post(request2_url, :params => gen_request(:deny, :reason => "deny reason"))
 
       expected_msg = "Automation request #{request2.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => api_automation_request_url(nil, request2.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_automation_request_url(nil, request2))
     end
 
     it "supports approving multiple requests" do
@@ -223,12 +223,12 @@ describe "Automation Requests API" do
           {
             "message" => a_string_matching(/Automation request #{request1.id} approved/i),
             "success" => true,
-            "href"    => api_automation_request_url(nil, request1.compressed_id)
+            "href"    => api_automation_request_url(nil, request1)
           },
           {
             "message" => a_string_matching(/Automation request #{request2.id} approved/i),
             "success" => true,
-            "href"    => api_automation_request_url(nil, request2.compressed_id)
+            "href"    => api_automation_request_url(nil, request2)
           }
         )
       }
@@ -247,12 +247,12 @@ describe "Automation Requests API" do
           {
             "message" => a_string_matching(/Automation request #{request1.id} denied/i,),
             "success" => true,
-            "href"    => api_automation_request_url(nil, request1.compressed_id)
+            "href"    => api_automation_request_url(nil, request1)
           },
           {
             "message" => a_string_matching(/Automation request #{request2.id} denied/i),
             "success" => true,
-            "href"    => api_automation_request_url(nil, request2.compressed_id)
+            "href"    => api_automation_request_url(nil, request2)
           }
         )
       }

--- a/spec/requests/blueprints_spec.rb
+++ b/spec/requests/blueprints_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Blueprints API" do
         "subcount"  => 1,
         "name"      => "blueprints",
         "resources" => [
-          hash_including("href" => api_blueprint_url(nil, blueprint.compressed_id))
+          hash_including("href" => api_blueprint_url(nil, blueprint))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -35,7 +35,7 @@ RSpec.describe "Blueprints API" do
 
       get(api_blueprint_url(nil, blueprint))
 
-      expect(response.parsed_body).to include("href" => api_blueprint_url(nil, blueprint.compressed_id))
+      expect(response.parsed_body).to include("href" => api_blueprint_url(nil, blueprint))
       expect(response).to have_http_status(:ok)
     end
 
@@ -167,11 +167,11 @@ RSpec.describe "Blueprints API" do
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
-            "id"   => blueprint1.compressed_id,
+            "id"   => blueprint1.id.to_s,
             "name" => "baz"
           ),
           a_hash_including(
-            "id"   => blueprint2.compressed_id,
+            "id"   => blueprint2.id.to_s,
             "name" => "qux"
           )
         )
@@ -240,8 +240,8 @@ RSpec.describe "Blueprints API" do
 
       expected = {
         "results" => a_collection_containing_exactly(
-          a_hash_including("id" => blueprint1.compressed_id, "status" => "published"),
-          a_hash_including("id" => blueprint2.compressed_id, "status" => "published")
+          a_hash_including("id" => blueprint1.id.to_s, "status" => "published"),
+          a_hash_including("id" => blueprint2.id.to_s, "status" => "published")
         )
       }
 
@@ -299,7 +299,7 @@ RSpec.describe "Blueprints API" do
       post(api_blueprint_url(nil, blueprint), :params => { :action => "publish" })
 
       expected = {
-        "id"     => blueprint.compressed_id,
+        "id"     => blueprint.id.to_s,
         "status" => "published"
       }
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "categories API" do
 
     expect_result_resources_to_include_hrefs(
       "resources",
-      categories.map { |category| api_category_url(nil, category.compressed_id) }
+      categories.map { |category| api_category_url(nil, category) }
     )
     expect(response).to have_http_status(:ok)
   end
@@ -20,7 +20,7 @@ RSpec.describe "categories API" do
     get api_categories_url, :params => { :filter => ["name=foo"] }
 
     expect_query_result(:categories, 1, 2)
-    expect_result_resources_to_include_hrefs("resources", [api_category_url(nil, category_1.compressed_id)])
+    expect_result_resources_to_include_hrefs("resources", [api_category_url(nil, category_1)])
   end
 
   it "will return a bad request error if the filter name is invalid" do
@@ -40,8 +40,8 @@ RSpec.describe "categories API" do
     expect_result_to_match_hash(
       response.parsed_body,
       "description" => category.description,
-      "href"        => api_category_url(nil, category.compressed_id),
-      "id"          => category.compressed_id
+      "href"        => api_category_url(nil, category),
+      "id"          => category.id.to_s
     )
     expect(response).to have_http_status(:ok)
   end
@@ -67,7 +67,7 @@ RSpec.describe "categories API" do
 
     expect_result_resources_to_include_hrefs(
       "resources",
-      [api_category_tag_url(nil, category.compressed_id, tag.compressed_id)]
+      [api_category_tag_url(nil, category, tag)]
     )
     expect(response).to have_http_status(:ok)
   end
@@ -107,7 +107,7 @@ RSpec.describe "categories API" do
       api_basic_authorize collection_action_identifier(:categories, :create)
 
       post api_categories_url, :params => { :name => "test", :description => "Test" }
-      category = Category.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
+      category = Category.find(response.parsed_body["results"].first["id"])
 
       expect(category.tag.name).to eq("/managed/test")
     end

--- a/spec/requests/chargebacks_spec.rb
+++ b/spec/requests/chargebacks_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "chargebacks API" do
     get api_chargebacks_url
 
     expect_result_resources_to_include_hrefs(
-      "resources", [api_chargeback_url(nil, chargeback_rate.compressed_id)]
+      "resources", [api_chargeback_url(nil, chargeback_rate)]
     )
     expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)
@@ -24,8 +24,8 @@ RSpec.describe "chargebacks API" do
       response.parsed_body,
       "description" => chargeback_rate.description,
       "guid"        => chargeback_rate.guid,
-      "id"          => chargeback_rate.compressed_id,
-      "href"        => api_chargeback_url(nil, chargeback_rate.compressed_id)
+      "id"          => chargeback_rate.id.to_s,
+      "href"        => api_chargeback_url(nil, chargeback_rate)
     )
     expect(response).to have_http_status(:ok)
   end
@@ -45,7 +45,7 @@ RSpec.describe "chargebacks API" do
     expect_query_result(:rates, 1, 1)
     expect_result_resources_to_include_hrefs(
       "resources",
-      [api_chargeback_rate_url(nil, chargeback_rate.compressed_id, chargeback_rate_detail.compressed_id)]
+      [api_chargeback_rate_url(nil, chargeback_rate, chargeback_rate_detail)]
     )
   end
 
@@ -63,9 +63,9 @@ RSpec.describe "chargebacks API" do
 
     expect_result_to_match_hash(
       response.parsed_body,
-      "chargeback_rate_id" => chargeback_rate.compressed_id,
-      "href"               => api_chargeback_rate_url(nil, chargeback_rate.compressed_id, chargeback_rate_detail.compressed_id),
-      "id"                 => chargeback_rate_detail.compressed_id,
+      "chargeback_rate_id" => chargeback_rate.id.to_s,
+      "href"               => api_chargeback_rate_url(nil, chargeback_rate, chargeback_rate_detail),
+      "id"                 => chargeback_rate_detail.id.to_s,
       "description"        => "rate_1"
     )
     expect(response).to have_http_status(:ok)
@@ -78,7 +78,7 @@ RSpec.describe "chargebacks API" do
     get '/api/currencies'
 
     expect_result_resources_to_include_hrefs(
-      "resources", ["/api/currencies/#{currency.compressed_id}"]
+      "resources", [api_currency_url(nil, currency)]
     )
     expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)
@@ -93,8 +93,8 @@ RSpec.describe "chargebacks API" do
     expect_result_to_match_hash(
       response.parsed_body,
       "name" => currency.name,
-      "id"   => currency.compressed_id,
-      "href" => "/api/currencies/#{currency.compressed_id}"
+      "id"   => currency.id.to_s,
+      "href" => api_currency_url(nil, currency)
     )
     expect(response).to have_http_status(:ok)
   end
@@ -106,7 +106,7 @@ RSpec.describe "chargebacks API" do
     get '/api/measures'
 
     expect_result_resources_to_include_hrefs(
-      "resources", ["/api/measures/#{measure.compressed_id}"]
+      "resources", [api_measure_url(nil, measure)]
     )
     expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)
@@ -121,8 +121,8 @@ RSpec.describe "chargebacks API" do
     expect_result_to_match_hash(
       response.parsed_body,
       "name" => measure.name,
-      "id"   => measure.compressed_id,
-      "href" => "/api/measures/#{measure.compressed_id}",
+      "id"   => measure.id.to_s,
+      "href" => api_measure_url(nil, measure)
     )
     expect(response).to have_http_status(:ok)
   end

--- a/spec/requests/cloud_networks_spec.rb
+++ b/spec/requests/cloud_networks_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe 'Cloud Networks API' do
     let(:provider) { FactoryGirl.create(:ems_amazon_with_cloud_networks) }
 
     it 'queries Providers cloud_networks' do
-      cloud_network_ids = provider.cloud_networks.select(:id).collect(&:compressed_id)
+      cloud_network_ids = provider.cloud_networks.pluck(:id)
       api_basic_authorize subcollection_action_identifier(:providers, :cloud_networks, :read, :get)
 
       get api_provider_cloud_networks_url(nil, provider), :params => { :expand => 'resources' }
 
       expect_query_result(:cloud_networks, 2)
-      expect_result_resources_to_include_data('resources', 'id' => cloud_network_ids)
+      expect_result_resources_to_include_data('resources', 'id' => cloud_network_ids.collect(&:to_s))
     end
 
     it "will not list cloud networks of a provider without the appropriate role" do
@@ -46,7 +46,7 @@ RSpec.describe 'Cloud Networks API' do
 
       get(api_provider_cloud_network_url(nil, provider, network))
 
-      expect_single_resource_query('name' => network.name, 'id' => network.compressed_id, 'ems_ref' => network.ems_ref)
+      expect_single_resource_query('name' => network.name, 'id' => network.id.to_s, 'ems_ref' => network.ems_ref)
     end
 
     it "will not show the cloud network of a provider without the appropriate role" do

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'CloudSubnets API' do
         'subcount'  => 1,
         'name'      => 'cloud_subnets',
         'resources' => [
-          hash_including('href' => api_cloud_subnet_url(nil, cloud_subnet.compressed_id))
+          hash_including('href' => api_cloud_subnet_url(nil, cloud_subnet))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -33,7 +33,7 @@ RSpec.describe 'CloudSubnets API' do
 
       get(api_cloud_subnet_url(nil, cloud_subnet))
 
-      expect(response.parsed_body).to include('href' => api_cloud_subnet_url(nil, cloud_subnet.compressed_id))
+      expect(response.parsed_body).to include('href' => api_cloud_subnet_url(nil, cloud_subnet))
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/requests/cloud_tenants_spec.rb
+++ b/spec/requests/cloud_tenants_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'CloudTenants API' do
         'subcount'  => 1,
         'name'      => 'cloud_tenants',
         'resources' => [
-          hash_including('href' => api_cloud_tenant_url(nil, cloud_tenant.compressed_id))
+          hash_including('href' => api_cloud_tenant_url(nil, cloud_tenant))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -33,7 +33,7 @@ RSpec.describe 'CloudTenants API' do
 
       get(api_cloud_tenant_url(nil, cloud_tenant))
 
-      expect(response.parsed_body).to include('href' => api_cloud_tenant_url(nil, cloud_tenant.compressed_id))
+      expect(response.parsed_body).to include('href' => api_cloud_tenant_url(nil, cloud_tenant))
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -36,8 +36,8 @@ describe "Cloud Volumes API" do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href" => api_cloud_volume_url(nil, cloud_volume.compressed_id),
-      "id"   => cloud_volume.compressed_id
+      "href" => api_cloud_volume_url(nil, cloud_volume),
+      "id"   => cloud_volume.id.to_s
     )
   end
 

--- a/spec/requests/conditions_spec.rb
+++ b/spec/requests/conditions_spec.rb
@@ -72,7 +72,7 @@ describe "Conditions API" do
 
       expect(response).to have_http_status(:ok)
 
-      condition_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      condition_id = response.parsed_body["results"].first["id"]
 
       expect(Condition.find(condition_id).expression.class).to eq(MiqExpression)
     end
@@ -164,7 +164,7 @@ describe "Conditions API" do
       expect_query_result(:conditions, 3, 3)
       expect_result_resources_to_include_hrefs(
         "resources",
-        Condition.select(:id).collect { |c| api_condition_url(nil, c.compressed_id) }
+        Condition.select(:id).collect { |c| api_condition_url(nil, c) }
       )
     end
 

--- a/spec/requests/configuration_script_payloads_spec.rb
+++ b/spec/requests/configuration_script_payloads_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Configuration Script Payloads API' do
         'subcount'  => 1,
         'name'      => 'configuration_script_payloads',
         'resources' => [
-          hash_including('href' => api_configuration_script_payload_url(nil, script_payload.compressed_id))
+          hash_including('href' => api_configuration_script_payload_url(nil, script_payload))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -35,7 +35,7 @@ RSpec.describe 'Configuration Script Payloads API' do
       get(api_configuration_script_payload_url(nil, script_payload))
 
       expect(response.parsed_body)
-        .to include('href' => api_configuration_script_payload_url(nil, script_payload.compressed_id))
+        .to include('href' => api_configuration_script_payload_url(nil, script_payload))
       expect(response).to have_http_status(:ok)
     end
 
@@ -59,7 +59,7 @@ RSpec.describe 'Configuration Script Payloads API' do
 
       expected = {
         'resources' => [
-          a_hash_including('id' => authentication.compressed_id)
+          a_hash_including('id' => authentication.id.to_s)
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -152,7 +152,7 @@ RSpec.describe 'Configuration Script Payloads API' do
       get(api_configuration_script_payload_authentication_url(nil, playbook, authentication))
 
       expected = {
-        'id' => authentication.compressed_id
+        'id' => authentication.id.to_s
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/configuration_script_sources_spec.rb
+++ b/spec/requests/configuration_script_sources_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Configuration Script Sources API' do
         'count'     => 1,
         'subcount'  => 1,
         'name'      => 'configuration_script_sources',
-        'resources' => [hash_including('href' => api_configuration_script_source_url(nil, repository.compressed_id))]
+        'resources' => [hash_including('href' => api_configuration_script_source_url(nil, repository))]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -39,7 +39,7 @@ RSpec.describe 'Configuration Script Sources API' do
       get(api_configuration_script_source_url(nil, repository))
 
       expected = {
-        'href' => api_configuration_script_source_url(nil, repository.compressed_id)
+        'href' => api_configuration_script_source_url(nil, repository)
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -455,7 +455,7 @@ RSpec.describe 'Configuration Script Sources API' do
 
       expected = {
         'resources' => [
-          {'href' => a_string_including(api_configuration_script_source_configuration_script_payload_url(nil, config_script_src.compressed_id, payload.compressed_id))}
+          {'href' => api_configuration_script_source_configuration_script_payload_url(nil, config_script_src, payload)}
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -473,7 +473,7 @@ RSpec.describe 'Configuration Script Sources API' do
       expected = {
         'subcount'  => 1,
         'resources' => [
-          {'href' => a_string_including(api_configuration_script_source_configuration_script_payload_url(nil, config_script_src.compressed_id, payload.compressed_id))}
+          {'href' => api_configuration_script_source_configuration_script_payload_url(nil, config_script_src, payload)}
         ]
       }
       expect(response).to have_http_status(:ok)

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -162,7 +162,7 @@ describe "Custom Actions API" do
 
       post(api_service_url(nil, svc1), :params => gen_request(:button1, "button_key1" => "value", "button_key2" => "value"))
 
-      expect_single_action_result(:success => true, :message => /.*/, :href => api_service_url(nil, svc1.compressed_id))
+      expect_single_action_result(:success => true, :message => /.*/, :href => api_service_url(nil, svc1))
     end
 
     it "accepts a custom action as case insensitive" do
@@ -170,7 +170,7 @@ describe "Custom Actions API" do
 
       post(api_service_url(nil, svc1), :params => gen_request(:BuTtOn1, "button_key1" => "value", "button_key2" => "value"))
 
-      expect_single_action_result(:success => true, :message => /.*/, :href => api_service_url(nil, svc1.compressed_id))
+      expect_single_action_result(:success => true, :message => /.*/, :href => api_service_url(nil, svc1))
     end
   end
 
@@ -212,7 +212,7 @@ describe "Custom Actions API" do
           "buttons"       => [
             hash_including(
               "id"              => anything,
-              "resource_action" => hash_including("id" => ra2.compressed_id, "dialog_id" => ra2.dialog.compressed_id)
+              "resource_action" => hash_including("id" => ra2.id.to_s, "dialog_id" => ra2.dialog.id.to_s)
             )
           ]
         }

--- a/spec/requests/custom_attributes_spec.rb
+++ b/spec/requests/custom_attributes_spec.rb
@@ -38,6 +38,6 @@ RSpec.describe "Custom Attributes API" do
     post(api_provider_custom_attribute_url(nil, provider, custom_attribute), :params => { :action => :edit, :name => 'name1' })
 
     expect(response).to have_http_status(:ok)
-    expect(response.parsed_body['href']).to include(api_provider_custom_attribute_url(nil, provider.compressed_id, custom_attribute.compressed_id))
+    expect(response.parsed_body['href']).to include(api_provider_custom_attribute_url(nil, provider, custom_attribute))
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -40,7 +40,7 @@ describe "Events API" do
       expect_query_result(:events, 3, 3)
       expect_result_resources_to_include_hrefs(
         "resources",
-        MiqEventDefinition.select(:id).collect { |med| api_event_url(nil, med.compressed_id) }
+        MiqEventDefinition.select(:id).collect { |med| api_event_url(nil, med) }
       )
     end
 

--- a/spec/requests/floating_ips_spec.rb
+++ b/spec/requests/floating_ips_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'FloatingIp API' do
         'subcount'  => 1,
         'name'      => 'floating_ips',
         'resources' => [
-          hash_including('href' => api_floating_ip_url(nil, floating_ip.compressed_id))
+          hash_including('href' => api_floating_ip_url(nil, floating_ip))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -33,7 +33,7 @@ RSpec.describe 'FloatingIp API' do
 
       get(api_floating_ip_url(nil, floating_ip))
 
-      expect(response.parsed_body).to include('href' => api_floating_ip_url(nil, floating_ip.compressed_id))
+      expect(response.parsed_body).to include('href' => api_floating_ip_url(nil, floating_ip))
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
 
     it 'lists all generic object definitions with an appropriate role' do
       api_basic_authorize collection_action_identifier(:generic_object_definitions, :read, :get)
-      object_def_href = api_generic_object_definition_url(nil, object_def.compressed_id)
+      object_def_href = api_generic_object_definition_url(nil, object_def)
 
       get(api_generic_object_definitions_url)
 
@@ -36,7 +36,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'does not let you query object definitions without an appropriate role' do
       api_basic_authorize
 
-      get(api_generic_object_definition_url(nil, object_def.compressed_id))
+      get(api_generic_object_definition_url(nil, object_def))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -47,7 +47,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
       get(api_generic_object_definition_url(nil, object_def))
 
       expected = {
-        'id'   => object_def.compressed_id,
+        'id'   => object_def.id.to_s,
         'name' => object_def.name
       }
       expect(response).to have_http_status(:ok)
@@ -60,7 +60,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
       get(api_generic_object_definition_url(nil, object_def.name))
 
       expected = {
-        'id'   => object_def.compressed_id,
+        'id'   => object_def.id.to_s,
         'name' => object_def.name
       }
       expect(response).to have_http_status(:ok)
@@ -135,17 +135,17 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'action'    => 'edit',
         'resources' => [
           { 'name' => object_def.name, 'resource' => { 'name' => 'updated 1' } },
-          { 'id' => object_def2.compressed_id, 'resource' => { 'name' => 'updated 2' }},
-          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id), 'resource' => { 'name' => 'updated 3' }}
+          { 'id' => object_def2.id.to_s, 'resource' => { 'name' => 'updated 2' }},
+          { 'href' => api_generic_object_definition_url(nil, object_def3), 'resource' => { 'name' => 'updated 3' }}
         ]
       }
       post(api_generic_object_definitions_url, :params => request)
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => object_def.compressed_id, 'name' => 'updated 1'),
-          a_hash_including('id' => object_def2.compressed_id, 'name' => 'updated 2'),
-          a_hash_including('id' => object_def3.compressed_id, 'name' => 'updated 3')
+          a_hash_including('id' => object_def.id.to_s, 'name' => 'updated 1'),
+          a_hash_including('id' => object_def2.id.to_s, 'name' => 'updated 2'),
+          a_hash_including('id' => object_def3.id.to_s, 'name' => 'updated 3')
         )
       }
       expect(response).to have_http_status(:ok)
@@ -159,17 +159,17 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'action'    => 'add_associations',
         'resources' => [
           { 'name' => object_def.name, 'resource' => { 'associations' => { 'association1' => 'AvailabilityZone' } } },
-          { 'id' => object_def2.compressed_id, 'resource' => { 'associations' => { 'association2' => 'AvailabilityZone' } }},
-          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id), 'resource' => { 'associations' => { 'association3' => 'AvailabilityZone' } }}
+          { 'id' => object_def2.id.to_s, 'resource' => { 'associations' => { 'association2' => 'AvailabilityZone' } }},
+          { 'href' => api_generic_object_definition_url(nil, object_def3), 'resource' => { 'associations' => { 'association3' => 'AvailabilityZone' } }}
         ]
       }
       post(api_generic_object_definitions_url, :params => request)
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => object_def.compressed_id, 'properties' => a_hash_including('associations' => {'association1' => 'AvailabilityZone'})),
-          a_hash_including('id' => object_def2.compressed_id, 'properties' => a_hash_including('associations' => {'association2' => 'AvailabilityZone'})),
-          a_hash_including('id' => object_def3.compressed_id, 'properties' => a_hash_including('associations' => {'association3' => 'AvailabilityZone'}))
+          a_hash_including('id' => object_def.id.to_s, 'properties' => a_hash_including('associations' => {'association1' => 'AvailabilityZone'})),
+          a_hash_including('id' => object_def2.id.to_s, 'properties' => a_hash_including('associations' => {'association2' => 'AvailabilityZone'})),
+          a_hash_including('id' => object_def3.id.to_s, 'properties' => a_hash_including('associations' => {'association3' => 'AvailabilityZone'}))
         )
       }
       expect(response).to have_http_status(:ok)
@@ -194,17 +194,17 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'action'    => 'remove_associations',
         'resources' => [
           { 'name' => object_def.name, 'resource' => { 'associations' => { 'association1' => 'AvailabilityZone' } } },
-          { 'id' => object_def2.compressed_id, 'resource' => { 'associations' => { 'association2' => 'AvailabilityZone' } }},
-          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id), 'resource' => { 'associations' => { 'association3' => 'AvailabilityZone' } }}
+          { 'id' => object_def2.id.to_s, 'resource' => { 'associations' => { 'association2' => 'AvailabilityZone' } }},
+          { 'href' => api_generic_object_definition_url(nil, object_def3), 'resource' => { 'associations' => { 'association3' => 'AvailabilityZone' } }}
         ]
       }
       post(api_generic_object_definitions_url, :params => request)
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => object_def.compressed_id, 'properties' => a_hash_including('associations' => {})),
-          a_hash_including('id' => object_def2.compressed_id, 'properties' => a_hash_including('associations' => {})),
-          a_hash_including('id' => object_def3.compressed_id, 'properties' => a_hash_including('associations' => {}))
+          a_hash_including('id' => object_def.id.to_s, 'properties' => a_hash_including('associations' => {})),
+          a_hash_including('id' => object_def2.id.to_s, 'properties' => a_hash_including('associations' => {})),
+          a_hash_including('id' => object_def3.id.to_s, 'properties' => a_hash_including('associations' => {}))
         )
       }
       expect(response).to have_http_status(:ok)
@@ -226,17 +226,17 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'action'    => 'add_attributes',
         'resources' => [
           { 'name' => object_def.name, 'resource' => { 'attributes' => { 'attr1' => 'string' } } },
-          { 'id' => object_def2.compressed_id, 'resource' => { 'attributes' => { 'attr2' => 'string' } }},
-          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id), 'resource' => { 'attributes' => { 'attr3' => 'string' } }}
+          { 'id' => object_def2.id.to_s, 'resource' => { 'attributes' => { 'attr2' => 'string' } }},
+          { 'href' => api_generic_object_definition_url(nil, object_def3), 'resource' => { 'attributes' => { 'attr3' => 'string' } }}
         ]
       }
       post(api_generic_object_definitions_url, :params => request)
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => object_def.compressed_id, 'properties' => a_hash_including('attributes' => {'attr1' => 'string'})),
-          a_hash_including('id' => object_def2.compressed_id, 'properties' => a_hash_including('attributes' => {'attr2' => 'string'})),
-          a_hash_including('id' => object_def3.compressed_id, 'properties' => a_hash_including('attributes' => {'attr3' => 'string'}))
+          a_hash_including('id' => object_def.id.to_s, 'properties' => a_hash_including('attributes' => {'attr1' => 'string'})),
+          a_hash_including('id' => object_def2.id.to_s, 'properties' => a_hash_including('attributes' => {'attr2' => 'string'})),
+          a_hash_including('id' => object_def3.id.to_s, 'properties' => a_hash_including('attributes' => {'attr3' => 'string'}))
         )
       }
       expect(response).to have_http_status(:ok)
@@ -261,17 +261,17 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'action'    => 'remove_attributes',
         'resources' => [
           { 'name' => object_def.name, 'resource' => { 'attributes' => { 'attr1' => 'string' } } },
-          { 'id' => object_def2.compressed_id, 'resource' => { 'attributes' => { 'attr2' => 'string' } }},
-          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id), 'resource' => { 'attributes' => { 'attr3' => 'string' } }}
+          { 'id' => object_def2.id.to_s, 'resource' => { 'attributes' => { 'attr2' => 'string' } }},
+          { 'href' => api_generic_object_definition_url(nil, object_def3), 'resource' => { 'attributes' => { 'attr3' => 'string' } }}
         ]
       }
       post(api_generic_object_definitions_url, :params => request)
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => object_def.compressed_id, 'properties' => a_hash_including('attributes' => {})),
-          a_hash_including('id' => object_def2.compressed_id, 'properties' => a_hash_including('attributes' => {})),
-          a_hash_including('id' => object_def3.compressed_id, 'properties' => a_hash_including('attributes' => {}))
+          a_hash_including('id' => object_def.id.to_s, 'properties' => a_hash_including('attributes' => {})),
+          a_hash_including('id' => object_def2.id.to_s, 'properties' => a_hash_including('attributes' => {})),
+          a_hash_including('id' => object_def3.id.to_s, 'properties' => a_hash_including('attributes' => {}))
         )
       }
       expect(response).to have_http_status(:ok)
@@ -293,17 +293,17 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'action'    => 'add_methods',
         'resources' => [
           { 'name' => object_def.name, 'resource' => { 'methods' => ['method1'] } },
-          { 'id' => object_def2.compressed_id, 'resource' => { 'methods' => ['method2'] }},
-          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id), 'resource' => { 'methods' => ['method3'] }}
+          { 'id' => object_def2.id.to_s, 'resource' => { 'methods' => ['method2'] }},
+          { 'href' => api_generic_object_definition_url(nil, object_def3), 'resource' => { 'methods' => ['method3'] }}
         ]
       }
       post(api_generic_object_definitions_url, :params => request)
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => object_def.compressed_id, 'properties' => a_hash_including('methods' => ['method1'])),
-          a_hash_including('id' => object_def2.compressed_id, 'properties' => a_hash_including('methods' => ['method2'])),
-          a_hash_including('id' => object_def3.compressed_id, 'properties' => a_hash_including('methods' => ['method3']))
+          a_hash_including('id' => object_def.id.to_s, 'properties' => a_hash_including('methods' => ['method1'])),
+          a_hash_including('id' => object_def2.id.to_s, 'properties' => a_hash_including('methods' => ['method2'])),
+          a_hash_including('id' => object_def3.id.to_s, 'properties' => a_hash_including('methods' => ['method3']))
         )
       }
       expect(response).to have_http_status(:ok)
@@ -370,7 +370,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           ]
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(request.except('action'))
@@ -387,7 +387,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           }
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'error' => a_hash_including(
@@ -410,7 +410,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'can delete an object definition by id' do
       api_basic_authorize action_identifier(:generic_object_definitions, :delete)
 
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => { :action => 'delete' })
+      post(api_generic_object_definition_url(nil, object_def), :params => { :action => 'delete' })
 
       expect(response).to have_http_status(:ok)
     end
@@ -438,17 +438,17 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'action'    => 'delete',
         'resources' => [
           { 'name' => object_def.name },
-          { 'id' => object_def2.compressed_id},
-          { 'href' => api_generic_object_definition_url(nil, object_def3.compressed_id)}
+          { 'id' => object_def2.id.to_s},
+          { 'href' => api_generic_object_definition_url(nil, object_def3)}
         ]
       }
       post(api_generic_object_definitions_url, :params => request)
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => object_def.compressed_id),
-          a_hash_including('id' => object_def2.compressed_id),
-          a_hash_including('id' => object_def3.compressed_id)
+          a_hash_including('id' => object_def.id.to_s),
+          a_hash_including('id' => object_def2.id.to_s),
+          a_hash_including('id' => object_def3.id.to_s)
         )
       }
       expect(response).to have_http_status(:ok)
@@ -467,7 +467,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           }
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'attributes' => {
@@ -490,7 +490,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           }
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'error' => a_hash_including(
@@ -515,7 +515,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           }
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'attributes' => {
@@ -535,7 +535,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           'methods' => ['foo', 'bar']
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'methods' => ['foo', 'bar']
@@ -555,7 +555,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           'methods' => ['foo']
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'methods' => ['bar']
@@ -584,7 +584,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           }
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'associations' => {
@@ -608,7 +608,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           }
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'error' => a_hash_including(
@@ -631,7 +631,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
           'associations' => { 'az' => 'AvailabilityZone' }
         }
       }
-      post(api_generic_object_definition_url(nil, object_def.compressed_id), :params => request)
+      post(api_generic_object_definition_url(nil, object_def), :params => request)
 
       expected = {
         'associations' => { 'chargeback' => 'ChargebackVm' }
@@ -645,7 +645,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
     it 'can delete a generic_object_definition by id' do
       api_basic_authorize action_identifier(:generic_object_definitions, :delete, :resource_actions, :delete)
 
-      delete(api_generic_object_definition_url(nil, object_def.compressed_id))
+      delete(api_generic_object_definition_url(nil, object_def))
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spec/requests/generic_objects_spec.rb
+++ b/spec/requests/generic_objects_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'GenericObjects API' do
         'subcount'  => 1,
         'name'      => 'generic_objects',
         'resources' => [
-          a_hash_including('href' => api_generic_object_url(nil, object.compressed_id))
+          a_hash_including('href' => api_generic_object_url(nil, object))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -46,10 +46,10 @@ RSpec.describe 'GenericObjects API' do
       expected = {
         'resources' => [
           a_hash_including(
-            'id'                  => object.compressed_id,
+            'id'                  => object.id.to_s,
             'property_attributes' => {},
-            'vms'                 => a_collection_including(a_hash_including('id' => vm.compressed_id), a_hash_including('id' => vm2.compressed_id)),
-            'services'            => [a_hash_including('id' => service.compressed_id)]
+            'vms'                 => a_collection_including(a_hash_including('id' => vm.id.to_s), a_hash_including('id' => vm2.id.to_s)),
+            'services'            => [a_hash_including('id' => service.id.to_s)]
           )
         ]
       }
@@ -71,7 +71,7 @@ RSpec.describe 'GenericObjects API' do
     it 'returns a generic object with property_attributes' do
       api_basic_authorize action_identifier(:generic_objects, :read, :resource_actions, :get)
 
-      get(api_generic_object_url(nil, object.compressed_id))
+      get(api_generic_object_url(nil, object))
 
       expected = {
         'name'                => 'object 1',
@@ -84,15 +84,15 @@ RSpec.describe 'GenericObjects API' do
     it 'allows specification of property_associations and returns them accordingly' do
       api_basic_authorize action_identifier(:generic_objects, :read, :resource_actions, :get)
 
-      get(api_generic_object_url(nil, object.compressed_id), :params => {:associations => 'vms,services'})
+      get(api_generic_object_url(nil, object), :params => {:associations => 'vms,services'})
 
       expected = {
         'name'                => 'object 1',
         'property_attributes' => { 'widget' => 'a widget string', 'is_something' => true },
-        'services'            => a_collection_containing_exactly(a_hash_including('href' => api_service_url(nil, service.compressed_id), 'id' => service.compressed_id)),
+        'services'            => a_collection_containing_exactly(a_hash_including('href' => api_service_url(nil, service), 'id' => service.id.to_s)),
         'vms'                 => a_collection_containing_exactly(
-          a_hash_including('href' => api_instance_url(nil, vm.compressed_id), 'id' => vm.compressed_id),
-          a_hash_including('href' => api_instance_url(nil, vm2.compressed_id), 'id' => vm2.compressed_id)
+          a_hash_including('href' => api_instance_url(nil, vm), 'id' => vm.id.to_s),
+          a_hash_including('href' => api_instance_url(nil, vm2), 'id' => vm2.id.to_s)
         )
       }
       expect(response).to have_http_status(:ok)
@@ -113,7 +113,7 @@ RSpec.describe 'GenericObjects API' do
       api_basic_authorize collection_action_identifier(:generic_objects, :create)
 
       generic_object = {
-        'generic_object_definition' => { 'href' => api_generic_object_definition_url(nil, object_definition.compressed_id) },
+        'generic_object_definition' => { 'href' => api_generic_object_definition_url(nil, object_definition) },
         'name'                      => 'go_name1',
         'uid'                       => 'optional_uid',
         'property_attributes'       => {
@@ -122,11 +122,11 @@ RSpec.describe 'GenericObjects API' do
         },
         'associations'              => {
           'vms'      => [
-            { 'href' => api_vm_url(nil, vm.compressed_id) },
-            { 'href' => api_vm_url(nil, vm2.compressed_id) }
+            { 'href' => api_vm_url(nil, vm) },
+            { 'href' => api_vm_url(nil, vm2) }
           ],
           'services' => [
-            { 'href' => api_service_url(nil, service.compressed_id) }
+            { 'href' => api_service_url(nil, service) }
           ]
         }
       }
@@ -136,7 +136,7 @@ RSpec.describe 'GenericObjects API' do
         'results' => [
           a_hash_including('name'                         => 'go_name1',
                            'uid'                          => 'optional_uid',
-                           'generic_object_definition_id' => object_definition.compressed_id)
+                           'generic_object_definition_id' => object_definition.id.to_s)
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -147,7 +147,7 @@ RSpec.describe 'GenericObjects API' do
       api_basic_authorize collection_action_identifier(:generic_objects, :create)
 
       generic_object = {
-        'generic_object_definition' => { 'href' => api_generic_object_definition_url(nil, object_definition.compressed_id) },
+        'generic_object_definition' => { 'href' => api_generic_object_definition_url(nil, object_definition) },
         'name'                      => 'go_name1',
         'uid'                       => 'optional_uid',
         'property_attributes'       => {
@@ -156,11 +156,11 @@ RSpec.describe 'GenericObjects API' do
         },
         'associations'              => {
           'not_an_association' => [
-            { 'href' => api_vm_url(nil, vm.compressed_id) },
-            { 'href' => api_vm_url(nil, vm2.compressed_id) }
+            { 'href' => api_vm_url(nil, vm) },
+            { 'href' => api_vm_url(nil, vm2) }
           ],
           'services'           => [
-            { 'href' => api_service_url(nil, service.compressed_id) }
+            { 'href' => api_service_url(nil, service) }
           ]
         }
       }
@@ -182,14 +182,14 @@ RSpec.describe 'GenericObjects API' do
       request = {
         'action'    => 'edit',
         'resources' => [
-          { 'href' => api_generic_object_url(nil, object.compressed_id), 'name' => 'updated name', 'property_attributes' => {'widget' => 'updated widget'} }
+          { 'href' => api_generic_object_url(nil, object), 'name' => 'updated name', 'property_attributes' => {'widget' => 'updated widget'} }
         ]
       }
       post(api_generic_objects_url, :params => request)
 
       expected = {
         'results' => [
-          a_hash_including('id' => object.compressed_id, 'name' => 'updated name')
+          a_hash_including('id' => object.id.to_s, 'name' => 'updated name')
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -202,7 +202,7 @@ RSpec.describe 'GenericObjects API' do
       request = {
         'action'    => 'edit',
         'resources' => [
-          { 'href' => api_generic_object_url(nil, object.compressed_id), 'associations' => { 'not_an_association' => {}} }
+          { 'href' => api_generic_object_url(nil, object), 'associations' => { 'not_an_association' => {}} }
         ]
       }
       post(api_generic_objects_url, :params => request)
@@ -223,7 +223,7 @@ RSpec.describe 'GenericObjects API' do
       request = {
         'action'    => 'delete',
         'resources' => [
-          { 'href' => api_generic_object_url(nil, object.compressed_id) }
+          { 'href' => api_generic_object_url(nil, object) }
         ]
       }
       post(api_generic_objects_url, :params => request)
@@ -250,12 +250,12 @@ RSpec.describe 'GenericObjects API' do
             'is_something' => false
           },
           'associations'        => {
-            'vms'      => [{'href' => api_vm_url(nil, vm3.compressed_id)}],
+            'vms'      => [{'href' => api_vm_url(nil, vm3)}],
             'services' => []
           }
         }
       }
-      post(api_generic_object_url(nil, object.compressed_id), :params => request)
+      post(api_generic_object_url(nil, object), :params => request)
 
       expected = {
         'name'                => 'updated object',
@@ -273,7 +273,7 @@ RSpec.describe 'GenericObjects API' do
     it 'deletes a generic object' do
       api_basic_authorize action_identifier(:generic_objects, :delete)
 
-      post(api_generic_object_url(nil, object.compressed_id), :params => { :action => 'delete' })
+      post(api_generic_object_url(nil, object), :params => { :action => 'delete' })
 
       expected = {
         'success' => true,
@@ -288,7 +288,7 @@ RSpec.describe 'GenericObjects API' do
     it 'can delete a generic object' do
       api_basic_authorize action_identifier(:generic_objects, :delete, :resource_actions, :delete)
 
-      delete(api_generic_object_url(nil, object.compressed_id))
+      delete(api_generic_object_url(nil, object))
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -70,7 +70,7 @@ describe "Groups API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      group_id = response.parsed_body["results"].first["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -82,7 +82,7 @@ describe "Groups API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      group_id = response.parsed_body["results"].first["id"]
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -98,14 +98,14 @@ describe "Groups API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       result = response.parsed_body["results"].first
-      created_group = MiqGroup.find_by(:id => ApplicationRecord.uncompress_id(result["id"]))
+      created_group = MiqGroup.find_by(:id => result["id"])
 
       expect(created_group).to be_present
       expect(created_group.entitlement.miq_user_role).to eq(role3)
 
       expect_result_to_match_hash(result,
                                   "description" => "sample_group3",
-                                  "tenant_id"   => tenant3.compressed_id)
+                                  "tenant_id"   => tenant3.id.to_s)
     end
 
     it "supports single group creation with filters specified" do
@@ -123,7 +123,7 @@ describe "Groups API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       group_id = response.parsed_body["results"][0]["id"]
-      expected_group = MiqGroup.find_by(:id => ApplicationRecord.uncompress_id(group_id))
+      expected_group = MiqGroup.find_by(:id => group_id)
       expect(expected_group).to be_present
       expect(expected_group.description).to eq(sample_group["description"])
       expect(expected_group.entitlement).to be_present
@@ -139,8 +139,8 @@ describe "Groups API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       results = response.parsed_body["results"]
-      group1_id = ApplicationRecord.uncompress_id(results.first["id"])
-      group2_id = ApplicationRecord.uncompress_id(results.second["id"])
+      group1_id = results.first["id"]
+      group2_id = results.second["id"]
       expect(MiqGroup.exists?(group1_id)).to be_truthy
       expect(MiqGroup.exists?(group2_id)).to be_truthy
     end
@@ -169,7 +169,7 @@ describe "Groups API" do
 
       post(api_group_url(nil, group1), :params => gen_request(:edit, "description" => "updated_group"))
 
-      expect_single_resource_query("id"          => group1.compressed_id,
+      expect_single_resource_query("id"          => group1.id.to_s,
                                    "description" => "updated_group")
       expect(group1.reload.description).to eq("updated_group")
     end
@@ -182,8 +182,8 @@ describe "Groups API" do
                                                    {"href" => api_group_url(nil, group2), "description" => "updated_group2"}]))
 
       expect_results_to_match_hash("results",
-                                   [{"id" => group1.compressed_id, "description" => "updated_group1"},
-                                    {"id" => group2.compressed_id, "description" => "updated_group2"}])
+                                   [{"id" => group1.id.to_s, "description" => "updated_group1"},
+                                    {"id" => group2.id.to_s, "description" => "updated_group2"}])
 
       expect(group1.reload.name).to eq("updated_group1")
       expect(group2.reload.name).to eq("updated_group2")
@@ -241,7 +241,7 @@ describe "Groups API" do
 
       post(g1_url, :params => gen_request(:delete))
 
-      expect_single_action_result(:success => true, :message => "deleting", :href => api_group_url(nil, group1.compressed_id))
+      expect_single_action_result(:success => true, :message => "deleting", :href => api_group_url(nil, group1))
       expect(MiqGroup.exists?(g1_id)).to be_falsey
     end
 
@@ -254,7 +254,7 @@ describe "Groups API" do
       post(api_groups_url, :params => gen_request(:delete, [{"href" => g1_url}, {"href" => g2_url}]))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [api_group_url(nil, group1.compressed_id), api_group_url(nil, group2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_group_url(nil, group1), api_group_url(nil, group2)])
       expect(MiqGroup.exists?(g1_id)).to be_falsey
       expect(MiqGroup.exists?(g2_id)).to be_falsey
     end

--- a/spec/requests/instances_spec.rb
+++ b/spec/requests/instances_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Instances API" do
       get(api_instances_url)
 
       expect_query_result(:instances, 1, 1)
-      expect_result_resources_to_include_hrefs("resources", [api_instance_url(nil, instance.compressed_id)])
+      expect_result_resources_to_include_hrefs("resources", [api_instance_url(nil, instance)])
     end
   end
 
@@ -53,7 +53,7 @@ RSpec.describe "Instances API" do
       expect_single_action_result(
         :success => true,
         :message => /#{instance.id}.* terminating/i,
-        :href    => api_instance_url(nil, instance.compressed_id)
+        :href    => api_instance_url(nil, instance)
       )
     end
 
@@ -67,12 +67,12 @@ RSpec.describe "Instances API" do
           a_hash_including(
             "message" => a_string_matching(/#{instance1.id}.* terminating/i),
             "success" => true,
-            "href"    => api_instance_url(nil, instance1.compressed_id)
+            "href"    => api_instance_url(nil, instance1)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{instance2.id}.* terminating/i),
             "success" => true,
-            "href"    => api_instance_url(nil, instance2.compressed_id)
+            "href"    => api_instance_url(nil, instance2)
           )
         )
       }
@@ -104,7 +104,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:stop))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
     end
 
     it "stops a valid instance" do
@@ -112,7 +112,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:stop))
 
-      expect_single_action_result(:success => true, :message => "stopping", :href => api_instance_url(nil, instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "stopping", :href => api_instance_url(nil, instance), :task => true)
     end
 
     it "stops multiple valid instances" do
@@ -121,7 +121,7 @@ RSpec.describe "Instances API" do
       post(api_instances_url, :params => gen_request(:stop, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1), api_instance_url(nil, instance2)])
     end
   end
 
@@ -147,7 +147,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => false, :message => "is powered on", :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is powered on", :href => api_instance_url(nil, instance))
     end
 
     it "starts an instance" do
@@ -156,7 +156,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => api_instance_url(nil, instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "starting", :href => api_instance_url(nil, instance), :task => true)
     end
 
     it "starts multiple instances" do
@@ -166,7 +166,7 @@ RSpec.describe "Instances API" do
       post(api_instances_url, :params => gen_request(:start, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1), api_instance_url(nil, instance2)])
     end
   end
 
@@ -193,7 +193,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
     end
 
     it "fails to pause a paused instance" do
@@ -202,7 +202,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
     end
 
     it "pauses an instance" do
@@ -210,7 +210,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => true, :message => "pausing", :href => api_instance_url(nil, instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "pausing", :href => api_instance_url(nil, instance), :task => true)
     end
 
     it "pauses multiple instances" do
@@ -219,7 +219,7 @@ RSpec.describe "Instances API" do
       post(api_instances_url, :params => gen_request(:pause, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1), api_instance_url(nil, instance2)])
     end
   end
 
@@ -246,7 +246,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
     end
 
     it "cannot suspend a suspended instance" do
@@ -255,7 +255,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
     end
 
     it "suspends an instance" do
@@ -263,7 +263,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => true, :message => "suspending", :href => api_instance_url(nil, instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "suspending", :href => api_instance_url(nil, instance), :task => true)
     end
 
     it "suspends multiple instances" do
@@ -272,7 +272,7 @@ RSpec.describe "Instances API" do
       post(api_instances_url, :params => gen_request(:suspend, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1), api_instance_url(nil, instance2)])
     end
   end
 
@@ -299,7 +299,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance))
     end
 
     it "shelves a suspended instance" do
@@ -308,7 +308,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance))
     end
 
     it "shelves a paused instance" do
@@ -317,7 +317,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance))
     end
 
     it "cannot shelve a shelved instance" do
@@ -329,7 +329,7 @@ RSpec.describe "Instances API" do
       expect_single_action_result(
         :success => false,
         :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused",
-        :href    => api_instance_url(nil, instance.compressed_id)
+        :href    => api_instance_url(nil, instance)
       )
     end
 
@@ -340,7 +340,7 @@ RSpec.describe "Instances API" do
 
       expect_single_action_result(:success => true,
                                   :message => "shelving",
-                                  :href    => api_instance_url(nil, instance.compressed_id),
+                                  :href    => api_instance_url(nil, instance),
                                   :task    => true)
     end
 
@@ -350,7 +350,7 @@ RSpec.describe "Instances API" do
       post(api_instances_url, :params => gen_request(:shelve, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1), api_instance_url(nil, instance2)])
     end
   end
 
@@ -377,7 +377,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
     end
 
     it "reboots a valid instance" do
@@ -385,7 +385,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => true, :message => "rebooting", :href => api_instance_url(nil, instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "rebooting", :href => api_instance_url(nil, instance), :task => true)
     end
 
     it "reboots multiple valid instances" do
@@ -394,7 +394,7 @@ RSpec.describe "Instances API" do
       post(api_instances_url, :params => gen_request(:reboot_guest, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1), api_instance_url(nil, instance2)])
     end
   end
 
@@ -421,7 +421,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:reset))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
     end
 
     it "resets a valid instance" do
@@ -429,7 +429,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:reset))
 
-      expect_single_action_result(:success => true, :message => "resetting", :href => api_instance_url(nil, instance.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "resetting", :href => api_instance_url(nil, instance), :task => true)
     end
 
     it "resets multiple valid instances" do
@@ -438,7 +438,7 @@ RSpec.describe "Instances API" do
       post(api_instances_url, :params => gen_request(:reset, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1.compressed_id), api_instance_url(nil, instance2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_instance_url(nil, instance1), api_instance_url(nil, instance2)])
     end
   end
 
@@ -460,7 +460,7 @@ RSpec.describe "Instances API" do
       expected = {
         'name'      => 'load_balancers',
         'resources' => [
-          { 'href' => api_instance_load_balancer_url(nil, @vm.compressed_id, @load_balancer.compressed_id) }
+          { 'href' => api_instance_load_balancer_url(nil, @vm, @load_balancer) }
         ]
       }
       get(api_instance_load_balancers_url(nil, @vm))
@@ -482,7 +482,7 @@ RSpec.describe "Instances API" do
       get(api_instance_load_balancer_url(nil, @vm, @load_balancer))
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => @load_balancer.compressed_id)
+      expect(response.parsed_body).to include('id' => @load_balancer.id.to_s)
     end
 
     it "will not show an instance's load balancer without the appropriate role" do

--- a/spec/requests/load_balancers_spec.rb
+++ b/spec/requests/load_balancers_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'LoadBalancers API' do
         'subcount'  => 1,
         'name'      => 'load_balancers',
         'resources' => [
-          hash_including('href' => api_load_balancer_url(nil, load_balancer.compressed_id))
+          hash_including('href' => api_load_balancer_url(nil, load_balancer))
         ]
       }
       get(api_load_balancers_url)
@@ -34,7 +34,7 @@ RSpec.describe 'LoadBalancers API' do
 
       get(api_load_balancer_url(nil, load_balancer))
 
-      expect(response.parsed_body).to include('href' => api_load_balancer_url(nil, load_balancer.compressed_id))
+      expect(response.parsed_body).to include('href' => api_load_balancer_url(nil, load_balancer))
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/requests/metric_rollups_spec.rb
+++ b/spec/requests/metric_rollups_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'MetricRollups API' do
         'count'     => 4,
         'subcount'  => 1,
         'resources' => [
-          { 'href' => a_string_including(api_metric_rollup_url(nil, vm_metric.compressed_id)) }
+          { 'href' => a_string_including(api_metric_rollup_url(nil, vm_metric)) }
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -65,7 +65,7 @@ RSpec.describe 'MetricRollups API' do
         'count'     => 5,
         'subcount'  => 1,
         'resources' => [
-          { 'href' => a_string_including(api_metric_rollup_url(nil, vm_daily.compressed_id)) }
+          { 'href' => a_string_including(api_metric_rollup_url(nil, vm_daily)) }
         ]
       }
       expect(response).to have_http_status(:ok)

--- a/spec/requests/network_routers_spec.rb
+++ b/spec/requests/network_routers_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'NetworkRouters API' do
         'subcount'  => 1,
         'name'      => 'network_routers',
         'resources' => [
-          hash_including('href' => api_network_router_url(nil, network_router.compressed_id))
+          hash_including('href' => api_network_router_url(nil, network_router))
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -29,7 +29,7 @@ RSpec.describe 'NetworkRouters API' do
       network_router = FactoryGirl.create(:network_router)
       api_basic_authorize action_identifier(:network_routers, :read, :resource_actions, :get)
       get(api_network_router_url(nil, network_router))
-      expect(response.parsed_body).to include('href' => api_network_router_url(nil, network_router.compressed_id))
+      expect(response.parsed_body).to include('href' => api_network_router_url(nil, network_router))
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -48,7 +48,7 @@ describe 'Notifications API' do
 
         post(notification_url, :params => gen_request(:delete))
         expect(response).to have_http_status(:ok)
-        expect_single_action_result(:success => true, :href => api_notification_url(nil, notification_recipient.compressed_id))
+        expect_single_action_result(:success => true, :href => api_notification_url(nil, notification_recipient))
         expect { notification_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -75,7 +75,7 @@ describe 'Notifications API' do
         post(api_notifications_url, :params => gen_request(:delete, :href => notification_url))
         expect(response).to have_http_status(:ok)
         expect_results_to_match_hash('results', [{'success' => true,
-                                                  'href'    => api_notification_url(nil, notification_recipient.compressed_id)}])
+                                                  'href'    => api_notification_url(nil, notification_recipient)}])
         expect { notification_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -122,7 +122,7 @@ describe 'Notifications API' do
 
       expect(notification_recipient.seen).to be_falsey
       post(notification_url, :params => gen_request(:mark_as_seen))
-      expect_single_action_result(:success => true, :href => api_notification_url(nil, notification_recipient.compressed_id))
+      expect_single_action_result(:success => true, :href => api_notification_url(nil, notification_recipient))
       expect(notification_recipient.reload.seen).to be_truthy
     end
   end

--- a/spec/requests/picture_spec.rb
+++ b/spec/requests/picture_spec.rb
@@ -27,8 +27,8 @@ describe "Pictures" do
     expect_result_to_match_hash(response.parsed_body, "id" => source_id)
     expect_result_to_have_keys(%w(id href picture))
     expect_result_to_match_hash(response.parsed_body["picture"],
-                                "id"          => picture.compressed_id,
-                                "resource_id" => template.compressed_id,
+                                "id"          => picture.id.to_s,
+                                "resource_id" => template.id.to_s,
                                 "image_href"  => /^http:.*#{picture.image_href}$/)
   end
 
@@ -38,7 +38,7 @@ describe "Pictures" do
 
       get api_service_template_url(nil, template), :params => { :attributes => "picture,picture.image_href" }
 
-      expect_result_to_include_picture_href(template.compressed_id)
+      expect_result_to_include_picture_href(template.id.to_s)
     end
   end
 
@@ -48,7 +48,7 @@ describe "Pictures" do
 
       get api_service_url(nil, service), :params => { :attributes => "picture,picture.image_href" }
 
-      expect_result_to_include_picture_href(service.compressed_id)
+      expect_result_to_include_picture_href(service.id.to_s)
     end
   end
 
@@ -58,7 +58,7 @@ describe "Pictures" do
 
       get api_service_request_url(nil, service_request), :params => { :attributes => "picture,picture.image_href" }
 
-      expect_result_to_include_picture_href(service_request.compressed_id)
+      expect_result_to_include_picture_href(service_request.id.to_s)
     end
   end
 

--- a/spec/requests/policies_assignment_spec.rb
+++ b/spec/requests/policies_assignment_spec.rb
@@ -81,7 +81,7 @@ describe "Policies Assignment API" do
     expect_multiple_action_result(policies.size)
     sc_prefix = subcollection.to_s.singularize
     results_hash = policies.collect do |policy|
-      {"success" => true, "href" => object_url, "#{sc_prefix}_href" => %r{/api/#{subcollection}/#{policy.compressed_id}}}
+      {"success" => true, "href" => object_url, "#{sc_prefix}_href" => %r{/api/#{subcollection}/#{policy.id.to_s}}}
     end
     expect_results_to_match_hash("results", results_hash)
     expect(object.get_policies.size).to eq(policies.size)
@@ -141,7 +141,7 @@ describe "Policies Assignment API" do
 
   context "Policy profile policies assignment" do
     it "adds Policies to a Policy Profile" do
-      test_assign_multiple_policies(api_policy_profile_url(nil, ps2.compressed_id),
+      test_assign_multiple_policies(api_policy_profile_url(nil, ps2),
                                     api_policy_profile_policies_url(nil, ps2),
                                     :policy_profiles,
                                     :policies,
@@ -164,11 +164,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Provider policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_provider_url(nil, provider.compressed_id), api_provider_policies_url(nil, provider), :providers, :policies)
+      test_policy_assign_invalid_policy_guid(api_provider_url(nil, provider), api_provider_policies_url(nil, provider), :providers, :policies)
     end
 
     it "assign Provider multiple policies" do
-      test_assign_multiple_policies(api_provider_url(nil, provider.compressed_id),
+      test_assign_multiple_policies(api_provider_url(nil, provider),
                                     api_provider_policies_url(nil, provider),
                                     :providers,
                                     :policies,
@@ -185,7 +185,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Provider policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_provider_url(nil, provider.compressed_id), api_provider_policies_url(nil, provider), :providers, :policies)
+      test_policy_unassign_invalid_policy_guid(api_provider_url(nil, provider), api_provider_policies_url(nil, provider), :providers, :policies)
     end
 
     it "unassign Provider multiple policies" do
@@ -203,11 +203,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Provider policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_provider_url(nil, provider.compressed_id), api_provider_policy_profiles_url(nil, provider), :providers, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_provider_url(nil, provider), api_provider_policy_profiles_url(nil, provider), :providers, :policy_profiles)
     end
 
     it "assign Provider multiple policy profiles" do
-      test_assign_multiple_policies(api_provider_url(nil, provider.compressed_id),
+      test_assign_multiple_policies(api_provider_url(nil, provider),
                                     api_provider_policy_profiles_url(nil, provider),
                                     :providers,
                                     :policy_profiles,
@@ -224,7 +224,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Provider policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_provider_url(nil, provider.compressed_id),
+      test_policy_unassign_invalid_policy_guid(api_provider_url(nil, provider),
                                                api_provider_policy_profiles_url(nil, provider),
                                                :providers,
                                                :policy_profiles)
@@ -248,11 +248,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Host policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_host_url(nil, host.compressed_id), api_host_policies_url(nil, host), :hosts, :policies)
+      test_policy_assign_invalid_policy_guid(api_host_url(nil, host), api_host_policies_url(nil, host), :hosts, :policies)
     end
 
     it "assign Host multiple policies" do
-      test_assign_multiple_policies(api_host_url(nil, host.compressed_id),
+      test_assign_multiple_policies(api_host_url(nil, host),
                                     api_host_policies_url(nil, host),
                                     :hosts,
                                     :policies,
@@ -269,7 +269,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Host policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_host_url(nil, host.compressed_id), api_host_policies_url(nil, host), :hosts, :policies)
+      test_policy_unassign_invalid_policy_guid(api_host_url(nil, host), api_host_policies_url(nil, host), :hosts, :policies)
     end
 
     it "unassign Host multiple policies" do
@@ -287,11 +287,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Host policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_host_url(nil, host.compressed_id), api_host_policy_profiles_url(nil, host), :hosts, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_host_url(nil, host), api_host_policy_profiles_url(nil, host), :hosts, :policy_profiles)
     end
 
     it "assign Host multiple policy profiles" do
-      test_assign_multiple_policies(api_host_url(nil, host.compressed_id),
+      test_assign_multiple_policies(api_host_url(nil, host),
                                     api_host_policy_profiles_url(nil, host),
                                     :hosts,
                                     :policy_profiles,
@@ -308,7 +308,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Host policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_host_url(nil, host.compressed_id),
+      test_policy_unassign_invalid_policy_guid(api_host_url(nil, host),
                                                api_host_policy_profiles_url(nil, host),
                                                :hosts,
                                                :policy_profiles)
@@ -332,11 +332,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Resource Pool policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_resource_pool_url(nil, rp.compressed_id), api_resource_pool_policies_url(nil, rp), :resource_pools, :policies)
+      test_policy_assign_invalid_policy_guid(api_resource_pool_url(nil, rp), api_resource_pool_policies_url(nil, rp), :resource_pools, :policies)
     end
 
     it "assign Resource Pool multiple policies" do
-      test_assign_multiple_policies(api_resource_pool_url(nil, rp.compressed_id),
+      test_assign_multiple_policies(api_resource_pool_url(nil, rp),
                                     api_resource_pool_policies_url(nil, rp),
                                     :resource_pools,
                                     :policies,
@@ -353,7 +353,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Resource Pool policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_resource_pool_url(nil, rp.compressed_id), api_resource_pool_policies_url(nil, rp), :resource_pools, :policies)
+      test_policy_unassign_invalid_policy_guid(api_resource_pool_url(nil, rp), api_resource_pool_policies_url(nil, rp), :resource_pools, :policies)
     end
 
     it "unassign Resource Pool multiple policies" do
@@ -371,11 +371,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Resource Pool policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_resource_pool_url(nil, rp.compressed_id), api_resource_pool_policy_profiles_url(nil, rp), :resource_pools, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_resource_pool_url(nil, rp), api_resource_pool_policy_profiles_url(nil, rp), :resource_pools, :policy_profiles)
     end
 
     it "assign Resource Pool multiple policy profiles" do
-      test_assign_multiple_policies(api_resource_pool_url(nil, rp.compressed_id),
+      test_assign_multiple_policies(api_resource_pool_url(nil, rp),
                                     api_resource_pool_policy_profiles_url(nil, rp),
                                     :resource_pools,
                                     :policy_profiles,
@@ -392,7 +392,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Resource Pool policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_resource_pool_url(nil, rp.compressed_id),
+      test_policy_unassign_invalid_policy_guid(api_resource_pool_url(nil, rp),
                                                api_resource_pool_policy_profiles_url(nil, rp),
                                                :resource_pools,
                                                :policy_profiles)
@@ -416,11 +416,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Cluster policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_cluster_url(nil, cluster.compressed_id), api_cluster_policies_url(nil, cluster), :clusters, :policies)
+      test_policy_assign_invalid_policy_guid(api_cluster_url(nil, cluster), api_cluster_policies_url(nil, cluster), :clusters, :policies)
     end
 
     it "assign Cluster multiple policies" do
-      test_assign_multiple_policies(api_cluster_url(nil, cluster.compressed_id),
+      test_assign_multiple_policies(api_cluster_url(nil, cluster),
                                     api_cluster_policies_url(nil, cluster),
                                     :clusters,
                                     :policies,
@@ -437,7 +437,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Cluster policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_cluster_url(nil, cluster.compressed_id), api_cluster_policies_url(nil, cluster), :clusters, :policies)
+      test_policy_unassign_invalid_policy_guid(api_cluster_url(nil, cluster), api_cluster_policies_url(nil, cluster), :clusters, :policies)
     end
 
     it "unassign Cluster multiple policies" do
@@ -455,11 +455,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Cluster policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_cluster_url(nil, cluster.compressed_id), api_cluster_policy_profiles_url(nil, cluster), :clusters, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_cluster_url(nil, cluster), api_cluster_policy_profiles_url(nil, cluster), :clusters, :policy_profiles)
     end
 
     it "assign Cluster multiple policy profiles" do
-      test_assign_multiple_policies(api_cluster_url(nil, cluster.compressed_id),
+      test_assign_multiple_policies(api_cluster_url(nil, cluster),
                                     api_cluster_policy_profiles_url(nil, cluster),
                                     :clusters,
                                     :policy_profiles,
@@ -476,7 +476,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Cluster policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_cluster_url(nil, cluster.compressed_id),
+      test_policy_unassign_invalid_policy_guid(api_cluster_url(nil, cluster),
                                                api_cluster_policy_profiles_url(nil, cluster),
                                                :clusters,
                                                :policy_profiles)
@@ -500,11 +500,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Vm policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_vm_url(nil, vm.compressed_id), api_vm_policies_url(nil, vm), :vms, :policies)
+      test_policy_assign_invalid_policy_guid(api_vm_url(nil, vm), api_vm_policies_url(nil, vm), :vms, :policies)
     end
 
     it "assign Vm multiple policies" do
-      test_assign_multiple_policies(api_vm_url(nil, vm.compressed_id),
+      test_assign_multiple_policies(api_vm_url(nil, vm),
                                     api_vm_policies_url(nil, vm),
                                     :vms,
                                     :policies,
@@ -521,7 +521,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Vm policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_vm_url(nil, vm.compressed_id), api_vm_policies_url(nil, vm), :vms, :policies)
+      test_policy_unassign_invalid_policy_guid(api_vm_url(nil, vm), api_vm_policies_url(nil, vm), :vms, :policies)
     end
 
     it "unassign Vm multiple policies" do
@@ -539,11 +539,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Vm policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_vm_url(nil, vm.compressed_id), api_vm_policy_profiles_url(nil, vm), :vms, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_vm_url(nil, vm), api_vm_policy_profiles_url(nil, vm), :vms, :policy_profiles)
     end
 
     it "assign Vm multiple policy profiles" do
-      test_assign_multiple_policies(api_vm_url(nil, vm.compressed_id),
+      test_assign_multiple_policies(api_vm_url(nil, vm),
                                     api_vm_policy_profiles_url(nil, vm),
                                     :vms,
                                     :policy_profiles,
@@ -560,7 +560,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Vm policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_vm_url(nil, vm.compressed_id),
+      test_policy_unassign_invalid_policy_guid(api_vm_url(nil, vm),
                                                api_vm_policy_profiles_url(nil, vm),
                                                :vms,
                                                :policy_profiles)
@@ -584,11 +584,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Template policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_template_url(nil, template.compressed_id), api_template_policies_url(nil, template), :templates, :policies)
+      test_policy_assign_invalid_policy_guid(api_template_url(nil, template), api_template_policies_url(nil, template), :templates, :policies)
     end
 
     it "assign Template multiple policies" do
-      test_assign_multiple_policies(api_template_url(nil, template.compressed_id),
+      test_assign_multiple_policies(api_template_url(nil, template),
                                     api_template_policies_url(nil, template),
                                     :templates,
                                     :policies,
@@ -605,7 +605,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Template policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_template_url(nil, template.compressed_id), api_template_policies_url(nil, template), :templates, :policies)
+      test_policy_unassign_invalid_policy_guid(api_template_url(nil, template), api_template_policies_url(nil, template), :templates, :policies)
     end
 
     it "unassign Template multiple policies" do
@@ -623,11 +623,11 @@ describe "Policies Assignment API" do
     end
 
     it "assign Template policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(api_template_url(nil, template.compressed_id), api_template_policy_profiles_url(nil, template), :templates, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(api_template_url(nil, template), api_template_policy_profiles_url(nil, template), :templates, :policy_profiles)
     end
 
     it "assign Template multiple policy profiles" do
-      test_assign_multiple_policies(api_template_url(nil, template.compressed_id),
+      test_assign_multiple_policies(api_template_url(nil, template),
                                     api_template_policy_profiles_url(nil, template),
                                     :templates,
                                     :policy_profiles,
@@ -644,7 +644,7 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Template policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(api_template_url(nil, template.compressed_id),
+      test_policy_unassign_invalid_policy_guid(api_template_url(nil, template),
                                                api_template_policy_profiles_url(nil, template),
                                                :templates,
                                                :policy_profiles)

--- a/spec/requests/policies_spec.rb
+++ b/spec/requests/policies_spec.rb
@@ -115,7 +115,7 @@ describe "Policies API" do
       expect_query_result(:policies, 3, 3)
       expect_result_resources_to_include_hrefs(
         "resources",
-        [api_policy_url(nil, p1.compressed_id), api_policy_url(nil, p2.compressed_id), api_policy_url(nil, p3.compressed_id)]
+        [api_policy_url(nil, p1), api_policy_url(nil, p2), api_policy_url(nil, p3)]
       )
     end
 
@@ -148,7 +148,7 @@ describe "Policies API" do
       expect_query_result(:policy_profiles, 2, 2)
       expect_result_resources_to_include_hrefs(
         "resources",
-        [api_policy_profile_url(nil, ps1.compressed_id), api_policy_profile_url(nil, ps2.compressed_id)]
+        [api_policy_profile_url(nil, ps1), api_policy_profile_url(nil, ps2)]
       )
     end
 
@@ -353,7 +353,7 @@ describe "Policies API" do
     it "creates new policy" do
       api_basic_authorize collection_action_identifier(:policies, :create)
       post(api_policies_url, :params => sample_policy.merge!(miq_policy_contents))
-      policy = MiqPolicy.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
+      policy = MiqPolicy.find(response.parsed_body["results"].first["id"])
       expect(response.parsed_body["results"].first["name"]).to eq("sample policy")
       expect(response.parsed_body["results"].first["towhat"]).to eq("ManageIQ::Providers::Redhat::InfraManager")
       expect(policy).to be_truthy
@@ -442,7 +442,7 @@ describe "Policies API" do
       expect(miq_policy.actions.count).to eq(0)
       expect(miq_policy.events.count).to eq(0)
       post(api_policy_url(nil, miq_policy), :params => gen_request(:edit, miq_policy_contents.merge('conditions_ids' => [])))
-      policy = MiqPolicy.find(ApplicationRecord.uncompress_id(response.parsed_body["id"]))
+      policy = MiqPolicy.find(response.parsed_body["id"])
       expect(response).to have_http_status(:ok)
       expect(policy.actions.count).to eq(1)
       expect(policy.events.count).to eq(1)
@@ -453,7 +453,7 @@ describe "Policies API" do
       api_basic_authorize collection_action_identifier(:policies, :edit)
       expect(miq_policy.description).to_not eq("BAR")
       post(api_policy_url(nil, miq_policy), :params => gen_request(:edit, :description => "BAR"))
-      policy = MiqPolicy.find(ApplicationRecord.uncompress_id(response.parsed_body["id"]))
+      policy = MiqPolicy.find(response.parsed_body["id"])
       expect(response).to have_http_status(:ok)
       expect(policy.description).to eq("BAR")
     end

--- a/spec/requests/policy_actions_spec.rb
+++ b/spec/requests/policy_actions_spec.rb
@@ -42,7 +42,7 @@ describe "Policy Actions API" do
       expect_query_result(:policy_actions, 4, 4)
       expect_result_resources_to_include_hrefs(
         "resources",
-        MiqAction.select(:id).collect { |ma| api_policy_action_url(nil, ma.compressed_id) }
+        MiqAction.select(:id).collect { |ma| api_policy_action_url(nil, ma) }
       )
     end
 

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -104,7 +104,7 @@ describe "Provision Requests API" do
         )
       )
 
-      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -132,7 +132,7 @@ describe "Provision Requests API" do
         )
       )
 
-      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -161,7 +161,7 @@ describe "Provision Requests API" do
         )
       )
 
-      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
   end
@@ -214,7 +214,7 @@ describe "Provision Requests API" do
         "count"     => 2,
         "subcount"  => 1,
         "resources" => a_collection_containing_exactly(
-          "href" => api_provision_request_url(nil, provision_request2.compressed_id),
+          "href" => api_provision_request_url(nil, provision_request2),
         )
       }
       expect(response).to have_http_status(:ok)
@@ -234,8 +234,8 @@ describe "Provision Requests API" do
         "count"     => 2,
         "subcount"  => 2,
         "resources" => a_collection_containing_exactly(
-          {"href" => api_provision_request_url(nil, provision_request1.compressed_id)},
-          {"href" => api_provision_request_url(nil, provision_request2.compressed_id)},
+          {"href" => api_provision_request_url(nil, provision_request1)},
+          {"href" => api_provision_request_url(nil, provision_request2)},
         )
       }
       expect(response).to have_http_status(:ok)
@@ -261,8 +261,8 @@ describe "Provision Requests API" do
       get api_provision_request_url(nil, provision_request)
 
       expected = {
-        "id"   => provision_request.compressed_id,
-        "href" => api_provision_request_url(nil, provision_request.compressed_id)
+        "id"   => provision_request.id.to_s,
+        "href" => api_provision_request_url(nil, provision_request)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -286,7 +286,7 @@ describe "Provision Requests API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -300,7 +300,7 @@ describe "Provision Requests API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      task_id = response.parsed_body["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -314,7 +314,7 @@ describe "Provision Requests API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = response.parsed_body["results"].collect { |r| ApplicationRecord.uncompress_id(r["id"]) }
+      task_id1, task_id2 = response.parsed_body["results"].collect { |r| r["id"] }
       expect(MiqProvisionRequest.exists?(task_id1)).to be_truthy
       expect(MiqProvisionRequest.exists?(task_id2)).to be_truthy
     end
@@ -336,7 +336,7 @@ describe "Provision Requests API" do
         post(api_provision_request_url(nil, provision_request), :params => { :action => "edit", :options => {:baz => "qux"} })
 
         expected = {
-          "id"      => provision_request.compressed_id,
+          "id"      => provision_request.id.to_s,
           "options" => a_hash_including("foo" => "bar", "baz" => "qux")
         }
         expect(response).to have_http_status(:ok)
@@ -392,7 +392,7 @@ describe "Provision Requests API" do
       post(provreq1_url, :params => gen_request(:approve))
 
       expected_msg = "Provision request #{provreq1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => api_provision_request_url(nil, provreq1.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_provision_request_url(nil, provreq1))
     end
 
     it "supports denying a request" do
@@ -401,7 +401,7 @@ describe "Provision Requests API" do
       post(provreq2_url, :params => gen_request(:deny))
 
       expected_msg = "Provision request #{provreq2.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => api_provision_request_url(nil, provreq2.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_provision_request_url(nil, provreq2))
     end
 
     it "supports approving multiple requests" do
@@ -414,12 +414,12 @@ describe "Provision Requests API" do
           {
             "message" => a_string_matching(/Provision request #{provreq1.id} approved/i),
             "success" => true,
-            "href"    => api_provision_request_url(nil, provreq1.compressed_id)
+            "href"    => api_provision_request_url(nil, provreq1)
           },
           {
             "message" => a_string_matching(/Provision request #{provreq2.id} approved/i),
             "success" => true,
-            "href"    => api_provision_request_url(nil, provreq2.compressed_id)
+            "href"    => api_provision_request_url(nil, provreq2)
           }
         )
       }
@@ -437,12 +437,12 @@ describe "Provision Requests API" do
           {
             "message" => a_string_matching(/Provision request #{provreq1.id} denied/i),
             "success" => true,
-            "href"    => api_provision_request_url(nil, provreq1.compressed_id)
+            "href"    => api_provision_request_url(nil, provreq1)
           },
           {
             "message" => a_string_matching(/Provision request #{provreq2.id} denied/i),
             "success" => true,
-            "href"    => api_provision_request_url(nil, provreq2.compressed_id)
+            "href"    => api_provision_request_url(nil, provreq2)
           }
         )
       }

--- a/spec/requests/queries_spec.rb
+++ b/spec/requests/queries_spec.rb
@@ -48,7 +48,7 @@ describe "Queries API" do
       get api_vms_url, :params => { :expand => "resources", :attributes => "guid" }
 
       expect_query_result(:vms, 1, 1)
-      expect_result_resources_to_match_hash([{"id" => vm1.compressed_id, "href" => api_vm_url(nil, vm1.compressed_id), "guid" => vm1.guid}])
+      expect_result_resources_to_match_hash([{"id" => vm1.id.to_s, "href" => api_vm_url(nil, vm1), "guid" => vm1.guid}])
     end
   end
 
@@ -59,7 +59,7 @@ describe "Queries API" do
 
       get vm1_url
 
-      expect_single_resource_query("id" => vm1.compressed_id, "href" => api_vm_url(nil, vm1.compressed_id), "guid" => vm1.guid)
+      expect_single_resource_query("id" => vm1.id.to_s, "href" => api_vm_url(nil, vm1), "guid" => vm1.guid)
     end
 
     it 'supports compressed ids' do
@@ -67,7 +67,7 @@ describe "Queries API" do
 
       get api_vm_url(nil, vm1.compressed_id)
 
-      expect_single_resource_query("id" => vm1.compressed_id, "href" => api_vm_url(nil, vm1.compressed_id), "guid" => vm1.guid)
+      expect_single_resource_query("id" => vm1.id.to_s, "href" => api_vm_url(nil, vm1), "guid" => vm1.guid)
     end
 
     it 'returns 404 on url with trailing garbage' do
@@ -98,8 +98,8 @@ describe "Queries API" do
 
       expect_query_result(:accounts, 2)
       expect_result_resources_to_include_hrefs("resources",
-                                               [api_vm_account_url(nil, vm1.compressed_id, acct1.compressed_id),
-                                                api_vm_account_url(nil, vm1.compressed_id, acct2.compressed_id)])
+                                               [api_vm_account_url(nil, vm1, acct1),
+                                                api_vm_account_url(nil, vm1, acct2)])
     end
 
     it "includes both id and href when getting a single resource" do
@@ -108,8 +108,8 @@ describe "Queries API" do
       get acct1_url
 
       expect_single_resource_query(
-        "id"   => acct1.compressed_id,
-        "href" => api_vm_account_url(nil, vm1.compressed_id, acct1.compressed_id),
+        "id"   => acct1.id.to_s,
+        "href" => api_vm_account_url(nil, vm1, acct1),
         "name" => acct1.name
       )
     end
@@ -125,9 +125,9 @@ describe "Queries API" do
       expect_query_result(:accounts, 2)
       expect_result_resources_to_include_keys("resources", %w(id href))
       expect_result_resources_to_include_hrefs("resources",
-                                               [api_vm_account_url(nil, vm1.compressed_id, acct1.compressed_id),
-                                                api_vm_account_url(nil, vm1.compressed_id, acct2.compressed_id)])
-      expect_result_resources_to_include_data("resources", "id" => [acct1.compressed_id, acct2.compressed_id])
+                                               [api_vm_account_url(nil, vm1, acct1),
+                                                api_vm_account_url(nil, vm1, acct2)])
+      expect_result_resources_to_include_data("resources", "id" => [acct1.id.to_s, acct2.id.to_s])
     end
 
     it 'supports compressed ids' do
@@ -136,8 +136,8 @@ describe "Queries API" do
       get(api_vm_account_url(nil, vm1.compressed_id, acct1))
 
       expect_single_resource_query(
-        "id"   => acct1.compressed_id,
-        "href" => api_vm_account_url(nil, vm1.compressed_id, acct1.compressed_id),
+        "id"   => acct1.id.to_s,
+        "href" => api_vm_account_url(nil, vm1, acct1),
         "name" => acct1.name
       )
     end

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -521,7 +521,7 @@ describe "Querying" do
 
       get(api_vms_url, :params => { :filter => ["retires_on = 2016-01-02", "vendor_display = VMware"] })
 
-      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -533,7 +533,7 @@ describe "Querying" do
 
       get(api_vms_url, :params => { :filter => ["retires_on > 2016-01-01", "vendor_display = VMware"] })
 
-      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -545,7 +545,7 @@ describe "Querying" do
 
       get(api_vms_url, :params => { :filter => ["last_scan_on > 2016-01-01T07:59:59Z", "vendor_display = VMware"] })
 
-      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -557,7 +557,7 @@ describe "Querying" do
 
       get(api_vms_url, :params => { :filter => ["retires_on < 2016-01-03", "vendor_display = VMware"] })
 
-      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -569,7 +569,7 @@ describe "Querying" do
 
       get(api_vms_url, :params => { :filter => ["last_scan_on < 2016-01-01T08:00:00Z", "vendor_display = VMware"] })
 
-      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2.compressed_id)}]}
+      expected = {"resources" => [{"href" => api_vm_url(nil, vm_2)}]}
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -623,7 +623,7 @@ describe "Querying" do
       expected = {
         "count"     => 2,
         "subcount"  => 1,
-        "resources" => [{"href" => api_tag_url(nil, tag_1.compressed_id)}]
+        "resources" => [{"href" => api_tag_url(nil, tag_1)}]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -713,8 +713,8 @@ describe "Querying" do
         "subcount"  => 1,
         "resources" => [
           {
-            "id"        => vm.compressed_id,
-            "href"      => api_vm_url(nil, vm.compressed_id),
+            "id"        => vm.id.to_s,
+            "href"      => api_vm_url(nil, vm),
             "href_slug" => "vms/#{vm.compressed_id}",
             "name"      => "aa",
             "vendor"    => anything

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -36,8 +36,8 @@ describe "Regions API" do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "href" => api_region_url(nil, region.compressed_id),
-      "id"   => region.compressed_id
+      "href" => api_region_url(nil, region),
+      "id"   => region.id.to_s
     )
   end
 end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "reports API" do
     expect_result_resources_to_include_hrefs(
       "resources",
       [
-        api_report_url(nil, report_1.compressed_id),
-        api_report_url(nil, report_2.compressed_id)
+        api_report_url(nil, report_1),
+        api_report_url(nil, report_2)
       ]
     )
     expect_result_to_match_hash(response.parsed_body, "count" => 2, "name" => "reports")
@@ -35,8 +35,8 @@ RSpec.describe "reports API" do
 
     expect_result_to_match_hash(
       response.parsed_body,
-      "href"  => api_report_url(nil, report.compressed_id),
-      "id"    => report.compressed_id,
+      "href"  => api_report_url(nil, report),
+      "id"    => report.id.to_s,
       "name"  => report.name,
       "title" => report.title
     )
@@ -60,7 +60,7 @@ RSpec.describe "reports API" do
       expect_result_resources_to_include_hrefs(
         "resources",
         [
-          api_report_result_url(nil, report.compressed_id, report_result.compressed_id)
+          api_report_result_url(nil, report, report_result)
         ]
       )
       expect(response.parsed_body["resources"]).not_to be_any { |resource| resource.key?("result_set") }
@@ -92,7 +92,7 @@ RSpec.describe "reports API" do
       expect_result_resources_to_include_hrefs(
         "resources",
         [
-          api_result_url(nil, result.compressed_id).to_s
+          api_result_url(nil, result).to_s
         ]
       )
       expect(response).to have_http_status(:ok)
@@ -152,8 +152,8 @@ RSpec.describe "reports API" do
     expect_result_resources_to_include_hrefs(
       "resources",
       [
-        api_report_schedule_url(nil, report.compressed_id, schedule_1.compressed_id),
-        api_report_schedule_url(nil, report.compressed_id, schedule_2.compressed_id),
+        api_report_schedule_url(nil, report, schedule_1),
+        api_report_schedule_url(nil, report, schedule_2),
       ]
     )
     expect(response).to have_http_status(:ok)
@@ -184,8 +184,8 @@ RSpec.describe "reports API" do
 
     expect_result_to_match_hash(
       response.parsed_body,
-      "href" => api_report_schedule_url(nil, report.compressed_id, schedule.compressed_id),
-      "id"   => schedule.compressed_id,
+      "href" => api_report_schedule_url(nil, report, schedule),
+      "id"   => schedule.id.to_s,
       "name" => 'unit_test'
     )
     expect(response).to have_http_status(:ok)
@@ -211,11 +211,11 @@ RSpec.describe "reports API" do
         post api_report_url(nil, report).to_s, :params => { :action => "run" }
       end.to change(MiqReportResult, :count).by(1)
       expect_single_action_result(
-        :href    => api_report_url(nil, report.compressed_id),
+        :href    => api_report_url(nil, report),
         :success => true,
         :message => "running report #{report.id}"
       )
-      actual = MiqReportResult.find(ApplicationRecord.uncompress_id(response.parsed_body["result_id"]))
+      actual = MiqReportResult.find(response.parsed_body["result_id"])
       expect(actual.userid).to eq("api_user_id")
     end
 
@@ -238,7 +238,7 @@ RSpec.describe "reports API" do
         )
       end.to change(MiqSchedule, :count).by(1)
       expect_single_action_result(
-        :href    => api_report_url(nil, report.compressed_id),
+        :href    => api_report_url(nil, report),
         :success => true,
         :message => "scheduling of report #{report.id}"
       )

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe "Requests API" do
       get api_request_url(nil, service_request)
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("id"   => service_request.compressed_id,
-                                              "href" => api_request_url(nil, service_request.compressed_id))
+      expect(response.parsed_body).to include("id"   => service_request.id.to_s,
+                                              "href" => api_request_url(nil, service_request))
     end
 
     it "lists all the service requests if you are admin" do
@@ -89,8 +89,8 @@ RSpec.describe "Requests API" do
         "count"     => 2,
         "subcount"  => 2,
         "resources" => a_collection_containing_exactly(
-          {"href" => api_request_url(nil, service_request_1.compressed_id)},
-          {"href" => api_request_url(nil, service_request_2.compressed_id)},
+          {"href" => api_request_url(nil, service_request_1)},
+          {"href" => api_request_url(nil, service_request_2)},
         )
       }
       expect(response).to have_http_status(:ok)
@@ -109,8 +109,8 @@ RSpec.describe "Requests API" do
       get api_request_url(nil, service_request)
 
       expected = {
-        "id"   => service_request.compressed_id,
-        "href" => api_request_url(nil, service_request.compressed_id)
+        "id"   => service_request.id.to_s,
+        "href" => api_request_url(nil, service_request)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -192,7 +192,7 @@ RSpec.describe "Requests API" do
             "approval_state" => "pending_approval",
             "type"           => "ServiceReconfigureRequest",
             "requester_name" => api_config(:user_name),
-            "options"        => a_hash_including("src_id" => service.compressed_id)
+            "options"        => a_hash_including("src_id" => service.id.to_s)
           )
         ]
       }
@@ -221,7 +221,7 @@ RSpec.describe "Requests API" do
             "approval_state" => "approved",
             "type"           => "ServiceReconfigureRequest",
             "requester_name" => approver.name,
-            "options"        => a_hash_including("src_id" => service.compressed_id, "other_attr" => "other value")
+            "options"        => a_hash_including("src_id" => service.id.to_s, "other_attr" => "other value")
           )
         ]
       }
@@ -249,7 +249,7 @@ RSpec.describe "Requests API" do
       get api_request_url(nil, request), :params => { :attributes => "workflow,v_allowed_tags,v_workflow_class" }
 
       expected_response = a_hash_including(
-        "id"               => request.compressed_id,
+        "id"               => request.id.to_s,
         "workflow"         => a_hash_including("values"),
         "v_allowed_tags"   => [a_hash_including("children")],
         "v_workflow_class" => a_hash_including(
@@ -280,7 +280,7 @@ RSpec.describe "Requests API" do
       get api_request_url(nil, request), :params => { :attributes => "workflow.values" }
 
       expected_response = a_hash_including(
-        "id"       => request.compressed_id,
+        "id"       => request.id.to_s,
         "workflow" => a_hash_including("values")
       )
 
@@ -300,7 +300,7 @@ RSpec.describe "Requests API" do
       get api_request_url(nil, request), :params => { :attributes => "workflow,v_allowed_tags,v_workflow_class" }
 
       expected_response = a_hash_including(
-        "id"               => request.compressed_id,
+        "id"               => request.id.to_s,
         "v_workflow_class" => {}
       )
 
@@ -343,7 +343,7 @@ RSpec.describe "Requests API" do
       post(api_request_url(nil, request), :params => gen_request(:edit, :options => { :some_option => "some_value" }))
 
       expected = {
-        "id"      => request.compressed_id,
+        "id"      => request.id.to_s,
         "options" => a_hash_including("some_option" => "some_value")
       }
 
@@ -378,7 +378,7 @@ RSpec.describe "Requests API" do
       post(request1_url, :params => gen_request(:approve, :reason => "approval reason"))
 
       expected_msg = "Request #{request1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => api_request_url(nil, request1.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_request_url(nil, request1))
     end
 
     it "fails approving a request if the reason is missing" do
@@ -396,7 +396,7 @@ RSpec.describe "Requests API" do
       post(request1_url, :params => gen_request(:deny, :reason => "denial reason"))
 
       expected_msg = "Request #{request1.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => api_request_url(nil, request1.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_request_url(nil, request1))
     end
 
     it "fails denying a request if the reason is missing" do
@@ -419,12 +419,12 @@ RSpec.describe "Requests API" do
           {
             "message" => a_string_matching(/Request #{request1.id} approved/i),
             "success" => true,
-            "href"    => api_request_url(nil, request1.compressed_id)
+            "href"    => api_request_url(nil, request1)
           },
           {
             "message" => a_string_matching(/Request #{request2.id} approved/i),
             "success" => true,
-            "href"    => api_request_url(nil, request2.compressed_id)
+            "href"    => api_request_url(nil, request2)
           }
         )
       }
@@ -443,12 +443,12 @@ RSpec.describe "Requests API" do
           {
             "message" => a_string_matching(/Request #{request1.id} denied/i),
             "success" => true,
-            "href"    => api_request_url(nil, request1.compressed_id)
+            "href"    => api_request_url(nil, request1)
           },
           {
             "message" => a_string_matching(/Request #{request2.id} denied/i),
             "success" => true,
-            "href"    => api_request_url(nil, request2.compressed_id)
+            "href"    => api_request_url(nil, request2)
           }
         )
       }
@@ -466,8 +466,8 @@ RSpec.describe "Requests API" do
       get api_requests_url, :params => { :expand => :resources }
 
       expected = [
-        a_hash_including('href' => a_string_including(api_request_url(nil, provision_request.compressed_id))),
-        a_hash_including('href' => a_string_including(api_request_url(nil, automation_request.compressed_id)))
+        a_hash_including('href' => a_string_including(api_request_url(nil, provision_request))),
+        a_hash_including('href' => a_string_including(api_request_url(nil, automation_request)))
       ]
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['resources']).to match_array(expected)

--- a/spec/requests/roles_spec.rb
+++ b/spec/requests/roles_spec.rb
@@ -116,7 +116,7 @@ describe "Roles API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      role_id = response.parsed_body["results"].first["id"]
 
       get(api_role_url(nil, role_id), :params => { :expand => "features" })
 
@@ -135,7 +135,7 @@ describe "Roles API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+      role_id = response.parsed_body["results"].first["id"]
       role = MiqUserRole.find(role_id)
       sample_role1['features'].each do |feature|
         expect(role.allows?(feature)).to be_truthy
@@ -151,8 +151,8 @@ describe "Roles API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       results = response.parsed_body["results"]
-      r1_id = ApplicationRecord.uncompress_id(results.first["id"])
-      r2_id = ApplicationRecord.uncompress_id(results.second["id"])
+      r1_id = results.first["id"]
+      r2_id = results.second["id"]
 
       role1 = MiqUserRole.find(r1_id)
       role2 = MiqUserRole.find(r2_id)
@@ -170,7 +170,7 @@ describe "Roles API" do
     it "rejects role edits without appropriate role" do
       role = FactoryGirl.create(:miq_user_role)
       api_basic_authorize
-      post(api_roles_url, :params => gen_request(:edit, "name" => "role name", "href" => api_role_url(nil, role.compressed_id)))
+      post(api_roles_url, :params => gen_request(:edit, "name" => "role name", "href" => api_role_url(nil, role)))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -197,7 +197,7 @@ describe "Roles API" do
         )
       )
 
-      expect_single_resource_query("id"       => role.compressed_id,
+      expect_single_resource_query("id"       => role.id.to_s,
                                    "name"     => "updated role",
                                    "settings" => {"restrictions" => {"vms" => "user_or_group"}})
       expect(role.reload.name).to eq("updated role")
@@ -215,8 +215,8 @@ describe "Roles API" do
                                                   {"href" => api_role_url(nil, r2), "name" => "updated role2"}]))
 
       expect_results_to_match_hash("results",
-                                   [{"id" => r1.compressed_id, "name" => "updated role1"},
-                                    {"id" => r2.compressed_id, "name" => "updated role2"}])
+                                   [{"id" => r1.id.to_s, "name" => "updated role1"},
+                                    {"id" => r2.id.to_s, "name" => "updated role2"}])
 
       expect(r1.reload.name).to eq("updated role1")
       expect(r2.reload.name).to eq("updated role2")

--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -43,8 +43,8 @@ describe "Service Dialogs API" do
       get api_service_dialog_url(nil, dialog1)
 
       expect_single_resource_query(
-        "id"    => dialog1.compressed_id,
-        "href"  => api_service_dialog_url(nil, dialog1.compressed_id),
+        "id"    => dialog1.id.to_s,
+        "href"  => api_service_dialog_url(nil, dialog1),
         "label" => dialog1.label
       )
       expect_result_to_have_keys(%w(content))
@@ -127,13 +127,13 @@ describe "Service Dialogs API" do
           'label'   => 'updated label',
           'content' => {
             'dialog_tabs' => [
-              'id'            => dialog_tab.compressed_id,
+              'id'            => dialog_tab.id.to_s,
               'label'         => 'updated tab label',
               'dialog_groups' => [
                 {
-                  'id'            => dialog_group.compressed_id,
+                  'id'            => dialog_group.id.to_s,
                   'dialog_fields' => [
-                    { 'id' => dialog_field.compressed_id }
+                    { 'id' => dialog_field.id.to_s }
                   ]
                 }
               ]
@@ -142,8 +142,8 @@ describe "Service Dialogs API" do
         }
 
         expected = {
-          'href'        => a_string_including(api_service_dialog_url(nil, dialog.compressed_id)),
-          'id'          => dialog.compressed_id,
+          'href'        => a_string_including(api_service_dialog_url(nil, dialog)),
+          'id'          => dialog.id.to_s,
           'label'       => 'updated label',
           'dialog_tabs' => a_collection_including(
             a_hash_including('label' => 'updated tab label')
@@ -177,11 +177,11 @@ describe "Service Dialogs API" do
         expected = {
           'results' => a_collection_containing_exactly(
             a_hash_including(
-              'id'    => dialog.compressed_id,
+              'id'    => dialog.id.to_s,
               'label' => 'foo bar'
             ),
             a_hash_including(
-              'id'    => dialog2.compressed_id,
+              'id'    => dialog2.id.to_s,
               'label' => 'bar'
             )
           )
@@ -294,7 +294,7 @@ describe "Service Dialogs API" do
       get(api_service_template_service_dialog_url(nil, template, dialog1), :params => { :attributes => "content" })
       expected = {
         'content' => a_collection_including(
-          a_hash_including('id' => dialog1.compressed_id)
+          a_hash_including('id' => dialog1.id.to_s)
         )}
 
       expect(response).to have_http_status(:ok)
@@ -349,7 +349,7 @@ describe "Service Dialogs API" do
       expect(response.parsed_body).to include(
         "success" => true,
         "message" => a_string_matching(/refreshing dialog fields/i),
-        "href"    => api_service_dialog_url(nil, dialog1.compressed_id),
+        "href"    => api_service_dialog_url(nil, dialog1),
         "result"  => hash_including("text1")
       )
     end

--- a/spec/requests/service_orders_spec.rb
+++ b/spec/requests/service_orders_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "service orders API" do
     get api_service_orders_url
 
     expect(response).to have_http_status(:ok)
-    expect_result_resources_to_include_hrefs("resources", [api_service_order_url(nil, service_order.compressed_id)])
+    expect_result_resources_to_include_hrefs("resources", [api_service_order_url(nil, service_order)])
   end
 
   it "won't show another user's service orders" do
@@ -19,7 +19,7 @@ RSpec.describe "service orders API" do
     expected = {
       "count"     => 2,
       "subcount"  => 1,
-      "resources" => [{"href" => api_service_order_url(nil, shopping_cart_for_user.compressed_id)}]
+      "resources" => [{"href" => api_service_order_url(nil, shopping_cart_for_user)}]
     }
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(expected)
@@ -90,8 +90,8 @@ RSpec.describe "service orders API" do
     get api_service_order_url(nil, "cart")
 
     expect(response).to have_http_status(:ok)
-    expect(response.parsed_body).to include("id"   => shopping_cart.compressed_id,
-                                            "href" => api_service_order_url(nil, shopping_cart.compressed_id))
+    expect(response.parsed_body).to include("id"   => shopping_cart.id.to_s,
+                                            "href" => api_service_order_url(nil, shopping_cart))
   end
 
   it "returns an empty response when there is no shopping cart" do
@@ -183,7 +183,7 @@ RSpec.describe "service orders API" do
 
         get(api_service_order_service_requests_url(nil, "cart"))
 
-        expected_href = api_service_order_service_request_url(nil, "cart", service_request.compressed_id)
+        expected_href = api_service_order_service_request_url(nil, "cart", service_request)
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include("count"     => 1,
                                          "name"      => "service_requests",
@@ -199,8 +199,8 @@ RSpec.describe "service orders API" do
         get(api_service_order_service_request_url(nil, "cart", service_request))
 
         expected = {
-          "id"   => service_request.compressed_id,
-          "href" => api_service_order_service_request_url(nil, "cart", service_request.compressed_id)
+          "id"   => service_request.id.to_s,
+          "href" => api_service_order_service_request_url(nil, "cart", service_request)
         }
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)
@@ -233,8 +233,8 @@ RSpec.describe "service orders API" do
             a_hash_including(
               "success"              => true,
               "message"              => /Adding service_request/,
-              "service_request_id"   => actual_requests.first.compressed_id,
-              "service_request_href" => api_service_request_url(nil, actual_requests.first.compressed_id)
+              "service_request_id"   => actual_requests.first.id.to_s,
+              "service_request_href" => api_service_request_url(nil, actual_requests.first)
             )
           ]
         }
@@ -275,14 +275,14 @@ RSpec.describe "service orders API" do
             a_hash_including(
               "success"              => true,
               "message"              => /Adding service_request/,
-              "service_request_id"   => actual_requests.first.compressed_id,
-              "service_request_href" => api_service_request_url(nil, actual_requests.first.compressed_id)
+              "service_request_id"   => actual_requests.first.id.to_s,
+              "service_request_href" => api_service_request_url(nil, actual_requests.first)
             ),
             a_hash_including(
               "success"              => true,
               "message"              => /Adding service_request/,
-              "service_request_id"   => actual_requests.second.compressed_id,
-              "service_request_href" => api_service_request_url(nil, actual_requests.second.compressed_id)
+              "service_request_id"   => actual_requests.second.id.to_s,
+              "service_request_href" => api_service_request_url(nil, actual_requests.second)
             )
           )
         }
@@ -300,8 +300,8 @@ RSpec.describe "service orders API" do
         expected = {
           "success"              => true,
           "message"              => a_string_starting_with("Removing Service Request id:#{service_request.id}"),
-          "service_request_href" => api_service_request_url(nil, service_request.compressed_id),
-          "service_request_id"   => service_request.compressed_id
+          "service_request_href" => api_service_request_url(nil, service_request),
+          "service_request_id"   => service_request.id.to_s
         }
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)
@@ -333,14 +333,14 @@ RSpec.describe "service orders API" do
             a_hash_including(
               "success"              => true,
               "message"              => a_string_starting_with("Removing Service Request id:#{service_request_1.id}"),
-              "service_request_href" => api_service_request_url(nil, service_request_1.compressed_id),
-              "service_request_id"   => service_request_1.compressed_id
+              "service_request_href" => api_service_request_url(nil, service_request_1),
+              "service_request_id"   => service_request_1.id.to_s
             ),
             a_hash_including(
               "success"              => true,
               "message"              => a_string_starting_with("Removing Service Request id:#{service_request_2.id}"),
-              "service_request_href" => api_service_request_url(nil, service_request_2.compressed_id),
-              "service_request_id"   => service_request_2.compressed_id
+              "service_request_href" => api_service_request_url(nil, service_request_2),
+              "service_request_id"   => service_request_2.id.to_s
             )
           )
         }
@@ -374,14 +374,14 @@ RSpec.describe "service orders API" do
             a_hash_including(
               "success"              => true,
               "message"              => a_string_starting_with("Removing Service Request id:#{service_request_1.id}"),
-              "service_request_href" => api_service_request_url(nil, service_request_1.compressed_id),
-              "service_request_id"   => service_request_1.compressed_id
+              "service_request_href" => api_service_request_url(nil, service_request_1),
+              "service_request_id"   => service_request_1.id.to_s
             ),
             a_hash_including(
               "success"              => true,
               "message"              => a_string_starting_with("Removing Service Request id:#{service_request_2.id}"),
-              "service_request_href" => api_service_request_url(nil, service_request_2.compressed_id),
-              "service_request_id"   => service_request_2.compressed_id
+              "service_request_href" => api_service_request_url(nil, service_request_2),
+              "service_request_id"   => service_request_2.id.to_s
             )
           )
         }
@@ -402,8 +402,8 @@ RSpec.describe "service orders API" do
         post api_service_order_url(nil, "cart"), :params => { :action => :clear }
 
         expected = {
-          "href" => api_service_order_url(nil, shopping_cart.compressed_id),
-          "id"   => shopping_cart.compressed_id
+          "href" => api_service_order_url(nil, shopping_cart),
+          "id"   => shopping_cart.id.to_s
         }
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)

--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -102,7 +102,7 @@ describe "Service Requests API" do
       post(svcreq1_url, :params => gen_request(:approve, :reason => "approve reason"))
 
       expected_msg = "Service request #{svcreq1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => api_service_request_url(nil, svcreq1.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_service_request_url(nil, svcreq1))
     end
 
     it "supports denying a request" do
@@ -111,7 +111,7 @@ describe "Service Requests API" do
       post(svcreq2_url, :params => gen_request(:deny, :reason => "deny reason"))
 
       expected_msg = "Service request #{svcreq2.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => api_service_request_url(nil, svcreq2.compressed_id))
+      expect_single_action_result(:success => true, :message => expected_msg, :href => api_service_request_url(nil, svcreq2))
     end
 
     it "supports approving multiple requests" do
@@ -125,12 +125,12 @@ describe "Service Requests API" do
           {
             "message" => a_string_matching(/Service request #{svcreq1.id} approved/i),
             "success" => true,
-            "href"    => api_service_request_url(nil, svcreq1.compressed_id)
+            "href"    => api_service_request_url(nil, svcreq1)
           },
           {
             "message" => a_string_matching(/Service request #{svcreq2.id} approved/i),
             "success" => true,
-            "href"    => api_service_request_url(nil, svcreq2.compressed_id)
+            "href"    => api_service_request_url(nil, svcreq2)
           }
         )
       }
@@ -149,12 +149,12 @@ describe "Service Requests API" do
           {
             "message" => a_string_matching(/Service request #{svcreq1.id} denied/i),
             "success" => true,
-            "href"    => api_service_request_url(nil, svcreq1.compressed_id)
+            "href"    => api_service_request_url(nil, svcreq1)
           },
           {
             "message" => a_string_matching(/Service request #{svcreq2.id} denied/i),
             "success" => true,
-            "href"    => api_service_request_url(nil, svcreq2.compressed_id)
+            "href"    => api_service_request_url(nil, svcreq2)
           }
         )
       }
@@ -228,8 +228,8 @@ describe "Service Requests API" do
       get api_service_request_url(nil, service_request)
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("id"   => service_request.compressed_id,
-                                              "href" => api_service_request_url(nil, service_request.compressed_id))
+      expect(response.parsed_body).to include("id"   => service_request.id.to_s,
+                                              "href" => api_service_request_url(nil, service_request))
     end
 
     it "lists all the service requests if you are admin" do
@@ -251,8 +251,8 @@ describe "Service Requests API" do
         "count"     => 2,
         "subcount"  => 2,
         "resources" => a_collection_containing_exactly(
-          {"href" => api_service_request_url(nil, service_request_1.compressed_id)},
-          {"href" => api_service_request_url(nil, service_request_2.compressed_id)},
+          {"href" => api_service_request_url(nil, service_request_1)},
+          {"href" => api_service_request_url(nil, service_request_2)},
         )
       }
       expect(response).to have_http_status(:ok)
@@ -271,8 +271,8 @@ describe "Service Requests API" do
       get api_service_request_url(nil, service_request)
 
       expected = {
-        "id"   => service_request.compressed_id,
-        "href" => api_service_request_url(nil, service_request.compressed_id)
+        "id"   => service_request.id.to_s,
+        "href" => api_service_request_url(nil, service_request)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -360,7 +360,7 @@ describe "Service Requests API" do
         post(api_service_request_url(nil, service_request), :params => { :action => 'add_approver', :user_id => user.id })
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.compressed_id)
+      expect(response.parsed_body).to include('id' => service_request.id.to_s)
     end
 
     it 'can add approvers to multiple service requests' do
@@ -375,8 +375,8 @@ describe "Service Requests API" do
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => service_request.compressed_id),
-          a_hash_including('id' => service_request_2.compressed_id)
+          a_hash_including('id' => service_request.id.to_s),
+          a_hash_including('id' => service_request_2.id.to_s)
         )
       }
       expect do
@@ -412,7 +412,7 @@ describe "Service Requests API" do
         post(api_service_request_url(nil, service_request), :params => { :action => 'add_approver', :user => { :id => user.id } })
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.compressed_id)
+      expect(response.parsed_body).to include('id' => service_request.id.to_s)
     end
 
     it 'supports user reference hash with href' do
@@ -430,7 +430,7 @@ describe "Service Requests API" do
         )
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.compressed_id)
+      expect(response.parsed_body).to include('id' => service_request.id.to_s)
     end
 
     it 'raises an error if no user is supplied' do
@@ -458,7 +458,7 @@ describe "Service Requests API" do
         post(api_service_request_url(nil, service_request), :params => { :action => 'remove_approver', :user_id => user.id })
       end.to change(MiqApproval, :count).by(-1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.compressed_id)
+      expect(response.parsed_body).to include('id' => service_request.id.to_s)
     end
 
     it 'can remove approvers to multiple service requests' do
@@ -473,8 +473,8 @@ describe "Service Requests API" do
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => service_request.compressed_id),
-          a_hash_including('id' => service_request2.compressed_id)
+          a_hash_including('id' => service_request.id.to_s),
+          a_hash_including('id' => service_request2.id.to_s)
         )
       }
       expect do
@@ -516,7 +516,7 @@ describe "Service Requests API" do
         )
       end.to change(MiqApproval, :count).by(-1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.compressed_id)
+      expect(response.parsed_body).to include('id' => service_request.id.to_s)
     end
 
     it 'raises an error if no user is supplied' do
@@ -540,7 +540,7 @@ describe "Service Requests API" do
 
       post(api_service_request_url(nil, service_request), :params => { :action => 'remove_approver', :user_id => user.id })
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.compressed_id)
+      expect(response.parsed_body).to include('id' => service_request.id.to_s)
     end
   end
 
@@ -565,7 +565,7 @@ describe "Service Requests API" do
       post(api_service_request_url(nil, service_request), :params => { :action => "edit", :options => {:baz => "qux"} })
 
       expected = {
-        "id"      => service_request.compressed_id,
+        "id"      => service_request.id.to_s,
         "options" => a_hash_including("foo" => "bar")
       }
       expect(response).to have_http_status(:ok)

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -44,7 +44,7 @@ describe "Service Templates API" do
       )
 
       expect_query_result(:resource_actions, 1, 2)
-      expect_result_resources_to_match_hash(["id" => ra1.compressed_id, "action" => ra1.action, "dialog_id" => dialog1.compressed_id])
+      expect_result_resources_to_match_hash(["id" => ra1.id.to_s, "action" => ra1.action, "dialog_id" => dialog1.id.to_s])
     end
 
     it "allows queries of the related picture" do
@@ -53,7 +53,7 @@ describe "Service Templates API" do
       get api_service_template_url(nil, template), :params => { :attributes => "picture" }
 
       expect_result_to_have_keys(%w(id href picture))
-      expected = {"id" => template.compressed_id, "href" => api_service_template_url(nil, template.compressed_id)}
+      expected = {"id" => template.id.to_s, "href" => api_service_template_url(nil, template)}
       expect_result_to_match_hash(response.parsed_body, expected)
     end
 
@@ -64,8 +64,8 @@ describe "Service Templates API" do
 
       expect_result_to_have_keys(%w(id href picture))
       expect_result_to_match_hash(response.parsed_body["picture"],
-                                  "id"          => picture.compressed_id,
-                                  "resource_id" => template.compressed_id,
+                                  "id"          => picture.id.to_s,
+                                  "resource_id" => template.id.to_s,
                                   "image_href"  => /^http:.*#{picture.image_href}$/)
     end
 
@@ -77,10 +77,10 @@ describe "Service Templates API" do
       expected = {
         'config_info' => a_hash_including(
           "provision"  => a_hash_including(
-            "dialog_id" => dialog1.compressed_id
+            "dialog_id" => dialog1.id.to_s
           ),
           "retirement" => a_hash_including(
-            "dialog_id" => dialog2.compressed_id
+            "dialog_id" => dialog2.id.to_s
           )
         )
       }
@@ -138,7 +138,7 @@ describe "Service Templates API" do
       st = FactoryGirl.create(:service_template, :name => "st1")
       post(api_service_template_url(nil, st), :params => gen_request(:edit, updated_catalog_item_options))
 
-      expect_single_resource_query("id" => st.compressed_id, "href" => api_service_template_url(nil, st.compressed_id), "name" => "Updated Template Name")
+      expect_single_resource_query("id" => st.id.to_s, "href" => api_service_template_url(nil, st), "name" => "Updated Template Name")
       expect(st.reload.name).to eq("Updated Template Name")
     end
 
@@ -153,8 +153,8 @@ describe "Service Templates API" do
 
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
-                                   [{"id" => st1.compressed_id, "name" => "Updated Template Name"},
-                                    {"id" => st2.compressed_id, "name" => "Updated Template Name"}])
+                                   [{"id" => st1.id.to_s, "name" => "Updated Template Name"},
+                                    {"id" => st2.id.to_s, "name" => "Updated Template Name"}])
       expect(st1.reload.name).to eq("Updated Template Name")
       expect(st2.reload.name).to eq("Updated Template Name")
     end
@@ -166,7 +166,7 @@ describe "Service Templates API" do
       post(api_service_template_url(nil, st1), :params => gen_request(:edit, 'name' => 'updated template'))
 
       expected = {
-        'id'   => st1.compressed_id,
+        'id'   => st1.id.to_s,
         'name' => 'updated template'
       }
       expect(response).to have_http_status(:ok)
@@ -219,7 +219,7 @@ describe "Service Templates API" do
       end.to change(ServiceTemplate, :count).by(-1)
 
       expected = {
-        "href"    => api_service_template_url(nil, service_template.compressed_id),
+        "href"    => api_service_template_url(nil, service_template),
         "message" => "service_templates id: #{service_template.id} deleting",
         "success" => true
       }
@@ -249,7 +249,7 @@ describe "Service Templates API" do
                                                               {"href" => api_service_template_url(nil, st2)}]))
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results",
-                                               [api_service_template_url(nil, st1.compressed_id), api_service_template_url(nil, st2.compressed_id)])
+                                               [api_service_template_url(nil, st1), api_service_template_url(nil, st2)])
 
       expect { st1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { st2.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -285,7 +285,7 @@ describe "Service Templates API" do
         "resources" => [
           {
             "href" => a_string_matching(
-              api_service_template_service_request_url(nil, service_template.compressed_id, service_request.compressed_id)
+              api_service_template_service_request_url(nil, service_template, service_request)
             )
           }
         ]

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -74,8 +74,8 @@ describe "Services API" do
           'type'                   => 'ServiceOrchestration',
           'name'                   => 'svc_new',
           'parent_service'         => { 'href' => api_service_url(nil, svc1)},
-          'orchestration_template' => { 'href' => api_orchestration_template_url(nil, orchestration_template.compressed_id) },
-          'orchestration_manager'  => { 'href' => api_provider_url(nil, ems.compressed_id) }
+          'orchestration_template' => { 'href' => api_orchestration_template_url(nil, orchestration_template) },
+          'orchestration_manager'  => { 'href' => api_provider_url(nil, ems) }
         }
       }
       expect do
@@ -120,7 +120,7 @@ describe "Services API" do
 
       post(api_service_url(nil, svc), :params => gen_request(:edit, "name" => "updated svc1"))
 
-      expect_single_resource_query("id" => svc.compressed_id, "href" => api_service_url(nil, svc.compressed_id), "name" => "updated svc1")
+      expect_single_resource_query("id" => svc.id.to_s, "href" => api_service_url(nil, svc), "name" => "updated svc1")
       expect(svc.reload.name).to eq("updated svc1")
     end
 
@@ -131,14 +131,14 @@ describe "Services API" do
         'action'   => 'edit',
         'resource' => {
           'parent_service'         => { 'href' => api_service_url(nil, svc1) },
-          'orchestration_template' => { 'href' => api_orchestration_template_url(nil, orchestration_template.compressed_id) },
-          'orchestration_manager'  => { 'href' => api_provider_url(nil, ems.compressed_id) }
+          'orchestration_template' => { 'href' => api_orchestration_template_url(nil, orchestration_template) },
+          'orchestration_manager'  => { 'href' => api_provider_url(nil, ems) }
         }
       }
       post(api_service_url(nil, svc_orchestration), :params => resource)
 
       expected = {
-        'id'       => svc_orchestration.compressed_id,
+        'id'       => svc_orchestration.id.to_s,
         'ancestry' => svc1.id.to_s
       }
       expect(response.parsed_body).to include(expected)
@@ -162,7 +162,7 @@ describe "Services API" do
       post(api_service_url(nil, svc_orchestration), :params => resource)
 
       expected = {
-        'id'       => svc_orchestration.compressed_id,
+        'id'       => svc_orchestration.id.to_s,
         'ancestry' => svc1.id.to_s
       }
       expect(response.parsed_body).to include(expected)
@@ -177,7 +177,7 @@ describe "Services API" do
 
       put(api_service_url(nil, svc), :params => { "name" => "updated svc1" })
 
-      expect_single_resource_query("id" => svc.compressed_id, "href" => api_service_url(nil, svc.compressed_id), "name" => "updated svc1")
+      expect_single_resource_query("id" => svc.id.to_s, "href" => api_service_url(nil, svc), "name" => "updated svc1")
       expect(svc.reload.name).to eq("updated svc1")
     end
 
@@ -188,7 +188,7 @@ describe "Services API" do
                                                    {"action" => "remove", "path" => "description"},
                                                    {"action" => "add",    "path" => "display", "value" => true}])
 
-      expect_single_resource_query("id" => svc.compressed_id, "name" => "updated svc1", "display" => true)
+      expect_single_resource_query("id" => svc.id.to_s, "name" => "updated svc1", "display" => true)
       expect(svc.reload.name).to eq("updated svc1")
       expect(svc.description).to be_nil
       expect(svc.display).to be_truthy
@@ -203,8 +203,8 @@ describe "Services API" do
 
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
-                                   [{"id" => svc1.compressed_id, "name" => "updated svc1"},
-                                    {"id" => svc2.compressed_id, "name" => "updated svc2"}])
+                                   [{"id" => svc1.id.to_s, "name" => "updated svc1"},
+                                    {"id" => svc2.id.to_s, "name" => "updated svc2"}])
       expect(svc1.reload.name).to eq("updated svc1")
       expect(svc2.reload.name).to eq("updated svc2")
     end
@@ -255,7 +255,7 @@ describe "Services API" do
       expected = {
         "success" => true,
         "message" => "services id: #{service.id} deleting",
-        "href"    => api_service_url(nil, service.compressed_id)
+        "href"    => api_service_url(nil, service)
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -280,7 +280,7 @@ describe "Services API" do
                                                      {"href" => api_service_url(nil, svc2)}]))
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results",
-                                               [api_service_url(nil, svc1.compressed_id), api_service_url(nil, svc2.compressed_id)])
+                                               [api_service_url(nil, svc1), api_service_url(nil, svc2)])
       expect { svc1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { svc2.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
@@ -314,7 +314,7 @@ describe "Services API" do
 
       post(api_service_url(nil, svc), :params => gen_request(:retire))
 
-      expect_single_resource_query("id" => svc.compressed_id, "href" => api_service_url(nil, svc.compressed_id))
+      expect_single_resource_query("id" => svc.id.to_s, "href" => api_service_url(nil, svc))
     end
 
     it "supports single service retirement in future" do
@@ -324,7 +324,7 @@ describe "Services API" do
 
       post(api_service_url(nil, svc), :params => gen_request(:retire, "date" => ret_date, "warn" => 2))
 
-      expect_single_resource_query("id" => svc.compressed_id, "retires_on" => ret_date, "retirement_warn" => 2)
+      expect_single_resource_query("id" => svc.id.to_s, "retires_on" => ret_date, "retirement_warn" => 2)
       expect(format_retirement_date(svc.reload.retires_on)).to eq(ret_date)
       expect(svc.retirement_warn).to eq(2)
     end
@@ -338,7 +338,7 @@ describe "Services API" do
                                                     [{"href" => api_service_url(nil, svc1)},
                                                      {"href" => api_service_url(nil, svc2)}]))
 
-      expect_results_to_match_hash("results", [{"id" => svc1.compressed_id}, {"id" => svc2.compressed_id}])
+      expect_results_to_match_hash("results", [{"id" => svc1.id.to_s}, {"id" => svc2.id.to_s}])
     end
 
     it "supports multiple service retirement in future" do
@@ -351,8 +351,8 @@ describe "Services API" do
                                                      {"href" => api_service_url(nil, svc2), "date" => ret_date, "warn" => 5}]))
 
       expect_results_to_match_hash("results",
-                                   [{"id" => svc1.compressed_id, "retires_on" => ret_date, "retirement_warn" => 3},
-                                    {"id" => svc2.compressed_id, "retires_on" => ret_date, "retirement_warn" => 5}])
+                                   [{"id" => svc1.id.to_s, "retires_on" => ret_date, "retirement_warn" => 3},
+                                    {"id" => svc2.id.to_s, "retires_on" => ret_date, "retirement_warn" => 5}])
       expect(format_retirement_date(svc1.reload.retires_on)).to eq(ret_date)
       expect(svc1.retirement_warn).to eq(3)
       expect(format_retirement_date(svc2.reload.retires_on)).to eq(ret_date)
@@ -412,7 +412,7 @@ describe "Services API" do
 
       post(api_service_url(nil, svc1), :params => gen_request(:reconfigure, "text1" => "updated_text"))
 
-      expect_single_action_result(:success => true, :message => /reconfiguring/i, :href => api_service_url(nil, svc1.compressed_id))
+      expect_single_action_result(:success => true, :message => /reconfiguring/i, :href => api_service_url(nil, svc1))
     end
   end
 
@@ -432,9 +432,9 @@ describe "Services API" do
     end
 
     def expect_svc_with_vms
-      expect_single_resource_query("href" => api_service_url(nil, svc1.compressed_id))
+      expect_single_resource_query("href" => api_service_url(nil, svc1))
       expect_result_resources_to_include_hrefs("vms",
-                                               [api_service_vm_url(nil, svc1.compressed_id, vm1.compressed_id), api_service_vm_url(nil, svc1.compressed_id, vm2.compressed_id)])
+                                               [api_service_vm_url(nil, svc1, vm1), api_service_vm_url(nil, svc1, vm2)])
     end
 
     it "can query vms as subcollection" do
@@ -442,8 +442,8 @@ describe "Services API" do
 
       expect_query_result(:vms, 2, 2)
       expect_result_resources_to_include_hrefs("resources",
-                                               [api_service_vm_url(nil, svc1.compressed_id, vm1.compressed_id),
-                                                api_service_vm_url(nil, svc1.compressed_id, vm2.compressed_id)])
+                                               [api_service_vm_url(nil, svc1, vm1),
+                                                api_service_vm_url(nil, svc1, vm2)])
     end
 
     it "supports expansion of virtual attributes" do
@@ -468,16 +468,16 @@ describe "Services API" do
       get api_service_url(nil, svc1), :params => { :expand => "vms", :attributes => "vms.cpu_total_cores" }
 
       expect_svc_with_vms
-      expect_results_to_match_hash("vms", [{"id" => vm1.compressed_id, "cpu_total_cores" => 2},
-                                           {"id" => vm2.compressed_id, "cpu_total_cores" => 4}])
+      expect_results_to_match_hash("vms", [{"id" => vm1.id.to_s, "cpu_total_cores" => 2},
+                                           {"id" => vm2.id.to_s, "cpu_total_cores" => 4}])
     end
 
     it "can query vms as subcollection via decorators with additional decorators" do
       get api_service_url(nil, svc1), :params => { :expand => "vms", :attributes => "", :decorators => "vms.supports_console?" }
 
       expect_svc_with_vms
-      expect_results_to_match_hash("vms", [{"id" => vm1.compressed_id, "supports_console?" => true},
-                                           {"id" => vm2.compressed_id, "supports_console?" => true}])
+      expect_results_to_match_hash("vms", [{"id" => vm1.id.to_s, "supports_console?" => true},
+                                           {"id" => vm2.id.to_s, "supports_console?" => true}])
     end
 
     it "cannot query vms via both virtual attribute and subcollection" do
@@ -496,7 +496,7 @@ describe "Services API" do
         post(api_service_url(nil, service), :params => { :action => "start" })
 
         expected = {
-          "href"    => api_service_url(nil, service.compressed_id),
+          "href"    => api_service_url(nil, service),
           "success" => true,
           "message" => a_string_matching("starting")
         }
@@ -516,12 +516,12 @@ describe "Services API" do
                              "message"   => a_string_matching("starting"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => api_service_url(nil, service_1.compressed_id)),
+                             "href"      => api_service_url(nil, service_1)),
             a_hash_including("success"   => true,
                              "message"   => a_string_matching("starting"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => api_service_url(nil, service_2.compressed_id)),
+                             "href"      => api_service_url(nil, service_2)),
           )
         }
         expect(response.parsed_body).to include(expected)
@@ -546,7 +546,7 @@ describe "Services API" do
         post(api_service_url(nil, service), :params => { :action => "stop" })
 
         expected = {
-          "href"    => api_service_url(nil, service.compressed_id),
+          "href"    => api_service_url(nil, service),
           "success" => true,
           "message" => a_string_matching("stopping")
         }
@@ -566,12 +566,12 @@ describe "Services API" do
                              "message"   => a_string_matching("stopping"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => api_service_url(nil, service_1.compressed_id)),
+                             "href"      => api_service_url(nil, service_1)),
             a_hash_including("success"   => true,
                              "message"   => a_string_matching("stopping"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => api_service_url(nil, service_2.compressed_id)),
+                             "href"      => api_service_url(nil, service_2)),
           )
         }
         expect(response.parsed_body).to include(expected)
@@ -596,7 +596,7 @@ describe "Services API" do
         post(api_service_url(nil, service), :params => { :action => "suspend" })
 
         expected = {
-          "href"    => api_service_url(nil, service.compressed_id),
+          "href"    => api_service_url(nil, service),
           "success" => true,
           "message" => a_string_matching("suspending")
         }
@@ -616,12 +616,12 @@ describe "Services API" do
                              "message"   => a_string_matching("suspending"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => api_service_url(nil, service_1.compressed_id)),
+                             "href"      => api_service_url(nil, service_1)),
             a_hash_including("success"   => true,
                              "message"   => a_string_matching("suspending"),
                              "task_id"   => anything,
                              "task_href" => anything,
-                             "href"      => api_service_url(nil, service_2.compressed_id)),
+                             "href"      => api_service_url(nil, service_2)),
           )
         }
         expect(response.parsed_body).to include(expected)
@@ -653,7 +653,7 @@ describe "Services API" do
 
       expected = {
         'resources' => [
-          a_hash_including('id' => os.compressed_id)
+          a_hash_including('id' => os.id.to_s)
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -665,7 +665,7 @@ describe "Services API" do
 
       get(api_service_orchestration_stack_url(nil, svc, os))
 
-      expected = {'id' => os.compressed_id}
+      expected = {'id' => os.id.to_s}
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
     end
@@ -677,7 +677,7 @@ describe "Services API" do
       get(api_service_orchestration_stack_url(nil, svc, os), :params => { :attributes => "stdout" })
 
       expected = {
-        'id'     => os.compressed_id,
+        'id'     => os.id.to_s,
         'stdout' => "default text stdout"
       }
       expect(response).to have_http_status(:ok)
@@ -691,7 +691,7 @@ describe "Services API" do
       get(api_service_orchestration_stack_url(nil, svc, os), :params => { :attributes => "stdout", :format_attributes => "stdout=json" })
 
       expected = {
-        'id'     => os.compressed_id,
+        'id'     => os.id.to_s,
         'stdout' => "json stdout"
       }
       expect(response).to have_http_status(:ok)
@@ -716,7 +716,7 @@ describe "Services API" do
       request = {
         'action'    => 'add_resource',
         'resources' => [
-          { 'href' => api_service_url(nil, svc.compressed_id), 'resource' => {'href' => api_vm_url(nil, vm1)} },
+          { 'href' => api_service_url(nil, svc), 'resource' => {'href' => api_vm_url(nil, vm1)} },
           { 'href' => api_service_url(nil, svc1), 'resource' => {'href' => api_vm_url(nil, vm2)} }
         ]
       }
@@ -742,8 +742,8 @@ describe "Services API" do
       request = {
         'action'    => 'add_resource',
         'resources' => [
-          { 'href' => api_service_url(nil, svc.compressed_id), 'resource' => {'href' => api_vm_url(nil, vm1)} },
-          { 'href' => api_service_url(nil, svc1), 'resource' => {'href' => api_user_url(nil, user.compressed_id)} }
+          { 'href' => api_service_url(nil, svc), 'resource' => {'href' => api_vm_url(nil, vm1)} },
+          { 'href' => api_service_url(nil, svc1), 'resource' => {'href' => api_user_url(nil, user)} }
         ]
       }
 
@@ -781,7 +781,7 @@ describe "Services API" do
       api_basic_authorize(collection_action_identifier(:services, :add_resource))
       request = {
         'action'   => 'add_resource',
-        'resource' => { 'resource' => { 'href' => api_user_url(nil, user.compressed_id) } }
+        'resource' => { 'resource' => { 'href' => api_user_url(nil, user) } }
       }
 
       post(api_service_url(nil, svc), :params => request)
@@ -854,7 +854,7 @@ describe "Services API" do
       request = {
         'action'    => 'remove_resource',
         'resources' => [
-          { 'href' => api_service_url(nil, svc.compressed_id), 'resource' => { 'href' => api_vm_url(nil, vm1)} },
+          { 'href' => api_service_url(nil, svc), 'resource' => { 'href' => api_vm_url(nil, vm1)} },
           { 'href' => api_service_url(nil, svc1), 'resource' => { 'href' => api_vm_url(nil, vm2)} }
         ]
       }
@@ -898,7 +898,7 @@ describe "Services API" do
       request = {
         'action'    => 'remove_resource',
         'resources' => [
-          { 'href' => api_service_url(nil, svc.compressed_id), 'resource' => {} }
+          { 'href' => api_service_url(nil, svc), 'resource' => {} }
         ]
       }
 
@@ -964,7 +964,7 @@ describe "Services API" do
       request = {
         'action'    => 'remove_all_resources',
         'resources' => [
-          { 'href' => api_service_url(nil, svc.compressed_id) },
+          { 'href' => api_service_url(nil, svc) },
           { 'href' => api_service_url(nil, svc1) }
         ]
       }

--- a/spec/requests/set_ownership_spec.rb
+++ b/spec/requests/set_ownership_spec.rb
@@ -45,7 +45,7 @@ describe "Set Ownership" do
 
       post(api_service_url(nil, svc), :params => gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
-      expect_single_action_result(:success => false, :message => /.*/, :href => api_service_url(nil, svc.compressed_id))
+      expect_single_action_result(:success => false, :message => /.*/, :href => api_service_url(nil, svc))
     end
 
     it "to a service" do
@@ -53,7 +53,7 @@ describe "Set Ownership" do
 
       post(api_service_url(nil, svc), :params => gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc), @user)
     end
 
     it "by owner name to a service" do
@@ -61,7 +61,7 @@ describe "Set Ownership" do
 
       post(api_service_url(nil, svc), :params => gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
-      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc), @user)
     end
 
     it "by owner href to a service" do
@@ -69,7 +69,7 @@ describe "Set Ownership" do
 
       post(api_service_url(nil, svc), :params => gen_request(:set_ownership, "owner" => {"href" => api_user_url(nil, @user)}))
 
-      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc), @user)
     end
 
     it "by owner id to a service" do
@@ -77,7 +77,7 @@ describe "Set Ownership" do
 
       post(api_service_url(nil, svc), :params => gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
-      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc), @user)
     end
 
     it "by group id to a service" do
@@ -85,7 +85,7 @@ describe "Set Ownership" do
 
       post(api_service_url(nil, svc), :params => gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
-      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), nil, @group)
+      expect_set_ownership_success(svc, api_service_url(nil, svc), nil, @group)
     end
 
     it "by group description to a service" do
@@ -93,7 +93,7 @@ describe "Set Ownership" do
 
       post(api_service_url(nil, svc), :params => gen_request(:set_ownership, "group" => {"description" => @group.description}))
 
-      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), nil, @group)
+      expect_set_ownership_success(svc, api_service_url(nil, svc), nil, @group)
     end
 
     it "with owner and group to a service" do
@@ -101,7 +101,7 @@ describe "Set Ownership" do
 
       post(api_service_url(nil, svc), :params => gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(svc, api_service_url(nil, svc.compressed_id), @user)
+      expect_set_ownership_success(svc, api_service_url(nil, svc), @user)
     end
 
     it "to multiple services" do
@@ -114,7 +114,7 @@ describe "Set Ownership" do
       post(api_services_url, :params => gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *svc_urls))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [api_service_url(nil, svc1.compressed_id), api_service_url(nil, svc2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_service_url(nil, svc1), api_service_url(nil, svc2)])
       expect(svc1.reload.evm_owner).to eq(@user)
       expect(svc2.reload.evm_owner).to eq(@user)
     end
@@ -152,7 +152,7 @@ describe "Set Ownership" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
-      expect_single_action_result(:success => false, :message => /.*/, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => false, :message => /.*/, :href => api_vm_url(nil, vm))
     end
 
     it "to a vm" do
@@ -160,7 +160,7 @@ describe "Set Ownership" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm), @user)
     end
 
     it "by owner name to a vm" do
@@ -168,7 +168,7 @@ describe "Set Ownership" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
-      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm), @user)
     end
 
     it "by owner href to a vm" do
@@ -176,7 +176,7 @@ describe "Set Ownership" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:set_ownership, "owner" => {"href" => api_user_url(nil, @user)}))
 
-      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm), @user)
     end
 
     it "by owner id to a vm" do
@@ -184,7 +184,7 @@ describe "Set Ownership" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
-      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm), @user)
     end
 
     it "by group id to a vm" do
@@ -192,7 +192,7 @@ describe "Set Ownership" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
-      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), nil, @group)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm), nil, @group)
     end
 
     it "by group description to a vm" do
@@ -200,7 +200,7 @@ describe "Set Ownership" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:set_ownership, "group" => {"description" => @group.description}))
 
-      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), nil, @group)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm), nil, @group)
     end
 
     it "with owner and group to a vm" do
@@ -208,7 +208,7 @@ describe "Set Ownership" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(vm, api_vm_url(nil, vm.compressed_id), @user)
+      expect_set_ownership_success(vm, api_vm_url(nil, vm), @user)
     end
 
     it "to multiple vms" do
@@ -221,7 +221,7 @@ describe "Set Ownership" do
       post(api_vms_url, :params => gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *vm_urls))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1.compressed_id), api_vm_url(nil, vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
       expect(vm1.reload.evm_owner).to eq(@user)
       expect(vm2.reload.evm_owner).to eq(@user)
     end
@@ -259,7 +259,7 @@ describe "Set Ownership" do
 
       post(api_template_url(nil, template), :params => gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
-      expect_single_action_result(:success => false, :message => /.*/, :href => api_template_url(nil, template.compressed_id))
+      expect_single_action_result(:success => false, :message => /.*/, :href => api_template_url(nil, template))
     end
 
     it "to a template" do
@@ -267,7 +267,7 @@ describe "Set Ownership" do
 
       post(api_template_url(nil, template), :params => gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template), @user)
     end
 
     it "by owner name to a template" do
@@ -275,7 +275,7 @@ describe "Set Ownership" do
 
       post(api_template_url(nil, template), :params => gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
-      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template), @user)
     end
 
     it "by owner href to a template" do
@@ -283,7 +283,7 @@ describe "Set Ownership" do
 
       post(api_template_url(nil, template), :params => gen_request(:set_ownership, "owner" => {"href" => api_user_url(nil, @user)}))
 
-      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template), @user)
     end
 
     it "by owner id to a template" do
@@ -291,7 +291,7 @@ describe "Set Ownership" do
 
       post(api_template_url(nil, template), :params => gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
-      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template), @user)
     end
 
     it "by group id to a template" do
@@ -299,7 +299,7 @@ describe "Set Ownership" do
 
       post(api_template_url(nil, template), :params => gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
-      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), nil, @group)
+      expect_set_ownership_success(template, api_template_url(nil, template), nil, @group)
     end
 
     it "by group description to a template" do
@@ -308,7 +308,7 @@ describe "Set Ownership" do
       post(api_template_url(nil, template),
            :params => gen_request(:set_ownership, "group" => {"description" => @group.description}))
 
-      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), nil, @group)
+      expect_set_ownership_success(template, api_template_url(nil, template), nil, @group)
     end
 
     it "with owner and group to a template" do
@@ -316,7 +316,7 @@ describe "Set Ownership" do
 
       post(api_template_url(nil, template), :params => gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
-      expect_set_ownership_success(template, api_template_url(nil, template.compressed_id), @user)
+      expect_set_ownership_success(template, api_template_url(nil, template), @user)
     end
 
     it "to multiple templates" do
@@ -329,7 +329,7 @@ describe "Set Ownership" do
       post(api_templates_url, :params => gen_request(:set_ownership, {"owner" => {"userid" => api_config(:user)}}, *template_urls))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [api_template_url(nil, template1.compressed_id), api_template_url(nil, template2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_template_url(nil, template1), api_template_url(nil, template2)])
       expect(template1.reload.evm_owner).to eq(@user)
       expect(template2.reload.evm_owner).to eq(@user)
     end

--- a/spec/requests/snapshots_spec.rb
+++ b/spec/requests/snapshots_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Snapshots API" do
           "name"      => "snapshots",
           "subcount"  => 1,
           "resources" => [
-            {"href" => api_vm_snapshot_url(nil, vm.compressed_id, snapshot.compressed_id)}
+            {"href" => api_vm_snapshot_url(nil, vm, snapshot)}
           ]
         }
         expect(response.parsed_body).to include(expected)
@@ -43,9 +43,9 @@ RSpec.describe "Snapshots API" do
 
         expected = {
           "create_time"       => create_time.iso8601,
-          "href"              => api_vm_snapshot_url(nil, vm.compressed_id, snapshot.compressed_id),
-          "id"                => snapshot.compressed_id,
-          "vm_or_template_id" => vm.compressed_id
+          "href"              => api_vm_snapshot_url(nil, vm, snapshot),
+          "id"                => snapshot.id.to_s,
+          "vm_or_template_id" => vm.id.to_s
         }
         expect(response.parsed_body).to include(expected)
         expect(response).to have_http_status(:ok)
@@ -361,7 +361,7 @@ RSpec.describe "Snapshots API" do
           "name"      => "snapshots",
           "subcount"  => 1,
           "resources" => [
-            {"href" => api_instance_snapshot_url(nil, instance.compressed_id, snapshot.compressed_id)}
+            {"href" => api_instance_snapshot_url(nil, instance, snapshot)}
           ]
         }
         expect(response.parsed_body).to include(expected)
@@ -390,9 +390,9 @@ RSpec.describe "Snapshots API" do
 
         expected = {
           "create_time"       => create_time.iso8601,
-          "href"              => api_instance_snapshot_url(nil, instance.compressed_id, snapshot.compressed_id),
-          "id"                => snapshot.compressed_id,
-          "vm_or_template_id" => instance.compressed_id
+          "href"              => api_instance_snapshot_url(nil, instance, snapshot),
+          "id"                => snapshot.id.to_s,
+          "vm_or_template_id" => instance.id.to_s
         }
         expect(response.parsed_body).to include(expected)
         expect(response).to have_http_status(:ok)

--- a/spec/requests/tag_collections_spec.rb
+++ b/spec/requests/tag_collections_spec.rb
@@ -56,7 +56,7 @@ describe "Tag Collections API" do
 
       post(api_provider_tags_url(nil, provider), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_provider_url(nil, provider.compressed_id)))
+      expect_tagging_result(tag1_results(api_provider_url(nil, provider)))
     end
 
     it "does not unassign a tag from a Provider without appropriate role" do
@@ -73,7 +73,7 @@ describe "Tag Collections API" do
 
       post(api_provider_tags_url(nil, provider), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_provider_url(nil, provider.compressed_id)))
+      expect_tagging_result(tag1_results(api_provider_url(nil, provider)))
       expect_resource_has_tags(provider, tag2[:path])
     end
   end
@@ -102,7 +102,7 @@ describe "Tag Collections API" do
 
       post(api_host_tags_url(nil, host), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_host_url(nil, host.compressed_id)))
+      expect_tagging_result(tag1_results(api_host_url(nil, host)))
     end
 
     it "does not unassign a tag from a Host without appropriate role" do
@@ -119,7 +119,7 @@ describe "Tag Collections API" do
 
       post(api_host_tags_url(nil, host), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_host_url(nil, host.compressed_id)))
+      expect_tagging_result(tag1_results(api_host_url(nil, host)))
       expect_resource_has_tags(host, tag2[:path])
     end
   end
@@ -150,7 +150,7 @@ describe "Tag Collections API" do
 
       post(api_data_store_tags_url(nil, ds), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_data_store_url(nil, ds.compressed_id)))
+      expect_tagging_result(tag1_results(api_data_store_url(nil, ds)))
     end
 
     it "does not unassign a tag from a Data Store without appropriate role" do
@@ -167,7 +167,7 @@ describe "Tag Collections API" do
 
       post(api_data_store_tags_url(nil, ds), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_data_store_url(nil, ds.compressed_id)))
+      expect_tagging_result(tag1_results(api_data_store_url(nil, ds)))
       expect_resource_has_tags(ds, tag2[:path])
     end
   end
@@ -198,7 +198,7 @@ describe "Tag Collections API" do
 
       post(api_resource_pool_tags_url(nil, rp), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_resource_pool_url(nil, rp.compressed_id)))
+      expect_tagging_result(tag1_results(api_resource_pool_url(nil, rp)))
     end
 
     it "does not unassign a tag from a Resource Pool without appropriate role" do
@@ -215,7 +215,7 @@ describe "Tag Collections API" do
 
       post(api_resource_pool_tags_url(nil, rp), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_resource_pool_url(nil, rp.compressed_id)))
+      expect_tagging_result(tag1_results(api_resource_pool_url(nil, rp)))
       expect_resource_has_tags(rp, tag2[:path])
     end
   end
@@ -252,7 +252,7 @@ describe "Tag Collections API" do
 
       post(api_cluster_tags_url(nil, cluster), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_cluster_url(nil, cluster.compressed_id)))
+      expect_tagging_result(tag1_results(api_cluster_url(nil, cluster)))
     end
 
     it "does not unassign a tag from a Cluster without appropriate role" do
@@ -269,7 +269,7 @@ describe "Tag Collections API" do
 
       post(api_cluster_tags_url(nil, cluster), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_cluster_url(nil, cluster.compressed_id)))
+      expect_tagging_result(tag1_results(api_cluster_url(nil, cluster)))
       expect_resource_has_tags(cluster, tag2[:path])
     end
   end
@@ -300,7 +300,7 @@ describe "Tag Collections API" do
 
       post(api_service_tags_url(nil, service), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_service_url(nil, service.compressed_id)))
+      expect_tagging_result(tag1_results(api_service_url(nil, service)))
     end
 
     it "does not unassign a tag from a Service without appropriate role" do
@@ -317,7 +317,7 @@ describe "Tag Collections API" do
 
       post(api_service_tags_url(nil, service), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_service_url(nil, service.compressed_id)))
+      expect_tagging_result(tag1_results(api_service_url(nil, service)))
       expect_resource_has_tags(service, tag2[:path])
     end
   end
@@ -348,7 +348,7 @@ describe "Tag Collections API" do
 
       post(api_service_template_tags_url(nil, service_template), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_service_template_url(nil, service_template.compressed_id)))
+      expect_tagging_result(tag1_results(api_service_template_url(nil, service_template)))
     end
 
     it "does not unassign a tag from a Service Template without appropriate role" do
@@ -365,7 +365,7 @@ describe "Tag Collections API" do
 
       post(api_service_template_tags_url(nil, service_template), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_service_template_url(nil, service_template.compressed_id)))
+      expect_tagging_result(tag1_results(api_service_template_url(nil, service_template)))
       expect_resource_has_tags(service_template, tag2[:path])
     end
   end
@@ -396,7 +396,7 @@ describe "Tag Collections API" do
 
       post(api_tenant_tags_url(nil, tenant), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_tenant_url(nil, tenant.compressed_id)))
+      expect_tagging_result(tag1_results(api_tenant_url(nil, tenant)))
     end
 
     it "does not unassign a tag from a Tenant without appropriate role" do
@@ -413,7 +413,7 @@ describe "Tag Collections API" do
 
       post(api_tenant_tags_url(nil, tenant), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
-      expect_tagging_result(tag1_results(api_tenant_url(nil, tenant.compressed_id)))
+      expect_tagging_result(tag1_results(api_tenant_url(nil, tenant)))
       expect_resource_has_tags(tenant, tag2[:path])
     end
   end
@@ -541,11 +541,11 @@ describe "Tag Collections API" do
       expected = {
         'results' => [
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_vm_url(nil, vm1.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm1)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_vm_url(nil, vm2.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm2)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -573,11 +573,11 @@ describe "Tag Collections API" do
         'results' => [
           a_hash_including('success' => false, 'message' => a_string_including("Couldn't find Vm")),
           a_hash_including('success'      => false,
-                           'href'         => a_string_including(api_vm_url(nil, vm2.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm2)),
                            'tag_category' => bad_tag[:category],
                            'tag_name'     => bad_tag[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_vm_url(nil, vm2.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm2)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name])
         ]
@@ -609,11 +609,11 @@ describe "Tag Collections API" do
       expected = {
         'results' => [
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_vm_url(nil, vm1.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm1)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_vm_url(nil, vm2.compressed_id)),
+                           'href'         => a_string_including(api_vm_url(nil, vm2)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -822,11 +822,11 @@ describe "Tag Collections API" do
       expected = {
         'results' => [
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_service_url(nil, service1.compressed_id)),
+                           'href'         => a_string_including(api_service_url(nil, service1)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_service_url(nil, service2.compressed_id)),
+                           'href'         => a_string_including(api_service_url(nil, service2)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -850,11 +850,11 @@ describe "Tag Collections API" do
       expected = {
         'results' => [
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_service_url(nil, service1.compressed_id)),
+                           'href'         => a_string_including(api_service_url(nil, service1)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
-                           'href'         => a_string_including(api_service_url(nil, service2.compressed_id)),
+                           'href'         => a_string_including(api_service_url(nil, service2)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -29,10 +29,10 @@ describe "Tags API" do
         expect { post api_tags_url, :params => options }.to change(Tag, :count).by(1)
 
         result = response.parsed_body["results"].first
-        tag = Tag.find(ApplicationRecord.uncompress_id(result["id"]))
+        tag = Tag.find(result["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
-        expect(result["href"]).to include(api_tag_url(nil, tag.compressed_id))
+        expect(result["href"]).to include(api_tag_url(nil, tag))
         expect(response).to have_http_status(:ok)
       end
 
@@ -44,7 +44,7 @@ describe "Tags API" do
           post api_tags_url, :params => { :name => "test_tag", :description => "Test Tag", :category => {:id => category.id} }
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
+        tag = Tag.find(response.parsed_body["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -59,7 +59,7 @@ describe "Tags API" do
           post api_tags_url, :params => { :name => "test_tag", :description => "Test Tag", :category => {:name => category.name} }
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
+        tag = Tag.find(response.parsed_body["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -73,7 +73,7 @@ describe "Tags API" do
         expect do
           post(api_category_tags_url(nil, category), :params => { :name => "test_tag", :description => "Test Tag" })
         end.to change(Tag, :count).by(1)
-        tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
+        tag = Tag.find(response.parsed_body["results"].first["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -165,7 +165,7 @@ describe "Tags API" do
         tag2 = classification2.tag
 
         expect do
-          post(api_category_tags_url(nil, category.id), :params => gen_request(:delete, [{:id => tag1.id}, {:id => tag2.id}]))
+          post(api_category_tags_url(nil, category), :params => gen_request(:delete, [{:id => tag1.id}, {:id => tag2.id}]))
         end.to change(Tag, :count).by(-2)
         expect { classification1.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { classification2.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -270,8 +270,8 @@ describe "Tags API" do
       get api_tag_url(nil, tag), :params => { :attributes => attr_list }
 
       expect_single_resource_query(
-        "href"           => api_tag_url(nil, tag.compressed_id),
-        "id"             => tag.compressed_id,
+        "href"           => api_tag_url(nil, tag),
+        "id"             => tag.id.to_s,
         "name"           => tag.name,
         "category"       => {"name" => tag.category.name,       "description" => tag.category.description},
         "classification" => {"name" => tag.classification.name, "description" => tag.classification.description}
@@ -285,8 +285,8 @@ describe "Tags API" do
       get api_tag_url(nil, tag), :params => { :attributes => "categorization" }
 
       expect_single_resource_query(
-        "href"           => api_tag_url(nil, tag.compressed_id),
-        "id"             => tag.compressed_id,
+        "href"           => api_tag_url(nil, tag),
+        "id"             => tag.id.to_s,
         "name"           => tag.name,
         "categorization" => {
           "name"         => tag.classification.name,

--- a/spec/requests/templates_spec.rb
+++ b/spec/requests/templates_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Templates API" do
       end.to change(MiqTemplate, :count).by(-1)
 
       expected = {
-        "href"    => api_template_url(nil, template.compressed_id),
+        "href"    => api_template_url(nil, template),
         "message" => "templates id: #{template.id} deleting",
         "success" => true
       }

--- a/spec/requests/tenant_quotas_spec.rb
+++ b/spec/requests/tenant_quotas_spec.rb
@@ -13,8 +13,8 @@ describe "tenant quotas API" do
       expect_result_resources_to_include_hrefs(
         "resources",
         [
-          "/api/tenants/#{tenant.compressed_id}/quotas/#{quota_1.compressed_id}",
-          "/api/tenants/#{tenant.compressed_id}/quotas/#{quota_2.compressed_id}",
+          api_tenant_quota_url(nil, tenant, quota_1),
+          api_tenant_quota_url(nil, tenant, quota_2)
         ]
       )
 
@@ -30,9 +30,9 @@ describe "tenant quotas API" do
 
       expect_result_to_match_hash(
         response.parsed_body,
-        "href"      => "/api/tenants/#{tenant.compressed_id}/quotas/#{quota.compressed_id}",
-        "id"        => quota.compressed_id,
-        "tenant_id" => tenant.compressed_id,
+        "href"      => api_tenant_quota_url(nil, tenant, quota),
+        "id"        => quota.id.to_s,
+        "tenant_id" => tenant.id.to_s,
         "name"      => "cpu_allocated",
         "unit"      => "fixnum",
         "value"     => 1.0
@@ -45,7 +45,7 @@ describe "tenant quotas API" do
 
       expected = {
         'results' => [
-          a_hash_including('href' => a_string_including(api_tenant_quotas_url(nil, tenant.compressed_id)))
+          a_hash_including('href' => a_string_including(api_tenant_quotas_url(nil, tenant)))
         ]
       }
       expect do
@@ -81,7 +81,7 @@ describe "tenant quotas API" do
       expect(response).to have_http_status(:ok)
       quota.reload
       expect(quota.value).to eq(5)
-      expect(response.parsed_body).to include('href' => a_string_including("tenants/#{tenant.compressed_id}/quotas/#{quota.compressed_id}"))
+      expect(response.parsed_body).to include('href' => api_tenant_quota_url(nil, tenant, quota))
     end
 
     it "can update multiple quotas from a tenant with POST" do
@@ -100,8 +100,8 @@ describe "tenant quotas API" do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash(
         "results",
-        [{"id" => quota_1.compressed_id, "value" => 3},
-         {"id" => quota_2.compressed_id, "value" => 4}]
+        [{"id" => quota_1.id.to_s, "value" => 3},
+         {"id" => quota_2.id.to_s, "value" => 4}]
       )
       expect(quota_1.reload.value).to eq(3)
       expect(quota_2.reload.value).to eq(4)

--- a/spec/requests/tenants_spec.rb
+++ b/spec/requests/tenants_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe "tenants API" do
     expect_result_resources_to_include_hrefs(
       "resources",
       [
-        api_tenant_url(nil, root_tenant.compressed_id),
-        api_tenant_url(nil, tenant_1.compressed_id),
-        api_tenant_url(nil, tenant_2.compressed_id)
+        api_tenant_url(nil, root_tenant),
+        api_tenant_url(nil, tenant_1),
+        api_tenant_url(nil, tenant_2)
       ]
     )
 
@@ -33,8 +33,8 @@ RSpec.describe "tenants API" do
 
     expect_result_to_match_hash(
       response.parsed_body,
-      "href"        => api_tenant_url(nil, tenant.compressed_id),
-      "id"          => tenant.compressed_id,
+      "href"        => api_tenant_url(nil, tenant),
+      "id"          => tenant.id.to_s,
       "name"        => "Test Tenant",
       "description" => "Tenant for this test"
     )
@@ -111,8 +111,8 @@ RSpec.describe "tenants API" do
         get api_tenant_url(nil, root_tenant)
 
         expect_result_to_match_hash(response.parsed_body,
-                                    "href" => api_tenant_url(nil, root_tenant.compressed_id),
-                                    "id"   => root_tenant.compressed_id,
+                                    "href" => api_tenant_url(nil, root_tenant),
+                                    "id"   => root_tenant.id.to_s,
                                     "name" => ::Settings.server.company,
                                    )
         expect(response).to have_http_status(:ok)
@@ -141,8 +141,8 @@ RSpec.describe "tenants API" do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash(
         "results",
-        [{"id" => tenant_1.compressed_id, "name" => "Updated Test Tenant 1"},
-         {"id" => tenant_2.compressed_id, "name" => "Updated Test Tenant 2"}]
+        [{"id" => tenant_1.id.to_s, "name" => "Updated Test Tenant 1"},
+         {"id" => tenant_2.id.to_s, "name" => "Updated Test Tenant 2"}]
       )
       expect(tenant_1.reload.name).to eq("Updated Test Tenant 1")
       expect(tenant_2.reload.name).to eq("Updated Test Tenant 2")

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -47,7 +47,7 @@ describe "Vms API" do
     it 'can edit a VM with an appropriate role' do
       api_basic_authorize collection_action_identifier(:vms, :edit)
       children = new_vms.collect do |vm|
-        { 'href' => api_vm_url(nil, vm.compressed_id) }
+        { 'href' => api_vm_url(nil, vm) }
       end
 
       post(
@@ -143,8 +143,8 @@ describe "Vms API" do
 
       expect_query_result(:accounts, 2)
       expect_result_resources_to_include_hrefs("resources",
-                                               [api_vm_account_url(nil, vm.compressed_id, acct1.compressed_id),
-                                                api_vm_account_url(nil, vm.compressed_id, acct2.compressed_id)])
+                                               [api_vm_account_url(nil, vm, acct1),
+                                                api_vm_account_url(nil, vm, acct2)])
     end
 
     it "query VM accounts subcollection with a valid Account Id" do
@@ -173,8 +173,8 @@ describe "Vms API" do
 
       expect_single_resource_query("guid" => vm_guid)
       expect_result_resources_to_include_hrefs("accounts",
-                                               [api_vm_account_url(nil, vm.compressed_id, acct1.compressed_id),
-                                                api_vm_account_url(nil, vm.compressed_id, acct2.compressed_id)])
+                                               [api_vm_account_url(nil, vm, acct1),
+                                                api_vm_account_url(nil, vm, acct2)])
     end
   end
 
@@ -202,8 +202,8 @@ describe "Vms API" do
 
       expect_query_result(:software, 2)
       expect_result_resources_to_include_hrefs("resources",
-                                               [api_vm_software_url(nil, vm.compressed_id, sw1.compressed_id),
-                                                api_vm_software_url(nil, vm.compressed_id, sw2.compressed_id)])
+                                               [api_vm_software_url(nil, vm, sw1),
+                                                api_vm_software_url(nil, vm, sw2)])
     end
 
     it "query VM software subcollection with a valid Software Id" do
@@ -232,8 +232,8 @@ describe "Vms API" do
 
       expect_single_resource_query("guid" => vm_guid)
       expect_result_resources_to_include_hrefs("software",
-                                               [api_vm_software_url(nil, vm.compressed_id, sw1.compressed_id),
-                                                api_vm_software_url(nil, vm.compressed_id, sw2.compressed_id)])
+                                               [api_vm_software_url(nil, vm, sw1),
+                                                api_vm_software_url(nil, vm, sw2)])
     end
   end
 
@@ -259,7 +259,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => false, :message => "is powered on", :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => false, :message => "is powered on", :href => api_vm_url(nil, vm))
     end
 
     it "starts a vm" do
@@ -268,7 +268,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => api_vm_url(nil, vm.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "starting", :href => api_vm_url(nil, vm), :task => true)
     end
 
     it "starting a vm queues it properly" do
@@ -277,7 +277,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => api_vm_url(nil, vm.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "starting", :href => api_vm_url(nil, vm), :task => true)
       expect(MiqQueue.where(:class_name  => vm.class.name,
                             :instance_id => vm.id,
                             :method_name => "start",
@@ -291,7 +291,7 @@ describe "Vms API" do
       post(api_vms_url, :params => gen_request(:start, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1.compressed_id), api_vm_url(nil, vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -318,7 +318,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:stop))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm))
     end
 
     it "stops a vm" do
@@ -326,7 +326,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:stop))
 
-      expect_single_action_result(:success => true, :message => "stopping", :href => api_vm_url(nil, vm.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "stopping", :href => api_vm_url(nil, vm), :task => true)
     end
 
     it "stops multiple vms" do
@@ -335,7 +335,7 @@ describe "Vms API" do
       post(api_vms_url, :params => gen_request(:stop, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1.compressed_id), api_vm_url(nil, vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -362,7 +362,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm))
     end
 
     it "suspends a suspended vm" do
@@ -371,7 +371,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm))
     end
 
     it "suspends a vm" do
@@ -379,7 +379,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => true, :message => "suspending", :href => api_vm_url(nil, vm.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "suspending", :href => api_vm_url(nil, vm), :task => true)
     end
 
     it "suspends multiple vms" do
@@ -388,7 +388,7 @@ describe "Vms API" do
       post(api_vms_url, :params => gen_request(:suspend, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1.compressed_id), api_vm_url(nil, vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -415,7 +415,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm))
     end
 
     it "pauses a pauseed vm" do
@@ -424,7 +424,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm))
     end
 
     it "pauses a vm" do
@@ -432,7 +432,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => true, :message => "pausing", :href => api_vm_url(nil, vm.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "pausing", :href => api_vm_url(nil, vm), :task => true)
     end
 
     it "pauses multiple vms" do
@@ -441,7 +441,7 @@ describe "Vms API" do
       post(api_vms_url, :params => gen_request(:pause, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1.compressed_id), api_vm_url(nil, vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -468,7 +468,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack))
     end
 
     it "shelves a suspended vm" do
@@ -477,7 +477,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack))
     end
 
     it "shelves a paused off vm" do
@@ -486,7 +486,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack.compressed_id))
+      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack))
     end
 
     it "shelves a shelveed vm" do
@@ -497,7 +497,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused",
-                                  :href    => api_vm_url(nil, vm_openstack.compressed_id))
+                                  :href    => api_vm_url(nil, vm_openstack))
     end
 
     it "shelves a vm" do
@@ -505,7 +505,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => "shelving", :href => api_vm_url(nil, vm_openstack.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "shelving", :href => api_vm_url(nil, vm_openstack), :task => true)
     end
 
     it "shelve for a VMWare vm is not supported" do
@@ -515,7 +515,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "Shelve Operation is not available for Vmware VM.",
-                                  :href    => api_vm_url(nil, vm.compressed_id),
+                                  :href    => api_vm_url(nil, vm),
                                   :task    => false)
     end
 
@@ -525,7 +525,7 @@ describe "Vms API" do
       post(api_vms_url, :params => gen_request(:shelve, nil, vm_openstack1_url, vm_openstack2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm_openstack1.compressed_id), api_vm_url(nil, vm_openstack2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm_openstack1), api_vm_url(nil, vm_openstack2)])
     end
   end
 
@@ -553,7 +553,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack.compressed_id))
+                                  :href    => api_vm_url(nil, vm_openstack))
     end
 
     it "shelve_offloads a powered off vm" do
@@ -564,7 +564,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack.compressed_id))
+                                  :href    => api_vm_url(nil, vm_openstack))
     end
 
     it "shelve_offloads a suspended vm" do
@@ -575,7 +575,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack.compressed_id))
+                                  :href    => api_vm_url(nil, vm_openstack))
     end
 
     it "shelve_offloads a paused off vm" do
@@ -586,7 +586,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack.compressed_id))
+                                  :href    => api_vm_url(nil, vm_openstack))
     end
 
     it "shelve_offloads a shelve_offloaded vm" do
@@ -597,7 +597,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack.compressed_id))
+                                  :href    => api_vm_url(nil, vm_openstack))
     end
 
     it "shelve_offloads a shelved vm" do
@@ -608,7 +608,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => true,
                                   :message => "shelve-offloading",
-                                  :href    => api_vm_url(nil, vm_openstack.compressed_id))
+                                  :href    => api_vm_url(nil, vm_openstack))
     end
 
     it "shelve_offload for a VMWare vm is not supported" do
@@ -618,7 +618,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "Shelve Offload Operation is not available for Vmware VM.",
-                                  :href    => api_vm_url(nil, vm.compressed_id),
+                                  :href    => api_vm_url(nil, vm),
                                   :task    => false)
     end
 
@@ -631,7 +631,7 @@ describe "Vms API" do
       post(api_vms_url, :params => gen_request(:shelve_offload, nil, vm_openstack1_url, vm_openstack2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm_openstack1.compressed_id), api_vm_url(nil, vm_openstack2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm_openstack1), api_vm_url(nil, vm_openstack2)])
     end
   end
 
@@ -665,7 +665,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:delete))
 
-      expect_single_action_result(:success => true, :message => "deleting", :href => api_vm_url(nil, vm.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "deleting", :href => api_vm_url(nil, vm), :task => true)
     end
 
     it "deletes a vm via a resource DELETE" do
@@ -715,7 +715,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:set_owner, "owner" => "bad_user"))
 
-      expect_single_action_result(:success => false, :message => /.*/, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => false, :message => /.*/, :href => api_vm_url(nil, vm))
     end
 
     it "set_owner to a vm" do
@@ -723,7 +723,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:set_owner, "owner" => api_config(:user)))
 
-      expect_single_action_result(:success => true, :message => "setting owner", :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => "setting owner", :href => api_vm_url(nil, vm))
       expect(vm.reload.evm_owner).to eq(@user)
     end
 
@@ -733,7 +733,7 @@ describe "Vms API" do
       post(api_vms_url, :params => gen_request(:set_owner, {"owner" => api_config(:user)}, vm1_url, vm2_url))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1.compressed_id), api_vm_url(nil, vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
       expect(vm1.reload.evm_owner).to eq(@user)
       expect(vm2.reload.evm_owner).to eq(@user)
     end
@@ -761,8 +761,8 @@ describe "Vms API" do
 
       expect_query_result(:custom_attributes, 2)
       expect_result_resources_to_include_hrefs("resources",
-                                               [api_vm_custom_attributes_url(nil, vm.compressed_id, ca1.compressed_id),
-                                                api_vm_custom_attributes_url(nil, vm.compressed_id, ca2.compressed_id)])
+                                               [api_vm_custom_attributes_url(nil, vm, ca1),
+                                                api_vm_custom_attributes_url(nil, vm, ca2)])
     end
 
     it "getting custom_attributes from a vm in expanded form" do
@@ -887,7 +887,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:add_lifecycle_event, events[0]))
 
-      expect_single_action_result(:success => true, :message => /adding lifecycle event/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /adding lifecycle event/i, :href => api_vm_url(nil, vm))
       expect(vm.lifecycle_events.size).to eq(1)
       expect(vm.lifecycle_events.first.event).to eq(events[0][:event])
     end
@@ -926,7 +926,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:scan))
 
-      expect_single_action_result(:success => true, :message => "scanning", :href => api_vm_url(nil, vm.compressed_id), :task => true)
+      expect_single_action_result(:success => true, :message => "scanning", :href => api_vm_url(nil, vm), :task => true)
     end
 
     it "scan multiple Vms" do
@@ -935,7 +935,7 @@ describe "Vms API" do
       post(api_vms_url, :params => gen_request(:scan, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1.compressed_id), api_vm_url(nil, vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -961,7 +961,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:add_event, :event_type => "special", :event_message => "message"))
 
-      expect_single_action_result(:success => true, :message => /adding event/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /adding event/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple Vms" do
@@ -981,12 +981,12 @@ describe "Vms API" do
           {
             "message" => a_string_matching(/adding event .*etype1/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm1.compressed_id)
+            "href"    => api_vm_url(nil, vm1)
           },
           {
             "message" => a_string_matching(/adding event .*etype2/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm2.compressed_id)
+            "href"    => api_vm_url(nil, vm2)
           }
         )
       }
@@ -1017,7 +1017,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:retire))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple Vms" do
@@ -1030,12 +1030,12 @@ describe "Vms API" do
           {
             "message" => a_string_matching(/#{vm1.id}.* retiring/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm1.compressed_id)
+            "href"    => api_vm_url(nil, vm1)
           },
           {
             "message" => a_string_matching(/#{vm2.id}.* retiring/ii),
             "success" => true,
-            "href"    => api_vm_url(nil, vm2.compressed_id)
+            "href"    => api_vm_url(nil, vm2)
           }
         )
       }
@@ -1048,7 +1048,7 @@ describe "Vms API" do
       date = 2.weeks.from_now
       post(vm_url, :params => gen_request(:retire, :date => date.iso8601))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => api_vm_url(nil, vm))
     end
   end
 
@@ -1074,7 +1074,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:reset))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* resetting/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* resetting/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple Vms" do
@@ -1087,12 +1087,12 @@ describe "Vms API" do
           a_hash_including(
             "message" => a_string_matching(/#{vm1.id}.* resetting/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm1.compressed_id)
+            "href"    => api_vm_url(nil, vm1)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{vm2.id}.* resetting/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm2.compressed_id)
+            "href"    => api_vm_url(nil, vm2)
           )
         )
       }
@@ -1123,7 +1123,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:shutdown_guest))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* shutting down/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* shutting down/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple Vms" do
@@ -1136,12 +1136,12 @@ describe "Vms API" do
           a_hash_including(
             "message" => a_string_matching(/#{vm1.id}.* shutting down/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm1.compressed_id)
+            "href"    => api_vm_url(nil, vm1)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{vm2.id}.* shutting down/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm2.compressed_id)
+            "href"    => api_vm_url(nil, vm2)
           )
         )
       }
@@ -1172,7 +1172,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:refresh))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* refreshing/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* refreshing/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple Vms" do
@@ -1185,12 +1185,12 @@ describe "Vms API" do
           a_hash_including(
             "message" => a_string_matching(/#{vm1.id}.* refreshing/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm1.compressed_id)
+            "href"    => api_vm_url(nil, vm1)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{vm2.id}.* refreshing/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm2.compressed_id)
+            "href"    => api_vm_url(nil, vm2)
           )
         )
       }
@@ -1221,7 +1221,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* rebooting/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* rebooting/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple Vms" do
@@ -1234,12 +1234,12 @@ describe "Vms API" do
           a_hash_including(
             "message" => a_string_matching(/#{vm1.id}.* rebooting/i,),
             "success" => true,
-            "href"    => api_vm_url(nil, vm1.compressed_id)
+            "href"    => api_vm_url(nil, vm1)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{vm2.id}.* rebooting/i),
             "success" => true,
-            "href"    => api_vm_url(nil, vm2.compressed_id)
+            "href"    => api_vm_url(nil, vm2)
           )
         )
       }
@@ -1270,7 +1270,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:request_console))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* requesting console/i, :href => api_vm_url(nil, vm.compressed_id))
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* requesting console/i, :href => api_vm_url(nil, vm))
     end
   end
 
@@ -1327,7 +1327,7 @@ describe "Vms API" do
       get api_vms_url, :params => { :expand => "resources", :filter => ["tags.name='#{tag2[:path]}'"] }
 
       expect_query_result(:vms, 1, 2)
-      expect_result_resources_to_include_hrefs("resources", [api_vm_url(nil, vm2.compressed_id)])
+      expect_result_resources_to_include_hrefs("resources", [api_vm_url(nil, vm2)])
     end
 
     it "assigns a tag to a Vm without appropriate role" do
@@ -1344,7 +1344,7 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm1), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
       expect_tagging_result(
-        [{:success => true, :href => api_vm_url(nil, vm1.compressed_id), :tag_category => tag1[:category], :tag_name => tag1[:name]}]
+        [{:success => true, :href => api_vm_url(nil, vm1), :tag_category => tag1[:category], :tag_name => tag1[:name]}]
       )
     end
 
@@ -1354,7 +1354,7 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm1), :params => gen_request(:assign, :name => tag1[:path]))
 
       expect_tagging_result(
-        [{:success => true, :href => api_vm_url(nil, vm1.compressed_id), :tag_category => tag1[:category], :tag_name => tag1[:name]}]
+        [{:success => true, :href => api_vm_url(nil, vm1), :tag_category => tag1[:category], :tag_name => tag1[:name]}]
       )
     end
 
@@ -1364,7 +1364,7 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm1), :params => gen_request(:assign, :href => api_tag_url(nil, Tag.find_by(:name => tag1[:path]))))
 
       expect_tagging_result(
-        [{:success => true, :href => api_vm_url(nil, vm1.compressed_id), :tag_category => tag1[:category], :tag_name => tag1[:name]}]
+        [{:success => true, :href => api_vm_url(nil, vm1), :tag_category => tag1[:category], :tag_name => tag1[:name]}]
       )
     end
 
@@ -1382,7 +1382,7 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm1), :params => gen_request(:assign, :name => "/managed/bad_category/bad_name"))
 
       expect_tagging_result(
-        [{:success => false, :href => api_vm_url(nil, vm1.compressed_id), :tag_category => "bad_category", :tag_name => "bad_name"}]
+        [{:success => false, :href => api_vm_url(nil, vm1), :tag_category => "bad_category", :tag_name => "bad_name"}]
       )
     end
 
@@ -1392,8 +1392,8 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm1), :params => gen_request(:assign, [{:name => tag1[:path]}, {:name => tag2[:path]}]))
 
       expect_tagging_result(
-        [{:success => true, :href => api_vm_url(nil, vm1.compressed_id), :tag_category => tag1[:category], :tag_name => tag1[:name]},
-         {:success => true, :href => api_vm_url(nil, vm1.compressed_id), :tag_category => tag2[:category], :tag_name => tag2[:name]}]
+        [{:success => true, :href => api_vm_url(nil, vm1), :tag_category => tag1[:category], :tag_name => tag1[:name]},
+         {:success => true, :href => api_vm_url(nil, vm1), :tag_category => tag2[:category], :tag_name => tag2[:name]}]
       )
     end
 
@@ -1404,8 +1404,8 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm1), :params => gen_request(:assign, [{:name => tag1[:path]}, {:href => api_tag_url(nil, tag)}]))
 
       expect_tagging_result(
-        [{:success => true, :href => api_vm_url(nil, vm1.compressed_id), :tag_category => tag1[:category], :tag_name => tag1[:name]},
-         {:success => true, :href => api_vm_url(nil, vm1.compressed_id), :tag_category => tag2[:category], :tag_name => tag2[:name]}]
+        [{:success => true, :href => api_vm_url(nil, vm1), :tag_category => tag1[:category], :tag_name => tag1[:name]},
+         {:success => true, :href => api_vm_url(nil, vm1), :tag_category => tag2[:category], :tag_name => tag2[:name]}]
       )
     end
 
@@ -1423,7 +1423,7 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm2), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
       expect_tagging_result(
-        [{:success => true, :href => api_vm_url(nil, vm2.compressed_id), :tag_category => tag1[:category], :tag_name => tag1[:name]}]
+        [{:success => true, :href => api_vm_url(nil, vm2), :tag_category => tag1[:category], :tag_name => tag1[:name]}]
       )
       expect(vm2.tags.count).to eq(1)
       expect(vm2.tags.first.name).to eq(tag2[:path])
@@ -1436,8 +1436,8 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm2), :params => gen_request(:unassign, [{:name => tag1[:path]}, {:href => api_tag_url(nil, tag)}]))
 
       expect_tagging_result(
-        [{:success => true, :href => api_vm_url(nil, vm2.compressed_id), :tag_category => tag1[:category], :tag_name => tag1[:name]},
-         {:success => true, :href => api_vm_url(nil, vm2.compressed_id), :tag_category => tag2[:category], :tag_name => tag2[:name]}]
+        [{:success => true, :href => api_vm_url(nil, vm2), :tag_category => tag1[:category], :tag_name => tag1[:name]},
+         {:success => true, :href => api_vm_url(nil, vm2), :tag_category => tag2[:category], :tag_name => tag2[:name]}]
       )
       expect(vm2.tags.count).to eq(0)
     end
@@ -1526,7 +1526,7 @@ describe "Vms API" do
       expected = {
         "success" => true,
         "message" => "Invoked custom action test button for vms id: #{vm.id}",
-        "href"    => api_vm_url(nil, vm.compressed_id)
+        "href"    => api_vm_url(nil, vm)
       }
       expect(response.parsed_body).to include(expected)
     end


### PR DESCRIPTION
Support for compressed ids was added and enabled by default (rendering
all ids in their compressed form) with the thought of killing two birds with one stone:

1. JavaScript doesn't support very large numbers
2. we wanted to add support for compressed ids

It turns out that (2) wasn't solving any problems in UI land
anymore. With the added complexity and emerging issues¹ that came as a
result of this change, it seemed better to remove the compressed id
support and simply render all ids as strings instead, which is
sufficient to solve the javascript large numbers issue.

Support for incoming compressed ids in URLs has been left, since this
has already been incorporated into the Fine release.

1. See #49, ManageIQ/manageiq#15658

@miq-bot assign @abellotti 
/cc @chrisarcand @Fryguy 
