### PR TITLE
Reflect session timeout settings updates in the UI requester type

### DIFF
--- a/lib/services/api/user_token_service.rb
+++ b/lib/services/api/user_token_service.rb
@@ -1,8 +1,6 @@
 module Api
   class UserTokenService
     TYPES = %w(api ui ws).freeze
-    # Additional Requester type token ttl's for authentication
-    TYPE_TO_TTL_OVERRIDE = {'ui' => ::Settings.session.timeout}.freeze
 
     def initialize(config = ApiConfig, args = {})
       @config = config
@@ -31,8 +29,11 @@ module Api
 
       $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type}")
 
+      # Additional Requester type token ttl's for authentication
+      type_to_ttl_override = {'ui' => ::Settings.session.timeout}
+
       token_mgr(requester_type).gen_token(:userid             => userid,
-                                          :token_ttl_override => TYPE_TO_TTL_OVERRIDE[requester_type])
+                                          :token_ttl_override => type_to_ttl_override[requester_type])
     end
 
     def validate_requester_type(requester_type)

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -237,6 +237,17 @@ describe "Authentication API" do
           expect(response.parsed_body["token_ttl"]).to eq(::Settings.session.timeout.to_i_with_method)
         end
 
+        it "gets a token based identifier with an updated UI based token_ttl" do
+          ::Settings.session.timeout = 1234
+          api_basic_authorize
+
+          get api_auth_url, :params => { :requester_type => "ui" }
+
+          expect(response).to have_http_status(:ok)
+          expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
+          expect(response.parsed_body["token_ttl"]).to eq(1234)
+        end
+
         it "forgets the current token when asked to" do
           api_basic_authorize
 


### PR DESCRIPTION
The `TYPE_TO_TTL_OVERRIDE` had been set as a frozen constant thereby ignoring updates made to the timeout setting.

This PR prevents timeout settings from being missed by refreshing the `type_to_ttl_override` 

To Test:
--------
Setup an appliance
Login to the classic UI and change the session timemout to 5 mins.
Do **_not_** restart evmserverd
Login the SSUI, wait 5 minutes
Verify the SSUI times out after 5 minutes, displaying the message: _**Your session has timed out.**_

https://bugzilla.redhat.com/show_bug.cgi?id=1468000