### PR TITLE
Gracefully fail on resource create

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -19,6 +19,7 @@ module Api
             data.delete(sc.to_s)
           end
         end
+        validate_type(klass, data['type']) if data['type']
         resource = klass.new(data)
         if resource.save
           add_subcollection_data_to_resource(resource, type, subcollection_data)
@@ -121,6 +122,12 @@ module Api
       end
 
       private
+
+      def validate_type(klass, type)
+        klass.descendant_get(type)
+      rescue ArgumentError => err
+        raise BadRequestError, "Invalid type #{type} specified - #{err}"
+      end
 
       def add_subcollection_data_to_resource(resource, type, subcollection_data)
         subcollection_data.each do |sc, sc_data|

--- a/spec/requests/orchestration_template_spec.rb
+++ b/spec/requests/orchestration_template_spec.rb
@@ -83,6 +83,21 @@ RSpec.describe 'Orchestration Template API' do
 
       expect_bad_request(/Resource id or href should not be specified/)
     end
+
+    it 'fails gracefully with invalid type specified' do
+      api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
+
+      post(api_orchestration_templates_url, :params => { :type => 'OrchestrationTemplateCfn' })
+
+      expected = {
+        'error' => a_hash_including(
+          'kind'    => 'bad_request',
+          'message' => a_string_including('Invalid type OrchestrationTemplateCfn specified')
+        )
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   context 'orchestration_template edit' do


### PR DESCRIPTION
Calling create on an object with an incorrect `type` specified raises an internal server error. By leveraging `descendant_get` we can raise the appropriate bad request to notify the user that an incorrect type was specified. 

https://bugzilla.redhat.com/show_bug.cgi?id=1510215

@miq-bot add_label bug 