### PR TITLE
Fix api.yml trailing whitespace

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1099,7 +1099,7 @@
     :options:
     - :collection
     :subcollections:
-    - :custom_attributes 
+    - :custom_attributes
     - :load_balancers
     - :snapshots
     :collection_actions:


### PR DESCRIPTION
Because I *will* commit this in a totally unrelated revision by
mistake if I don't do this here.

:heart: :rainbow: :lollipop:

@miq-bot assign @abellotti 