### PR TITLE
Add support for Physical Servers refresh

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1527,6 +1527,8 @@
         :identifier: physical_server_power_off
       - :name: power_off_now
         :identifier: physical_server_power_off_now
+      - :name: refresh
+        :identifier: physical_server_refresh
       - :name: restart
         :identifier: physical_server_restart
       - :name: restart_now
@@ -1552,6 +1554,8 @@
         :identifier: physical_server_power_off
       - :name: power_off_now
         :identifier: physical_server_power_off_now
+      - :name: refresh
+        :identifier: physical_server_refresh
       - :name: restart
         :identifier: physical_server_restart
       - :name: restart_now


### PR DESCRIPTION
This PR enables:
- Refresh of one or more Physical Servers.

Related to [#2547](https://github.com/ManageIQ/manageiq-ui-classic/pull/2547)