### PR TITLE
Remove sqlfilter warning

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -26,8 +26,6 @@ module Api
             raise BadRequestError, "Unsupported HTTP Method #{mname} for the #{ctype} #{cname} specified"
           end
         end
-
-        validate_api_parameters
       end
 
       def validate_optional_collection_classes
@@ -39,12 +37,6 @@ module Api
       def validate_api_action
         return unless @req.collection
         send("validate_#{@req.method}_method")
-      end
-
-      def validate_api_parameters
-        return unless params['sqlfilter']
-
-        raise BadRequestError, "The sqlfilter parameter is no longer supported, please use the filter parameter instead"
       end
 
       #


### PR DESCRIPTION
Support for the sqlfilter parameter was removed in 2014 in version
1.1 (see
http://manageiq.org/docs/reference/latest/api/overview/versioning). Now
on version 3.0.0-pre, it seems appropriate to silently ignore this
instead of returning a 400.

@miq-bot assign @abellotti 