### PR TITLE
Added support for collection specific hide_resources option.

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -43,7 +43,7 @@ module Api
 
           json.set! 'pages', link_builder.pages if link_builder.links?
 
-          unless @req.hide?("resources")
+          unless @req.hide?("resources") || collection_option?(:hide_resources)
             json.resources resources.collect do |resource|
               if opts[:expand_resources]
                 add_hash json, resource_to_jbuilder(type, reftype, resource, opts).attributes!

--- a/config/api.yml
+++ b/config/api.yml
@@ -256,6 +256,7 @@
     :description: Automate Workspaces
     :options:
     - :collection
+    - :hide_resources
     :verbs: *gp
     :klass: AutomateWorkspace
     :collection_actions:

--- a/spec/requests/automate_workspaces_spec.rb
+++ b/spec/requests/automate_workspaces_spec.rb
@@ -5,6 +5,16 @@ describe "Automate Workspaces API" do
   describe 'GET' do
     let(:user) { FactoryGirl.create(:user_with_group, :userid => "admin") }
     let(:aw) { FactoryGirl.create(:automate_workspace, :user => user, :tenant => user.current_tenant) }
+
+    it 'should not return resources when fetching the collection' do
+      api_basic_authorize collection_action_identifier(:automate_workspaces, :read, :get)
+      aw
+      get(api_automate_workspaces_url)
+
+      expect(response.parsed_body).not_to include("resources")
+      expect(response).to have_http_status(:ok)
+    end
+
     it 'should not allow fetching using id' do
       api_basic_authorize action_identifier(:automate_workspaces, :read, :resource_actions, :get)
       get(api_automate_workspace_url(nil, aw.id))


### PR DESCRIPTION
This is needed for the new automate_workspaces collection where
we don't want to return current set of workspaces as they
are only accessible by resource guid from automate.

We're leveraging the current mechanism we have in place for
the hide=resources parameter and supported at the collection
level via the api.yml.

We've contemplated the 404 on the collection but that breaks
the clients and inhibits it from getting collection level
actions and such.