### PR TITLE
DRY up version regex

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -64,7 +64,7 @@ module Api
 
       def href_collection_id(path)
         path_array = path.split('/')
-        cidx = path_array[2] && path_array[2].match(ApiConfig.version.regex) ? 3 : 2
+        cidx = path_array[2] && path_array[2].match(Api::VERSION_REGEX) ? 3 : 2
 
         collection, c_id    = path_array[cidx..cidx + 1]
         subcollection, s_id = path_array[cidx + 2..cidx + 3]

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -123,7 +123,7 @@ module Api
         end
 
         def version_override?
-          @params[:version] && @params[:version].match(ApiConfig.version[:regex]) # v#.# version signature
+          @params[:version] && @params[:version].match(Api::VERSION_REGEX) # v#.# version signature
         end
 
         def fullpath

--- a/config/api.yml
+++ b/config/api.yml
@@ -5,7 +5,6 @@
   :description: REST API
   :version: '3.0.0-pre'
 :version:
-  :regex: !ruby/regexp /^v[0-9]+(?>\\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?/
   :definitions:
   - :name: '3.0.0-pre'
     :ident: 'v3.0.0-pre'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # Enablement for the REST API
 
-  namespace :api, :path => "api(/:version)", :version => Api::VERSION_REGEX, :defaults => {:format => "json"} do
+  namespace :api, :path => "api(/:version)", :version => Api::VERSION_CONSTRAINT, :defaults => {:format => "json"} do
     root :to => "api#index", :as => :entrypoint
     match "/", :to => "api#options", :via => :options
 

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,5 +1,5 @@
 module Api
-  VERSION_CONSTRAINT = /v[\d]+(\.[\da-zA-Z]+)*(\-[\da-zA-Z\-\.]+)?/
+  VERSION_CONSTRAINT = /v\d+(\.[\da-zA-Z]+)*(\-[\da-zA-Z\-\.]+)?/
   VERSION_REGEX = /\A#{VERSION_CONSTRAINT}\z/
 
   VERBS_ACTIONS_MAP = {

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,6 +1,6 @@
 module Api
-  # Semantic Versioning Regex for API, i.e. vMajor.minor.patch[-pre]
-  VERSION_REGEX = /v[\d]+(\.[\da-zA-Z]+)*(\-[\da-zA-Z]+)?/
+  VERSION_CONSTRAINT = /v[\d]+(\.[\da-zA-Z]+)*(\-[\da-zA-Z\-\.]+)?/
+  VERSION_REGEX = /\A#{VERSION_CONSTRAINT}\z/
 
   VERBS_ACTIONS_MAP = {
     :get     => "show",

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -1,4 +1,38 @@
 RSpec.describe Api do
+  describe "::VERSION_REGEX" do
+    it "detects the major version" do
+      expect("v1").to be_a_valid_version
+    end
+
+    it "detects the minor version" do
+      expect("v1.2").to be_a_valid_version
+    end
+
+    it "detects the patch version" do
+      expect("v1.2.3").to be_a_valid_version
+    end
+
+    it "detects the prerelease version" do
+      expect("v1.2.3-pre").to be_a_valid_version
+      expect("v1.2.3-pre1").to be_a_valid_version
+      expect("v1.2.3-pre-1").to be_a_valid_version
+      expect("v1.2.3-pre.four").to be_a_valid_version
+      expect("v1.2.3-alpha").to be_a_valid_version
+      expect("v1.2.3-beta").to be_a_valid_version
+      expect("v1.2.3-alpha.45").to be_a_valid_version
+      expect("v1.2.3 pre").not_to be_a_valid_version
+    end
+
+    specify "versions must be prefixed with a 'v'" do
+      expect("1.2.3").not_to be_a_valid_version
+      expect("abcv1.2.3").not_to be_a_valid_version
+    end
+
+    def be_a_valid_version
+      match(Api::VERSION_REGEX)
+    end
+  end
+
   describe ".compressed_id?" do
     it "returns true for a compressed id" do
       expect(Api.compressed_id?("1r1")).to be(true)


### PR DESCRIPTION
We currently have two things claiming to be the version regex -
`Api::VERSION_REGEX` and `ApiConfig.version.regex`. It seems sensible
to remove one of them. Somewhat alarmingly they are not exactly the
same, but the tests do pass. If it turns out we do need two different
ones, we should probably:

* put them in the same place
* use better naming to convey intent
* add tests that cover the unique behavior

@miq-bot add-label technical debt
@miq-bot assign @abellotti 