### PR TITLE
DRY up Api version

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -23,10 +23,10 @@ module Api
     private
 
     def entrypoint_versions
-      ApiConfig.version.definitions.select(&:ident).collect do |version_specification|
+      Api::SUPPORTED_VERSIONS.collect do |version|
         {
-          :name => version_specification[:name],
-          :href => "#{@req.base}#{@req.prefix(false)}/#{version_specification[:ident]}"
+          :name => version,
+          :href => "#{@req.base}#{@req.prefix(false)}/v#{version}"
         }
       end
     end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -8,7 +8,7 @@ module Api
       res = {
         :name         => ApiConfig.base.name,
         :description  => ApiConfig.base.description,
-        :version      => ApiConfig.base.version,
+        :version      => ManageIQ::Api::VERSION,
         :versions     => entrypoint_versions,
         :settings     => user_settings,
         :identity     => auth_identity,

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -11,7 +11,7 @@ module Api
         # API Version Validation
         if @req.version
           vname = @req.version
-          unless ApiConfig.version.definitions.collect { |vent| vent[:name] }.include?(vname)
+          unless Api::SUPPORTED_VERSIONS.include?(vname)
             raise BadRequestError, "Unsupported API Version #{vname} specified"
           end
         end

--- a/config/api.yml
+++ b/config/api.yml
@@ -3,10 +3,6 @@
   :module: api
   :name: API
   :description: REST API
-:version:
-  :definitions:
-  - :name: '4.0.0-pre'
-    :ident: 'v4.0.0-pre'
 :verb:
   :names:
   - :get

--- a/config/api.yml
+++ b/config/api.yml
@@ -3,7 +3,6 @@
   :module: api
   :name: API
   :description: REST API
-  :version: '4.0.0-pre'
 :version:
   :definitions:
   - :name: '4.0.0-pre'

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,4 +1,5 @@
 module Api
+  SUPPORTED_VERSIONS = [ManageIQ::Api::VERSION].freeze
   VERSION_CONSTRAINT = /v\d+(\.[\da-zA-Z]+)*(\-[\da-zA-Z\-\.]+)?/
   VERSION_REGEX = /\A#{VERSION_CONSTRAINT}\z/
 

--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -69,7 +69,7 @@ module Api
       @version ||= if version?
                      href.version[1..-1] # Switching API Version
                    else
-                     ApiConfig.base[:version] # Default API Version
+                     ManageIQ::Api::VERSION # Default API Version
                    end
     end
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -45,7 +45,7 @@ describe "Authentication API" do
     end
 
     it "returns a correctly formatted versions href" do
-      version_ident = "v#{Api::ApiConfig.base.version}"
+      version_ident = "v#{ManageIQ::Api::VERSION}"
       api_basic_authorize
 
       get api_entrypoint_url(version_ident)


### PR DESCRIPTION
There should now be only one thing that needs to be updated when we bump the version 🎉 

TBH though I'm not totally convinced https://github.com/ManageIQ/manageiq-api/blob/master/lib/manageiq/api/version.rb#L3 is the right place for this. Are we saying that the manageiq-api gem's version is and will always be the same as the "API version"?

@miq-bot add-label refactoring, technical debt
@miq-bot assign @abellotti 