### PR TITLE
Allow generic object definition picture to be removed via edit

### DIFF
--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -123,6 +123,7 @@ module Api
     private
 
     def add_picture_resource(data)
+      return nil if data.empty?
       id = parse_id(data, :pictures)
       return resource_search(id, :pictures, collection_class(:pictures)) if id
       Picture.create_from_base64(data)

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -275,6 +275,28 @@ RSpec.describe 'GenericObjectDefinitions API' do
       expect(response.parsed_body).to include(expected)
     end
 
+    it 'can remove a picture via edit' do
+      api_basic_authorize collection_action_identifier(:generic_object_definitions, :edit)
+      object_def.update_attributes!(:picture => picture)
+
+      request = {
+        'action'    => 'edit',
+        'resources' => [
+          { 'name' => object_def.name, 'resource' => { 'name' => 'updated 1', 'picture' => {} } }
+        ]
+      }
+      post(api_generic_object_definitions_url, :params => request)
+
+      expected = {
+        'results' => a_collection_including(
+          a_hash_including('id' => object_def.id.to_s, 'name' => 'updated 1')
+        )
+      }
+      expect(object_def.reload.picture).to be_nil
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it 'can add associations by id, name, or href' do
       api_basic_authorize collection_action_identifier(:generic_object_definitions, :add_associations)
 


### PR DESCRIPTION
#### Usage
```
{
  "action"    : "edit",
  "resources" : [
  { "id" : ":id", "resource" : { "name" : "updated 1", "picture" : {} } }
  ]
}
```

@miq-bot assign @abellotti 
@miq-bot add_label enhancement
cc: @AparnaKarve 