### PR TITLE
Extract a #create action

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -59,6 +59,10 @@ module Api
       render_collection(@req.subject, res, opts)
     end
 
+    def create
+      render_resource(@req.collection.to_sym, update_collection(@req.subject.to_sym, @req.subject_id))
+    end
+
     def show
       klass = collection_class(@req.subject)
       opts  = {:name => @req.subject, :is_subcollection => @req.subcollection?, :expand_actions => true}

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -77,9 +77,8 @@ module Api
           create_resource(@req.subject.to_sym, nil, r)
         end
       end
-      created = {"results" => results}
 
-      render_resource(@req.collection.to_sym, created)
+      render_resource(@req.collection.to_sym, "results" => results)
     end
 
     def show

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -61,10 +61,8 @@ module Api
 
     def create
       target = target_resource_method(@req.subject.to_sym, @req.action)
-      render_resource(
-        @req.collection.to_sym,
-        get_and_update_multiple_collections(@req.subcollection?, target, @req.subject.to_sym)
-      )
+      created = get_and_update_multiple_collections(@req.subcollection?, target, @req.subject.to_sym)
+      render_resource(@req.collection.to_sym, created)
     end
 
     def show

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -60,18 +60,11 @@ module Api
     end
 
     def create
-      resources = []
-      if @req.json_body.key?("resources")
-        resources += @req.json_body["resources"]
-      else
-        resources << json_body_resource
-      end
-
-      if resources.all?(&:blank?)
+      if @req.resources.all?(&:blank?)
         raise BadRequestError, "No #{@req.subject} resources were specified for the create action"
       end
 
-      results = resources.collect do |r|
+      results = @req.resources.collect do |r|
         next if r.blank?
         if parse_id(r, @req.subject.to_sym)
           raise BadRequestError, "Resource id or href should not be specified for creating a new #{@req.subject}"

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -77,7 +77,12 @@ module Api
         if parse_id(r, @req.subject.to_sym)
           raise BadRequestError, "Resource id or href should not be specified for creating a new #{@req.subject}"
         end
-        update_one_collection(@req.subcollection?, target, @req.subject.to_sym, nil, r)
+
+        if @req.subcollection?
+          send(target, parent_resource_obj, @req.subject.to_sym, nil, r)
+        else
+          send(target, @req.subject.to_sym, nil, r)
+        end
       end
       created = {"results" => results}
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -60,7 +60,6 @@ module Api
     end
 
     def create
-      target = target_resource_method(@req.subject.to_sym, @req.action)
       resources = []
       if @req.json_body.key?("resources")
         resources += @req.json_body["resources"]
@@ -79,6 +78,7 @@ module Api
         end
 
         if @req.subcollection?
+          target = target_resource_method(@req.subject.to_sym, @req.action)
           send(target, parent_resource_obj, @req.subject.to_sym, nil, r)
         else
           create_resource(@req.subject.to_sym, nil, r)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -81,7 +81,7 @@ module Api
         if @req.subcollection?
           send(target, parent_resource_obj, @req.subject.to_sym, nil, r)
         else
-          send(target, @req.subject.to_sym, nil, r)
+          create_resource(@req.subject.to_sym, nil, r)
         end
       end
       created = {"results" => results}

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -61,7 +61,13 @@ module Api
 
     def create
       target = target_resource_method(@req.subject.to_sym, @req.action)
-      created = get_and_update_multiple_collections(@req.subcollection?, target, @req.subject.to_sym)
+      resources = []
+      if @req.json_body.key?("resources")
+        resources += @req.json_body["resources"]
+      else
+        resources << json_body_resource
+      end
+      created = update_multiple_collections(@req.subcollection?, target, @req.subject.to_sym, resources)
       render_resource(@req.collection.to_sym, created)
     end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -60,7 +60,11 @@ module Api
     end
 
     def create
-      render_resource(@req.collection.to_sym, update_collection(@req.subject.to_sym, @req.subject_id))
+      target = target_resource_method(@req.subject.to_sym, @req.action)
+      render_resource(
+        @req.collection.to_sym,
+        get_and_update_multiple_collections(@req.subcollection?, target, @req.subject.to_sym)
+      )
     end
 
     def show

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -88,22 +88,11 @@ module Api
       end
 
       def get_and_update_one_collection(is_subcollection, target, type, id)
-        resource = json_body_resource
-        update_one_collection(is_subcollection, target, type, id, resource)
+        update_one_collection(is_subcollection, target, type, id, @req.resource)
       end
 
       def get_and_update_multiple_collections(is_subcollection, target, type)
-        resources = []
-        if @req.json_body.key?("resources")
-          resources += @req.json_body["resources"]
-        else
-          resources << json_body_resource
-        end
-        update_multiple_collections(is_subcollection, target, type, resources)
-      end
-
-      def json_body_resource
-        @req.json_body["resource"] || @req.json_body.except("action")
+        update_multiple_collections(is_subcollection, target, type, @req.resources)
       end
 
       def update_one_collection(is_subcollection, target, type, id, resource)

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -89,6 +89,18 @@ module Api
           @href ||= Href.new(url)
         end
 
+        def resources
+          if json_body.key?("resources")
+            json_body["resources"]
+          else
+            [resource]
+          end
+        end
+
+        def resource
+          json_body["resource"] || json_body.except("action")
+        end
+
         private
 
         def expand_requested

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -11,7 +11,7 @@ module Api
     def update
       aname = @req.action
       if aname == "edit" && !api_user_role_allows?(aname) && update_target_is_api_user?
