### PR TITLE
DRY up RequestParser and HrefParser logic

### DIFF
--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -55,9 +55,9 @@ module Api
     def validate_auth_attrs(data)
       raise 'must supply a manager resource' unless data['manager_resource']
       attrs = data.dup.except('manager_resource')
-      manager_collection, manager_id = HrefParser.parse(data['manager_resource']['href'])
-      raise 'invalid manger_resource href specified' unless manager_collection && manager_id
-      manager_resource = resource_search(manager_id, manager_collection, collection_class(manager_collection))
+      href = HrefParser.new(data['manager_resource']['href'])
+      raise 'invalid manger_resource href specified' unless href.subject && href.subject_id
+      manager_resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
       [manager_resource, attrs]
     end
   end

--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -55,7 +55,7 @@ module Api
     def validate_auth_attrs(data)
       raise 'must supply a manager resource' unless data['manager_resource']
       attrs = data.dup.except('manager_resource')
-      href = HrefParser.new(data['manager_resource']['href'])
+      href = Href.new(data['manager_resource']['href'])
       raise 'invalid manger_resource href specified' unless href.subject && href.subject_id
       manager_resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
       [manager_resource, attrs]

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -70,9 +70,9 @@ module Api
 
     def destroy
       if @req.subcollection?
-        delete_subcollection_resource @req.subcollection.to_sym, @req.s_id
+        delete_subcollection_resource @req.subcollection.to_sym, @req.subcollection_id
       else
-        delete_resource(@req.collection.to_sym, @req.c_id)
+        delete_resource(@req.collection.to_sym, @req.collection_id)
       end
       render_normal_destroy
     end

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -128,7 +128,7 @@ module Api
           raise BadRequestError, "Cannot assign #{sc} to a #{type} resource" unless respond_to?(typed_target)
           sc_data.each do |sr|
             next if sr.blank?
-            href = HrefParser.new(sr["href"])
+            href = Href.new(sr["href"])
             if href.subject == sc && href.subject_id
               sr.delete("id")
               sr.delete("href")

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -128,12 +128,12 @@ module Api
           raise BadRequestError, "Cannot assign #{sc} to a #{type} resource" unless respond_to?(typed_target)
           sc_data.each do |sr|
             next if sr.blank?
-            collection, rid = HrefParser.parse(sr["href"])
-            if collection == sc && rid
+            href = HrefParser.new(sr["href"])
+            if href.subject == sc && href.subject_id
               sr.delete("id")
               sr.delete("href")
             end
-            send(typed_target, resource, type, rid.to_i, sr)
+            send(typed_target, resource, type, href.subject_id.to_i, sr)
           end
         end
       end

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -54,7 +54,7 @@ module Api
 
       def delete_resource(type, id = nil, _data = nil)
         klass = collection_class(type)
-        id ||= @req.c_id
+        id ||= @req.collection_id
         raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
         delete_resource_action(klass, type, id)
       end
@@ -85,7 +85,7 @@ module Api
 
       def custom_action_resource(type, id, data = nil)
         action = @req.action.downcase
-        id ||= @req.c_id
+        id ||= @req.collection_id
         if id.blank?
           raise BadRequestError, "Must specify an id for invoking the custom action #{action} on a #{type} resource"
         end

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -20,7 +20,7 @@ module Api
 
       def parent_resource_obj
         type = @req.collection.to_sym
-        resource_search(@req.c_id, type, collection_class(type))
+        resource_search(@req.collection_id, type, collection_class(type))
       end
 
       def collection_class(type)

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -79,7 +79,7 @@ module Api
       end
 
       def subcollection_href(type, value)
-        normalize_url("#{@req.collection}/#{@req.c_id}/#{type}/#{value}")
+        normalize_url("#{@req.collection}/#{@req.collection_id}/#{type}/#{value}")
       end
 
       def collection_href(type, value)

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -159,7 +159,7 @@ module Api
 
       def validate_method_action(method_name, action_name)
         cname, target = if collection_option?(:arbitrary_resource_path)
-                          [@req.collection, (@req.c_id ? :resource : :collection)]
+                          [@req.collection, (@req.collection_id ? :resource : :collection)]
                         else
                           [@req.subject, request_type_target.last]
                         end
@@ -179,9 +179,9 @@ module Api
 
       def request_type_target
         if @req.subcollection
-          @req.s_id ? [:resource, :subresource] : [:collection, :subcollection]
+          @req.subcollection_id ? [:resource, :subresource] : [:collection, :subcollection]
         else
-          @req.c_id ? [:resource, :resource] : [:collection, :collection]
+          @req.collection_id ? [:resource, :resource] : [:collection, :collection]
         end
       end
 
