### PR TITLE
Added support for arbitrary resource identifier.

### DIFF
--- a/app/controllers/api/automate_workspaces_controller.rb
+++ b/app/controllers/api/automate_workspaces_controller.rb
@@ -1,18 +1,7 @@
 module Api
   class AutomateWorkspacesController < BaseController
-    def show
-      obj = AutomateWorkspace.find_by(:guid => @req.c_id)
-      if obj.nil?
-        raise NotFoundError, "Invalid Workspace #{@req.c_id} specified"
-      end
-      render_resource(:automate_workspaces, obj)
-    end
-
-    def edit_resource(_type, id, data = {})
-      obj = AutomateWorkspace.find_by(:guid => id)
-      if obj.nil?
-        raise NotFoundError, "Invalid Workspace #{id} specified"
-      end
+    def edit_resource(type, id, data = {})
+      obj = resource_search(id, type, collection_class(type))
       obj.merge_output!(data)
     end
   end

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -208,7 +208,8 @@ module Api
         action_result(false, err.to_s)
       end
 
-      def validate_id(id, klass)
+      def validate_id(id, type, klass)
+        return if collection_config.resource_identifier(type) != "id"
         raise NotFoundError, "Invalid #{klass} id #{id} specified" unless id.kind_of?(Integer) || id =~ /\A\d+\z/
       end
     end

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -10,7 +10,8 @@ module Api
         attrs = normalize_select_attributes(obj, opts)
         result = {}
 
-        href = new_href(type, obj["id"], obj["href"])
+        key_id = collection_config.resource_identifier(type)
+        href = new_href(type, obj[key_id], obj["href"])
         if href.present?
           result["href"] = href
           attrs -= ["href"]

--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -31,8 +31,8 @@ module Api
       service_order
     end
 
-    def validate_id(id, klass)
-      id == USER_CART_ID || super(id, klass)
+    def validate_id(id, type, klass)
+      id == USER_CART_ID || super(id, type, klass)
     end
 
     def find_service_orders(id)

--- a/config/api.yml
+++ b/config/api.yml
@@ -256,6 +256,7 @@
     :options:
     - :collection
     - :hide_resources
+    :resource_identifier: guid
     :verbs: *gp
     :klass: AutomateWorkspace
     :collection_actions:

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -8,7 +8,7 @@ module Api
       # Config::Options implements a system method causing self[:system] to error.
       # i.e. subcollection name system in an arbitraty path /api/automate/manageiq/system
       @cfg[collection_name.to_sym]
-    rescue => _err
+    rescue
       nil
     end
 

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -5,7 +5,11 @@ module Api
     end
 
     def [](collection_name)
+      # Config::Options implements a system method causing self[:system] to error.
+      # i.e. subcollection name system in an arbitraty path /api/automate/manageiq/system
       @cfg[collection_name.to_sym]
+    rescue => _err
+      nil
     end
 
     def option?(collection_name, option_name)
@@ -88,6 +92,10 @@ module Api
       @cfg.each_with_object({}) do |(collection, cspec), result|
         result[collection] = cspec[:description] if cspec[:options].include?(:collection)
       end
+    end
+
+    def resource_identifier(collection_name)
+      self[collection_name].try(:resource_identifier) || "id"
     end
 
     private

--- a/spec/lib/api/collection_config_spec.rb
+++ b/spec/lib/api/collection_config_spec.rb
@@ -22,4 +22,10 @@ RSpec.describe Api::CollectionConfig do
       expect(subject.name_for_subclass(String)).to be_nil
     end
   end
+
+  describe "[]" do
+    it "returns nil for :system" do
+      expect(subject[:system]).to be_nil
+    end
+  end
 end

--- a/spec/requests/automate_workspaces_spec.rb
+++ b/spec/requests/automate_workspaces_spec.rb
@@ -28,6 +28,23 @@ describe "Automate Workspaces API" do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it 'fetching by guid should return resources with guid based references' do
+      api_basic_authorize action_identifier(:automate_workspaces, :read, :resource_actions, :get)
+      get(api_automate_workspace_url(nil, aw.guid))
+
+      expect(response.parsed_body).to include(
+        "href"    => api_automate_workspace_url(nil, aw.guid),
+        "id"      => aw.id.to_s,
+        "guid"    => aw.guid,
+        "actions" => a_collection_including(
+          "name"   => "edit",
+          "method" => "post",
+          "href"   => api_automate_workspace_url(nil, aw.guid)
+        )
+      )
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe 'POST' do


### PR DESCRIPTION
Generally, resources are accessed by their id attribute.  For
automate_workspaces, this is not the case as we only want
resources accessed by their guid.

The enhancement adds support for arbitrary resource identifier
declared in the collection definition in the api.yml.
hrefs created for the resource themselves as well as the actions
made available to those resources will have the guid (as defined
by the :resource_identifier: paramter) in the href and not the id.

With the href properly built, the clients leveraging them will
continue to work as they do today.