### PR TITLE
Fix coercing of string to 0 in parse_id

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -39,7 +39,7 @@ module Api
       end
 
       def parse_id(resource, collection)
-        return nil if resource.blank?
+        return nil if !resource.kind_of?(Hash) || resource.blank?
 
         href_id = href_id(resource["href"], collection)
         case

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1079,6 +1079,21 @@ describe "Services API" do
       expect(response.parsed_body).to include(expected)
     end
 
+    it 'requires provider hash to be passed with id or href' do
+      api_basic_authorize action_identifier(:services, :add_provider_vms)
+
+      post(api_service_url(nil, svc), :params => { :action  => 'add_provider_vms',
+                                                   :uid_ems => ['uids'] ,
+                                                   :provider => 'api/providers/:id'})
+
+      expected = {
+        'success' => false,
+        'message' => a_string_including('Must specify a valid provider href or id')
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it 'can bulk add_provider_vms' do
       api_basic_authorize action_identifier(:services, :add_provider_vms)
       svc.update_attributes!(:evm_owner => @user)


### PR DESCRIPTION
Currently, parse_id returns a 0 if a string is passed in, rather than a hash. This checks to ensure the resource passed in is a hash and returns nil otherwise, allowing normal error handling to proceed. 

I couldn't find a better place for the test, seems like it doesn't quite belong there and is more of a general case. Thoughts?

@miq-bot add_label bug, gaprindashvili/yes 