### PR TITLE
Don't try to uncompress ids from href slugs

### DIFF
--- a/lib/api/utils.rb
+++ b/lib/api/utils.rb
@@ -17,7 +17,7 @@ module Api
 
       klass = collection_config.klass(collection)
       key_id = collection_config.resource_identifier(collection)
-      target = key_id == "id" ? klass.find(ApplicationRecord.uncompress_id(id)) : klass.find_by!(key_id => id)
+      target = key_id == "id" ? klass.find(id) : klass.find_by!(key_id => id)
       Rbac.filtered_object(target, :user => user, :class => klass)
     end
   end

--- a/spec/lib/api/utils_spec.rb
+++ b/spec/lib/api/utils_spec.rb
@@ -119,17 +119,6 @@ RSpec.describe Api::Utils do
       expect(actual).to eq(nil)
     end
 
-    it "can interpret slugs with compressed ids" do
-      owner_tenant = FactoryGirl.create(:tenant)
-      owner_group  = FactoryGirl.create(:miq_group, :tenant => owner_tenant)
-      owner        = FactoryGirl.create(:user, :miq_groups => [owner_group])
-      vm = FactoryGirl.create(:vm_vmware, :tenant => owner_tenant)
-
-      actual = described_class.resource_search_by_href_slug("vms/#{vm.compressed_id}", owner)
-
-      expect(actual).to eq(vm)
-    end
-
     it "fetch automate workspace based on guid in href_slug" do
       actual = described_class.resource_search_by_href_slug(aw.href_slug, aw_user)
       expect(actual).to eq(aw)


### PR DESCRIPTION
In f3b6b2ef1541a2d374d4fb9bd75be00f784b612a we stopped generating href
slugs with compressed ids. We should no longer need to uncompress the
id when parsing an href slug.