### PR TITLE
Don't respond with 400 on ArgumentError

### DIFF
--- a/app/controllers/api/automate_workspaces_controller.rb
+++ b/app/controllers/api/automate_workspaces_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class AutomateWorkspacesController < BaseController
     def edit_resource(type, id, data = {})
+      raise BadRequestError, "must contain at least one attribute to edit" if data.blank?
       obj = resource_search(id, type, collection_class(type))
       obj.merge_output!(data)
     end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -43,7 +43,6 @@ module Api
     rescue_from(BadRequestError)                { |e| api_error(:bad_request, e) }
     rescue_from(NotFoundError)                  { |e| api_error(:not_found, e) }
     rescue_from(UnsupportedMediaTypeError)      { |e| api_error(:unsupported_media_type, e) }
-    rescue_from(ArgumentError)                  { |e| api_error(:bad_request, e) }
 
     def index
       klass = collection_class(@req.subject)


### PR DESCRIPTION
If an `ArgumentError` was raised it means that we either did something
wrong or we did not handle the request properly and we should respond
approriately with a 500.

@miq-bot add-label bug
@miq-bot assign @abellotti 