### PR TITLE
Add support for /api/orchestration_stacks

### DIFF
--- a/app/controllers/api/orchestration_stacks_controller.rb
+++ b/app/controllers/api/orchestration_stacks_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class OrchestrationStacksController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1594,9 +1594,9 @@
     :verbs: *gp
     :klass: OrchestrationStack
     :options:
-      - :collection
-      - :subcollection
-      - :custom_actions
+    - :collection
+    - :subcollection
+    - :custom_actions
     :collection_actions:
       :get:
       - :name: read
@@ -1611,11 +1611,11 @@
     :subcollection_actions:
       :get:
       - :name: read
-        :identifier: orchestration_stack_view
+        :identifier: orchestration_stack_show
     :subresource_actions:
       :get:
       - :name: read
-        :identifier: orchestration_stack_view
+        :identifier: orchestration_stack_show
   :orchestration_templates:
     :description: Orchestration Template
     :identifier: orchestration_templates_accord

--- a/config/api.yml
+++ b/config/api.yml
@@ -1590,10 +1590,24 @@
       - :name: delete
   :orchestration_stacks:
     :description: Orchestration Stacks
-    :options:
-    - :subcollection
-    :verbs: *g
+    :identifier: orchestration_stack
+    :verbs: *gp
     :klass: OrchestrationStack
+    :options:
+      - :collection
+      - :subcollection
+      - :custom_actions
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: orchestration_stack_show_list
+      :post:
+      - :name: query
+        :identifier: orchestration_stack_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: orchestration_stack_show
     :subcollection_actions:
       :get:
       - :name: read

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -383,6 +383,11 @@ describe "Rest API Collections" do
       FactoryGirl.create(:switch)
       test_collection_query(:switches, api_switches_url, Switch)
     end
+
+    it 'query OrchestrationStacks' do
+      FactoryGirl.create(:orchestration_stack)
+      test_collection_query(:orchestration_stacks, api_orchestration_stacks_url, OrchestrationStack)
+    end
   end
 
   context "Collections Bulk Queries" do
@@ -728,6 +733,11 @@ describe "Rest API Collections" do
     it 'bulk query switches' do
       FactoryGirl.create(:switch)
       test_collection_bulk_query(:switches, api_switches_url, Switch)
+    end
+
+    it 'bulk query orchestration stacks' do
+      FactoryGirl.create(:orchestration_stack)
+      test_collection_bulk_query(:orchestration_stacks, api_orchestration_stacks_url, OrchestrationStack)
     end
   end
 end

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -740,7 +740,7 @@ describe "Custom Actions API" do
   describe "Orchestration Stacks" do
     before(:each) do
       @resource = FactoryGirl.create(:orchestration_stack)
-      define_custom_button1(@resource)
+      @button = define_custom_button1(@resource)
     end
 
     it "queries return custom actions defined" do
@@ -749,16 +749,16 @@ describe "Custom Actions API" do
       get api_orchestration_stack_url(nil, @resource)
 
       expect(response.parsed_body).to include(
-                                        "id"      => @resource.id.to_s,
-                                        "href"    => api_orchestration_stack_url(nil, @resource),
-                                        "actions" => a_collection_including(a_hash_including("name" => "button1"))
-                                      )
+        "id"      => @resource.id.to_s,
+        "href"    => api_orchestration_stack_url(nil, @resource),
+        "actions" => a_collection_including(a_hash_including("name" => @button.name))
+      )
     end
 
     it "accept custom actions" do
       api_basic_authorize
 
-      post api_orchestration_stack_url(nil, @resource), :params => gen_request(:button1, "key1" => "value1")
+      post api_orchestration_stack_url(nil, @resource), :params => gen_request(@button.name, "key1" => "value1")
 
       expect_single_action_result(:success => true, :message => /.*/, :href => api_orchestration_stack_url(nil, @resource))
     end

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -737,6 +737,33 @@ describe "Custom Actions API" do
     end
   end
 
+  describe "Orchestration Stacks" do
+    before(:each) do
+      @resource = FactoryGirl.create(:orchestration_stack)
+      define_custom_button1(@resource)
+    end
+
+    it "queries return custom actions defined" do
+      api_basic_authorize(action_identifier(:orchestration_stacks, :read, :resource_actions, :get))
+
+      get api_orchestration_stack_url(nil, @resource)
+
+      expect(response.parsed_body).to include(
+                                        "id"      => @resource.id.to_s,
+                                        "href"    => api_orchestration_stack_url(nil, @resource),
+                                        "actions" => a_collection_including(a_hash_including("name" => "button1"))
+                                      )
+    end
+
+    it "accept custom actions" do
+      api_basic_authorize
+
+      post api_orchestration_stack_url(nil, @resource), :params => gen_request(:button1, "key1" => "value1")
+
+      expect_single_action_result(:success => true, :message => /.*/, :href => api_orchestration_stack_url(nil, @resource))
+    end
+  end
+
   describe "Storage" do
     before do
       @resource = FactoryGirl.create(:storage)

--- a/spec/requests/orchestration_stacks_spec.rb
+++ b/spec/requests/orchestration_stacks_spec.rb
@@ -1,0 +1,48 @@
+describe "Orchestration Stacks API" do
+  context 'GET /api/orchestration_stacks' do
+    it 'forbids access to orchestration_stacks without an appropriate role' do
+      api_basic_authorize
+
+      get(api_orchestration_stacks_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns orchestration_stacks with an appropriate role' do
+      orchestration_stack = FactoryGirl.create(:orchestration_stack)
+      api_basic_authorize(collection_action_identifier(:orchestration_stacks, :read, :get))
+
+      get(api_orchestration_stacks_url)
+
+      expected = {
+        'resources' => [{'href' => api_orchestration_stack_url(nil, orchestration_stack)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context 'GET /api/orchestration_stacks' do
+    let(:orchestration_stack) { FactoryGirl.create(:orchestration_stack) }
+
+    it 'forbids access to a orchestration_stack without an appropriate role' do
+      api_basic_authorize
+
+      get(api_orchestration_stack_url(nil, orchestration_stack))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns the orchestration_stack with an appropriate role' do
+      api_basic_authorize(action_identifier(:orchestration_stacks, :read, :resource_actions, :get))
+
+      get(api_orchestration_stack_url(nil, orchestration_stack))
+
+      expected = {
+        'href' => api_orchestration_stack_url(nil, orchestration_stack)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+end


### PR DESCRIPTION
- Add new collection
- GETs and queries
- supports custom_actions

As per earlier discussion, added in `orchestration_stacks` collection to work with custom actions. cc: @gmcculloug 

@miq-bot add_label enhancement
@miq-bot assign @abellotti 