### PR TITLE
Custom actions on generic objects

### DIFF
--- a/app/controllers/api/generic_objects_controller.rb
+++ b/app/controllers/api/generic_objects_controller.rb
@@ -28,11 +28,11 @@ module Api
     private
 
     def resource_custom_action_names(resource)
-      return [] unless resource.respond_to?(:property_methods)
-      resource.property_methods
+      (property_method_names(resource) << super).flatten
     end
 
     def invoke_custom_action(type, resource, action, data)
+      return super(type, resource.reload, action, data) if resource_custom_action_button(resource, action)
       result = begin
                  description = method_description(resource, action)
                  task_id = queue_object_action(resource, description, queue_args(action, data))
@@ -43,6 +43,10 @@ module Api
       add_href_to_result(result, type, resource.id)
       log_result(result)
       result
+    end
+
+    def property_method_names(resource)
+      resource.respond_to?(:property_methods) ? Array(resource.property_methods) : []
     end
 
     def method_description(resource, action)

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -411,6 +411,35 @@ describe "Custom Actions API" do
     end
   end
 
+  describe "Generic Objects" do
+    before do
+      @object_definition = FactoryGirl.create(:generic_object_definition, :name => 'object def')
+      @resource = FactoryGirl.create(:generic_object, :generic_object_definition => @object_definition)
+      @button = define_custom_button1(@object_definition)
+    end
+
+    it "queries return custom actions and property methods defined" do
+      @object_definition.add_property_method("a_property_method")
+      api_basic_authorize(action_identifier(:generic_objects, :read, :resource_actions, :get))
+
+      get api_generic_object_url(nil, @resource)
+
+      expect(response.parsed_body).to include(
+        "id"      => @resource.id.to_s,
+        "href"    => api_generic_object_url(nil, @resource),
+        "actions" => a_collection_including(a_hash_including("name" => @button.name), a_hash_including("name" => "a_property_method"))
+      )
+    end
+
+    it "accept custom actions" do
+      api_basic_authorize
+
+      post api_generic_object_url(nil, @resource), :params => gen_request(@button.name, "key1" => "value1")
+
+      expect_single_action_result(:success => true, :message => /.*/, :href => api_generic_object_url(nil, @resource))
+    end
+  end
+
   describe "Group" do
     before do
       @resource = FactoryGirl.create(:miq_group)


### PR DESCRIPTION
Currently, the method overrides do not take into account the custom actions, only the property methods, therefore not listing custom actions for the Generic Objects. This update will return both property methods and custom actions. This update also calls custom actions the way they are expected to be called, while keeping the existing functionality for the calling of property methods.

~~Dependent upon https://github.com/ManageIQ/manageiq/pull/16433~~
As for the above PR, reloading the object before passing it to `super` resolves the issue of receiving `["invalid method name: [[\"button1\"]]"] ` when calling a custom button on a generic object. Seems to be a generic object specific issue, and confirmed it was not isolated just to the test environment as I was able to reproduce by making a call to a custom button. Should probably be investigated further, but for the time being reload works.

@miq-bot assign @abellotti 
@miq-bot add_label gaprindashvili/yes 