### PR TITLE
Generic Objects Subcollection

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -119,6 +119,12 @@ module Api
       def new_href(type, current_id, current_href)
         normalize_href(type, current_id) if current_id.present? && current_href.blank?
       end
+
+      def create_resource_attributes_hash(attributes, resource)
+        attributes.each_with_object({}) do |attr, hash|
+          hash[attr] = resource.public_send(attr.to_sym) if resource.respond_to?(attr.to_sym)
+        end
+      end
     end
   end
 end

--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -1,5 +1,11 @@
 module Api
   class GenericObjectDefinitionsController < BaseController
+    include Api::Mixins::GenericObjects
+    include Subcollections::GenericObjects
+
+    before_action :set_additional_attributes, :if => :generic_objects_request?
+    before_action :set_associations, :only => [:index, :show], :if => :generic_objects_request?
+
     def create_resource(_type, _id, data)
       klass = collection_class(:generic_object_definitions)
       klass.create!(data.deep_symbolize_keys)
@@ -113,6 +119,10 @@ module Api
     end
 
     private
+
+    def generic_objects_request?
+      @req.subject == 'generic_objects'
+    end
 
     def fetch_generic_object_definition(type, id, data)
       id ||= data['name']

--- a/app/controllers/api/generic_objects_controller.rb
+++ b/app/controllers/api/generic_objects_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class GenericObjectsController < BaseController
+    include Api::Mixins::GenericObjects
     include Subcollections::Tags
 
     ADDITIONAL_ATTRS = %w(generic_object_definition associations).freeze
@@ -9,10 +10,7 @@ module Api
 
     def create_resource(_type, _id, data)
       object_def = retrieve_generic_object_definition(data)
-      object_def.create_object(data.except(*ADDITIONAL_ATTRS)).tap do |generic_object|
-        add_associations(generic_object, data, object_def) if data.key?('associations')
-        generic_object.save!
-      end
+      create_generic_object(object_def, data)
     rescue => err
       raise BadRequestError, "Failed to create new generic object - #{err}"
     end
@@ -43,19 +41,6 @@ module Api
     def retrieve_generic_object_definition(data)
       definition_id = parse_id(data['generic_object_definition'], :generic_object_definitions)
       resource_search(definition_id, :generic_object_definitions, collection_class(:generic_object_definitions))
-    end
-
-    def add_associations(generic_object, data, object_definition)
-      invalid_associations = data['associations'].keys - object_definition.property_associations.keys
-      raise BadRequestError, "Invalid associations #{invalid_associations.join(', ')}" unless invalid_associations.empty?
-
-      data['associations'].each do |association, resource_refs|
-        resources = resource_refs.collect do |ref|
-          collection, id = HrefParser.parse(ref['href'])
-          resource_search(id, collection, collection_class(collection))
-        end
-        generic_object.public_send("#{association}=", resources)
-      end
     end
   end
 end

--- a/app/controllers/api/generic_objects_controller.rb
+++ b/app/controllers/api/generic_objects_controller.rb
@@ -27,17 +27,6 @@ module Api
 
     private
 
-    def set_additional_attributes
-      @additional_attributes = %w(property_attributes)
-    end
-
-    def set_associations
-      return unless params[:associations]
-      params[:associations].split(',').each do |prop|
-        @additional_attributes << prop
-      end
-    end
-
     def retrieve_generic_object_definition(data)
       definition_id = parse_id(data['generic_object_definition'], :generic_object_definitions)
       resource_search(definition_id, :generic_object_definitions, collection_class(:generic_object_definitions))

--- a/app/controllers/api/mixins/generic_objects.rb
+++ b/app/controllers/api/mixins/generic_objects.rb
@@ -1,0 +1,40 @@
+module Api
+  module Mixins
+    module GenericObjects
+      ADDITIONAL_ATTRS = %w(generic_object_definition associations).freeze
+
+      private
+
+      def create_generic_object(object_definition, data)
+        object_definition.create_object(data.except(*ADDITIONAL_ATTRS)).tap do |generic_object|
+          add_associations(generic_object, data, object_definition) if data.key?('associations')
+          generic_object.save!
+        end
+      end
+
+      def add_associations(generic_object, data, object_definition)
+        invalid_associations = data['associations'].keys - object_definition.property_associations.keys
+        raise BadRequestError, "Invalid associations #{invalid_associations.join(', ')}" unless invalid_associations.empty?
+
+        data['associations'].each do |association, resource_refs|
+          resources = resource_refs.collect do |ref|
+            collection, id = parse_href(ref['href'])
+            resource_search(id, collection, collection_class(collection))
+          end
+          generic_object.send("#{association}=", resources)
+        end
+      end
+
+      def set_additional_attributes
+        @additional_attributes = %w(property_attributes)
+      end
+
+      def set_associations
+        return unless params[:associations]
+        params[:associations].split(',').each do |prop|
+          @additional_attributes << prop
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/mixins/generic_objects.rb
+++ b/app/controllers/api/mixins/generic_objects.rb
@@ -18,7 +18,7 @@ module Api
 
         data['associations'].each do |association, resource_refs|
           resources = resource_refs.collect do |ref|
-            collection, id = parse_href(ref['href'])
+            collection, id = HrefParser.parse(ref['href'])
             resource_search(id, collection, collection_class(collection))
           end
           generic_object.send("#{association}=", resources)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -5,6 +5,7 @@ module Api
     include Subcollections::Vms
     include Subcollections::OrchestrationStacks
     include Subcollections::MetricRollups
+    include Subcollections::GenericObjects
 
     def create_resource(_type, _id, data)
       validate_service_data(data)

