### PR TITLE
Fix return of orchestration stacks for a service

### DIFF
--- a/app/controllers/api/subcollections/orchestration_stacks.rb
+++ b/app/controllers/api/subcollections/orchestration_stacks.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module OrchestrationStacks
       def orchestration_stacks_query_resource(object)
-        object.orchestration_stacks
+        object.orchestration_stacks.compact
       end
 
       #


### PR DESCRIPTION
To preface, I have seen this issue before (we had another BZ related to it), and wrote it off to bad data. I do think that changes need to be made to the model to prevent the issue from happening, but for the time being, this will work.

Right now, sometimes services are returning orchestration stacks with nil values in an array, ie `[nil]`. This is causing the normalizer to fail because it is not expecting a nil object to be passed through. Thought about updating the normalizer, but felt that this was a case that should not happen anyway, and to leave that untouched. Using `compact` fixes this issue and allows the request to run successfully.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1496190

@miq-bot add_label bug
@miq-bot assign @abellotti 
