### PR TITLE
Don't compress ids when generating href slugs

### DIFF
--- a/lib/api/utils.rb
+++ b/lib/api/utils.rb
@@ -3,7 +3,7 @@ module Api
     def self.build_href_slug(klass, id)
       return unless id
       collection = Api::CollectionConfig.new.name_for_subclass(klass)
-      "#{collection}/#{ApplicationRecord.compress_id(id)}" if collection
+      "#{collection}/#{id}" if collection
     end
 
     def self.resource_search_by_href_slug(href_slug, user = User.current_user)

--- a/spec/lib/api/utils_spec.rb
+++ b/spec/lib/api/utils_spec.rb
@@ -1,4 +1,16 @@
 RSpec.describe Api::Utils do
+  describe ".build_href_slug" do
+    it "builds the href slug" do
+      actual = Api::Utils.build_href_slug(Vm, 1_000_000_000_123)
+      expect(actual).to eq("vms/1r123")
+    end
+
+    it "returns nil if the collection can't be found" do
+      actual = Api::Utils.build_href_slug(VmOrTemplate, 1_000_000_000_123)
+      expect(actual).to be_nil
+    end
+  end
+
   describe ".resource_search_by_href_slug" do
     before { allow(User).to receive_messages(:server_timezone => "UTC") }
 

--- a/spec/lib/api/utils_spec.rb
+++ b/spec/lib/api/utils_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Api::Utils do
   describe ".build_href_slug" do
     it "builds the href slug" do
       actual = Api::Utils.build_href_slug(Vm, 1_000_000_000_123)
-      expect(actual).to eq("vms/1r123")
+      expect(actual).to eq("vms/1000000000123")
     end
 
     it "returns nil if the collection can't be found" do

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -715,7 +715,7 @@ describe "Querying" do
           {
             "id"        => vm.id.to_s,
             "href"      => api_vm_url(nil, vm),
-            "href_slug" => "vms/#{vm.compressed_id}",
+            "href_slug" => "vms/#{vm.id}",
             "name"      => "aa",
             "vendor"    => anything
           }


### PR DESCRIPTION
Part of continuing work to deprecate compressed ids

@miq-bot add-label technical debt
@miq-bot assign @abellotti 