### PR TITLE
Do not allow user to have multiple carts

### DIFF
--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -7,6 +7,7 @@ module Api
       raise BadRequestError, "Can't create an ordered service order" if data["state"] == ServiceOrder::STATE_ORDERED
       service_requests = data.delete("service_requests")
       data["state"] ||= ServiceOrder::STATE_CART
+      raise BadRequestError, "Cart for user #{User.current_user.name} already exists" if cart?
       if service_requests.blank?
         super
       else
@@ -55,6 +56,12 @@ module Api
     end
 
     private
+
+    def cart?
+      ServiceOrder.cart_for(User.current_user)
+    rescue ActiveRecord::RecordNotFound
+      false
+    end
 
     def add_request_to_cart(workflow)
       workflow.add_request_to_cart

--- a/spec/requests/service_orders_spec.rb
+++ b/spec/requests/service_orders_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe "service orders API" do
     expect(response.parsed_body).to include(expected)
   end
 
+  it "will not create a new cart if one already exists for the user" do
+    api_basic_authorize collection_action_identifier(:service_orders, :create)
+    FactoryGirl.create(:service_order, :state => ServiceOrder::STATE_CART, :user => @user)
+
+    post api_service_orders_url, :params => { :name => "service order" }
+    expected = {
+      "error" => a_hash_including(
+        "message" => "Cart for user #{@user.name} already exists"
+      )
+    }
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body).to include(expected)
+  end
+
   it "can create a service order" do
     api_basic_authorize collection_action_identifier(:service_orders, :create)
 


### PR DESCRIPTION
Fixes a bug where a user is able to create multiple carts, when they are only supposed to have one cart at a time.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1493788

@miq-bot add_label bug
@miq-bot assign @abellotti 