### PR TITLE
Custom Button Set CRUD API

### DIFF
--- a/app/controllers/api/custom_button_sets_controller.rb
+++ b/app/controllers/api/custom_button_sets_controller.rb
@@ -1,41 +1,4 @@
 module Api
   class CustomButtonSetsController < BaseController
-    def create_resource(_type, _id, data)
-      klass = collection_class(:custom_button_sets)
-      klass.create!(data.deep_symbolize_keys)
-    rescue => err
-      raise BadRequestError, "Failed to create new custom button - #{err}"
-    end
-
-    def edit_resource(type, id, data)
-      custom_button_set = fetch_custom_button_set(type, id, data)
-      updated_data = data['resource'].try(:deep_symbolize_keys) || data.deep_symbolize_keys
-      custom_button_set.update_attributes!(updated_data) if data.present?
-      custom_button_set
-    rescue => err
-      raise BadRequestError, "Failed to update custom button set - #{err}"
-    end
-
-    def delete_resource(type, id, data = {})
-      custom_button_set = fetch_custom_button_set(type, id, data)
-      custom_button_set.destroy!
-    rescue => err
-      raise BadRequestError, "Failed to delete custom button set - #{err}"
-    end
-
-    private
-
-    def fetch_custom_button_set(type, id, _data)
-      resource_search(id, type, collection_class(type))
-    end
-
-    def resource_search(id, type, klass)
-      if ApplicationRecord.compressed_id?(id)
-        super
-      else
-        custom_button_set = klass.find_by!(:id => id)
-        filter_resource(custom_button_set, type, klass)
-      end
-    end
   end
 end

--- a/app/controllers/api/custom_button_sets_controller.rb
+++ b/app/controllers/api/custom_button_sets_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  class CustomButtonSetsController < BaseController
+    def create_resource(_type, _id, data)
+      klass = collection_class(:custom_button_sets)
+      klass.create!(data.deep_symbolize_keys)
+    rescue => err
+      raise BadRequestError, "Failed to create new custom button - #{err}"
+    end
+
+    def edit_resource(type, id, data)
+      custom_button_set = fetch_custom_button_set(type, id, data)
+      updated_data = data['resource'].try(:deep_symbolize_keys) || data.deep_symbolize_keys
+      custom_button_set.update_attributes!(updated_data) if data.present?
+      custom_button_set
+    rescue => err
+      raise BadRequestError, "Failed to update custom button set - #{err}"
+    end
+
+    def delete_resource(type, id, data = {})
+      custom_button_set = fetch_custom_button_set(type, id, data)
+      custom_button_set.destroy!
+    rescue => err
+      raise BadRequestError, "Failed to delete custom button set - #{err}"
+    end
+
+    private
+
+    def fetch_custom_button_set(type, id, _data)
+      resource_search(id, type, collection_class(type))
+    end
+
+    def resource_search(id, type, klass)
+      if ApplicationRecord.compressed_id?(id)
+        super
+      else
+        custom_button_set = klass.find_by!(:id => id)
+        filter_resource(custom_button_set, type, klass)
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -724,6 +724,39 @@
       - :name: delete
       :delete:
       - :name: delete
+  :custom_button_sets:
+    :description: Custom Button Sets
+    :identifier: ab_buttons_accord
+    :options:
+    - :collection
+    :verbs: *gpppd
+    :klass: CustomButtonSet
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: ab_group
+      :post:
+      - :name: create
+        :identifier: ab_group_new
+      - :name: edit
+        :identifier: ab_group_edit
+      - :name: delete
+        :identifier: ab_group_delete
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: ab_group
+      :post:
+      - :name: edit
+        :identifier: ab_group_edit
+      - :name: delete
+        :identifier: ab_group_delete
+      :put:
+      - :name: edit
+        :identifier: ab_group_edit
+      :delete:
+      - :name: delete
+        :identifier: ab_group_delete
   :data_stores:
     :description: Datastores
     :identifier: storage

--- a/spec/requests/custom_button_sets_spec.rb
+++ b/spec/requests/custom_button_sets_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'CustomButtonSets API' do
-  let(:cb_set) { FactoryGirl.create(:custom_button_set, :name => 'custom_button_set1') }
+  let(:cb_set) { FactoryGirl.create(:custom_button_set, :name => 'custom_button_set') }
   let(:cb_set2) { FactoryGirl.create(:custom_button_set, :name => 'custom_button_set2') }
 
   describe 'GET /api/custom_button_sets' do
