### PR TITLE
Loosen JBuilder dependency

### DIFF
--- a/manageiq-api.gemspec
+++ b/manageiq-api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "config"
-  s.add_dependency "jbuilder", "~> 2.5.0"
+  s.add_dependency "jbuilder", "~> 2.5"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
No reason this can't allow minor updates (and currently blocks me on dependency resolutions for Rails 5.1)