@@ -220,7 +220,7 @@ module Api
           ctype = "Collection"
           raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config[cname]
           if collection_config.primary?(cname)
-            if "#{@req.c_id}#{@req.subcollection}#{@req.s_id}".present?
+            if "#{@req.collection_id}#{@req.subcollection}#{@req.subcollection_id}".present?
               raise BadRequestError, "Invalid request for #{ctype} #{cname} specified"
             end
           else
@@ -247,7 +247,7 @@ module Api
         return if cname == @req.collection
         return if collection_config.subcollection_denied?(@req.collection, cname)
 
-        aspec = collection_config.typed_subcollection_actions(@req.collection, cname, @req.s_id ? :subresource : :subcollection)
+        aspec = collection_config.typed_subcollection_actions(@req.collection, cname, @req.subcollection_id ? :subresource : :subcollection)
         return unless aspec
 
         action_hash = fetch_action_hash(aspec, mname, aname)

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -10,7 +10,7 @@ module Api
         def to_hash
           [:method, :action, :fullpath, :url, :base,
            :path, :prefix, :version, :api_prefix,
-           :collection, :c_suffix, :c_id, :subcollection, :s_id]
+           :collection, :c_suffix, :collection_id, :subcollection, :subcollection_id]
             .each_with_object({}) { |attr, hash| hash[attr] = send(attr) }
         end
 
@@ -57,7 +57,7 @@ module Api
           @params[:c_suffix]
         end
 
-        def c_id
+        def collection_id
           href.collection_id
         end
 
@@ -65,7 +65,7 @@ module Api
           href.subcollection
         end
 
-        def s_id
+        def subcollection_id
           href.subcollection_id
         end
 

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -41,13 +41,6 @@ module Api
           url.partition(fullpath)[0] # http://target
         end
 
-        #
-        # c_path_parts returns: [collection, c_id, subcollection, s_id, ...]
-        #
-        def c_path_parts
-          @c_path_parts ||= version_override? ? path.split('/')[3..-1] : path.split('/')[2..-1]
-        end
-
         def subject
           href.subject
         end

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -49,15 +49,15 @@ module Api
         end
 
         def subject
-          subcollection || collection
+          href.subject
         end
 
         def subject_id
-          subcollection? ? s_id : c_id
+          href.subject_id
         end
 
         def collection
-          @collection ||= c_path_parts[0]
+          href.collection
         end
 
         def c_suffix
@@ -65,19 +65,19 @@ module Api
         end
 
         def c_id
-          @params[:c_id] || c_path_parts[1]
+          href.collection_id
         end
 
         def subcollection
-          @subcollection ||= c_path_parts[2]
+          href.subcollection
         end
 
         def s_id
-          @params[:s_id] || c_path_parts[3]
+          href.subcollection_id
         end
 
         def subcollection?
-          !!subcollection
+          href.subcollection?
         end
 
         def expand?(what)

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -101,7 +101,7 @@ module Api
         end
 
         def path
