### PR TITLE
Return correct version href 

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -26,7 +26,7 @@ module Api
       ApiConfig.version.definitions.select(&:ident).collect do |version_specification|
         {
           :name => version_specification[:name],
-          :href => "#{@req.api_prefix}/#{version_specification[:ident]}"
+          :href => "#{@req.base}#{@req.prefix(false)}/#{version_specification[:ident]}"
         }
       end
     end

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -116,6 +116,12 @@ module Api
           @request.original_url # http://target/api/...
         end
 
+        def prefix(version = true)
+          prefix = "/#{path.split('/')[1]}" # /api
+          return prefix unless version
+          version_override? ? "#{prefix}/#{@params[:version]}" : prefix
+        end
+
         private
 
         def expand_requested
@@ -128,11 +134,6 @@ module Api
 
         def fullpath
           @request.original_fullpath # /api/...&param=value...
-        end
-
-        def prefix
-          prefix = "/#{path.split('/')[1]}" # /api
-          version_override? ? "#{prefix}/#{@params[:version]}" : prefix
         end
       end
     end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -43,6 +43,18 @@ describe "Authentication API" do
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it "returns a correctly formatted versions href" do
+      version_ident = "v#{Api::ApiConfig.base.version}"
+      api_basic_authorize
+
+      get api_entrypoint_url(version_ident)
+
+      expected = {
+        "versions" => [a_hash_including("href" => api_entrypoint_url(version_ident))]
+      }
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   context "Basic Authentication with Group Authorization" do


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1485424

Currently, when `GET /api/:version` is called, the href that is returned for the version in the response is in the format `/api/:version/:version`. This ensures only `/api/:version` is returned.

@miq-bot add_label bug
@miq-bot assign @abellotti 