### PR TITLE
Allow update of miq_groups by authenticated User

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,7 +2,7 @@ module Api
   class UsersController < BaseController
     INVALID_USER_ATTRS = %w(id href current_group_id settings).freeze # Cannot update other people's settings
     INVALID_SELF_USER_ATTRS = %w(id href current_group_id).freeze
-    EDITABLE_ATTRS = %w(password email settings group current_group).freeze
+    EDITABLE_ATTRS = %w(password email settings group current_group miq_groups).freeze
 
     include Subcollections::Tags
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -207,6 +207,34 @@ RSpec.describe "users API" do
       expect(user1.reload.miq_groups).to match_array([group2, group3])
     end
 
+    it "allows for editing of multiple miq_groups and current_user of authenticated user" do
+      api_basic_authorize collection_action_identifier(:users, :edit)
+      group3 = FactoryGirl.create(:miq_group)
+
+      request = {
+        "action"    => "edit",
+        "resources" => [{
+          "href"          => api_user_url(nil, @user),
+          "miq_groups"    => [
+            { "id" => group2.id.to_s },
+            { "href" => api_group_url(nil, group3) },
+          ],
+          "current_group" => {
+            "href" => api_group_url(nil, group3)
+          }
+        }]
+      }
+      post(api_users_url, :params => request)
+
+      expected = {
+        'results' => [
+          a_hash_including("current_group_id" => group3.id.to_s)
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "rejects user edits without appropriate role" do
       api_basic_authorize
 


### PR DESCRIPTION
Although we allowed the authenticated user to update their current group in a [previous PR](https://github.com/ManageIQ/manageiq-api/pull/44), the `miq_groups` are still not editable by the current user, which is necessary for updating the current group.

#### Example of editing miq_groups and current_group 
```
{
  'action'    : 'edit',
  'resources' : [{
                    'href'          : '/api/groups/:id'
                    'miq_groups'    : [
                      { 'id' : '<id>' }, 
                      { 'href' : '/api/groups/:id' },
                    ],
                    'current_group' : {
                      'href' : '/api/groups/:id'
                    }
                  }]
}
```

cc: @AllenBW 
@miq-bot assign @abellotti 