### PR TITLE
symbolize parameters before sending to backend

### DIFF
--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -30,7 +30,7 @@ module Api
       klass = ConfigurationScriptSource.descendant_get(type)
       raise "ConfigurationScriptSource cannot be added to #{manager_ident(manager)}" unless klass.respond_to?(:create_in_provider_queue)
 
-      task_id = klass.create_in_provider_queue(manager.id, data.except('manager_resource'))
+      task_id = klass.create_in_provider_queue(manager.id, data.except('manager_resource').deep_symbolize_keys)
       action_result(true, "Creating ConfigurationScriptSource for #{manager_ident(manager)}", :task_id => task_id)
     rescue => err
       action_result(false, err.to_s)


### PR DESCRIPTION
Fixing the missing of `name` in task name

https://bugzilla.redhat.com/show_bug.cgi?id=1439203

@miq-bot add_label bug