### PR TITLE
Lock bin/setup to master branch

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,7 @@ gem_root = Pathname.new(__dir__).join("..")
 
 unless gem_root.join("spec/manageiq").exist?
   puts "== Cloning manageiq sample app =="
-  system "git clone https://github.com/ManageIQ/manageiq.git --depth 1 spec/manageiq"
+  system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s


### PR DESCRIPTION
This matches the other repos, and makes it easier to script changes to it for release branches.