### PR TITLE
Return correct automate_domains and policy_actions href_slugs

### DIFF
--- a/app/controllers/api/automate_domains_controller.rb
+++ b/app/controllers/api/automate_domains_controller.rb
@@ -27,6 +27,10 @@ module Api
       end
     end
 
+    def fetch_automate_domains_href_slug(resource)
+      "automate_domains/#{resource.id}"
+    end
+
     private
 
     def automate_domain_ident(domain)

--- a/app/controllers/api/policy_actions_controller.rb
+++ b/app/controllers/api/policy_actions_controller.rb
@@ -1,4 +1,7 @@
 module Api
   class PolicyActionsController < BaseController
+    def fetch_policy_actions_href_slug(resource)
+      "policy_actions/#{resource.id}"
+    end
   end
 end

--- a/spec/requests/automate_domains_spec.rb
+++ b/spec/requests/automate_domains_spec.rb
@@ -2,6 +2,23 @@
 # REST API Request Tests - /api/automate_domains
 #
 describe "Automate Domains API" do
+  describe 'GET /api/automate_domains' do
+    it 'returns the correct href_slug' do
+      git_domain = FactoryGirl.create(:miq_ae_git_domain)
+      api_basic_authorize collection_action_identifier(:automate_domains, :read, :get)
+
+      get(api_automate_domains_url, :params => { :expand => 'resources', :attributes => 'href_slug' })
+
+      expected = {
+        'resources' => [
+          a_hash_including('href_slug' => "automate_domains/#{git_domain.id}")
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
   describe 'refresh_from_source action' do
     let(:git_domain) { FactoryGirl.create(:miq_ae_git_domain) }
     it 'forbids access for users without proper permissions' do

--- a/spec/requests/policy_actions_spec.rb
+++ b/spec/requests/policy_actions_spec.rb
@@ -55,6 +55,21 @@ describe "Policy Actions API" do
       expect_query_result(:policy_actions, 4, 4)
       expect_result_resources_to_include_data("resources", "guid" => miq_action_guid_list)
     end
+
+    it "returns the correct href_slug" do
+      policy = FactoryGirl.create(:miq_action, :name => "action_policy_1")
+      api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
+
+      get(api_policy_actions_url, :params => { :expand => "resources", :attributes => 'href_slug' })
+
+      expected = {
+        'resources' => [
+          a_hash_including('href_slug' => "policy_actions/#{policy.id}")
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   context "Policy Action subcollection" do


### PR DESCRIPTION
Currently, the automate domain href_slugs return `automate/:id` because the Api config finds the first matching class. Similarly, policy_actions returns `actions/:id`. For now, it seems the best way to resolve this issue is to override the default href_slug virtual attribute itself.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1485310

@miq-bot add_label bug
@miq-bot assign @abellotti 