### PR TITLE
Remove some indirection in rendering

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -17,8 +17,7 @@ module Api
 
     def destroy
       api_token_mgr.invalidate_token(request.headers[HttpHeaders::AUTH_TOKEN])
-
-      render_normal_destroy
+      head :no_content
     end
 
     private

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -74,7 +74,7 @@ module Api
       else
         delete_resource(@req.collection.to_sym, @req.collection_id)
       end
-      render_normal_destroy
+      head :no_content
     end
 
     def options

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -65,7 +65,7 @@ module Api
     end
 
     def update
-      render_normal_update @req.collection.to_sym, update_collection(@req.subject.to_sym, @req.subject_id)
+      render_resource(@req.collection.to_sym, update_collection(@req.subject.to_sym, @req.subject_id))
     end
 
     def destroy

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -117,13 +117,6 @@ module Api
       end
 
       #
-      # Render nothing for normal update.
-      #
-      def render_normal_update(type, res = {})
-        render_resource type, res
-      end
-
-      #
       # Method name for optional accessor of virtual attributes
       #
       def virtual_attribute_accessor(type, attr)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -117,13 +117,6 @@ module Api
       end
 
       #
-      # Render nothing for normal resource deletes.
-      #
-      def render_normal_destroy
-        head :no_content
-      end
-
-      #
       # Render nothing for normal update.
       #
       def render_normal_update(type, res = {})

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -15,7 +15,7 @@ module Api
           raise BadRequestError,
                 "Cannot update attributes other than #{EDITABLE_ATTRS.join(', ')} for the authenticated user"
         end
-        render_normal_update :users, update_collection(:users, @req.collection_id)
+        render_resource(:users, update_collection(:users, @req.collection_id))
       else
         validate_api_action
         super


### PR DESCRIPTION
These methods add little while also harboring comment-lies ("Render nothing for normal update.") Removing them is, IMO, preferable.

@miq-bot add-label refactoring
@miq-bot assign @abellotti 