### PR TITLE
Deprecate compressed ids

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -88,14 +88,22 @@ module Api
           href_id
         when resource["id"].kind_of?(Integer)
           resource["id"]
-        when ApplicationRecord.compressed_id?(resource["id"])
-          ApplicationRecord.uncompress_id(resource["id"])
+        when resource["id"].kind_of?(String)
+          if Api.compressed_id?(resource["id"])
+            Api.uncompress_id(resource["id"])
+          else
+            resource["id"].to_i
+          end
         end
       end
 
       def href_id(href, collection)
         if href.present? && href.match(%r{^.*/#{collection}/(#{ApplicationRecord::CID_OR_ID_MATCHER})$})
-          ApplicationRecord.uncompress_id(Regexp.last_match(1))
+          if Api.compressed_id?(Regexp.last_match(1))
+            Api.uncompress_id(Regexp.last_match(1))
+          else
+            Regexp.last_match(1).to_i
+          end
         end
       end
 

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -65,8 +65,7 @@ module Api
         end
 
         def c_id
-          id = @params[:c_id] || c_path_parts[1]
-          ApplicationRecord.compressed_id?(id) ? ApplicationRecord.uncompress_id(id) : id
+          @c_id ||= ensure_uncompressed(@params[:c_id] || c_path_parts[1])
         end
 
         def subcollection
@@ -74,8 +73,7 @@ module Api
         end
 
         def s_id
-          id = @params[:s_id] || c_path_parts[3]
-          ApplicationRecord.compressed_id?(id) ? ApplicationRecord.uncompress_id(id) : id
+          @s_id ||= ensure_uncompressed(@params[:s_id] || c_path_parts[3])
         end
 
         def subcollection?
@@ -135,6 +133,10 @@ module Api
         def prefix
           prefix = "/#{path.split('/')[1]}" # /api
           version_override? ? "#{prefix}/#{@params[:version]}" : prefix
+        end
+
+        def ensure_uncompressed(id)
+          Api.compressed_id?(id) ? Api.uncompress_id(id) : id
         end
       end
     end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -33,4 +33,12 @@ module Api
   def self.resource_attribute?(attr)
     Environment.resource_attributes.include?(attr.to_s)
   end
+
+  # Since `ApplicationRecord.compressed_id?` returns truthy for
+  # uncompressed ids (it should be more properly named `cid_or_id?` or
+  # similar), we need a way to distinquish compressed ids from
+  # anything else so that we can deprecate their usage.
+  def self.compressed_id?(thing)
+    !!(ApplicationRecord::RE_COMPRESSED_ID =~ thing.to_s)
+  end
 end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -41,4 +41,9 @@ module Api
   def self.compressed_id?(thing)
     !!(ApplicationRecord::RE_COMPRESSED_ID =~ thing.to_s)
   end
+
+  def self.uncompress_id(id)
+    $api_log.warn("The use of compressed ids is deprecated, and the support for which will be removed in a future release.")
+    ApplicationRecord.uncompress_id(id)
+  end
 end

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -91,8 +91,8 @@ module Api
                                end
                              end
 
-      if filter_attr =~ /[_]?id$/ && ApplicationRecord.compressed_id?(filter_value)
-        filter_value = ApplicationRecord.uncompress_id(filter_value)
+      if filter_attr =~ /[_]?id$/ && Api.compressed_id?(filter_value)
+        filter_value = Api.uncompress_id(filter_value)
       end
 
       if filter_value =~ /%|\*/

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Api::Filter do
 
       actual = described_class.parse(filters, Vm)
 
-      expected = {"<" => {"field" => "Vm-id", "value" => 1_000_000_000_123}}
+      expected = {"<" => {"field" => "Vm-id", "value" => "1000000000123"}}
       expect(actual.exp).to eq(expected)
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Api::Filter do
 
       actual = described_class.parse(filters, Vm)
 
-      expected = {"<=" => {"field" => "Vm-id", "value" => 1_000_000_000_123}}
+      expected = {"<=" => {"field" => "Vm-id", "value" => "1000000000123"}}
       expect(actual.exp).to eq(expected)
     end
 
@@ -86,7 +86,7 @@ RSpec.describe Api::Filter do
 
       actual = described_class.parse(filters, Vm)
 
-      expected = {">" => {"field" => "Vm-id", "value" => 1_000_000_000_123}}
+      expected = {">" => {"field" => "Vm-id", "value" => "1000000000123"}}
       expect(actual.exp).to eq(expected)
     end
 
@@ -95,7 +95,7 @@ RSpec.describe Api::Filter do
 
       actual = described_class.parse(filters, Vm)
 
-      expected = {">=" => {"field" => "Vm-id", "value" => 1_000_000_000_123}}
+      expected = {">=" => {"field" => "Vm-id", "value" => "1000000000123"}}
       expect(actual.exp).to eq(expected)
     end
 
@@ -106,8 +106,8 @@ RSpec.describe Api::Filter do
 
       expected = {
         "OR" => [
-          {"=" => {"field" => "Vm-id", "value" => 1_000_000_000_123}},
-          {">" => {"field" => "Vm-id", "value" => 1_000_000_000_456}}
+          {"=" => {"field" => "Vm-id", "value" => "1000000000123"}},
+          {">" => {"field" => "Vm-id", "value" => "1000000000456"}}
         ]
       }
       expect(actual.exp).to eq(expected)
@@ -120,7 +120,7 @@ RSpec.describe Api::Filter do
 
       expected = {
         "AND" => [
-          {"=" => {"field" => "Vm-id", "value" => 1_000_000_000_123}},
+          {"=" => {"field" => "Vm-id", "value" => "1000000000123"}},
           {"=" => {"field" => "Vm-name", "value" => "foo"}}
         ]
       }
@@ -136,11 +136,11 @@ RSpec.describe Api::Filter do
         "OR" => [
           {
             "AND" => [
-              {"=" => {"field" => "Vm-id", "value" => 1_000_000_000_123}},
+              {"=" => {"field" => "Vm-id", "value" => "1000000000123"}},
               {"=" => {"field" => "Vm-name", "value" => "foo"}}
             ]
           },
-          {">" => {"field" => "Vm-id", "value" => 1_000_000_000_456}}
+          {">" => {"field" => "Vm-id", "value" => "1000000000456"}}
         ]
       }
       expect(actual.exp).to eq(expected)

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Api do
+  describe ".compressed_id?" do
+    it "returns true for a compressed id" do
+      expect(Api.compressed_id?("1r1")).to be(true)
+    end
+
+    it "returns false for an uncompressed id" do
+      expect(Api.compressed_id?(1_000_000_000_001)).to be(false)
+      expect(Api.compressed_id?("1000000000001")).to be(false)
+    end
+
+    it "returns false for nil" do
+      expect(Api.compressed_id?(nil)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Support for compressed ids in URLs, the filter, and in the request body was added and incorporated into the Fine release (see https://github.com/ManageIQ/manageiq/pull/11621,https://github.com/ManageIQ/manageiq/pull/11577, https://github.com/ManageIQ/manageiq/pull/11248, https://github.com/ManageIQ/manageiq/pull/10322).

Since that can't be removed immediately, I'm deprecating its use by maintaining the outward behavior but adding warnings to the log.

Somewhat surprisingly, the behavior of `Application.compressed_id?` was altered in https://github.com/ManageIQ/manageiq/pull/11621 to return true for uncompressed ids as well. Hence, I needed a new predicate (added in https://github.com/ManageIQ/manageiq-api/commit/8d740f6c5c4bcc5f131335dbbca7f935686dae9b) that encapsulated the original meaning of "compressed and definitely not a regular id". I chose to add it in this repository - if needed elsewhere it can be extracted. This collision of naming/concepts is a bit regrettable, but I'm OK with it as a compromise. I think the right thing to do would be to change `ApplicationRecord.compressed_id` to more accurately describe its behavior, update callers, etc., but this seems like it would be a big investment in code we are determined to be short-lived. 

/cc @chrisarcand @Fryguy 
@miq-bot add-label technical debt
@miq-bot assign @abellotti 