### PR TITLE
Fix cinder specs

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -148,7 +148,7 @@ describe "Providers API" do
 
   context 'Provider\'s virtual attributes(= direct or indirect associations) with RBAC' do
     let(:ems_openstack)  { FactoryGirl.create(:ems_openstack, :tenant_mapping_enabled => true) }
-    let(:ems_cinder)     { FactoryGirl.create(:ems_cinder, :parent_manager => ems_openstack) }
+    let(:ems_cinder)     { ManageIQ::Providers::StorageManager::CinderManager.find_by(:parent_manager => ems_openstack) }
     let(:ems_cinder_url) { api_provider_url(nil, ems_cinder) }
 
     let(:tenant) { FactoryGirl.create(:tenant, :source_type => 'CloudTenant') }


### PR DESCRIPTION
This began failing when
https://github.com/ManageIQ/manageiq/commit/742b0d68bf0d0a251fe226f81fde719dfac1086a
was merged. Because the cinder manager's name now delegates to the
parent manager (which when created, also creates a cinder manager),
there was a uniqueness validation failure. I've changed these specs
to look up the existing cinder manager rather than create a new one.

See https://travis-ci.org/ManageIQ/manageiq-api/jobs/282333329 for an example of this failing

/cc @durandom
@miq-bot add-label bug, test
@miq-bot assign @abellotti 
