### PR TITLE
Alert Definitions: add hash_expression

### DIFF
--- a/app/controllers/api/alert_definitions_controller.rb
+++ b/app/controllers/api/alert_definitions_controller.rb
@@ -1,16 +1,17 @@
 module Api
   class AlertDefinitionsController < BaseController
-    REQUIRED_FIELDS = %w(description db expression options).freeze
-
     before_action :set_additional_attributes
 
     def create_resource(type, id, data = {})
       assert_id_not_specified(data, type)
-      assert_all_required_fields_exists(data, type, REQUIRED_FIELDS)
       begin
-        data["expression"] = MiqExpression.new(data["expression"])
-        data["enabled"] = true if data["enabled"].nil?
-        super(type, id, data).serializable_hash.merge("expression" => data["expression"])
+        update_miq_expression(data) if data["expression"]
+        alert = if data["hash_expression"]
+                  super(type, id, data.deep_symbolize_keys).serializable_hash
+                else
+                  super(type, id, data).serializable_hash
+                end
+        alert.merge("expression" => alert["miq_expression"] || alert["hash_expression"])
       rescue => err
         raise BadRequestError, "Failed to create a new alert definition - #{err}"
       end
@@ -19,8 +20,12 @@ module Api
     def edit_resource(type, id = nil, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
       begin
-        data["expression"] = MiqExpression.new(data["expression"]) if data["expression"]
-        super(type, id, data)
+        update_miq_expression(data) if data["expression"]
+        if data["hash_expression"]
+          super(type, id, data.deep_symbolize_keys)
+        else
+          super(type, id, data)
+        end
       rescue => err
         raise BadRequestError, "Failed to update alert definition - #{err}"
       end
@@ -30,6 +35,11 @@ module Api
 
     def set_additional_attributes
       @additional_attributes = %w(expression)
+    end
+
+    def update_miq_expression(data)
+      data["miq_expression"] = data["expression"]
+      data.delete("expression")
     end
   end
 end


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/16397

Changes included: 

* Currently, it is possible to create an alert definition via API only with an expression as MiqExpression. Following the changes in https://github.com/ManageIQ/manageiq/pull/15315, this PR adds the ability to create an alert with hash expression. 

* Backward Compatibility: we would like to keep the option to create an alert with expression as MiqExpression without explicitly passing a `miq_expression` attribute. So the user will have now 3 options when sending a create request and will need to pass exactly one of the following:
1. `expression` which will be saved as MiqExpression (same as before).
2. `miq_expression`.
3. `hash_expression`.  

* Allowing editing an alert definition (with similar logic). 

* Deep symbolize for data. 

(This PR replaces https://github.com/ManageIQ/manageiq/pull/14979 with different implementation)