### PR TITLE
Return correct href for collections on Index

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -10,11 +10,13 @@ module Api
         attrs = normalize_select_attributes(obj, opts)
         result = {}
 
-        key_id = collection_config.resource_identifier(type)
-        href = new_href(type, obj[key_id], obj["href"])
-        if href.present?
-          result["href"] = href
-          attrs -= ["href"]
+        if type
+          key_id = collection_config.resource_identifier(type)
+          href = new_href(type, obj[key_id], obj["href"])
+          if href.present?
+            result["href"] = href
+            attrs -= ["href"]
+          end
         end
 
         attrs.each do |k|
@@ -30,7 +32,7 @@ module Api
         return if value.nil?
         if value.kind_of?(Array) || value.kind_of?(ActiveRecord::Relation)
           normalize_array(value)
-        elsif !attr.nil? && (value.respond_to?(:attributes) || value.respond_to?(:keys))
+        elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
         elsif attr == "id" || attr.to_s.ends_with?("_id")
           value.to_s

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -55,6 +55,21 @@ describe "Authentication API" do
       }
       expect(response.parsed_body).to include(expected)
     end
+
+    it "returns a correctly formatted collection hrefs" do
+      api_basic_authorize
+
+      get api_entrypoint_url
+
+      collection_names = Api::ApiConfig.collections.to_h.select { |_, v| v.options.include?(:collection) }.keys
+      hrefs = collection_names.collect { |name| url_for(:controller => name, :action => "index") }
+      expected = {
+        "collections" => a_collection_containing_exactly(
+          *hrefs.collect { |href| a_hash_including("href" => href) }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   context "Basic Authentication with Group Authorization" do


### PR DESCRIPTION
Fixes issues where the API prefix isn't passed back in the API index for collections

@miq-bot add_label bug
@miq-bot assign @abellotti 