### PR TITLE
Remove required filters from event streams

### DIFF
--- a/app/controllers/api/event_streams_controller.rb
+++ b/app/controllers/api/event_streams_controller.rb
@@ -1,19 +1,8 @@
 module Api
   class EventStreamsController < BaseController
-    before_action :validate_filters, :ensure_pagination, :only => :index
+    before_action :ensure_pagination, :only => :index
 
     private
-
-    def validate_filters
-      messages = []
-      messages << "must specify target_type" unless filter_contains?("target_type")
-      messages << "must specify a minimum value for timestamp" unless filter_contains?("timestamp>")
-      raise BadRequestError, messages.join(", ").capitalize if messages.any?
-    end
-
-    def filter_contains?(filter)
-      Array(params["filter"]).any? { |f| f.start_with?(filter) }
-    end
 
     def ensure_pagination
       params["limit"] ||= Settings.api.event_streams_default_limit


### PR DESCRIPTION
Opening for discussion. My thoughts were that since we have a default limit/page size in place, that should be sufficient for preventing the user from asking for anything crazy. IMO having required filters seems a little draconian in forcing the user to use this API a certain way. For instance, one of the requirements was to enforce a minimum timestamp filter to be present. If we do this, that prevents the user from writing a more elegant query in the case that they want event streams for a certain day. It would be more elegant to use the `=` filter, but they have to use two - specifying both a `<` and `>` value.

/cc @AllenBW @gtanzillo 

@miq-bot assign @abellotti 