### PR TITLE
Update references to OrchstrationTemplate subclasses due to rename

### DIFF
--- a/app/controllers/api/orchestration_templates_controller.rb
+++ b/app/controllers/api/orchestration_templates_controller.rb
@@ -4,7 +4,7 @@ module Api
       klass    = collection_class(type)
       resource = resource_search(id, type, klass)
       result = super
-      resource.raw_destroy if resource.kind_of?(OrchestrationTemplateVnfd)
+      resource.raw_destroy if resource.kind_of?(ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate)
       result
     end
 


### PR DESCRIPTION
As described in https://github.com/ManageIQ/manageiq/issues/15985 all subclasses of `OrchestrationTemplate` were moved to provider repos. This PR updates the only one explicit reference to `OrchestrationTemplate` subclasses in manageiq-api. 

Please advice how to keep the backward compatibility for OrchestrationTemplate api. The only thing I can think of is the create method where the type is required. We can have a hard-coded hash to translate old type to new type.

@miq-bot assign @abellotti 