### PR TITLE
Update API to support LXCA config patterns

### DIFF
--- a/app/controllers/api/configuration_templates_controller.rb
+++ b/app/controllers/api/configuration_templates_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ConfigurationTemplatesController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -663,6 +663,24 @@
       :delete:
       - :name: delete
         :identifier: embedded_configuration_script_source_delete
+  :configuration_templates:
+    :description: Configuration Templates
+    :identifier: configuration_template
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: ConfigurationTemplate
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: configuration_template_show_list
+      :post:
+      - :name: query
+        :identifier: configuration_template_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: configuration_template_show
   :container_deployments:
     :description: Container Provider Deployment
     :identifier: container_deployment

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -319,6 +319,11 @@ describe "Rest API Collections" do
       FactoryGirl.create(:physical_server)
       test_collection_query(:physical_servers, physical_servers_url, PhysicalServer)
     end
+
+    it 'query ConfigurationTemplates' do
+      FactoryGirl.create(:configuration_template)
+      test_collection_query(:configuration_templates, configuration_templates_url, ConfigurationTemplate)
+    end
   end
 
   context "Collections Bulk Queries" do
@@ -599,6 +604,11 @@ describe "Rest API Collections" do
     it 'bulk query PhysicalServers' do
       FactoryGirl.create(:physical_server)
       test_collection_bulk_query(:physical_servers, physical_servers_url, PhysicalServer)
+    end
+
+    it 'bulk query ConfigurationTemplates' do
+      FactoryGirl.create(:configuration_template)
+      test_collection_bulk_query(:configuration_templates, configuration_templates_url, ConfigurationTemplate)
     end
   end
 end

--- a/spec/requests/configuration_templates_spec.rb
+++ b/spec/requests/configuration_templates_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe "configuration templates API" do
+  describe "display a configuration template's details" do
+    context "with the user authorized" do
+      it "responds with configuration template details" do
+        config_template = FactoryGirl.create(:configuration_template,
+                                             :ems_id  => 1,
+                                             :ems_ref => "65",
+                                             :name    => "server-template")
+
+        api_basic_authorize action_identifier(:configuration_templates, :read, :resource_actions, :get)
+        run_get(configuration_templates_url(config_template.id))
+
+        expect_single_resource_query("ems_id"  => "1",
+                                     "ems_ref" => "65",
+                                     "name"    => "server-template")
+      end
+    end
+
+    context "with the user unauthorized" do
+      it "responds with a forbidden status" do
+        config_template = FactoryGirl.create(:configuration_template)
+
+        api_basic_authorize
+        run_get(configuration_templates_url(config_template.id))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds API support for Lenovo XClarity Administrator (LXCA) configuration patterns which can be thought of as templates describing the configuration of physical systems. These "templates" are used by LXCA to configure hardware such as servers, switches, and storage.