--- a/app/controllers/api/subcollections/generic_objects.rb
+++ b/app/controllers/api/subcollections/generic_objects.rb
@@ -2,7 +2,15 @@ module Api
   module Subcollections
     module GenericObjects
       def generic_objects_query_resource(object_definition)
-        object_definition.generic_objects
+        generic_objects = object_definition.generic_objects
+        go_attrs = attribute_selection_for('generic_objects')
+
+        return generic_objects if go_attrs.blank?
+
+        generic_objects.collect do |go|
+          attributes_hash = create_resource_attributes_hash(go_attrs, go)
+          go.as_json.merge(attributes_hash)
+        end
       end
 
       def generic_objects_create_resource(object, _type, _id, data)

--- a/app/controllers/api/subcollections/generic_objects.rb
+++ b/app/controllers/api/subcollections/generic_objects.rb
@@ -1,0 +1,13 @@
+module Api
+  module Subcollections
+    module GenericObjects
+      def generic_objects_query_resource(object_definition)
+        object_definition.generic_objects
+      end
+
+      def generic_objects_create_resource(object, _type, _id, data)
+        create_generic_object(object, data)
+      end
+    end
+  end
+end

--- a/app/controllers/api/subcollections/vms.rb
+++ b/app/controllers/api/subcollections/vms.rb
@@ -10,7 +10,7 @@ module Api
         return vms if vm_attrs.blank? && vm_decorators.blank?
 
         vms.collect do |vm|
-          attributes_hash = create_vm_attributes_hash(vm_attrs, vm)
+          attributes_hash = create_resource_attributes_hash(vm_attrs, vm)
           decorators_hash = create_vm_decorators_hash(vm_decorators, vm)
 
           conflictless_hash = attributes_hash.merge(decorators_hash || {}) do |key, _, _|

--- a/config/api.yml
+++ b/config/api.yml
@@ -865,6 +865,8 @@
     - :collection
     :verbs: *gpppd
     :klass: GenericObjectDefinition
+    :subcollections:
+    - :generic_objects
     :collection_actions:
       :get:
       - :name: read
@@ -947,6 +949,13 @@
       :delete:
       - :name: delete
         :identifier: generic_object_delete
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: generic_object_show_list
+      :post:
+      - :name: create
+        identifier: generic_object_new
     :tags_subcollection_actions:
       :post:
       - :name: assign

--- a/config/api.yml
+++ b/config/api.yml
@@ -2319,6 +2319,7 @@
     - :vms
     - :orchestration_stacks
     - :metric_rollups
+    - :generic_objects
     :collection_actions:
       :get:
       - :name: read
@@ -2390,6 +2391,10 @@
         :identifier: service_tag
       - :name: unassign
         :identifier: service_tag
+    :generic_objects_subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: generic_object_show_list
   :settings:
     :description: Settings
     :identifier: ops_settings


### PR DESCRIPTION
This PR adds a Generic Objects Subcollection on the Generic Object Definition

### Usage
#### GET /api/generic_object_definitions/:id/generic_objects
will return the collection of generic objects of that definition type:
```
{
  "name"      :"generic_objects",
  "count"     :2,
  "subcount"  :2,
  "resources" :[
   { "href" : "api/generic_object_definitions/:id/generic_objects/:id" },
   { "href" : "api/generic_object_definitions/:id/generic_objects/:id" },
  ]
}
```
#### GET /api/generic_object_definitions/:id/generic_objects/:id
will return property attributes by default:
```
{
  "href"                : "/api/generic_object_definitions/:id/generic_objects/:id",
  "id"                  : "1000000001",
  "name"                : "bar",
  ... 
  "property_attributes" : { "is_something" : true }
}
```
can specify `associations` on the request, ie: 
`GET /api/generic_object_definitions/:id/generic_objects/:id?associations=vms,services` 
returns:
```
{
  "href"                : "api/generic_object_definitions/:id/generic_objects/:id",
  "id"                  : "10000001",
  "name"                : "bar",
  "property_attributes" : { "is_something" : true },
  "vms"                 : [{ "id": "<vm id>" ...}],
  "services"            : [{"id": "<service id>"...}]
}

```
#### GET /api/services/:id/generic_objects
* Returns the generic objects associated with a service 
#### GET /api/services/:id?expand=resources,generic_objects&attributes=generic_objects.generic_object_definition
* will return the service as well as the generic objects with associated generic object definition:
```
{'name':'services',
 'count':1,
 'subcount':1,
 'resources':
   [{'href':'/api/services/:id',
     'id':':id',
     'name':'svc',
     ...
     'generic_objects':
       [{
         'id':':id',
         'name':'generic_object_0000000000001',
         ...
         'generic_object_definition' : {
            'id' : ':id',
            'name' : 'generic_object_definition_name'
            ...
          }
        }
       ]
    }
   ]
}
```

#### POST /api/generic_object_definitions/:id/generic_objects
it can create a new generic object for the specified generic object definition:
```
{
  "name"                : "go_name1",
  "uid"                 : "optional_uid",
  "property_attributes" : {
    "widget" : "widget value",
  },
  "associations"        : {
    "vms" : [
      { "href" : "/api/vms/:id" },
    ]
  }
}

```
#### Background
~There is shared code between the generic objects controller and the generic objects subcollection. The code is tightly coupled with the controllers, and therefore not suitable for a service, which was the design choice behind the mixin.~

~When writing the mixin, the initial intent was to not have it as a part of BaseController, it was instead to have `Api::Mixins::GenericObjects`, however, this caused sporadic test failures when included as `include Mixins::GenericObjects`.  I think this may require greater refactoring to achieve it as `Api::Mixins`, which might be better suited in another PR.~