### PR TITLE
Simplify href matching helper

### DIFF
--- a/spec/requests/alert_definitions_spec.rb
+++ b/spec/requests/alert_definitions_spec.rb
@@ -224,8 +224,8 @@ describe "Alerts Definition Profiles API" do
     expect(response).to have_http_status(:ok)
     expect_result_resources_to_include_hrefs(
       "resources",
-      [api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile, alert_definitions.first),
-       api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile, alert_definitions.first)]
+      [api_alert_definition_profile_alert_definition_url(nil, alert_definition_profile, alert_definitions.first),
+       api_alert_definition_profile_alert_definition_url(nil, alert_definition_profile, alert_definitions.second)]
     )
   end
 

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -761,8 +761,8 @@ describe "Vms API" do
 
       expect_query_result(:custom_attributes, 2)
       expect_result_resources_to_include_hrefs("resources",
-                                               [api_vm_custom_attributes_url(nil, vm, ca1),
-                                                api_vm_custom_attributes_url(nil, vm, ca2)])
+                                               [api_vm_custom_attribute_url(nil, vm, ca1),
+                                                api_vm_custom_attribute_url(nil, vm, ca2)])
     end
 
     it "getting custom_attributes from a vm in expanded form" do

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -6,10 +6,6 @@ module Spec
   module Support
     module Api
       module Helpers
-        def resources_include_suffix?(resources, key, suffix)
-          resources.any? { |r| r.key?(key) && r[key].match("#{suffix}$") }
-        end
-
         def api_config(param)
           @api_config ||= {
             :user       => "api_user_id",
@@ -123,11 +119,12 @@ module Spec
         end
 
         def expect_result_resources_to_include_hrefs(collection, hrefs)
-          expect(response.parsed_body).to have_key(collection)
-          expect(response.parsed_body[collection].size).to eq(hrefs.size)
-          hrefs.each do |href|
-            expect(resources_include_suffix?(response.parsed_body[collection], "href", href)).to be_truthy
-          end
+          expected = {
+            collection => a_collection_containing_exactly(
+              *hrefs.collect { |href| a_hash_including("href" => href) }
+            )
+          }
+          expect(response.parsed_body).to include(expected)
         end
 
         def expect_result_to_have_keys(keys)


### PR DESCRIPTION
Because we are now using the Rails path helpers everywhere, we no
longer need to match so flexibly in this helper for checking hrefs.

Doing so revealed that a couple of tests were giving false positives
and needed to be updated to faithfully test the actual behavior.

This also allowed for some deletions (it no longer depends on the
`resources_include_suffix?` helper) and simplified to make one
expectation where three were before. This should yield better test
feedback in the event of a regression - it'll provide a diff instead
of the old "expected true, got false".

@miq-bot add-label test, technical debt
@miq-bot assign @abellotti 