### PR TITLE
Allow update to request task as a subcollection of request

### DIFF
--- a/app/controllers/api/subcollections/request_tasks.rb
+++ b/app/controllers/api/subcollections/request_tasks.rb
@@ -7,7 +7,7 @@ module Api
       end
 
       def request_tasks_edit_resource(_object, type, id = nil, data = {})
-        raise BadRequestError, "Must specify a id for editing a #{type} resource" unless id
+        raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
         request_task = resource_search(id, type, collection_class(:request_tasks))
         request_task.update_request_task(data)
         request_task

--- a/app/controllers/api/subcollections/request_tasks.rb
+++ b/app/controllers/api/subcollections/request_tasks.rb
@@ -5,6 +5,13 @@ module Api
         klass = collection_class(:request_tasks)
         object ? klass.where(:miq_request_id => object.id) : {}
       end
+
+      def request_tasks_edit_resource(_object, type, id = nil, data = {})
+        raise BadRequestError, "Must specify a id for editing a #{type} resource" unless id
+        request_task = resource_search(id, type, collection_class(:request_tasks))
+        request_task.update_request_task(data)
+        request_task
+      end
     end
   end
 end

--- a/app/controllers/api/subcollections/request_tasks.rb
+++ b/app/controllers/api/subcollections/request_tasks.rb
@@ -9,7 +9,7 @@ module Api
       def request_tasks_edit_resource(_object, type, id = nil, data = {})
         raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
         request_task = resource_search(id, type, collection_class(:request_tasks))
-        request_task.update_request_task(data)
+        request_task.update_attributes(:options => request_task.options.merge(data['options'] || {}))
         request_task
       end
     end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1949,10 +1949,6 @@
         :identifier: miq_request_approval
       - :name: deny
         :identifier: miq_request_approval
-    :request_tasks_subcollection_actions:
-      :post:
-      - :name: edit
-        :identifier: miq_request_edit
   :resource_actions:
     :description: Resource Actions
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -1899,6 +1899,7 @@
     :subresource_actions:
       :post:
       - :name: edit
+        :identifier: miq_request_edit
   :requests:
     :description: Requests
     :identifier: miq_request

--- a/config/api.yml
+++ b/config/api.yml
@@ -301,6 +301,10 @@
         :identifier: miq_request_approval
       - :name: edit
         :identifier: miq_request_edit
+    :request_tasks_subcollection_actions:
+      :post:
+      - :name: edit
+        :identifier: miq_request_edit
   :availability_zones:
     :description: Availability Zones
     :identifier: availability_zone
@@ -1767,6 +1771,10 @@
         :identifier: miq_request_approval
       - :name: edit
         :identifier: miq_request_edit
+    :request_tasks_subcollection_actions:
+      :post:
+      - :name: edit
+        :identifier: miq_request_edit
   :quotas:
     :description: TenantQuotas
     :options:
@@ -1883,8 +1891,19 @@
     :options:
     - :collection
     - :subcollection
-    :verbs: *g
+    :verbs: *gp
     :klass: MiqRequestTask
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show
+    :subresource_actions:
+      :post:
+      - :name: edit
   :requests:
     :description: Requests
     :identifier: miq_request
@@ -1935,6 +1954,10 @@
         :identifier: miq_request_approval
       - :name: deny
         :identifier: miq_request_approval
+    :request_tasks_subcollection_actions:
+      :post:
+      - :name: edit
+        :identifier: miq_request_edit
   :resource_actions:
     :description: Resource Actions
     :options:
@@ -2274,6 +2297,10 @@
       :post:
       - :name: remove
         :identifier: svc_catalog_provision
+    :request_tasks_subcollection_actions:
+      :post:
+      - :name: edit
+        :identifier: miq_request_edit
   :service_templates:
     :description: Service Templates
     :identifier: catalog_items_accord

--- a/config/api.yml
+++ b/config/api.yml
@@ -301,10 +301,6 @@
         :identifier: miq_request_approval
       - :name: edit
         :identifier: miq_request_edit
-    :request_tasks_subcollection_actions:
-      :post:
-      - :name: edit
-        :identifier: miq_request_edit
   :availability_zones:
     :description: Availability Zones
     :identifier: availability_zone
@@ -1771,10 +1767,6 @@
         :identifier: miq_request_approval
       - :name: edit
         :identifier: miq_request_edit
-    :request_tasks_subcollection_actions:
-      :post:
-      - :name: edit
-        :identifier: miq_request_edit
   :quotas:
     :description: TenantQuotas
     :options:
@@ -1901,6 +1893,9 @@
       :get:
       - :name: read
         :identifier: miq_request_show
+      :post:
+      - :name: edit
+        :identifier: miq_request_edit
     :subresource_actions:
       :post:
       - :name: edit
