### PR TITLE
Ignore /bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/bin/
 
 /spec/manageiq
 


### PR DESCRIPTION
This adds /bin to gitignore as we do on ManageIQ core, allowing you to specify your own binstubs without constantly needing to version control them.