### PR TITLE
Allow assignments of alert profiles

### DIFF
--- a/app/controllers/api/alert_definition_profiles_controller.rb
+++ b/app/controllers/api/alert_definition_profiles_controller.rb
@@ -4,6 +4,8 @@ module Api
 
     REQUIRED_FIELDS = %w(description mode).freeze
 
+    before_action :set_additional_attributes, :only => [:show]
+
     def create_resource(type, id, data = {})
       assert_all_required_fields_exists(data, type, REQUIRED_FIELDS)
       begin
@@ -20,6 +22,53 @@ module Api
       rescue => err
         raise BadRequestError, "Failed to update alert definition profile - #{err}"
       end
+    end
+
+    def get_resource_from_href(href)
+      hrefobj = Href.new(href)
+      resource_search(hrefobj.subject_id, hrefobj.subject, collection_class(hrefobj.subject))
+    end
+
+    def assign_resource(type, id = nil, data = {})
+      profile = resource_search(id, type, collection_class(type))
+      raise BadRequestError, "Must specify either objects or tags for the assignment target" unless data.include?("objects") || data.include?("tags")
+      if data.include?("objects")
+        objects = data["objects"].collect do |ref|
+          get_resource_from_href(ref)
+        end
+        profile.assign_to_objects(objects)
+      end
+
+      if data.include?("tags")
+        data["tags"].each do |tag|
+          profile.assign_to_tags([get_resource_from_href(tag["href"]).classification], tag["class"])
+        end
+      end
+      profile.get_assigned_tos
+    end
+
+    def unassign_resource(type, id = nil, data = {})
+      profile = resource_search(id, type, collection_class(type))
+      raise BadRequestError, "Must specify either objects or tags for the assignment target" unless data.include?("objects") || data.include?("tags")
+
+      if data.include?("objects")
+        objects_to_unassign = data["objects"].collect do |ref|
+          get_resource_from_href(ref)
+        end
+        profile.unassign_objects(objects_to_unassign)
+      end
+
+      if data.include?("tags")
+        data["tags"].each do |tag|
+          profile.unassign_tags(get_resource_from_href(tag["href"]).classification, tag["class"])
+        end
+      end
+
+      profile.get_assigned_tos
+    end
+
+    def set_additional_attributes
+      @additional_attributes = %w(get_assigned_tos)
     end
   end
 end

--- a/app/controllers/api/enterprises_controller.rb
+++ b/app/controllers/api/enterprises_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class EnterprisesController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -113,6 +113,10 @@
         :identifier: alert_definition_profile_edit
       - :name: delete
         :identifier: alert_definition_profile_delete
+      - :name: assign
+        :identifier: alert_profile_assign
+      - :name: unassign
+        :identifier: alert_profile_assign
       :delete:
       - :name: delete
         :identifier: alert_definition_profile_delete
@@ -955,6 +959,15 @@
         :identifier: storage_tag
       - :name: unassign
         :identifier: storage_tag
+  :enterprises:
+    :description: Enterprise
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: MiqEnterprise
+    :collection_actions:
+      :get:
+      - :name: read
   :event_streams:
     :description: Event Streams
     :options:
@@ -972,15 +985,6 @@
       :get:
       - :name: read
         :identifier: event_streams_show
-  :enterprises:
-    :description: Enterprise
-    :options:
-    - :collection
-    :verbs: *g
-    :klass: MiqEnterprise
-    :collection_actions:
-      :get:
-      - :name: read
   :events:
     :description: Events
     :identifier: event

--- a/config/api.yml
+++ b/config/api.yml
@@ -972,6 +972,15 @@
       :get:
       - :name: read
         :identifier: event_streams_show
+  :enterprises:
+    :description: Enterprise
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: MiqEnterprise
+    :collection_actions:
+      :get:
+      - :name: read
   :events:
     :description: Events
     :identifier: event


### PR DESCRIPTION
### Description
Alert profiles can be assigned to objects or to tags.

This functionality exists in the UI under Control->Explorer->Alert Profiles -> select an alert profile -> configuration -> edit assignments for this alert profile.

The API added in this pull request allows getting a list of all assignments for a profile, and to assign or unassign a profile.

This PR depends on https://github.com/ManageIQ/manageiq/pull/16401

### **Usage examples**
**assign profile to object**
POST /alert_definition_profiles/:id
{"action": "assign", "objects": ["http://localhost:3000/api/enterprises/1"]}

**unassign profile from object**
POST /alert_definition_profiles/:id
{"action": "unassign", "objects": ["http://localhost:3000/api/enterprises/1"]}

**assign profile to tags**
POST /alert_definition_profiles/:id
{"action": "assign", "tags": [{"href":"http://localhost:3000/api/tags/95","class": "host"}]}

**unassign profile from tags**
POST /alert_definition_profiles/:id
{"action": "unassign", "tags": [{"href":"http://localhost:3000/api/tags/95","class": "host"}]}

(see https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/assignment_mixin.rb#L62 for explanation of what "class" can be. Also, tag assignment only works for tags which are classification tags)
