### PR TITLE
Fix failing tests from changed ovirt provider

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -415,6 +415,13 @@ describe "Providers API" do
   end
 
   describe "Providers create" do
+    before(:each) do
+      require "ovirtsdk4" # incase it hasn't been autoloaded yet
+
+      allow(OvirtSDK4::Probe).to receive(:probe)
+        .and_return([OvirtSDK4::ProbeResult.new(:version => '3')])
+    end
+
     it "rejects creation without appropriate role" do
       api_basic_authorize
 
@@ -596,6 +603,13 @@ describe "Providers API" do
   end
 
   describe "Providers edit" do
+    before(:each) do
+      require "ovirtsdk4" # incase it hasn't been autoloaded yet
+
+      allow(OvirtSDK4::Probe).to receive(:probe)
+        .and_return([OvirtSDK4::ProbeResult.new(:version => '3')])
+    end
+
     it "rejects resource edits without appropriate role" do
       api_basic_authorize
 


### PR DESCRIPTION
The manageiq-providers-ovirt had a new change recently that caused issues with the tests:

https://github.com/ManageIQ/manageiq-providers-ovirt/commit/87703c6

This causes the provider tests to fail because the ovirt provider does not properly handle a missing/not present SDK when asking for api versions by default.  This adds a stub to support that.

_**Note:**  We returning the v3 version from the stub since the :sample_rhevm attributes are only setup to work with that version of the API, and it fails to work with the v4 adapter._

Links:
-----
* https://github.com/ManageIQ/manageiq-providers-ovirt/pull/90