@@ -2297,10 +2292,6 @@
       :post:
       - :name: remove
         :identifier: svc_catalog_provision
-    :request_tasks_subcollection_actions:
-      :post:
-      - :name: edit
-        :identifier: miq_request_edit
   :service_templates:
     :description: Service Templates
     :identifier: catalog_items_accord

--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -263,8 +263,9 @@ describe "Automation Requests API" do
 
   context 'Tasks subcollection' do
     let(:automation_request) { FactoryGirl.create(:automation_request, :requester => @user) }
-    let(:task) { FactoryGirl.create(:miq_request_task, :miq_request_id => automation_request.id) }
-    let(:params) { gen_request(:edit, :options => { :a => "1" }) }
+    let(:task) { FactoryGirl.create(:miq_request_task, :miq_request => automation_request) }
+    let(:options) { { 'a' => 1 } }
+    let(:params) { gen_request(:edit, :options => options) }
 
     it 'redirects to request_tasks subcollection' do
       FactoryGirl.create(:miq_request_task, :miq_request_id => automation_request.id)
@@ -296,17 +297,18 @@ describe "Automation Requests API" do
     it 'allows access to underlying automation task' do
       api_basic_authorize collection_action_identifier(:automation_requests, :read, :get)
 
-      get("#{api_request_url(nil, automation_request)}/request_tasks/#{task.id}")
+      get("#{api_request_request_task_url(nil, automation_request, task)}")
 
       expect(response).to have_http_status(:ok)
     end
 
     it 'allows edit of task as a subcollection of automation request' do
-      tasks_url = "#{api_automation_request_url(nil, automation_request)}/request_tasks/#{task.id}"
+      tasks_url = api_request_request_task_url(nil, automation_request, task)
       api_basic_authorize subcollection_action_identifier(:automation_requests, :request_tasks, :edit)
       post(tasks_url, :params => params)
 
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['options']).to match(hash_including(options))
     end
   end
 end

--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -297,7 +297,7 @@ describe "Automation Requests API" do
     it 'allows access to underlying automation task' do
       api_basic_authorize collection_action_identifier(:automation_requests, :read, :get)
 
-      get("#{api_request_request_task_url(nil, automation_request, task)}")
+      get(api_request_request_task_url(nil, automation_request, task))
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -262,7 +262,9 @@ describe "Automation Requests API" do
   end
 
   context 'Tasks subcollection' do
-    let(:automation_request) { FactoryGirl.create(:automation_request) }
+    let(:automation_request) { FactoryGirl.create(:automation_request, :requester => @user) }
+    let(:task) { FactoryGirl.create(:miq_request_task, :miq_request_id => automation_request.id) }
+    let(:params) { gen_request(:edit, :options => { :a => "1" }) }
 
     it 'redirects to request_tasks subcollection' do
       FactoryGirl.create(:miq_request_task, :miq_request_id => automation_request.id)
@@ -275,13 +277,36 @@ describe "Automation Requests API" do
     end
 
     it 'redirects to request_tasks subresources' do
-      task = FactoryGirl.create(:miq_request_task, :miq_request_id => automation_request.id)
       api_basic_authorize
 
       get("#{api_automation_request_url(nil, automation_request)}/tasks/#{task.id}")
 
       expect(response).to have_http_status(:moved_permanently)
       expect(response.redirect_url).to include("#{api_automation_request_url(nil, automation_request)}/request_tasks/#{task.id}")
+    end
+
+    it 'does not allow direct edit of automation task' do
+      api_basic_authorize
+
+      post(api_request_task_url(nil, task), :params => params)
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'allows access to underlying automation task' do
+      api_basic_authorize collection_action_identifier(:automation_requests, :read, :get)
+
+      get("#{api_request_url(nil, automation_request)}/request_tasks/#{task.id}")
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'allows edit of task as a subcollection of automation request' do
+      tasks_url = "#{api_automation_request_url(nil, automation_request)}/request_tasks/#{task.id}"
+      api_basic_authorize subcollection_action_identifier(:automation_requests, :request_tasks, :edit)
+      post(tasks_url, :params => params)
+
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -487,7 +487,7 @@ describe "Provision Requests API" do
     it 'allows access to underlying provision task' do
       api_basic_authorize collection_action_identifier(:provision_requests, :read, :get)
 
-      get("#{api_request_request_task_url(nil, provision_request, task)}")
+      get(api_request_request_task_url(nil, provision_request, task))
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -453,8 +453,9 @@ describe "Provision Requests API" do
 
   context 'Tasks subcollection' do
     let(:provision_request) { FactoryGirl.create(:miq_provision_request, :requester => @user) }
