### PR TITLE
Container Nodes Collection

### DIFF
--- a/app/controllers/api/container_nodes_controller.rb
+++ b/app/controllers/api/container_nodes_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ContainerNodesController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -703,6 +703,24 @@
       :get:
       - :name: read
         :identifier: container_deployment_show
+  :container_nodes:
+    :description: Container Nodes
+    :identifier: container_node
+    :klass: ContainerNode
+    :verbs: *gp
+    :options:
+    - :collection
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: container_node_show_list
+      :post:
+      - :name: query
+        :identifier: container_node_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: container_node_show
   :currencies:
     :description: Currencies
     :identifier: currency

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -659,5 +659,10 @@ describe "Rest API Collections" do
       FactoryGirl.create(:guest_device)
       test_collection_bulk_query(:guest_devices, api_guest_devices_url, GuestDevice)
     end
+
+    it 'bulk query container nodes' do
+      FactoryGirl.create(:container_node)
+      test_collection_bulk_query(:container_nodes, api_container_nodes_url, ContainerNode)
+    end
   end
 end

--- a/spec/requests/container_nodes_spec.rb
+++ b/spec/requests/container_nodes_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe 'Container Nodes API' do
+  describe 'GET /api/container_nodes' do
+    it 'will not list container nodes without an appropriate role' do
+      api_basic_authorize
+
+      get(api_container_nodes_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'lists all container nodes with an appropriate role' do
+      node1, node2 = FactoryGirl.create_list(:container_node, 2)
+      api_basic_authorize collection_action_identifier(:container_nodes, :read, :get)
+
+      get(api_container_nodes_url)
+
+      expected = {
+        'count'     => 2,
+        'name'      => 'container_nodes',
+        'resources' => a_collection_including(
+          {'href' => api_container_node_url(nil, node1)}, {'href' => api_container_node_url(nil, node2)}
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'GET /api/container_nodes/:id' do
+    it 'will not show a container node without an appropriate role' do
+      api_basic_authorize
+      node = FactoryGirl.create(:container_node)
+
+      get(api_container_node_url(nil, node))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'will show a container node with an appropriate role' do
+      node = FactoryGirl.create(:container_node)
+      api_basic_authorize action_identifier(:container_nodes, :read, :resource_actions, :get)
+
+      get(api_container_node_url(nil, node))
+
+      expect(response.parsed_body).to include('id' => node.id.to_s, 'href' => api_container_node_url(nil, node))
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
### Container Nodes Collection 

`GET /api/container_nodes`
`GET /api/container_nodes/:id`

will likely need to add a subcollection in the future.

@miq-bot add_label enhancement
@miq-bot assign @abellotti 