### PR TITLE
Add a rudimentary event streams API

### DIFF
--- a/app/controllers/api/event_streams_controller.rb
+++ b/app/controllers/api/event_streams_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  class EventStreamsController < BaseController
+    before_action :validate_filters, :ensure_pagination, :only => :index
+
+    private
+
+    def validate_filters
+      messages = []
+      messages << "must specify target_type" unless filter_contains?("target_type")
+      messages << "must specify a minimum value for timestamp" unless filter_contains?("timestamp>")
+      raise BadRequestError, messages.join(", ").capitalize if messages.any?
+    end
+
+    def filter_contains?(filter)
+      Array(params["filter"]).any? { |f| f.start_with?(filter) }
+    end
+
+    def ensure_pagination
+      params["limit"] ||= Settings.api.event_streams_default_limit
+      params["offset"] ||= 0
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -739,6 +739,23 @@
         :identifier: storage_tag
       - :name: unassign
         :identifier: storage_tag
+  :event_streams:
+    :description: Event Streams
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: EventStream
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: event_streams_show_list
+      :post:
+      - :name: query
+        identifier: event_streams_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: event_streams_show
   :events:
     :description: Events
     :identifier: event

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,4 @@
   :token_ttl: 10.minutes
   :authentication_timeout: 30.seconds
   :metrics_default_limit: 1000
+  :event_streams_default_limit: 1000

