### PR TITLE
Paginate all the things

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -26,6 +26,7 @@ module Api
     before_action :validate_api_action, :except => [:options]
     before_action :validate_response_format, :except => [:destroy]
     before_action :redirect_on_compressed_path
+    before_action :ensure_pagination, :only => :index
     after_action :log_api_response
 
     respond_to :json
@@ -117,6 +118,11 @@ module Api
 
       render :json => ErrorSerializer.new(type, error).serialize, :status => Rack::Utils.status_code(type)
       log_api_response
+    end
+
+    def ensure_pagination
+      params["limit"] ||= Settings.api.max_results_per_page
+      params["offset"] ||= 0
     end
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -121,6 +121,9 @@ module Api
     end
 
     def ensure_pagination
+      if params["limit"].to_i > Settings.api.max_results_per_page
+        $api_log.warn("The limit specified (#{params["limit"]}) exceeded the maximum (#{Settings.api.max_results_per_page}). Applying the maximum limit instead.")
+      end
       params["limit"] = [Settings.api.max_results_per_page, params["limit"]].compact.collect(&:to_i).min
       params["offset"] ||= 0
     end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -121,7 +121,7 @@ module Api
     end
 
     def ensure_pagination
-      params["limit"] ||= Settings.api.max_results_per_page
+      params["limit"] = [Settings.api.max_results_per_page, params["limit"]].compact.collect(&:to_i).min
       params["offset"] ||= 0
     end
   end

--- a/app/controllers/api/event_streams_controller.rb
+++ b/app/controllers/api/event_streams_controller.rb
@@ -5,7 +5,7 @@ module Api
     private
 
     def ensure_pagination
-      params["limit"] ||= Settings.api.event_streams_default_limit
+      params["limit"] ||= Settings.api.max_results_per_page
       params["offset"] ||= 0
     end
   end

--- a/app/controllers/api/event_streams_controller.rb
+++ b/app/controllers/api/event_streams_controller.rb
@@ -1,12 +1,4 @@
 module Api
   class EventStreamsController < BaseController
-    before_action :ensure_pagination, :only => :index
-
-    private
-
-    def ensure_pagination
-      params["limit"] ||= Settings.api.max_results_per_page
-      params["offset"] ||= 0
-    end
   end
 end

--- a/app/controllers/api/metric_rollups_controller.rb
+++ b/app/controllers/api/metric_rollups_controller.rb
@@ -2,7 +2,7 @@ module Api
   class MetricRollupsController < BaseController
     def index
       params[:offset] ||= 0
-      params[:limit] ||= Settings.api.metrics_default_limit
+      params[:limit] ||= Settings.api.max_results_per_page
 
       rollups_service = MetricRollupsService.new(params)
       resources = rollups_service.query_metric_rollups

--- a/app/controllers/api/metric_rollups_controller.rb
+++ b/app/controllers/api/metric_rollups_controller.rb
@@ -1,9 +1,6 @@
 module Api
   class MetricRollupsController < BaseController
     def index
-      params[:offset] ||= 0
-      params[:limit] ||= Settings.api.max_results_per_page
-
       rollups_service = MetricRollupsService.new(params)
       resources = rollups_service.query_metric_rollups
       res = collection_filterer(resources, :metric_rollups, MetricRollup).flatten

--- a/app/controllers/api/subcollections/metric_rollups.rb
+++ b/app/controllers/api/subcollections/metric_rollups.rb
@@ -6,8 +6,6 @@ module Api
       }.freeze
 
       def metric_rollups_query_resource(object)
-        params[:offset] ||= 0
-        params[:limit] ||= Settings.api.max_results_per_page
         params[:resource_type] = RESOURCE_TYPES[@req.collection] || object.class.to_s
         params[:resource_ids] ||= [object.id]
 

--- a/app/controllers/api/subcollections/metric_rollups.rb
+++ b/app/controllers/api/subcollections/metric_rollups.rb
@@ -7,7 +7,7 @@ module Api
 
       def metric_rollups_query_resource(object)
         params[:offset] ||= 0
-        params[:limit] ||= Settings.api.metrics_default_limit
+        params[:limit] ||= Settings.api.max_results_per_page
         params[:resource_type] = RESOURCE_TYPES[@req.collection] || object.class.to_s
         params[:resource_ids] ||= [object.id]
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,4 @@
 :api:
   :token_ttl: 10.minutes
   :authentication_timeout: 30.seconds
-  :metrics_default_limit: 1000
-  :event_streams_default_limit: 1000
+  :max_results_per_page: 1000

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,0 @@
-:api:
-  :metrics_default_limit: 10000

--- a/spec/requests/event_streams_spec.rb
+++ b/spec/requests/event_streams_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Event Streams" do
     end
 
     it "limits the resources returned" do
-      stub_settings_merge(:api => {:event_streams_default_limit => 2})
+      stub_settings_merge(:api => {:max_results_per_page => 2})
       api_basic_authorize(action_identifier(:event_streams, :read, :collection_actions, :get))
       vm = FactoryGirl.create(:vm_vmware)
       FactoryGirl.create_list(:miq_event, 3, :target => vm, :timestamp => Time.zone.now)

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -116,12 +116,12 @@ describe "Querying" do
       expect(response.parsed_body["links"].keys).to match_array(%w(self previous first last))
     end
 
-    it "only returns paging links if both offset and limit are specified" do
+    it "returns `self`, `first` and `last` links when result set size < max results" do
       create_vms_by_name %w(aa bb)
 
-      get api_vms_url, :params => { :offset => 0, :expand => :resources }
+      get api_vms_url
 
-      expect(response.parsed_body.keys).to eq(%w(name count subcount resources actions))
+      expect(response.parsed_body).to include("links" => a_hash_including("self", "first", "last"))
     end
 
     it "returns the correct page count" do

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -34,6 +34,15 @@ describe "Querying" do
       expect_query_result(:vms, 2, 3)
     end
 
+    specify "a user cannot exceed the maximum allowed page size" do
+      stub_settings_merge(:api => {:max_results_per_page => 2})
+      FactoryGirl.create_list(:vm, 3)
+
+      get api_vms_url, :params => { :limit => 3 }
+
+      expect(response.parsed_body).to include("count" => 3, "subcount" => 2)
+    end
+
     it "supports offset and limit" do
       create_vms_by_name(%w(aa bb cc))
 


### PR DESCRIPTION
Unifies the separate collection default settings by providing a single
configurable value for the max results per page, that's now applied to
all collections.

Thanks to @chrisarcand for naming 💙 

@miq-bot add-label enhancement
@miq-bot assign @abellotti 