### PR TITLE
Return put and patch edit actions for resources

### DIFF
--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -31,12 +31,19 @@ RSpec.describe 'Authentications API' do
 
   describe 'GET /api/authentications/:id' do
     it 'will show an authentication configuration script base' do
-      api_basic_authorize action_identifier(:authentications, :read, :resource_actions, :get)
+      api_basic_authorize action_identifier(:authentications, :read, :resource_actions, :get),
+                          action_identifier(:authentications, :edit)
+      href = api_authentication_url(nil, auth)
 
-      get(api_authentication_url(nil, auth))
+      get(href)
 
       expected = {
-        'href' => api_authentication_url(nil, auth)
+        'href'    => href,
+        'actions' => [
+          { 'name' => 'edit', 'method' => 'post', 'href' => href },
+          { 'name' => 'edit', 'method' => 'patch', 'href' => href },
+          { 'name' => 'edit', 'method' => 'put', 'href' => href }
+        ]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -75,7 +75,7 @@ describe "Custom Actions API" do
       get api_service_url(nil, svc1)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit add_resource remove_resource remove_all_resources add_provider_vms))
+      expect(response.parsed_body["actions"].select { |a| a["method"] == "post" }.pluck("name")).to match_array(%w(edit add_resource remove_resource remove_all_resources add_provider_vms))
     end
   end
 
@@ -91,7 +91,7 @@ describe "Custom Actions API" do
       get api_service_url(nil, svc1)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3 add_resource remove_resource remove_all_resources add_provider_vms))
+      expect(response.parsed_body["actions"].select { |a| a["method"] == "post" }.pluck("name")).to match_array(%w(edit button1 button2 button3 add_resource remove_resource remove_all_resources add_provider_vms))
     end
 
     it "supports the custom_actions attribute" do
@@ -128,7 +128,7 @@ describe "Custom Actions API" do
 
       expect_result_to_have_keys(%w(id href actions))
       action_specs = response.parsed_body["actions"]
-      expect(action_specs.size).to eq(1)
+      expect(action_specs.size).to eq(3)
       expect(action_specs.first["name"]).to eq("edit")
     end
 


### PR DESCRIPTION
Currently, only the POST method for resource edits is returned, even if put and patch verbs are specified. This will add in the additional actions for put and patch.

https://bugzilla.redhat.com/show_bug.cgi?id=1491336

@miq-bot assign @abellotti 
@miq-bot add_label bug, gaprindashvili/yes 
