### PR TITLE
Use HTTP status to indicated that cids have been deprecated

### DIFF
--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -65,7 +65,7 @@ module Api
         end
 
         def c_id
-          @c_id ||= ensure_uncompressed(@params[:c_id] || c_path_parts[1])
+          @params[:c_id] || c_path_parts[1]
         end
 
         def subcollection
@@ -73,7 +73,7 @@ module Api
         end
 
         def s_id
-          @s_id ||= ensure_uncompressed(@params[:s_id] || c_path_parts[3])
+          @params[:s_id] || c_path_parts[3]
         end
 
         def subcollection?
@@ -133,10 +133,6 @@ module Api
         def prefix
           prefix = "/#{path.split('/')[1]}" # /api
           version_override? ? "#{prefix}/#{@params[:version]}" : prefix
-        end
-
-        def ensure_uncompressed(id)
-          Api.compressed_id?(id) ? Api.uncompress_id(id) : id
         end
       end
     end

--- a/spec/requests/queries_spec.rb
+++ b/spec/requests/queries_spec.rb
@@ -62,12 +62,13 @@ describe "Queries API" do
       expect_single_resource_query("id" => vm1.id.to_s, "href" => api_vm_url(nil, vm1), "guid" => vm1.guid)
     end
 
-    it 'supports compressed ids' do
+    specify 'support for compressed ids has been deprecated' do
       api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
 
       get api_vm_url(nil, vm1.compressed_id)
 
-      expect_single_resource_query("id" => vm1.id.to_s, "href" => api_vm_url(nil, vm1), "guid" => vm1.guid)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.redirect_url).to eq(api_vm_url(nil, vm1))
     end
 
     it 'returns 404 on url with trailing garbage' do
@@ -130,16 +131,13 @@ describe "Queries API" do
       expect_result_resources_to_include_data("resources", "id" => [acct1.id.to_s, acct2.id.to_s])
     end
 
-    it 'supports compressed ids' do
+    specify 'support for compressed ids has been deprecated' do
       api_basic_authorize
 
       get(api_vm_account_url(nil, vm1.compressed_id, acct1))
 
-      expect_single_resource_query(
-        "id"   => acct1.id.to_s,
-        "href" => api_vm_account_url(nil, vm1, acct1),
-        "name" => acct1.name
-      )
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response.redirect_url).to eq(api_vm_account_url(nil, vm1, acct1))
     end
 
     it 'returns 404 on url with trailing garbage' do


### PR DESCRIPTION
Using the HTTP status is the Right Way :tm: to show that a resource
has been moved (which, to the outside world, it has - it has a
different id). With this change we can remove some of the handling
done in the request parser that checks for compressed ids. We still
need some of the custom handling, however, since we still support
compressed ids in hrefs in the request body, which cannot use the same
strategy.

Thanks @chrisarcand for reminding me that HTTP exists 😁 

@miq-bot add-label technical debt
@miq-bot assign @abellotti 