### PR TITLE
Fix Generic Object Creation

### DIFF
--- a/app/controllers/api/mixins/generic_objects.rb
+++ b/app/controllers/api/mixins/generic_objects.rb
@@ -1,12 +1,13 @@
 module Api
   module Mixins
     module GenericObjects
-      ADDITIONAL_ATTRS = %w(generic_object_definition associations).freeze
+      ADDITIONAL_ATTRS = %w(associations).freeze
 
       private
 
       def create_generic_object(object_definition, data)
-        object_definition.create_object(data.except(*ADDITIONAL_ATTRS)).tap do |generic_object|
+        data['generic_object_definition'] = object_definition
+        GenericObject.new(data.except(*ADDITIONAL_ATTRS)).tap do |generic_object|
           add_associations(generic_object, data, object_definition) if data.key?('associations')
           generic_object.save!
         end

--- a/spec/requests/generic_objects_spec.rb
+++ b/spec/requests/generic_objects_spec.rb
@@ -170,7 +170,9 @@ RSpec.describe 'GenericObjects API' do
           ]
         }
       }
-      post(api_generic_objects_url, :params => generic_object)
+      expect do
+        post(api_generic_objects_url, :params => generic_object)
+      end.to_not change(GenericObject, :count)
 
       expected = {
         'error' => a_hash_including(


### PR DESCRIPTION
Fix so that a generic object definition is not created if it is a bad request, ie if there are invalid associations.

@miq-bot add_label bug
@miq-bot assign @abellotti 

bz: https://bugzilla.redhat.com/show_bug.cgi?id=1500865