### PR TITLE
Add symbolization to data for Custom Buttons to fix a UI icon issue

### DIFF
--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -1,12 +1,15 @@
 module Api
   class CustomButtonsController < BaseController
     def create_resource(_type, _id, data)
-      custom_button = CustomButton.new(data.except("resource_action"))
+      custom_button = CustomButton.new(data.except("resource_action", "options"))
       custom_button.userid = User.current_user.userid
+      custom_button.options = data["options"].deep_symbolize_keys if data["options"]
       custom_button.resource_action = find_or_create_resource_action(data["resource_action"]) if data.key?("resource_action")
-      custom_button.save!
-    rescue => err
-      raise BadRequestError, "Failed to create new custom button - #{err}"
+      if custom_button.save
+        custom_button
+      else
+        raise BadRequestError, "Failed to create new custom button - #{custom_button.errors.full_messages.join(", ")}"
+      end
     end
 
     def edit_resource(type, id, data)

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -74,7 +74,9 @@ RSpec.describe 'CustomButtons API' do
       post(api_custom_buttons_url, :params => cb_rec)
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body['results'].first).to eq(true)
+      custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
+      expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")
+      expect(response.parsed_body['results'].first).to include(cb_rec.except('resource_action'))
     end
 
     it 'can edit custom buttons by id' do


### PR DESCRIPTION
- Add symbolization to `data["options"]` for Custom Buttons to fix a UI icon issue
- Also return the created record in order to send the `record id` in the `response` body (required by the UI)