### PR TITLE
Consolidate some API spec helpers

### DIFF
--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -6,7 +6,7 @@ describe "Authentication API" do
 
   context "Basic Authentication" do
     it "test basic authentication with bad credentials" do
-      basic_authorize "baduser", "badpassword"
+      api_basic_authorize :user => 'baduser', :password => 'badpassword'
 
       get api_entrypoint_url
 

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -403,8 +403,7 @@ describe "Services API" do
     end
 
     it "accepts action when service is reconfigurable" do
-      api_basic_authorize
-      update_user_role(@role, action_identifier(:services, :reconfigure))
+      api_basic_authorize action_identifier(:services, :reconfigure)
 
       st1.resource_actions = [ra1]
       svc1.service_template_id = st1.id

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -19,16 +19,14 @@ module Spec
         end
 
         def api_basic_authorize(*identifiers, user: @user.userid, password: @user.password)
-          update_user_role(@role, *identifiers)
-          request_headers["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
-        end
-
-        def update_user_role(role, *identifiers)
-          return if identifiers.blank?
-          product_features = identifiers.flatten.collect do |identifier|
-            MiqProductFeature.find_or_create_by(:identifier => identifier)
+          if identifiers.present?
+            product_features = identifiers.flatten.collect do |identifier|
+              MiqProductFeature.find_or_create_by(:identifier => identifier)
+            end
+            @role.update_attributes!(:miq_product_features => product_features)
           end
-          role.update_attributes!(:miq_product_features => product_features)
+
+          request_headers["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
         end
 
         def stub_api_action_role(collection, action_type, method, action, identifier)

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -18,12 +18,8 @@ module Spec
                                       :miq_groups => [@group])
         end
 
-        def api_basic_authorize(*identifiers)
+        def api_basic_authorize(*identifiers, user: @user.userid, password: @user.password)
           update_user_role(@role, *identifiers)
-          basic_authorize @user.userid, @user.password
-        end
-
-        def basic_authorize(user, password)
           request_headers["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
         end
 


### PR DESCRIPTION
A few clean up items while I'm working on something else.

* `basic_authorize` is really just a helper method for `api_basic_authorize` and the thing it does itself is only used in a single place. The `api_basic_authorize` can just be more flexible about it, and we don't need two methods that are confusingly similar.
* `update_user_role` is a really simple thing by itself and parameterizes the role which you almost never need to do. You should basically never need to update a role mid-spec so it's a bit of an antipattern anyway.