### PR TITLE
Return correct action responses for bulk delete

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -139,17 +139,15 @@ module Api
       end
 
       def delete_resource_action(klass, type, id)
-        api_log_info("Deleting #{type} id #{id}")
-        resource = resource_search(id, type, klass)
-        result = begin
-                   resource.destroy!
-                   action_result(true, "#{type} id: #{id} deleting")
-                 rescue => err
-                   action_result(false, "#{err} - #{resource.errors.full_messages.join(', ')}")
-                 end
-        add_href_to_result(result, type, id)
-        log_result(result)
-        result
+        delete_action_handler do
+          api_log_info("Deleting #{type} id #{id}")
+          resource = resource_search(id, type, klass)
+          resource.destroy!
+          result = action_result(true, "#{type} id: #{id} deleting")
+          add_href_to_result(result, type, id)
+          log_result(result)
+          result
+        end
       end
 
       def invoke_custom_action(type, resource, action, data)

--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -6,7 +6,7 @@ module Api
       def delete_action_handler
         yield
       rescue ActiveRecord::RecordNotFound => err
-        @req.method == :delete ? raise(err) : action_result(false, err.to_s)
+        @req.method == :delete || @req.json_body.key?('resource') ? raise(err) : action_result(false, err.to_s)
       rescue => err
         action_result(false, err.to_s)
       end

--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -6,9 +6,13 @@ module Api
       def delete_action_handler
         yield
       rescue ActiveRecord::RecordNotFound => err
-        @req.method == :delete || @req.json_body.key?('resource') ? raise(err) : action_result(false, err.to_s)
+        single_resource? ? raise(err) : action_result(false, err.to_s)
       rescue => err
         action_result(false, err.to_s)
+      end
+
+      def single_resource?
+        @req.method == :delete || !@req.json_body.key?('resources')
       end
 
       def action_result(success, message = nil, options = {})

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe 'Authentications API' do
       expect(response).to have_http_status(:ok)
     end
 
+    it 'raises a not found for nonexistent authentication' do
+      api_basic_authorize collection_action_identifier(:authentications, :delete, :post)
+
+      post(api_authentication_url(nil, 0), :params => { :action => 'delete' })
+
+      expect(response).to have_http_status(:not_found)
+    end
+
     it 'verifies that the type is supported' do
       api_basic_authorize collection_action_identifier(:authentications, :delete, :post)
       auth = FactoryGirl.create(:authentication)

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -284,6 +284,22 @@ describe "Services API" do
       expect { svc1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { svc2.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "returns correct action response messages" do
+      api_basic_authorize collection_action_identifier(:services, :delete)
+
+      post(api_services_url, :params => gen_request(:delete,
+                                                    [{"href" => api_service_url(nil, 0)},
+                                                     {"href" => api_service_url(nil, svc)}]))
+      expected = {
+        "results" => [
+          a_hash_including("success" => false, "message" => "Couldn't find Service with 'id'=0"),
+          a_hash_including("success" => true, "message" => "services id: #{svc.id} deleting")
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   describe "Services retirement" do


### PR DESCRIPTION
The way deleting works now is that resource search happens prior to the rescue block, which is causing an issue when the first item in bulk deletion happens- it raises a not found when it should just be an action response and continue on to delete the other resources. This PR leverages the existing delete_action_handler to ensure that not founds get returned for single resource actions, but action results are returned for bulk actions.

https://bugzilla.redhat.com/show_bug.cgi?id=1504693

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @abellotti 