### PR TITLE
Add support for /api/container_projects

### DIFF
--- a/app/controllers/api/container_projects_controller.rb
+++ b/app/controllers/api/container_projects_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ContainerProjectsController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -710,6 +710,25 @@
       :get:
       - :name: read
         :identifier: container_node_show
+  :container_projects:
+    :description: Container Projects
+    :identifier: container_project
+    :klass: ContainerProject
+    :verbs: *gp
+    :options:
+    - :collection
+    - :custom_actions
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: container_project_show_list
+      :post:
+      - :name: query
+        :identifier: container_project_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: container_project_show
   :currencies:
     :description: Currencies
     :identifier: currency

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -309,6 +309,11 @@ describe "Rest API Collections" do
       test_collection_query(:container_deployments, api_container_deployments_url, ContainerDeployment)
     end
 
+    it "query ContainerProjects" do
+      FactoryGirl.create(:container_project)
+      test_collection_query(:container_projects, api_container_projects_url, ContainerProject)
+    end
+
     it 'queries CloudNetworks' do
       FactoryGirl.create(:cloud_network)
       test_collection_query(:cloud_networks, api_cloud_networks_url, CloudNetwork)
@@ -663,6 +668,11 @@ describe "Rest API Collections" do
     it 'bulk query cloud templates' do
       FactoryGirl.create(:template_cloud)
       test_collection_bulk_query(:cloud_templates, api_cloud_templates_url, ManageIQ::Providers::CloudManager::Template)
+    end
+
+    it 'bulk query container_projects' do
+      FactoryGirl.create(:container_project)
+      test_collection_bulk_query(:container_projects, api_container_projects_url, ContainerProject)
     end
   end
 end

--- a/spec/requests/container_projects_spec.rb
+++ b/spec/requests/container_projects_spec.rb
@@ -1,0 +1,48 @@
+describe "Container Projects API" do
+  context 'GET /api/container_projects' do
+    it 'forbids access to container projects without an appropriate role' do
+      api_basic_authorize
+
+      get(api_container_projects_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns container projects with an appropriate role' do
+      container_project = FactoryGirl.create(:container_project)
+      api_basic_authorize(collection_action_identifier(:container_projects, :read, :get))
+
+      get(api_container_projects_url)
+
+      expected = {
+        'resources' => [{'href' => api_container_project_url(nil, container_project)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context 'GET /api/container_projects' do
+    let(:container_project) { FactoryGirl.create(:container_project) }
+
+    it 'forbids access to a container project without an appropriate role' do
+      api_basic_authorize
+
+      get(api_container_project_url(nil, container_project))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns the container project with an appropriate role' do
+      api_basic_authorize(action_identifier(:container_projects, :read, :resource_actions, :get))
+
+      get(api_container_project_url(nil, container_project))
+
+      expected = {
+        'href' => api_container_project_url(nil, container_project)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+end

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -244,8 +244,6 @@ describe "Custom Actions API" do
   end
 
   def define_custom_button1(resource)
-    dialog1 = FactoryGirl.create(:dialog, :label => "dialog1")
-    FactoryGirl.create(:resource_action, :dialog_id => dialog1.id)
     FactoryGirl.create(:custom_button, :with_resource_action_dialog, :applies_to => resource)
   end
 
@@ -383,6 +381,33 @@ describe "Custom Actions API" do
       post api_container_node_url(nil, @resource), :params => gen_request(@button1.name.to_sym, "key1" => "value1")
 
       expect_single_action_result(:success => true, :message => /.*/, :href => api_container_node_url(nil, @resource))
+    end
+  end
+
+  describe "ContainerProjects" do
+    before do
+      @resource = FactoryGirl.create(:container_project)
+      @button = define_custom_button1(@resource)
+    end
+
+    it "queries return custom actions defined" do
+      api_basic_authorize(action_identifier(:container_projects, :read, :resource_actions, :get))
+
+      get(api_container_project_url(nil, @resource))
+
+      expect(response.parsed_body).to include(
+        "id"      => @resource.id.to_s,
+        "href"    => api_container_project_url(nil, @resource),
+        "actions" => a_collection_including(a_hash_including("name" => @button.name))
+      )
+    end
+
+    it "accept custom actions" do
+      api_basic_authorize
+
+      post(api_container_project_url(nil, @resource), :params => gen_request(@button.name, "key1" => "value1"))
+
+      expect_single_action_result(:success => true, :message => /.*/, :href => api_container_project_url(nil, @resource))
     end
   end
 


### PR DESCRIPTION
Add container projects collection with custom actions.

Marked as WIP to wait for https://github.com/ManageIQ/manageiq-api/pull/163 to finish up the specs.

@miq-bot add_label enhancement, gaprindashvili/yes
@miq-bot assign @abellotti 