### PR TITLE
Mask password attributes from AutomateWorkspace

### DIFF
--- a/app/controllers/api/automate_workspaces_controller.rb
+++ b/app/controllers/api/automate_workspaces_controller.rb
@@ -22,5 +22,10 @@ module Api
        'attribute' => data['attribute'],
        'value'     => obj.decrypt(data['object'], data['attribute'])}
     end
+
+    def normalize_attr(attr, value)
+      return "password::********" if value.kind_of?(String) && value.start_with?("password::")
+      super
+    end
   end
 end

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -34,6 +34,8 @@ module Api
           normalize_array(value)
         elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
+        elsif @req.subject == "automate_workspaces" && value =~ /^password::/
+          "password::********"
         elsif attr == "id" || attr.to_s.ends_with?("_id")
           value.to_s
         elsif Api.time_attribute?(attr)

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -34,7 +34,7 @@ module Api
           normalize_array(value)
         elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
-        elsif @req.subject == "automate_workspaces" && value =~ /^password::/
+        elsif @req.subject == "automate_workspaces" && value =~ /\Apassword::/
           "password::********"
         elsif attr == "id" || attr.to_s.ends_with?("_id")
           value.to_s

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -34,8 +34,6 @@ module Api
           normalize_array(value)
         elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
-        elsif @req.subject == "automate_workspaces" && value =~ /\Apassword::/
-          "password::********"
         elsif attr == "id" || attr.to_s.ends_with?("_id")
           value.to_s
         elsif Api.time_attribute?(attr)

--- a/spec/requests/automate_workspaces_spec.rb
+++ b/spec/requests/automate_workspaces_spec.rb
@@ -15,6 +15,7 @@ describe "Automate Workspaces API" do
     { 'objects'           => {'root' => { 'var1' => '1', 'var2' => var2v }},
       'method_parameters' => {'arg1' => "password::#{encrypted}"} }
   end
+  let(:masked_password) { "password::********" }
 
   describe 'GET' do
     it 'should not return resources when fetching the collection' do
@@ -38,6 +39,15 @@ describe "Automate Workspaces API" do
       get(api_automate_workspace_url(nil, aw.guid))
 
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'should mask password attributes' do
+      api_basic_authorize action_identifier(:automate_workspaces, :read, :resource_actions, :get)
+      get(api_automate_workspace_url(nil, aw.guid))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['input']['objects']['root']['var2']).to eq(masked_password)
+      expect(response.parsed_body['input']['method_parameters']['arg1']).to eq(masked_password)
     end
 
     it 'fetching by guid should return resources with guid based references' do

--- a/spec/requests/automate_workspaces_spec.rb
+++ b/spec/requests/automate_workspaces_spec.rb
@@ -12,7 +12,7 @@ describe "Automate Workspaces API" do
   let(:encrypted) { MiqAePassword.encrypt(password) }
   let(:var2v) { "password::#{encrypted}" }
   let(:input) do
-    { 'objects'           => {'root' => { 'var1' => '1', 'var2' => var2v }},
+    { 'objects'           => {'root' => { 'var1' => 1, 'var2' => var2v }},
       'method_parameters' => {'arg1' => "password::#{encrypted}"} }
   end
   let(:masked_password) { "password::********" }
@@ -49,7 +49,8 @@ describe "Automate Workspaces API" do
         'input' => a_hash_including(
           'objects'           => a_hash_including(
             'root' => a_hash_including(
-              'var2' => masked_password
+              'var2' => masked_password,
+              'var1' => 1
             )
           ),
           'method_parameters' => a_hash_including(

--- a/spec/requests/automate_workspaces_spec.rb
+++ b/spec/requests/automate_workspaces_spec.rb
@@ -45,9 +45,21 @@ describe "Automate Workspaces API" do
       api_basic_authorize action_identifier(:automate_workspaces, :read, :resource_actions, :get)
       get(api_automate_workspace_url(nil, aw.guid))
 
+      expected = {
+        'input' => a_hash_including(
+          'objects'           => a_hash_including(
+            'root' => a_hash_including(
+              'var2' => masked_password
+            )
+          ),
+          'method_parameters' => a_hash_including(
+            'arg1' => masked_password
+          )
+        )
+      }
+
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body['input']['objects']['root']['var2']).to eq(masked_password)
-      expect(response.parsed_body['input']['method_parameters']['arg1']).to eq(masked_password)
+      expect(response.parsed_body).to include(expected)
     end
 
     it 'fetching by guid should return resources with guid based references' do


### PR DESCRIPTION
The Automate Workspace can optionally have objects and method
parameters that contain encrypted fields. When these attributes
parameters are sent back to the client we should mask it.
This PR masks the value to password::********