-        if (Array(json_body_resource.try(:keys)) - EDITABLE_ATTRS).present?
+        if (Array(@req.resource.try(:keys)) - EDITABLE_ATTRS).present?
           raise BadRequestError,
                 "Cannot update attributes other than #{EDITABLE_ATTRS.join(', ')} for the authenticated user"
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
             when :delete
               delete "/:c_id", :action => :destroy
             when :post
+              post "/", :action => :create, :constraints => Api::CreateConstraint.new
               post "(/:c_id)", :action => :update
             end
           end
@@ -68,6 +69,7 @@ Rails.application.routes.draw do
             when :delete
               delete "/:c_id/#{subcollection_name}/:s_id", :action => :destroy
             when :post
+              post "/:c_id/#{subcollection_name}", :action => :create, :constraints => Api::CreateConstraint.new
               post "/:c_id/#{subcollection_name}(/:s_id)", :action => :update
             end
           end

--- a/lib/api/create_constraint.rb
+++ b/lib/api/create_constraint.rb
@@ -1,0 +1,9 @@
+module Api
+  class CreateConstraint
+    def matches?(request)
+      Hash(JSON.parse(request.body.read)).fetch("action", "create").in?(%w(create add))
+    ensure
+      request.body.rewind
+    end
+  end
+end

--- a/spec/requests/creating_spec.rb
+++ b/spec/requests/creating_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe "Creating" do
+  it "responds OK if there is a resource at the top level" do
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url, :params => {:name => "Alice's Role"})
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "responds OK if there is a resource in the \"resource\" node" do
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url, :params => {:resource => {:name => "Alice's Role"}})
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "respondes OK if there is at least one resource in the \"resources\" node" do
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url, :params => {:resources => [{:name => "Alice's Role"}, {}]})
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "responds with Bad Request if there are no resources at the top level" do
+    skip("Currently results in an internal server error")
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url)
+
+    expect(response.parsed_body).to include_error_with_message("No roles resources were specified for the create action")
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "responds with Bad Request if there is a null resource in the \"resource\" node" do
+    skip("Currently results in an internal server error")
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url, :params => {:resource => nil})
+
+    expect(response.parsed_body).to include_error_with_message("No roles resources were specified for the create action")
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "responds with Bad Request if there is an emtpy resource in the \"resource\" node" do
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url, :params => {:resource => {}})
+
+    expect(response.parsed_body).to include_error_with_message("No roles resources were specified for the create action")
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "responds with Bad Request if there are no resources at the top level" do
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url, :params => {:resources => []})
+
+    expect(response.parsed_body).to include_error_with_message("No roles resources were specified for the create action")
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "responds with Bad Request if an id is present in the URL" do
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_role_url(nil, 123), :params => {:name => "Alice's Group"})
+
+    expect(response.parsed_body).to include_error_with_message("Unsupported Action create for the roles resource specified")
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "responds with Bad Request if we specify an id in the body" do
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url, :params => {:id => 123, :name => "Alice's Group"})
+
+    expect(response.parsed_body).to include_error_with_message("Resource id or href should not be specified for creating a new roles")
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "responds with Bad Request if we specify an href in the body" do
+    api_basic_authorize(action_identifier(:roles, :create, :collection_actions))
+
+    post(api_roles_url, :params => {:href => api_vm_url(nil, 123), :name => "Alice's Group"})
+
+    expect(response.parsed_body).to include_error_with_message("Resource id or href should not be specified for creating a new roles")
+    expect(response).to have_http_status(:bad_request)
+  end
+end

--- a/spec/requests/logging_spec.rb
+++ b/spec/requests/logging_spec.rb
@@ -40,7 +40,7 @@ describe "Logging" do
       post(api_services_url, :params => gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
 
       expect(@log.string).to include(
-        'Parameters:     {"action"=>"update", "controller"=>"api/services", "format"=>"json", ' \
+        'Parameters:     {"action"=>"create", "controller"=>"api/services", "format"=>"json", ' \
         '"body"=>{"action"=>"create", "resource"=>{"name"=>"new_service_1", ' \
         '"options"=>{"password"=>"[FILTERED]"}}}}'
       )


### PR DESCRIPTION
There are currently a few different ways to create a resource:

```http
POST /api/<collection>

{
  "action": "create", 
  "some": "attributes"
}
```

```http
POST /api/<collection>

{
  "action": "create", 
  "resource": {
    "some": "attributes"
  }
}
```

```http
POST /api/<collection>

{
  "action": "create", 
  "resources": [
    {"some": "attributes"},
    {"some": "other attributes"}
  ]
}
```

In all three, the "action" can also be "add", or omitted entirely.

Perhaps surprisingly, these all get routed through the `#update` action, which implicitly handles both the creation and updating of resources.

Most Rails developers would expect this to be handled through the more conventional `#create` action. I've added this functionality here, extracting the create-specific code into this new action.

There are a few benefits that I'd like to highlight:

1. it's more familiar to Rails developers. Having an `#update` action that is also responsible for creating resources is very confusing/surprising
1. the newly extracted `#create` action can be hooked into, overridden, etc.. without disturbing any of the deeply-nested `#update` logic
1. this teases apart some of that logic so that we're not mixing in knowledge of how to create resources in a low-level method called `#update_one_collection`, etc..
1. it should now be much easier to understand/read since most of the indirection involved in the `#update` action could be eliminated for `#create`

@miq-bot add-label refactoring, technical debt
@miq-bot assign @chrisarcand 
