### PR TITLE
Do not allow removal of all miq groups 

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -82,6 +82,7 @@ module Api
     def validate_user_data(data = {})
       bad_attrs = data.keys.select { |k| INVALID_USER_ATTRS.include?(k) }.compact.join(", ")
       raise BadRequestError, "Invalid attribute(s) #{bad_attrs} specified for a user" if bad_attrs.present?
+      raise BadRequestError, "Users must be assigned groups" if data.key?("miq_groups") && data["miq_groups"].empty?
     end
 
     def validate_self_user_data(data = {})

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -207,6 +207,27 @@ RSpec.describe "users API" do
       expect(user1.reload.miq_groups).to match_array([group2, group3])
     end
 
+    it "does not allow setting of empty miq_groups" do
+      api_basic_authorize collection_action_identifier(:users, :edit)
+
+      request = {
+        "action"    => "edit",
+        "resources" => [{
+          "href"       => api_user_url(nil, user1),
+          "miq_groups" => []
+        }]
+      }
+      post(api_users_url, :params => request)
+
+      expected = {
+        'error' => a_hash_including(
+          'message' => 'Users must be assigned groups'
+        )
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "rejects user edits without appropriate role" do
       api_basic_authorize
 


### PR DESCRIPTION
Validate that the request is not trying to set MiqGroups to an empty array, thus removing all of the User's groups.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1497295

@miq-bot add_label bug
@miq-bot assign @abellotti 