### PR TITLE
Search for resources based on href_slug  for automate workspace

### DIFF
--- a/lib/api/utils.rb
+++ b/lib/api/utils.rb
@@ -16,7 +16,9 @@ module Api
       raise _("User must be defined") unless user
 
       klass = collection_config.klass(collection)
-      Rbac.filtered_object(klass.find(ApplicationRecord.uncompress_id(id)), :user => user, :class => klass)
+      key_id = collection_config.resource_identifier(collection)
+      target = key_id == "id" ? klass.find(ApplicationRecord.uncompress_id(id)) : klass.find_by!(key_id => id)
+      Rbac.filtered_object(target, :user => user, :class => klass)
     end
   end
 end

--- a/spec/lib/api/utils_spec.rb
+++ b/spec/lib/api/utils_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe Api::Utils do
   end
 
   describe ".resource_search_by_href_slug" do
+    let(:aw_user) { FactoryGirl.create(:user_with_group) }
+    let(:aw) do
+      FactoryGirl.create(:automate_workspace,
+                         :user   => aw_user,
+                         :tenant => aw_user.current_tenant)
+    end
     before { allow(User).to receive_messages(:server_timezone => "UTC") }
 
     it "returns nil when nil is specified" do
@@ -122,6 +128,17 @@ RSpec.describe Api::Utils do
       actual = described_class.resource_search_by_href_slug("vms/#{vm.compressed_id}", owner)
 
       expect(actual).to eq(vm)
+    end
+
+    it "fetch automate workspace based on guid in href_slug" do
+      actual = described_class.resource_search_by_href_slug(aw.href_slug, aw_user)
+      expect(actual).to eq(aw)
+    end
+
+    it "raises error for automate workspace with invalid href_slug" do
+      expect do
+        described_class.resource_search_by_href_slug("automate_workspaces/99999", aw_user)
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end


### PR DESCRIPTION
Automate workspaces can only be accessed using GUID's and not ID's. The href_slug for Automate Workspaces includes the GUID. The search function has been modified to account for that.