### PR TITLE
Return picture href for generic objects subcollections

### DIFF
--- a/app/controllers/api/subcollections/generic_objects.rb
+++ b/app/controllers/api/subcollections/generic_objects.rb
@@ -9,6 +9,12 @@ module Api
 
         generic_objects.collect do |go|
           attributes_hash = create_resource_attributes_hash(go_attrs, go)
+
+          if attributes_hash['picture']
+            picture = attributes_hash['picture']
+            attributes_hash['picture'] = picture.attributes.merge('image_href' => picture.image_href, 'extension' => picture.extension)
+          end
+
           go.as_json.merge(attributes_hash)
         end
       end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1102,7 +1102,8 @@ describe "Services API" do
   end
 
   describe "Generic Objects Subcollection" do
-    let(:generic_object_definition) { FactoryGirl.create(:generic_object_definition) }
+    let(:picture) { FactoryGirl.create(:picture) }
+    let(:generic_object_definition) { FactoryGirl.create(:generic_object_definition, :picture => picture) }
     let(:generic_object) { FactoryGirl.create(:generic_object, :generic_object_definition => generic_object_definition) }
 
     before do
@@ -1136,7 +1137,7 @@ describe "Services API" do
     it "allows expansion of generic objects and specification of generic object attributes" do
       api_basic_authorize(action_identifier(:services, :read, :resource_actions, :get))
 
-      get api_services_url, :params => { :expand => 'resources,generic_objects', :attributes => 'generic_objects.generic_object_definition' }
+      get api_services_url, :params => { :expand => 'resources,generic_objects', :attributes => 'generic_objects.generic_object_definition,generic_objects.picture' }
 
       expected = {
         'name'      => 'services',
@@ -1148,7 +1149,8 @@ describe "Services API" do
             'generic_objects' => [
               a_hash_including(
                 'href'                      => api_service_generic_object_url(nil, svc, generic_object),
-                'generic_object_definition' => a_hash_including('id' => generic_object_definition.id.to_s)
+                'generic_object_definition' => a_hash_including('id' => generic_object_definition.id.to_s),
+                'picture'                   => a_hash_including('image_href' => a_string_including(picture.image_href), 'extension' => picture.extension)
               )
             ]
           )


### PR DESCRIPTION
This enhancement automatically returns the picture href if the picture attribute is specified for generic objects.

#### Example Usage
`GET /api/pictures/10r1?expand=generic_objects&attributes=generic_objects.picture`

@miq-bot add_label enhancement
@miq-bot assign @abellotti 

cc: @chalettu 