@@ -80,7 +80,7 @@ RSpec.describe 'CustomButtonSets API' do
       request = {
         'action'    => 'edit',
         'resources' => [
-          { 'id' => cb_set.id.to_s, 'resource' => { 'name' => 'updated 1' }},
+          { 'id' => cb_set.id.to_s, 'name' => 'updated 1' },
         ]
       }
       post(api_custom_button_sets_url, :params => request)
@@ -132,7 +132,8 @@ RSpec.describe 'CustomButtonSets API' do
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => cb_set.id.to_s),
+          a_hash_including('success' => true, 'message' => "custom_button_sets id: #{cb_set.id} deleting"),
+          a_hash_including('success' => true, 'message' => "custom_button_sets id: #{cb_set2.id} deleting"),
         )
       }
       expect(response).to have_http_status(:ok)

--- a/spec/requests/custom_button_sets_spec.rb
+++ b/spec/requests/custom_button_sets_spec.rb
@@ -1,0 +1,171 @@
+RSpec.describe 'CustomButtonSets API' do
+  let(:cb_set) { FactoryGirl.create(:custom_button_set, :name => 'custom_button_set1') }
+  let(:cb_set2) { FactoryGirl.create(:custom_button_set, :name => 'custom_button_set2') }
+
+  describe 'GET /api/custom_button_sets' do
+    it 'does not list custom button sets without an appropriate role' do
+      api_basic_authorize
+
+      get(api_custom_button_sets_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'lists all custom button sets with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:custom_button_sets, :read, :get)
+      cb_set_href = api_custom_button_set_url(nil, cb_set)
+
+      get(api_custom_button_sets_url)
+
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'custom_button_sets',
+        'resources' => [
+          hash_including('href' => a_string_matching(cb_set_href))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'GET /api/custom_button_sets/:id' do
+    it 'does not let you query custom button sets without an appropriate role' do
+      api_basic_authorize
+
+      get(api_custom_button_set_url(nil, cb_set))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can query a custom button set by its id' do
+      api_basic_authorize action_identifier(:custom_button_sets, :read, :resource_actions, :get)
+
+      get(api_custom_button_set_url(nil, cb_set))
+
+      expected = {
+        'id'   => cb_set.id.to_s,
+        'name' => cb_set.name
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'POST /api/custom_button_sets' do
+    it 'can create a new custom button set' do
+      api_basic_authorize collection_action_identifier(:custom_button_sets, :create)
+
+      cb_set_rec = {
+        'name'        => 'Generic Object Custom Button Group',
+        'description' => 'Generic Object Custom Button Group description',
+        'set_data'    => {
+          'button_icon'      => 'ff ff-view-expanded',
+          'button_color'     => '#4727ff',
+          'display'          => true,
+          'applies_to_class' => 'GenericObjectDefinition',
+          'applies_to_id'    => '10000000000050',
+        },
+      }
+      post(api_custom_button_sets_url, :params => cb_set_rec)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['results'].first).to include(cb_set_rec)
+    end
+
+    it 'can edit custom button sets by id' do
+      api_basic_authorize collection_action_identifier(:custom_button_sets, :edit)
+
+      request = {
+        'action'    => 'edit',
+        'resources' => [
+          { 'id' => cb_set.id.to_s, 'resource' => { 'name' => 'updated 1' }},
+        ]
+      }
+      post(api_custom_button_sets_url, :params => request)
+
+      expected = {
+        'results' => a_collection_including(
+          a_hash_including('id' => cb_set.id.to_s, 'name' => 'updated 1'),
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'POST /api/custom_button_sets/:id' do
+    it 'can update a custom button set by id' do
+      api_basic_authorize action_identifier(:custom_button_sets, :edit)
+
+      request = {
+        'action'      => 'edit',
+        'name'        => 'Generic Object Custom Button set Updated',
+        'description' => 'Generic Object Custom Button set description Updated',
+      }
+      post(api_custom_button_set_url(nil, cb_set), :params => request)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(request.except('action'))
+    end
+
+    it 'can delete a custom button set by id' do
+      api_basic_authorize action_identifier(:custom_button_sets, :delete)
+
+      post(api_custom_button_set_url(nil, cb_set), :params => { :action => 'delete' })
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'can delete custom button set in bulk by id' do
+      api_basic_authorize collection_action_identifier(:custom_button_sets, :delete)
+
+      request = {
+        'action'    => 'delete',
+        'resources' => [
+          { 'id' => cb_set.id.to_s},
+          { 'id' => cb_set2.id.to_s},
+        ]
+      }
+      post(api_custom_button_sets_url, :params => request)
+
+      expected = {
+        'results' => a_collection_including(
+          a_hash_including('id' => cb_set.id.to_s),
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'DELETE /api/custom_button_sets/:id' do
+    it 'can delete a custom button set by id' do
+      api_basic_authorize action_identifier(:custom_button_sets, :delete, :resource_actions, :delete)
+
+      delete(api_custom_button_set_url(nil, cb_set))
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
+  describe 'PUT /api/custom_button_sets/:id' do
+    it 'can edit a custom button set' do
+      api_basic_authorize action_identifier(:custom_button_sets, :edit)
+
+      request = {
+        'name'        => 'Generic Object Custom Button Set Updated',
+        'description' => 'Generic Object Custom Button Set Description Updated',
+      }
+      put(api_custom_button_set_url(nil, cb_set), :params => request)
+
+      expected = {
+        'name'        => 'Generic Object Custom Button Set Updated',
+        'description' => 'Generic Object Custom Button Set Description Updated',
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+end

--- a/spec/requests/custom_button_sets_spec.rb
+++ b/spec/requests/custom_button_sets_spec.rb
@@ -169,4 +169,31 @@ RSpec.describe 'CustomButtonSets API' do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  describe 'PATCH /api/custom_button_sets/:id' do
+    it 'can edit a custom button set' do
+      api_basic_authorize action_identifier(:custom_button_sets, :edit)
+
+      request = [
+        {
+          'action' => 'edit',
+          'path'   => 'name',
+          'value'  => 'Generic Object Custom Button Set Updated',
+        },
+        {
+          'action' => 'edit',
+          'path'   => 'description',
+          'value'  => 'Generic Object Custom Button Set Description Updated',
+        }
+      ]
+      patch(api_custom_button_set_url(nil, cb_set), :params => request)
+
+      expected = {
+        'name'        => 'Generic Object Custom Button Set Updated',
+        'description' => 'Generic Object Custom Button Set Description Updated',
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
 end

--- a/spec/requests/custom_button_sets_spec.rb
+++ b/spec/requests/custom_button_sets_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'CustomButtonSets API' do
         'subcount'  => 1,
         'name'      => 'custom_button_sets',
         'resources' => [
-          hash_including('href' => a_string_matching(cb_set_href))
+          hash_including('href' => cb_set_href)
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -46,7 +46,7 @@ RSpec.describe 'CustomButtonSets API' do
 
       expected = {
         'id'   => cb_set.id.to_s,
-        'name' => cb_set.name
+        'name' => "custom_button_set"
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)


### PR DESCRIPTION
Added CRUD API for Custom Button Sets

`Create -`
```
POST /api/custom_button_sets
{
  "name"        : "CustomButtonSet",
  "description" : "CustomButtonSet description",
  "set_data": {
    "button_order": [
      10000000000013,
      10000000000016
    ],
    "button_icon": "ff ff-view-expanded",
    "button_color": "#4727ff",
    "display": true,
    "applies_to_class": "GenericObjectDefinition",
    "applies_to_id": "10000000000050",
  },
}
```

`Retrieve - `
```
GET /api/custom_button_sets/
GET /api/custom_button_sets/:id
```

`Update - `
```
POST /api/custom_button_sets/:id      action: "edit"
PUT /api/custom_button_sets/:id
{
  "name" : "CustomButtonSet Updated",
}
```

`Delete -`
```
DELETE /api/custom_button_sets/:id
POST /api/custom_button_sets/:id      action: "delete"

Bulk delete -
POST /api/custom_button_sets
{
  "action" : "delete",
  "resources": [{"id": "101"}, {"id": "102"}]
}
```