### PR TITLE
Validate limit if offset is specified

### DIFF
--- a/lib/api/links_builder.rb
+++ b/lib/api/links_builder.rb
@@ -5,6 +5,7 @@ module Api
       @limit = params["limit"].to_i if params["limit"]
       @href = href
       @counts = counts if counts
+      validate_limit
     end
 
     def links
@@ -28,6 +29,10 @@ module Api
     private
 
     attr_reader :offset, :limit, :href, :counts
+
+    def validate_limit
+      raise BadRequestError, "Limit must be greater than zero if offset is specified" if links? && limit.zero?
+    end
 
     def self_href
       @self_href ||= format_href(offset)

--- a/spec/lib/api/links_builder_spec.rb
+++ b/spec/lib/api/links_builder_spec.rb
@@ -1,4 +1,12 @@
 RSpec.describe Api::LinksBuilder do
+  describe ".new" do
+    it "validates limit is not zero when offset is also specified" do
+      expect do
+        described_class.new({"offset" => 5, "limit" => 0}, '/api/collection/', nil)
+      end.to raise_error(Api::BadRequestError, "Limit must be greater than zero if offset is specified")
+    end
+  end
+
   describe "#links" do
     it "returns self, first, next, and last links when it is the first page" do
       offsets = { "offset" => 0, "limit" => 2 }


### PR DESCRIPTION
Currently if offset is specified and limit is set to 0 (ie `limit=0&offset=5`), the following error is returned due to division by 0:
```
{
    "error": {
        "kind": "internal_server_error",
        "message": "Infinity",
        "klass": "FloatDomainError"
    }
}
```

This updates the `LinksBuilder` to validate that the `limit` is greater than 0 if offset is specified.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1489885

@miq-bot add_label bug
@miq-bot assign @abellotti 