### PR TITLE
Tags Subcollection on Generic Objects

### DIFF
--- a/app/controllers/api/generic_objects_controller.rb
+++ b/app/controllers/api/generic_objects_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class GenericObjectsController < BaseController
+    include Subcollections::Tags
+
     ADDITIONAL_ATTRS = %w(generic_object_definition associations).freeze
 
     before_action :set_additional_attributes

--- a/config/api.yml
+++ b/config/api.yml
@@ -888,6 +888,8 @@
     - :subcollection
     :verbs: *gpd
     :klass: GenericObject
+    :subcollections:
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -911,6 +913,12 @@
       :delete:
       - :name: delete
         :identifier: generic_object_delete
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: generic_object_edit
+      - :name: unassign
+        :identifier: generic_object_edit
   :groups:
     :description: Groups
     :identifier: rbac_group


### PR DESCRIPTION
This allows for retrieval, assigning, and un-assigning of tags on Generic Objects

### Usage
#### POST /api/generic_objects/:id/tags
* Can assign tags as follows:
```
{
  'action': 'assign',
  'category': 'department',
  'name': 'finance'
}
```
* Can unassign tags as follows:
```
{
  'action': 'unassign',
  'category': 'department',
  'name': 'finance'
}
```
#### GET /api/generic_objects/:id/tags
* Returns all assigned tags on a generic object 

@miq-bot add_label enhancement
@miq-bot assign @abellotti 

cc: @chalettu 