-          URI.parse(url).path.sub(%r{/*$}, '') # /api/...
+          href.path
         end
 
         def version
@@ -123,6 +123,10 @@ module Api
         end
 
         private
+
+        def href
+          @href ||= Href.new(url)
+        end
 
         def expand_requested
           @expand ||= @params['expand'].to_s.split(',')

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -61,7 +61,7 @@ module Api
         end
 
         def c_suffix
-          @params[:c_suffix] || Array(c_path_parts[1..-1]).join('/')
+          @params[:c_suffix]
         end
 
         def c_id

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -2,7 +2,7 @@ module Api
   class BaseController
     module Parser
       class RequestAdapter
-        delegate :subject, :subject_id, :collection, :collection_id, :subcollection, :subcollection_id, :subcollection?, :path, :to => :href
+        delegate :subject, :subject_id, :collection, :collection_id, :subcollection, :subcollection_id, :subcollection?, :path, :version?, :to => :href
 
         def initialize(req, params)
           @request = req
@@ -68,7 +68,7 @@ module Api
         end
 
         def version
-          @version ||= if version_override?
+          @version ||= if version?
                          @params[:version][1..-1] # Switching API Version
                        else
                          ApiConfig.base[:version] # Default API Version
@@ -82,7 +82,7 @@ module Api
         def prefix(version = true)
           prefix = "/#{path.split('/')[1]}" # /api
           return prefix unless version
-          version_override? ? "#{prefix}/#{@params[:version]}" : prefix
+          version? ? "#{prefix}/#{@params[:version]}" : prefix
         end
 
         def href
@@ -93,10 +93,6 @@ module Api
 
         def expand_requested
           @expand ||= @params['expand'].to_s.split(',')
-        end
-
-        def version_override?
-          @params[:version] && @params[:version].match(Api::VERSION_REGEX) # v#.# version signature
         end
 
         def fullpath

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -2,6 +2,8 @@ module Api
   class BaseController
     module Parser
       class RequestAdapter
+        delegate :subject, :subject_id, :collection, :collection_id, :subcollection, :subcollection_id, :subcollection?, :path, :to => :href
+
         def initialize(req, params)
           @request = req
           @params = params
@@ -41,36 +43,8 @@ module Api
           url.partition(fullpath)[0] # http://target
         end
 
-        def subject
-          href.subject
-        end
-
-        def subject_id
-          href.subject_id
-        end
-
-        def collection
-          href.collection
-        end
-
         def c_suffix
           @params[:c_suffix]
-        end
-
-        def collection_id
-          href.collection_id
-        end
-
-        def subcollection
-          href.subcollection
-        end
-
-        def subcollection_id
-          href.subcollection_id
-        end
-
-        def subcollection?
-          href.subcollection?
         end
 
         def expand?(what)
@@ -93,10 +67,6 @@ module Api
           @method ||= @request.request_method.downcase.to_sym # :get, :patch, ...
         end
 
-        def path
-          href.path
-        end
-
         def version
           @version ||= if version_override?
                          @params[:version][1..-1] # Switching API Version
@@ -115,11 +85,11 @@ module Api
           version_override? ? "#{prefix}/#{@params[:version]}" : prefix
         end
 
-        private
-
         def href
           @href ||= Href.new(url)
         end
+
+        private
 
         def expand_requested
           @expand ||= @params['expand'].to_s.split(',')

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -69,7 +69,7 @@ module Api
 
         def version
           @version ||= if version?
-                         @params[:version][1..-1] # Switching API Version
+                         href.version[1..-1] # Switching API Version
                        else
                          ApiConfig.base[:version] # Default API Version
                        end
@@ -82,7 +82,7 @@ module Api
         def prefix(version = true)
           prefix = "/#{path.split('/')[1]}" # /api
           return prefix unless version
-          version? ? "#{prefix}/#{@params[:version]}" : prefix
+          version? ? "#{prefix}/#{href.version}" : prefix
         end
 
         def href

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -21,7 +21,7 @@ module Api
       # We want reftype to reflect subcollection if targeting as such.
       #
       def gen_reftype(type, opts)
-        opts[:is_subcollection] ? "#{@req.collection}/#{@req.c_id}/#{type}" : type
+        opts[:is_subcollection] ? "#{@req.collection}/#{@req.collection_id}/#{type}" : type
       end
 
       # Methods for Serialization as Jbuilder Objects.

--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -20,7 +20,7 @@ module Api
 
       def add_parent_href_to_result(hash, parent_id = nil)
         return if hash[:href].present?
-        hash[:href] = "#{@req.api_prefix}/#{@req.collection}/#{parent_id ? parent_id : @req.c_id}"
+        hash[:href] = "#{@req.api_prefix}/#{@req.collection}/#{parent_id ? parent_id : @req.collection_id}"
         hash
       end
 

--- a/app/controllers/api/mixins/generic_objects.rb
+++ b/app/controllers/api/mixins/generic_objects.rb
@@ -18,8 +18,8 @@ module Api
 
         data['associations'].each do |association, resource_refs|
           resources = resource_refs.collect do |ref|
-            collection, id = HrefParser.parse(ref['href'])
-            resource_search(id, collection, collection_class(collection))
+            href = HrefParser.new(ref['href'])
+            resource_search(href.subject_id, href.subject, collection_class(href.subject))
           end
           generic_object.send("#{association}=", resources)
         end

--- a/app/controllers/api/mixins/generic_objects.rb
+++ b/app/controllers/api/mixins/generic_objects.rb
@@ -18,7 +18,7 @@ module Api
 
         data['associations'].each do |association, resource_refs|
           resources = resource_refs.collect do |ref|
-            href = HrefParser.new(ref['href'])
+            href = Href.new(ref['href'])
             resource_search(href.subject_id, href.subject, collection_class(href.subject))
           end
           generic_object.send("#{association}=", resources)

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -51,7 +51,7 @@ module Api
     private
 
     def set_additional_attributes
-      if @req.subcollection == "results" && (@req.s_id || @req.expand?(:resources)) && attribute_selection == "all"
+      if @req.subcollection == "results" && (@req.subcollection_id || @req.expand?(:resources)) && attribute_selection == "all"
         @additional_attributes = %w(result_set)
       end
     end

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -124,11 +124,11 @@ module Api
       resource_href = data.fetch_path("resource", "href")
       raise "Must specify a resource reference" unless resource_href
 
-      resource_type, resource_id = HrefParser.parse(resource_href)
-      raise "Invalid resource href specified #{resource_href}" unless resource_type && resource_id
+      href = HrefParser.new(resource_href)
+      raise "Invalid resource href specified #{resource_href}" unless href.subject && href.subject_id
 
-      resource = resource_search(resource_id, resource_type, collection_class(resource_type))
-      [resource_type, resource]
+      resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
+      [href.subject, resource]
     end
 
     def build_service_attributes(data)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -124,7 +124,7 @@ module Api
       resource_href = data.fetch_path("resource", "href")
       raise "Must specify a resource reference" unless resource_href
 
-      href = HrefParser.new(resource_href)
+      href = Href.new(resource_href)
       raise "Invalid resource href specified #{resource_href}" unless href.subject && href.subject_id
 
       resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -15,7 +15,7 @@ module Api
           raise BadRequestError,
                 "Cannot update attributes other than #{EDITABLE_ATTRS.join(', ')} for the authenticated user"
         end
-        render_normal_update :users, update_collection(:users, @req.c_id)
+        render_normal_update :users, update_collection(:users, @req.collection_id)
       else
         validate_api_action
         super
@@ -51,7 +51,7 @@ module Api
     private
 
     def update_target_is_api_user?
-      User.current_user.id == @req.c_id.to_i
+      User.current_user.id == @req.collection_id.to_i
     end
 
     def parse_set_group(data)

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -10,7 +10,7 @@ module Api
     include Subcollections::MetricRollups
 
     VALID_EDIT_ATTRS = %w(description child_resources parent_resource).freeze
-    RELATIONSHIP_COLLECTIONS = [:vms, :templates].freeze
+    RELATIONSHIP_COLLECTIONS = %w(vms templates).freeze
 
     def start_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -289,7 +289,7 @@ module Api
     end
 
     def fetch_relationship(href)
-      href = HrefParser.new(href)
+      href = Href.new(href)
       raise "Invalid relationship type #{href.subject}" unless RELATIONSHIP_COLLECTIONS.include?(href.subject)
       resource_search(href.subject_id, href.subject, collection_class(href.subject))
     end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -289,9 +289,9 @@ module Api
     end
 
     def fetch_relationship(href)
-      collection, id = HrefParser.parse(href)
-      raise "Invalid relationship type #{collection}" unless RELATIONSHIP_COLLECTIONS.include?(collection)
-      resource_search(id, collection, collection_class(collection))
+      href = HrefParser.new(href)
+      raise "Invalid relationship type #{href.subject}" unless RELATIONSHIP_COLLECTIONS.include?(href.subject)
+      resource_search(href.subject_id, href.subject, collection_class(href.subject))
     end
 
     def valid_custom_attrs

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -12,16 +12,16 @@ module Api
       subcollection? ? subcollection_id : collection_id
     end
 
+    def path
+      @path ||= remove_trailing_slashes(fully_qualified? ? URI.parse(href).path : ensure_prefix(href))
+    end
+
     private
 
     attr_reader :href
 
     def subcollection?
       !!subcollection
-    end
-
-    def path
-      @path ||= remove_trailing_slashes(fully_qualified? ? URI.parse(href).path : ensure_prefix(href))
     end
 
     def fully_qualified?

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -36,6 +36,10 @@ module Api
       !!subcollection
     end
 
+    def version?
+      @version ||= !!(Api::VERSION_REGEX =~ path_parts[2])
+    end
+
     private
 
     attr_reader :href
@@ -57,10 +61,6 @@ module Api
 
     def ensure_uncompressed(id)
       Api.compressed_id?(id) ? Api.uncompress_id(id) : id
-    end
-
-    def version?
-      @version ||= !!(Api::VERSION_REGEX =~ path_parts[2])
     end
 
     def path_parts

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -64,7 +64,7 @@ module Api
     end
 
     def ensure_uncompressed(id)
-      Api.compressed_id?(id) ? Api.uncompress_id(id) : id
+      Api.compressed_id?(id) ? Api.uncompress_id(id).to_s : id
     end
 
     def path_segments

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -17,19 +17,19 @@ module Api
     end
 
     def collection
-      path_parts[version? ? 3 : 2]
+      path_segments[version? ? 3 : 2]
     end
 
     def collection_id
-      ensure_uncompressed(path_parts[version? ? 4 : 3])
+      ensure_uncompressed(path_segments[version? ? 4 : 3])
     end
 
     def subcollection
-      path_parts[version? ? 5 : 4]
+      path_segments[version? ? 5 : 4]
     end
 
     def subcollection_id
-      ensure_uncompressed(path_parts[version? ? 6 : 5])
+      ensure_uncompressed(path_segments[version? ? 6 : 5])
     end
 
     def subcollection?
@@ -37,11 +37,11 @@ module Api
     end
 
     def version
-      path_parts[2] if version?
+      path_segments[2] if version?
     end
 
     def version?
-      @has_version ||= !!(Api::VERSION_REGEX =~ path_parts[2])
+      @has_version ||= !!(Api::VERSION_REGEX =~ path_segments[2])
     end
 
     private
@@ -67,8 +67,8 @@ module Api
       Api.compressed_id?(id) ? Api.uncompress_id(id) : id
     end
 
-    def path_parts
-      @path_parts ||= path.split("/")
+    def path_segments
+      @path_segments ||= path.split("/")
     end
   end
 end

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -1,45 +1,79 @@
 module Api
   class Href
+    # @param href [String] the href string
+    #
+    #   Supports the following forms:
+    #   - <tt>"http://www.example.com/api"</tt>
+    #   - <tt>"http://www.example.com/api/collection"</tt>
+    #   - <tt>"http://www.example.com/api/collection/:cid"</tt>
+    #   - <tt>"http://www.example.com/api/collection/:cid/subcollection"</tt>
+    #   - <tt>"http://www.example.com/api/collection/:cid/subcollection/:sid"</tt>
+    #
+    #   Hrefs can also be supplied using just the path,
+    #   i.e. <tt>"/api/collection/:cid"</tt>. The preceding <tt>/</tt>
+    #   or <tt>/api</tt> may also be omitted, and all examples may be
+    #   suffixed with a <tt>/</tt>.
     def initialize(href)
       @href = href
     end
 
+    # @return [String, nil] the {#subcollection} if there is one,
+    #   otherwise returns the {#collection}. If neither are present,
+    #   returns nil
     def subject
       subcollection? ? subcollection : collection
     end
 
+    # @return [String, nil] the {#subcollection_id} if there is one,
+    #   otherwise returns the {#collection_id}. If neither are
+    #   present, returns nil.
     def subject_id
       subcollection? ? subcollection_id : collection_id
     end
 
+    # @return [String] the path portion of the href
     def path
       @path ||= remove_trailing_slashes(fully_qualified? ? URI.parse(href).path : ensure_prefix(href))
     end
 
+    # @return [String, nil] the name of the collection if there is
+    #   one, otherwise nil
     def collection
       path_segments[version? ? 3 : 2]
     end
 
+    # @return [String, nil] the collection id if there is one,
+    #   otherwise nil
     def collection_id
       ensure_uncompressed(path_segments[version? ? 4 : 3])
     end
 
+    # @return [String, nil] the name of the subcollection if there is
+    #   one, otherwise nil
     def subcollection
       path_segments[version? ? 5 : 4]
     end
 
+    # @return [String, nil] the subcollection id if there is one,
+    #   otherwise nil
     def subcollection_id
       ensure_uncompressed(path_segments[version? ? 6 : 5])
     end
 
+    # @return true if there is a subcollection path segment,
+    #   otherwise false
     def subcollection?
       !!subcollection
     end
 
+    # @return [String, nil] the version segment from the path if there
+    #   is one, otherwise nil
     def version
       path_segments[2] if version?
     end
 
+    # @return true if there is a version segment in the path,
+    #   otherwise false
     def version?
       @has_version ||= !!(Api::VERSION_REGEX =~ path_segments[2])
     end

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -1,5 +1,5 @@
 module Api
-  class HrefParser
+  class Href
     def initialize(href)
       @href = href
     end

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -36,8 +36,12 @@ module Api
       !!subcollection
     end
 
+    def version
+      path_parts[2] if version?
+    end
+
     def version?
-      @version ||= !!(Api::VERSION_REGEX =~ path_parts[2])
+      @has_version ||= !!(Api::VERSION_REGEX =~ path_parts[2])
     end
 
     private

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -5,7 +5,7 @@ module Api
     end
 
     def subject
-      (subcollection? ? subcollection : collection)&.to_sym
+      subcollection? ? subcollection : collection
     end
 
     def subject_id

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -16,29 +16,6 @@ module Api
       @path ||= remove_trailing_slashes(fully_qualified? ? URI.parse(href).path : ensure_prefix(href))
     end
 
-    private
-
-    attr_reader :href
-
-    def subcollection?
-      !!subcollection
-    end
-
-    def fully_qualified?
-      href =~ /^http/
-    end
-
-    def remove_trailing_slashes(str)
-      str.sub(/\/*$/, '')
-    end
-
-    def ensure_prefix(str)
-      result = str.dup
-      result.prepend("/")     unless result.start_with?("/")
-      result.prepend("/api")  unless result.start_with?("/api")
-      result
-    end
-
     def collection
       path_parts[version? ? 3 : 2]
     end
@@ -53,6 +30,29 @@ module Api
 
     def subcollection_id
       ensure_uncompressed(path_parts[version? ? 6 : 5])
+    end
+
+    def subcollection?
+      !!subcollection
+    end
+
+    private
+
+    attr_reader :href
+
+    def fully_qualified?
+      href =~ /^http/
+    end
+
+    def remove_trailing_slashes(str)
+      str.sub(/\/*$/, '')
+    end
+
+    def ensure_prefix(str)
+      result = str.dup
+      result.prepend("/")     unless result.start_with?("/")
+      result.prepend("/api")  unless result.start_with?("/api")
+      result
     end
 
     def ensure_uncompressed(id)

--- a/lib/api/href.rb
+++ b/lib/api/href.rb
@@ -5,7 +5,7 @@ module Api
     end
 
     def subject
-      (subcollection? ? subcollection : collection).to_sym
+      (subcollection? ? subcollection : collection)&.to_sym
     end
 
     def subject_id

--- a/lib/services/api/href_parser.rb
+++ b/lib/services/api/href_parser.rb
@@ -11,9 +11,9 @@ module Api
     def parse
       return [nil, nil] unless href
       if subcollection?
-        [subcollection.to_sym, ApplicationRecord.uncompress_id(subcollection_id)]
+        [subcollection.to_sym, Api.uncompress_id(subcollection_id)]
       else
-        [collection.to_sym, ApplicationRecord.uncompress_id(collection_id)]
+        [collection.to_sym, Api.uncompress_id(collection_id)]
       end
     end
 

--- a/lib/services/api/href_parser.rb
+++ b/lib/services/api/href_parser.rb
@@ -2,20 +2,13 @@ module Api
   class HrefParser
     def self.parse(href)
       return [nil, nil] unless href
-      new(href).parse
+      h = new(href)
+      [h.subject, h.subject_id]
     end
 
     def initialize(href)
       @href = href
     end
-
-    def parse
-      [subject, subject_id]
-    end
-
-    private
-
-    attr_reader :href
 
     def subject
       (subcollection? ? subcollection : collection).to_sym
@@ -24,6 +17,10 @@ module Api
     def subject_id
       subcollection? ? subcollection_id : collection_id
     end
+
+    private
+
+    attr_reader :href
 
     def subcollection?
       !!subcollection

--- a/lib/services/api/href_parser.rb
+++ b/lib/services/api/href_parser.rb
@@ -11,15 +11,19 @@ module Api
     def parse
       return [nil, nil] unless href
       if subcollection?
-        [subcollection.to_sym, subcollection_id]
+        [subject, subcollection_id]
       else
-        [collection.to_sym, collection_id]
+        [subject, collection_id]
       end
     end
 
     private
 
     attr_reader :href
+
+    def subject
+      (subcollection? ? subcollection : collection).to_sym
+    end
 
     def subcollection?
       !!subcollection

--- a/lib/services/api/href_parser.rb
+++ b/lib/services/api/href_parser.rb
@@ -1,11 +1,5 @@
 module Api
   class HrefParser
-    def self.parse(href)
-      return [nil, nil] unless href
-      h = new(href)
-      [h.subject, h.subject_id]
-    end
-
     def initialize(href)
       @href = href
     end

--- a/lib/services/api/href_parser.rb
+++ b/lib/services/api/href_parser.rb
@@ -1,6 +1,7 @@
 module Api
   class HrefParser
     def self.parse(href)
+      return [nil, nil] unless href
       new(href).parse
     end
 
@@ -9,7 +10,6 @@ module Api
     end
 
     def parse
-      return [nil, nil] unless href
       [subject, subject_id]
     end
 

--- a/lib/services/api/href_parser.rb
+++ b/lib/services/api/href_parser.rb
@@ -11,9 +11,9 @@ module Api
     def parse
       return [nil, nil] unless href
       if subcollection?
-        [subject, subcollection_id]
+        [subject, subject_id]
       else
-        [subject, collection_id]
+        [subject, subject_id]
       end
     end
 
@@ -23,6 +23,10 @@ module Api
 
     def subject
       (subcollection? ? subcollection : collection).to_sym
+    end
+
+    def subject_id
+      subcollection? ? subcollection_id : collection_id
     end
 
     def subcollection?

--- a/lib/services/api/href_parser.rb
+++ b/lib/services/api/href_parser.rb
@@ -11,9 +11,9 @@ module Api
     def parse
       return [nil, nil] unless href
       if subcollection?
-        [subcollection.to_sym, Api.uncompress_id(subcollection_id)]
+        [subcollection.to_sym, subcollection_id]
       else
-        [collection.to_sym, Api.uncompress_id(collection_id)]
+        [collection.to_sym, collection_id]
       end
     end
 
@@ -49,7 +49,7 @@ module Api
     end
 
     def collection_id
-      path_parts[version? ? 4 : 3]
+      ensure_uncompressed(path_parts[version? ? 4 : 3])
     end
 
     def subcollection
@@ -57,7 +57,11 @@ module Api
     end
 
     def subcollection_id
-      path_parts[version? ? 6 : 5]
+      ensure_uncompressed(path_parts[version? ? 6 : 5])
+    end
+
+    def ensure_uncompressed(id)
+      Api.compressed_id?(id) ? Api.uncompress_id(id) : id
     end
 
     def version?

--- a/lib/services/api/href_parser.rb
+++ b/lib/services/api/href_parser.rb
@@ -10,11 +10,7 @@ module Api
 
     def parse
       return [nil, nil] unless href
-      if subcollection?
-        [subject, subject_id]
-      else
-        [subject, subject_id]
-      end
+      [subject, subject_id]
     end
 
     private

--- a/spec/lib/api/href_spec.rb
+++ b/spec/lib/api/href_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::Href do
       let(:href) { "http://localhost:3000/api/collection/123" }
 
       it "can parse the resource and resource id" do
-        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
+        expect(described_class.new(href)).to have_attributes(:subject => "collection", :subject_id => "123")
       end
     end
 
@@ -12,7 +12,7 @@ RSpec.describe Api::Href do
       let(:href) { "http://localhost:3000/api/v1.2.3/collection/123" }
 
       it "can parse the resource and resource id" do
-        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
+        expect(described_class.new(href)).to have_attributes(:subject => "collection", :subject_id => "123")
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe Api::Href do
       let(:href) { "/api/collection/123" }
 
       it "can parse the resource and resource id" do
-        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
+        expect(described_class.new(href)).to have_attributes(:subject => "collection", :subject_id => "123")
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Api::Href do
       let(:href) { "/api/v1.2.3/collection/123" }
 
       it "can parse the resource and resource id" do
-        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
+        expect(described_class.new(href)).to have_attributes(:subject => "collection", :subject_id => "123")
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Api::Href do
       let(:href) { "api/collection/123" }
 
       it "can parse the resource and resource id" do
-        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
+        expect(described_class.new(href)).to have_attributes(:subject => "collection", :subject_id => "123")
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Api::Href do
       let(:href) { "api/v1.2.3/collection/123" }
 
       it "can parse the resource and resource id" do
-        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
+        expect(described_class.new(href)).to have_attributes(:subject => "collection", :subject_id => "123")
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Api::Href do
       let(:href) { "collection/123" }
 
       it "can parse the resource and resource id" do
-        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
+        expect(described_class.new(href)).to have_attributes(:subject => "collection", :subject_id => "123")
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Api::Href do
       let(:href) { "/collection/123" }
 
       it "can parse the resource and resource id" do
-        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
+        expect(described_class.new(href)).to have_attributes(:subject => "collection", :subject_id => "123")
       end
     end
 

--- a/spec/lib/api/href_spec.rb
+++ b/spec/lib/api/href_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::HrefParser do
+RSpec.describe Api::Href do
   describe ".new" do
     context "with a full url for the href" do
       let(:href) { "http://localhost:3000/api/collection/123" }

--- a/spec/lib/api/href_spec.rb
+++ b/spec/lib/api/href_spec.rb
@@ -63,5 +63,10 @@ RSpec.describe Api::Href do
         expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
+
+    it "can parse entrypoint urls" do
+      href = "http://localhost:3000/api"
+      expect(described_class.new(href).subject).to be_nil
+    end
   end
 end

--- a/spec/lib/services/api/href_parser_spec.rb
+++ b/spec/lib/services/api/href_parser_spec.rb
@@ -1,66 +1,66 @@
 RSpec.describe Api::HrefParser do
-  describe ".parse" do
+  describe ".new" do
     context "with a full url for the href" do
       let(:href) { "http://localhost:3000/api/collection/123" }
 
-      it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, "123"])
+      it "can parse the resource and resource id" do
+        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
 
     context "with a full url for the href and a API version" do
       let(:href) { "http://localhost:3000/api/v1.2.3/collection/123" }
 
-      it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, "123"])
+      it "can parse the resource and resource id" do
+        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
 
     context "with a partial URL that starts with '/api/...'" do
       let(:href) { "/api/collection/123" }
 
-      it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, "123"])
+      it "can parse the resource and resource id" do
+        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
 
     context "with a partial URL that starts with '/api/v1.2.3/...'" do
       let(:href) { "/api/v1.2.3/collection/123" }
 
-      it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, "123"])
+      it "can parse the resource and resource id" do
+        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
 
     context "with a partial URL that starts with 'api/...'" do
       let(:href) { "api/collection/123" }
 
-      it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, "123"])
+      it "can parse the resource and resource id" do
+        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
 
     context "with a partial URL that starts with 'api/v1.2.3/...'" do
       let(:href) { "api/v1.2.3/collection/123" }
 
-      it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, "123"])
+      it "can parse the resource and resource id" do
+        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
 
     context "with a partial URL without '/api/...'" do
       let(:href) { "collection/123" }
 
-      it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, "123"])
+      it "can parse the resource and resource id" do
+        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
 
     context "with a partial URL without '/api/...' and a leading slash" do
       let(:href) { "/collection/123" }
 
-      it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, "123"])
+      it "can parse the resource and resource id" do
+        expect(described_class.new(href)).to have_attributes(:subject => :collection, :subject_id => "123")
       end
     end
   end

--- a/spec/lib/services/api/href_parser_spec.rb
+++ b/spec/lib/services/api/href_parser_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::HrefParser do
       let(:href) { "http://localhost:3000/api/collection/123" }
 
       it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, 123])
+        expect(described_class.parse(href)).to eq([:collection, "123"])
       end
     end
 
@@ -12,7 +12,7 @@ RSpec.describe Api::HrefParser do
       let(:href) { "http://localhost:3000/api/v1.2.3/collection/123" }
 
       it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, 123])
+        expect(described_class.parse(href)).to eq([:collection, "123"])
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe Api::HrefParser do
       let(:href) { "/api/collection/123" }
 
       it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, 123])
+        expect(described_class.parse(href)).to eq([:collection, "123"])
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Api::HrefParser do
       let(:href) { "/api/v1.2.3/collection/123" }
 
       it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, 123])
+        expect(described_class.parse(href)).to eq([:collection, "123"])
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Api::HrefParser do
       let(:href) { "api/collection/123" }
 
       it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, 123])
+        expect(described_class.parse(href)).to eq([:collection, "123"])
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Api::HrefParser do
       let(:href) { "api/v1.2.3/collection/123" }
 
       it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, 123])
+        expect(described_class.parse(href)).to eq([:collection, "123"])
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Api::HrefParser do
       let(:href) { "collection/123" }
 
       it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, 123])
+        expect(described_class.parse(href)).to eq([:collection, "123"])
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Api::HrefParser do
       let(:href) { "/collection/123" }
 
       it "returns ['collection', 123]" do
-        expect(described_class.parse(href)).to eq([:collection, 123])
+        expect(described_class.parse(href)).to eq([:collection, "123"])
       end
     end
   end

--- a/spec/requests/logging_spec.rb
+++ b/spec/requests/logging_spec.rb
@@ -18,8 +18,8 @@ describe "Logging" do
 
       @log.rewind
       request_log_line = @log.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
-      expect(request_log_line).to include(':path=>"/api/users"', ':collection=>"users"', ":c_id=>nil",
-                                          ":subcollection=>nil", ":s_id=>nil")
+      expect(request_log_line).to include(':path=>"/api/users"', ':collection=>"users"', ":collection_id=>nil",
+                                          ":subcollection=>nil", ":subcollection_id=>nil")
     end
 
     it "logs all hash entries about the request" do
@@ -30,8 +30,8 @@ describe "Logging" do
       @log.rewind
       request_log_line = @log.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
       expect(request_log_line).to include(":method", ":action", ":fullpath", ":url", ":base", ":path", ":prefix",
-                                          ":version", ":api_prefix", ":collection", ":c_suffix", ":c_id",
-                                          ":subcollection", ":s_id")
+                                          ":version", ":api_prefix", ":collection", ":c_suffix", ":collection_id",
+                                          ":subcollection", ":subcollection_id")
     end
 
     it "filters password attributes in nested parameters" do


### PR DESCRIPTION
A lot of the same work was duplicated across `RequestParser` and `HrefParser`. By turning the `HrefParser` service into more of an object (and expanding its API by exposing some of its private methods) it was possible to delegate many things in the `RequestParser` to it, resulting in many ✂️ 

Builds on the work done in #71 

/cc @chrisarcand 

@miq-bot add-label refactoring
@miq-bot assign @abellotti 