### PR TITLE
Add VMs subcollection to providers

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -17,6 +17,7 @@ module Api
     include Subcollections::CloudTenants
     include Subcollections::CustomAttributes
     include Subcollections::LoadBalancers
+    include Subcollections::Vms
 
     def create_resource(type, _id, data = {})
       assert_id_not_specified(data, type)

--- a/config/api.yml
+++ b/config/api.yml
@@ -1573,6 +1573,7 @@
     - :cloud_tenants
     - :custom_attributes
     - :load_balancers
+    - :vms
     :collection_actions:
       :get:
       - :name: read


### PR DESCRIPTION
### Example usage
#### /api/providers/:id/vms
* returns the VMs on a provider
```
{
  "name"      : "vms",
  ...
  "resources" : [
    {"href" : "/api/providers/:p_id/vms/:vm_id"}
  ]
}
```
#### /api/providers?expand=resources,vms
* It can expand vms on all providers
```
{
  "name"      : "providers",
  "resources" : [
    {
      "href" : "/api/providers/:id",
      ...
      "vms"  : [
       {  "href" : "/api/providers/:id/vms/:id", "name" : "vm name" ... } 
      ]
    }
  ]
}
```

@miq-bot add_label enhancement
@miq-bot assign @abellotti 
cc: @zhitongLBN