### PR TITLE
Blacklist Config Values

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -30,7 +30,7 @@ module Api
         return if value.nil?
         if value.kind_of?(Array) || value.kind_of?(ActiveRecord::Relation)
           normalize_array(value)
-        elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
+        elsif !attr.nil? && (value.respond_to?(:attributes) || value.respond_to?(:keys))
           normalize_hash(attr, value)
         elsif attr == "id" || attr.to_s.ends_with?("_id")
           value.to_s

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -1,16 +1,11 @@
 module Api
   class CollectionConfig
-    BLACKLISTED = [:system, :display].freeze
-
     def initialize
       @cfg = ApiConfig.collections
     end
 
     def [](collection_name)
-      # Config::Options implements a system method causing self[:system] to error.
-      # i.e. subcollection name system in an arbitraty path /api/automate/manageiq/system
-      collection_name = collection_name.to_sym
-      return if BLACKLISTED.include?(collection_name)
+      return unless include?(collection_name)
       @cfg[collection_name.to_sym]
     end
 
@@ -101,6 +96,14 @@ module Api
     end
 
     private
+
+    def as_hash
+      @as_hash ||= @cfg.to_h
+    end
+
+    def include?(collection_name)
+      as_hash.include?(collection_name.to_sym)
+    end
 
     def names_for_features
       @names_for_features ||= @cfg.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(collection, cspec), result|

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -1,5 +1,7 @@
 module Api
   class CollectionConfig
+    BLACKLISTED = [:system, :display].freeze
+
     def initialize
       @cfg = ApiConfig.collections
     end
@@ -7,9 +9,9 @@ module Api
     def [](collection_name)
       # Config::Options implements a system method causing self[:system] to error.
       # i.e. subcollection name system in an arbitraty path /api/automate/manageiq/system
+      collection_name = collection_name.to_sym
+      return if BLACKLISTED.include?(collection_name)
       @cfg[collection_name.to_sym]
-    rescue
-      nil
     end
 
     def option?(collection_name, option_name)


### PR DESCRIPTION
Proposed solution to resolve https://github.com/ManageIQ/manageiq-api/issues/134 

Rather than rescuing an error, blacklist the `:system` and `:display` values. Not allowing the `:display` value to be called will resolve issues with the config being displayed in the console output, and removing the call to `:system` removes the need for the rescue block.

cc: @himdel @chrisarcand 

@miq-bot add_label bug 
@miq-bot assign @abellotti 