### PR TITLE
Allow assigning/un-assigning of alert definitions to alert profiles

### DIFF
--- a/app/controllers/api/subcollections/alert_definitions.rb
+++ b/app/controllers/api/subcollections/alert_definitions.rb
@@ -4,6 +4,26 @@ module Api
       def alert_definitions_query_resource(object)
         object.respond_to?(:miq_alerts) ? object.miq_alerts : []
       end
+
+      def alert_definitions_assign_resource(object, type, id = nil, _data = nil)
+        alert = resource_search(id, type, collection_class(type))
+        object.add_member(alert)
+        result = action_result(true, "Assigning alert_definition #{id} to profile #{object.id}")
+        add_parent_href_to_result(result)
+        add_subcollection_resource_to_result(result, type, alert)
+      rescue => err
+        action_result(false, err.to_s)
+      end
+
+      def alert_definitions_unassign_resource(object, type, id = nil, _data = nil)
+        alert = resource_search(id, type, collection_class(type))
+        success = object.remove_member(alert).present?
+        result = action_result(success, "Unassigning alert_definition #{id} from profile #{object.id}")
+        add_parent_href_to_result(result)
+        add_subcollection_resource_to_result(result, type, alert)
+      rescue => err
+        action_result(false, err.to_s)
+      end
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -116,6 +116,12 @@
       :delete:
       - :name: delete
         :identifier: alert_definition_profile_delete
+    :alert_definitions_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: alert_definition_profile_edit
+      - :name: unassign
+        :identifier: alert_definition_profile_edit
   :alert_definitions:
     :description: Alert Definitions
     :identifier: alert_definition


### PR DESCRIPTION
This commit allows assigning and un-assigning of alert definitions to alert definition profiles.

**Usage examples:**
to assign an alert definition to a profile:

POST /api/alert_definition_profiles/:id/alert_definitions
```json 
{"action": "assign",
 "resource": {"href": "/api/alert_definition/:alert_definition_id"}}
```

to un-assign an alert definition from a profile:

POST /api/alert_definition_profiles/:id/alert_definitions
```json 
{"action": "unassign",
 "resource": {"href": "/api/alert_definition/:alert_definition_id"}}
```