### PR TITLE
Validate that href is returned when ordering a service request

### DIFF
--- a/spec/requests/service_catalogs_spec.rb
+++ b/spec/requests/service_catalogs_spec.rb
@@ -354,6 +354,7 @@ describe "Service Catalogs API" do
       {"type"           => "ServiceTemplateProvisionRequest",
        "description"    => /provisioning service/i,
        "approval_state" => "pending_approval",
+       "href"           => /#{api_service_requests_url}/i,
        "status"         => "Ok"}
     end
 


### PR DESCRIPTION
Started looking into this BZ https://bugzilla.redhat.com/show_bug.cgi?id=1480281 about how the API is not returning the service request href when a service is ordered from the service catalog.

Found that it was already working, likely from another enhancement, but added a test/one line to validate. 

@miq-bot assign @abellotti 