### PR TITLE
Add a set_current_group method for users

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2779,6 +2779,7 @@
         :identifier: rbac_user_edit
       - :name: delete
         :identifier: rbac_user_delete
+      - :name: set_current_group
       :delete:
       - :name: delete
         :identifier: rbac_user_delete


### PR DESCRIPTION
The current way of setting a user’s `current_group` via edit uses `resource_search`, which encounters some RBAC issues. For example, when a user changes from the super administrator group to the tenant group, they are no longer able to switch back even though they belong to the group because `resource_search` returns a forbidden error. By choosing a group based off of their current miq_groups, it resolves the issue and keeps the ability to change groups consistent with that in the classic-ui.

**How it works in the classic ui:**
![group_switching_classic_ui](https://user-images.githubusercontent.com/2433314/32387787-f55fb000-c09b-11e7-979d-7d8e5c84468f.gif)

**The failure present in the SUI before the fix:**
![group_switching_sui](https://user-images.githubusercontent.com/2433314/32387076-b36f68f4-c099-11e7-9c38-b8ef0eb9f1b0.gif)

**The successful API call with `set_current_group`:**
![group_switching_api](https://user-images.githubusercontent.com/2433314/32387092-c0a0be38-c099-11e7-96d3-a363a8398cca.gif)

In addition, with update_attributes! it raises a validation error saying that the superadministrator group is not in their groups, also appears to be due to RBAC. I looked to the [classic UI](https://github.com/ManageIQ/manageiq-ui-classic/blob/eac23c268907f22feec9f1109f80eb795ad43dd8/app/controllers/dashboard_controller.rb#L657) to see how their behavior works, and chose to use `update_attribute` based off of that. Because this is different behavior than a typical edit, I felt that it also deserved a specialized method, thus removing this functionality from edit and moving it to `set_current_group`. 

This is also a unique use case, and did not think it would apply as a collection action, but am open to discussion around that. 

https://bugzilla.redhat.com/show_bug.cgi?id=1467364

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @abellotti 

cc: @AllenBW 