### PR TITLE
Return miq_groups on api entrypoint 

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -44,6 +44,7 @@ module Api
         :role_href  => "#{@req.api_prefix}/roles/#{group.miq_user_role.id}",
         :tenant     => group.tenant.name,
         :groups     => user.miq_groups.pluck(:description),
+        :miq_groups => normalize_array(user.miq_groups, :groups)
       }
     end
 

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -111,8 +111,8 @@ module Api
         end
       end
 
-      def normalize_array(obj)
-        type = @req.subject
+      def normalize_array(obj, type = nil)
+        type ||= @req.subject
         obj.collect { |item| normalize_attr(get_reftype(type, type, item), item) }
       end
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -104,7 +104,11 @@ describe "Authentication API" do
         "group_href" => "/api/groups/#{group2.id}",
         "role"       => @role.name,
         "role_href"  => "/api/roles/#{group2.miq_user_role.id}",
-        "tenant"     => @group.tenant.name
+        "tenant"     => @group.tenant.name,
+        "groups"     => @user.miq_groups.pluck(:description),
+        "miq_groups" => a_collection_including(
+          hash_including("href" => api_group_url(nil, @user.miq_groups.first))
+        )
       )
       expect(response.parsed_body["identity"]["groups"]).to match_array(@user.miq_groups.pluck(:description))
     end


### PR DESCRIPTION
Resolves https://github.com/ManageIQ/manageiq-api/issues/74 

This enhancement returns `miq_groups` on the entrypoint
```
GET /api
{
   "name": "API",
   "description": "REST API",
   "settings": {...},
   "identity": {
      ...
      "groups" [...],
      "miq_groups": [
         { "href": "/api/groups/:id", "id": ":id" ... } ...
      ]
   }
   ...
}
```

@miq-bot add_label enhancement
@miq-bot assign @abellotti 
cc: @AllenBW 