--- a/spec/requests/event_streams_spec.rb
+++ b/spec/requests/event_streams_spec.rb
@@ -1,0 +1,225 @@
+RSpec.describe "Event Streams" do
+  describe "GET /api/event_streams" do
+    around { |example| Timecop.freeze("2017-01-05 12:00 UTC") { example.run } }
+
+    specify "target_type is a required filter" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      FactoryGirl.create(:miq_event)
+
+      get(api_event_streams_url, :params => {:filter => ["timestamp>2017-01-01"]})
+
+      expect(response.parsed_body).to include_error_with_message("Must specify target_type")
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    specify "event streams must be filtered by timestamp occurring after a certain date" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      FactoryGirl.create(:miq_event)
+
+      get(api_event_streams_url, :params => {:filter => ["target_type=VmOrTemplate"]})
+
+      expect(response.parsed_body).to include_error_with_message("Must specify a minimum value for timestamp")
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "will aggregate required filter messages" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      FactoryGirl.create(:miq_event)
+
+      get(api_event_streams_url)
+
+      expect(response.parsed_body).to include_error_with_message("Must specify target_type, must specify a minimum value for timestamp")
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns a list of event streams with the appropriate role" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      vm = FactoryGirl.create(:vm_vmware)
+      event_stream = FactoryGirl.create(:miq_event, :target => vm, :timestamp => Time.zone.now)
+
+      get(api_event_streams_url, :params => {:filter => ["target_type=VmOrTemplate", "timestamp>2017-01-01"]})
+
+      expected = {"resources" => [{"href" => api_event_stream_url(nil, event_stream)}]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can filter by event type" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      vm = FactoryGirl.create(:vm_vmware)
+      start_event = FactoryGirl.create(:miq_event, :target => vm, :timestamp => Time.zone.now, :event_type => "vm_start")
+      _stop_event = FactoryGirl.create(:miq_event, :target => vm, :timestamp => Time.zone.now, :event_type => "vm_stop")
+
+      get(
+        api_event_streams_url,
+        :params => {
+          :filter => [
+            "target_type=VmOrTemplate",
+            "timestamp>2017-01-01",
+            "event_type=vm_start"
+          ]
+        }
+      )
+
+      expected = {"resources" => [a_hash_including("href" => api_event_stream_url(nil, start_event))]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can filter by timestamp" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      vm = FactoryGirl.create(:vm_vmware)
+      _event1 = FactoryGirl.create(:miq_event, :target => vm, :timestamp => 2.days.ago.end_of_day)
+      event2 = FactoryGirl.create(:miq_event, :target => vm, :timestamp => 1.day.ago.beginning_of_day)
+      event3 = FactoryGirl.create(:miq_event, :target => vm, :timestamp => 1.day.ago.end_of_day)
+      _event4 = FactoryGirl.create(:miq_event, :target => vm, :timestamp => Time.zone.today.beginning_of_day)
+
+      get(
+        api_event_streams_url,
+        :params => {
+          :filter => [
+            "target_type=VmOrTemplate",
+            "timestamp>2017-01-03",
+            "timestamp<2017-01-05"
+          ]
+        }
+      )
+
+      expected = {
+        "resources" => a_collection_containing_exactly(
+          a_hash_including("href" => api_event_stream_url(nil, event2)),
+          a_hash_including("href" => api_event_stream_url(nil, event3))
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can filter by target_type" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      vm = FactoryGirl.create(:vm_vmware)
+      host = FactoryGirl.create(:host_vmware)
+      vm_event = FactoryGirl.create(:miq_event, :timestamp => Time.zone.now, :target => vm)
+      _host_event = FactoryGirl.create(:miq_event, :timestamp => Time.zone.now, :target => host)
+
+      get(
+        api_event_streams_url,
+        :params => {
+          :filter => [
+            "target_type=VmOrTemplate",
+            "timestamp>2017-01-01"
+          ]
+        }
+      )
+
+      expected = {"resources" => [a_hash_including("href" => api_event_stream_url(nil, vm_event))]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can filter by target_id" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      vm1, vm2 = FactoryGirl.create_list(:vm_vmware, 2)
+      host = FactoryGirl.create(:host_vmware)
+      vm1_event = FactoryGirl.create(:miq_event, :timestamp => Time.zone.now, :target => vm1)
+      _vm2_event = FactoryGirl.create(:miq_event, :timestamp => Time.zone.now, :target => vm2)
+      _host_event = FactoryGirl.create(:miq_event, :timestamp => Time.zone.now, :target => host)
+
+      get(
+        api_event_streams_url,
+        :params => {
+          :filter => [
+            "target_id=#{vm1.id}",
+            "target_type=VmOrTemplate",
+            "timestamp>2017-01-01"
+          ]
+        }
+      )
+
+      expected = {"resources" => [a_hash_including("href" => api_event_stream_url(nil, vm1_event))]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "limits the resources returned" do
+      stub_settings_merge(:api => {:event_streams_default_limit => 2})
+      api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
+      vm = FactoryGirl.create(:vm_vmware)
+      FactoryGirl.create_list(:miq_event, 3, :target => vm, :timestamp => Time.zone.now)
+
+      get(api_event_streams_url, :params => {:filter => ["target_type=VmOrTemplate", "timestamp>2017-01-01"]})
+
+      expected = {
+        "links"    => a_hash_including(
+          "self" => a_string_matching("offset=0"),
+          "next" => a_string_matching("offset=2")
+        ),
+        "count"    => 3,
+        "subcount" => 2
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "will not authorize a request without the appropriate role" do
+      api_basic_authorize
+
+      get(api_event_streams_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "GET /api/event_streams/:id" do
+    it "returns the details of an event stream with the appropriate role" do
+      api_basic_authorize(action_identifier(:event_streams, :read, :resource_actions, :get))
+      event_stream = FactoryGirl.create(:miq_event, :message => "I'm an event stream!")
+
+      get(api_event_stream_url(nil, event_stream))
+
+      expect(response.parsed_body).to include("message" => "I'm an event stream!")
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "will not authorize a request without the appropriate role" do
+      api_basic_authorize
+      event_stream = FactoryGirl.create(:miq_event)
+
+      get(api_event_stream_url(nil, event_stream))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "POST /api/event_streams with query action" do
+    it "returns the details of the requested event streams with the appropriate role" do
+      api_basic_authorize(action_identifier(:event_streams, :query, :collection_actions, :post))
+      event_stream = FactoryGirl.create(:miq_event, :message => "I'm an event stream!")
+
+      post(
+        api_event_streams_url,
+        :params => {
+          :action    => "query",
+          :resources => [{"href" => api_event_stream_url(nil, event_stream)}]
+        }
+      )
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "will not authorize a request without the appropriate role" do
+      api_basic_authorize
+      event_stream = FactoryGirl.create(:miq_event)
+
+      post(
+        api_event_streams_url,
+        :params => {
+          :action    => "query",
+          :resources => [{"href" => api_event_stream_url(nil, event_stream)}]
+        }
+      )
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
Adds an Event Streams API with the rudimentary features as stipulated in https://www.pivotaltracker.com/story/show/149754397. If still required, I'll follow this up with event streams subcollection endpoints in another PR. Marking this as WIP as I have a few questions I need addressed before officially submitting this.

@miq-bot add-label wip, enhancement
@miq-bot assign @abellotti 

/cc @AllenBW 