### PR TITLE
Disable custom actions on /services

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2435,7 +2435,6 @@
     :identifier: service
     :options:
     - :collection
-    - :custom_actions
     :verbs: *gpppd
     :klass: Service
     :subcollections:


### PR DESCRIPTION
This is a temporary fix for https://bugzilla.redhat.com/show_bug.cgi?id=1499692

Including custom actions is incredibly slow due to the implementation of
custom buttons and how delegations happen, as well as a lack of
preloading on the API side. This causes massive N+1
queries and ultimately makes the query on /services 4-5x slower.

For now, disable custom actions on services only - but the entire
feature should be reviewed in the future.

This basically undoes the feature in https://github.com/ManageIQ/manageiq/pull/4394

I do not know of other things that might depend on this, and we'll need to review that quickly.