### PR TITLE
Return the correct href slugs for requests and service requests

### DIFF
--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -66,6 +66,10 @@ module Api
       {:requester => User.current_user}
     end
 
+    def fetch_requests_href_slug(resource)
+      "requests/#{resource.id}"
+    end
+
     private
 
     def authorize_request(typed_request_klass)

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -474,6 +474,17 @@ RSpec.describe "Requests API" do
     end
   end
 
+  context 'href_slug' do
+    it 'returns the correct slug for a request' do
+      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      request = FactoryGirl.create(:automation_request, :requester => @user)
+
+      get(api_request_url(nil, request), :params => { :attributes => 'href_slug' })
+
+      expect(response.parsed_body['href_slug']).to eq("requests/#{request.id}")
+    end
+  end
+
   context 'Tasks subcollection' do
     let(:request) do
       FactoryGirl.create(:service_template_provision_request,


### PR DESCRIPTION
Another [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1503852) that could probably use some refactoring...

When the `href_slug` is generated, it is using [name_for_subclass](https://github.com/ManageIQ/manageiq-api/blob/70e15767af07a45a3d49af87a6b34ade789ea440/lib/api/collection_config.rb#L80) which is essentially finding the collection name from the resource class.

This is causing problems in numerous places where resource classes are applicable to multiple collections - as can be seen [below](https://github.com/ManageIQ/manageiq-api/compare/master...jntullo:bz/return_correct_request_slug?expand=1#diff-8174336b6ca531d40c4f4ca9b7f06979) where an automation request being returned from the `/requests` endpoint returns the `automation_request/:id` slug, when it should be `requests`

@miq-bot add_label bug
@miq-bot assign @imtayadeway 