### PR TITLE
s/metrics_default_limit/large_collection_default_limit/

### DIFF
--- a/app/controllers/api/metric_rollups_controller.rb
+++ b/app/controllers/api/metric_rollups_controller.rb
@@ -2,7 +2,7 @@ module Api
   class MetricRollupsController < BaseController
     def index
       params[:offset] ||= 0
-      params[:limit] ||= Settings.api.metrics_default_limit
+      params[:limit] ||= Settings.api.large_collection_default_limit
 
       rollups_service = MetricRollupsService.new(params)
       resources = rollups_service.query_metric_rollups

--- a/app/controllers/api/subcollections/metric_rollups.rb
+++ b/app/controllers/api/subcollections/metric_rollups.rb
@@ -7,7 +7,7 @@ module Api
 
       def metric_rollups_query_resource(object)
         params[:offset] ||= 0
-        params[:limit] ||= Settings.api.metrics_default_limit
+        params[:limit] ||= Settings.api.large_collection_default_limit
         params[:resource_type] = RESOURCE_TYPES[@req.collection] || object.class.to_s
         params[:resource_ids] ||= [object.id]
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
 :api:
   :token_ttl: 10.minutes
   :authentication_timeout: 30.seconds
-  :metrics_default_limit: 1000
+  :large_collection_default_limit: 1000

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,2 @@
 :api:
-  :metrics_default_limit: 10000
+  :large_collection_default_limit: 10000


### PR DESCRIPTION
Since we want to use the same value/concept for the upcoming event
streams API, we need to give this configurable a more abstract name.

Disclaimer: naming is hard. If you have a good suggestion, please come forward. Also considered: `firehose_default_limit` and `big_$@!_collection_default_limit` 😁 

/cc @jntullo 
@miq-bot add-label refactoring
@miq-bot assign @abellotti 