### PR TITLE
Return image_href and extension for Pictures

### DIFF
--- a/app/controllers/api/pictures_controller.rb
+++ b/app/controllers/api/pictures_controller.rb
@@ -1,9 +1,17 @@
 module Api
   class PicturesController < BaseController
+    before_action :set_additional_attributes, :only => [:index, :show]
+
     def create_resource(_type, _id, data)
       Picture.create_from_base64(data)
     rescue => err
       raise BadRequestError, "Failed to create Picture - #{err}"
+    end
+
+    private
+
+    def set_additional_attributes
+      @additional_attributes = %w(image_href extension)
     end
   end
 end

--- a/spec/requests/picture_spec.rb
+++ b/spec/requests/picture_spec.rb
@@ -62,6 +62,33 @@ describe "Pictures" do
     end
   end
 
+  describe 'GET /api/pictures' do
+    it 'returns image_href, extension when resources are expanded' do
+      api_basic_authorize
+
+      expected = {
+        'resources' => [
+          a_hash_including('image_href' => a_string_including(picture.image_href), 'extension' => picture.extension)
+        ]
+      }
+      get(api_pictures_url, :params => { :expand => 'resources' })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'GET /api/pictures/:id' do
+    it 'returns image_href, extension by default' do
+      api_basic_authorize
+
+      get(api_picture_url(nil, picture))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('image_href' => a_string_including(picture.image_href), 'extension' => picture.extension)
+    end
+  end
+
   describe 'POST /api/pictures' do
     # Valid base64 image
     let(:content) do


### PR DESCRIPTION
This will return the image href and extension by default for `GET /api/pictures?expand=resources` and 'GET /api/pictures/:id`

@miq-bot add_label enhancement
@miq-bot assign @abellotti  