### PR TITLE
Support more cases for parse_href

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -62,7 +62,8 @@ module Api
       def parse_href(href)
         if href
           path = href.match(/^http/) ? URI.parse(href).path.sub(/\/*$/, '') : href
-          path = "/api/#{path}" unless path.match("/api")
+          path.prepend("/")     unless path.start_with?("/")
+          path = "/api#{path}" unless path.match("/api")
           path = path.sub(/\/*$/, '')
           return href_collection_id(path)
         end

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -61,10 +61,10 @@ module Api
       #
       def parse_href(href)
         if href
-          path = href.match(/^http/) ? URI.parse(href).path.sub(/\/*$/, '') : href
+          path = href.match(/^http/) ? URI.parse(href).path.sub!(/\/*$/, '') : href.dup
           path.prepend("/")     unless path.start_with?("/")
-          path = "/api#{path}" unless path.match("/api")
-          path = path.sub(/\/*$/, '')
+          path.prepend("/api")  unless path.match("/api")
+          path.sub!(/\/*$/, '')
           return href_collection_id(path)
         end
         [nil, nil]

--- a/spec/requests/base_controller/parser_spec.rb
+++ b/spec/requests/base_controller/parser_spec.rb
@@ -1,0 +1,45 @@
+describe Api::BaseController do
+  describe "Parser" do
+    describe "#parse_href" do
+      context "with a full url for the href" do
+        let(:href) { "http://localhost:3000/api/collection/123" }
+
+        it "returns ['collection', 123]" do
+          expect(subject.parse_href(href)).to eq([:collection, 123])
+        end
+      end
+
+      context "with a full url for the href and a API version" do
+        let(:href) { "http://localhost:3000/api/v1.2.3/collection/123" }
+
+        it "returns ['collection', 123]" do
+          expect(subject.parse_href(href)).to eq([:collection, 123])
+        end
+      end
+
+      context "with a partial URL that starts with '/api/...'" do
+        let(:href) { "/api/collection/123" }
+
+        it "returns ['collection', 123]" do
+          expect(subject.parse_href(href)).to eq([:collection, 123])
+        end
+      end
+
+      context "with a partial URL that starts with '/api/v1.2.3/...'" do
+        let(:href) { "/api/v1.2.3/collection/123" }
+
+        it "returns ['collection', 123]" do
+          expect(subject.parse_href(href)).to eq([:collection, 123])
+        end
+      end
+
+      context "with a partial URL without '/api/...'" do
+        let(:href) { "collection/123" }
+
+        it "returns ['collection', 123]" do
+          expect(subject.parse_href(href)).to eq([:collection, 123])
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/base_controller/parser_spec.rb
+++ b/spec/requests/base_controller/parser_spec.rb
@@ -33,8 +33,32 @@ describe Api::BaseController do
         end
       end
 
+      context "with a partial URL that starts with 'api/...'" do
+        let(:href) { "api/collection/123" }
+
+        it "returns ['collection', 123]" do
+          expect(subject.parse_href(href)).to eq([:collection, 123])
+        end
+      end
+
+      context "with a partial URL that starts with 'api/v1.2.3/...'" do
+        let(:href) { "api/v1.2.3/collection/123" }
+
+        it "returns ['collection', 123]" do
+          expect(subject.parse_href(href)).to eq([:collection, 123])
+        end
+      end
+
       context "with a partial URL without '/api/...'" do
         let(:href) { "collection/123" }
+
+        it "returns ['collection', 123]" do
+          expect(subject.parse_href(href)).to eq([:collection, 123])
+        end
+      end
+
+      context "with a partial URL without '/api/...' and a leading slash" do
+        let(:href) { "/collection/123" }
 
         it "returns ['collection', 123]" do
           expect(subject.parse_href(href)).to eq([:collection, 123])


### PR DESCRIPTION
When the path for a href is passed in without a leading `'/'`, the value can turn into something like `'/api/api/collection/:id'`, which is not desired and will break following methods in the API in a non-obvious way.

By normalizing all paths to make sure they start with a slash, we can then assume that is what we are working with when we append '/api' to the path if it is missing, allowing a more flexible interface for `#parse_href`

In the final commit, I also to a stab at reducing some object allocations a bit, but it is far from necessary.  Can be removed if desired.


Spec File Location
------------------

In a side conversation, we discussed that the `spec/requests/` dir is probably not the best place for this test to live, as no real "requests" are being made to confirm functionality, and a different dir should probably be used.  Other ideas were tossed around like this parser should probably be a service object, like `HrefParser`, and then it can be tested as a typical "plain old ruby object" instead of how it is now.

For now, I have followed the conventions of putting the spec file in the `spec/requests/` dir, but this ideally would change in the future (out of scope).

Links
-----
* Gitter conversation that raised this issue:  [link](https://gitter.im/ManageIQ/api?at=59c180007b7d98d30d15dcf7)