### PR TITLE
Add decorator for VNC Console

### DIFF
--- a/app/controllers/api/subcollections/vms.rb
+++ b/app/controllers/api/subcollections/vms.rb
@@ -47,6 +47,9 @@ module Api
         if vm_decorators.include? 'supports_cockpit?'
           hash['supports_cockpit?'] = vm.supports_launch_cockpit?
         end
+        if vm_decorators.include?('supports_vnc_console?')
+          hash['supports_vnc_console?'] = vm.console_supported?('VNC')
+        end
         hash
       end
     end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -473,11 +473,11 @@ describe "Services API" do
     end
 
     it "can query vms as subcollection via decorators with additional decorators" do
-      get api_service_url(nil, svc1), :params => { :expand => "vms", :attributes => "", :decorators => "vms.supports_console?" }
+      get api_service_url(nil, svc1), :params => { :expand => "vms", :attributes => "", :decorators => "vms.supports_console?,vms.supports_cockpit?,vms.supports_vnc_console?" }
 
       expect_svc_with_vms
-      expect_results_to_match_hash("vms", [{"id" => vm1.id.to_s, "supports_console?" => true},
-                                           {"id" => vm2.id.to_s, "supports_console?" => true}])
+      expect_results_to_match_hash("vms", [{"id" => vm1.id.to_s, "supports_console?" => true, "supports_cockpit?" => anything, "supports_vnc_console?" => anything},
+                                           {"id" => vm2.id.to_s, "supports_console?" => true, "supports_cockpit?" => anything, "supports_vnc_console?" => anything}])
     end
 
     it "cannot query vms via both virtual attribute and subcollection" do


### PR DESCRIPTION
SUI requires a check on VNC console because the existing decorators lead to a false positive about console enablement for VMWare consoles.

@miq-bot add_label bug, gaprindashvili/yes, fine/yes 
cc: @AllenBW 
