### PR TITLE
Return only id attributes if specified

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -367,6 +367,7 @@ module Api
         physical_attrs, virtual_attrs = [], []
         attrs = attribute_selection
         return [physical_attrs, virtual_attrs] if resource.kind_of?(Hash) || attrs == 'all'
+        return [attrs, virtual_attrs] if (attrs - ID_ATTRS).empty?
 
         attrs.each do |attr|
           if attr_physical?(resource, attr) || attr == 'actions'

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -85,6 +85,25 @@ describe "Querying" do
       expect(response).to have_http_status(:bad_request)
     end
 
+    it 'returns only id attributes if specified on a collection' do
+      vm = FactoryGirl.create(:vm)
+
+      get(api_vms_url, :params => { :expand => :resources, :attributes => 'id' })
+
+      expected = {
+        'resources' => [{'href' => api_vm_url(nil, vm), 'id' => vm.id.to_s}]
+      }
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'returns only id attributes if specified on a resource' do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      get(api_vm_url(nil, vm1), :params => { :attributes => 'id' })
+
+      expect(response.parsed_body).to eq("href" => api_vm_url(nil, vm1), "id" => vm1.id.to_s)
+    end
+
     it "returns correct paging links" do
       create_vms_by_name %w(bb ff aa cc ee gg dd)
 


### PR DESCRIPTION
Fixes [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1437201) where if you specify `expand=resources&attributes=id`, it returns all of the attributes.

Started to go down the 🐰 hole of refactoring attribute selection (it could use it), but felt it was best to get this fixed separately.

@miq-bot assign @imtayadeway 