-    let(:task) { FactoryGirl.create(:miq_request_task, :miq_request_id => provision_request.id) }
-    let(:params) { gen_request(:edit, :options => { :a => "1" }) }
+    let(:task) { FactoryGirl.create(:miq_request_task, :miq_request => provision_request) }
+    let(:options) { { 'a' => '1' } }
+    let(:params) { gen_request(:edit, :options => options) }
 
     it 'redirects to request_tasks subcollection' do
       FactoryGirl.create(:miq_request_task, :miq_request_id => provision_request.id)
@@ -486,17 +487,18 @@ describe "Provision Requests API" do
     it 'allows access to underlying provision task' do
       api_basic_authorize collection_action_identifier(:provision_requests, :read, :get)
 
-      get("#{api_request_url(nil, provision_request)}/request_tasks/#{task.id}")
+      get("#{api_request_request_task_url(nil, provision_request, task)}")
 
       expect(response).to have_http_status(:ok)
     end
 
     it 'allows edit of task as a subcollection of provision request' do
-      tasks_url = "#{api_provision_request_url(nil, provision_request)}/request_tasks/#{task.id}"
+      tasks_url = api_request_request_task_url(nil, provision_request, task)
       api_basic_authorize subcollection_action_identifier(:provision_requests, :request_tasks, :edit)
       post(tasks_url, :params => params)
 
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['options']).to match(hash_including(options))
     end
   end
 end

--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -602,8 +602,9 @@ describe "Service Requests API" do
   end
 
   context 'Tasks subcollection' do
-    let(:task) { FactoryGirl.create(:miq_request_task, :miq_request_id => service_request.id) }
-    let(:params) { gen_request(:edit, :options => { :a => "1" }) }
+    let(:task) { FactoryGirl.create(:miq_request_task, :miq_request => service_request) }
+    let(:options) { { "a" => 1 } }
+    let(:params) { gen_request(:edit, :options => options) }
     it 'redirects to request_tasks subcollection' do
       FactoryGirl.create(:miq_request_task, :miq_request_id => service_request.id)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
@@ -634,17 +635,18 @@ describe "Service Requests API" do
     it 'allows access to underlying service task' do
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      get("#{api_request_url(nil, service_request)}/request_tasks/#{task.id}")
+      get("#{api_request_request_task_url(nil, service_request, task)}")
 
       expect(response).to have_http_status(:ok)
     end
 
     it 'allows edit of task as a subcollection of service request' do
-      tasks_url = "#{api_service_request_url(nil, service_request)}/request_tasks/#{task.id}"
+      tasks_url = api_request_request_task_url(nil, service_request, task)
       api_basic_authorize subcollection_action_identifier(:service_requests, :request_tasks, :edit)
       post(tasks_url, :params => params)
 
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['options']).to match(hash_including(options))
     end
   end
 end

--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -602,6 +602,8 @@ describe "Service Requests API" do
   end
 
   context 'Tasks subcollection' do
+    let(:task) { FactoryGirl.create(:miq_request_task, :miq_request_id => service_request.id) }
+    let(:params) { gen_request(:edit, :options => { :a => "1" }) }
     it 'redirects to request_tasks subcollection' do
       FactoryGirl.create(:miq_request_task, :miq_request_id => service_request.id)
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
@@ -613,13 +615,36 @@ describe "Service Requests API" do
     end
 
     it 'redirects to request_tasks subresources' do
-      task = FactoryGirl.create(:miq_request_task, :miq_request_id => service_request.id)
       api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
 
       get("#{api_service_request_url(nil, service_request)}/tasks/#{task.id}")
 
       expect(response).to have_http_status(:moved_permanently)
       expect(response.redirect_url).to include("#{api_service_request_url(nil, service_request)}/request_tasks/#{task.id}")
+    end
+
+    it 'does not allow direct edit of task' do
+      api_basic_authorize
+
+      post(api_request_task_url(nil, task), :params => params)
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'allows access to underlying service task' do
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      get("#{api_request_url(nil, service_request)}/request_tasks/#{task.id}")
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'allows edit of task as a subcollection of service request' do
+      tasks_url = "#{api_service_request_url(nil, service_request)}/request_tasks/#{task.id}"
+      api_basic_authorize subcollection_action_identifier(:service_requests, :request_tasks, :edit)
+      post(tasks_url, :params => params)
+
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -635,7 +635,7 @@ describe "Service Requests API" do
     it 'allows access to underlying service task' do
       api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
 
-      get("#{api_request_request_task_url(nil, service_request, task)}")
+      get(api_request_request_task_url(nil, service_request, task))
 
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
Allow request tasks under
* provision_request
* service_request
* automation_request

To be edited.

The request_task is exposed as a sub collection of the request, since only the request has RBAC support and request task doesn't.

The controller directly updates the options hash in the Request task object