### PR TITLE
Adding custom_actions support for /api/cloud_networks

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -395,27 +395,32 @@
         :identifier: chargeback_rates_delete
   :cloud_networks:
     :description: Cloud Networks
-    :identifier: miq_cloud_networks
+    :identifier: cloud_network
     :options:
     - :collection
     - :subcollection
+    - :custom_actions
     :verbs: *gp
     :klass: CloudNetwork
     :collection_actions:
       :get:
       - :name: read
-        :identifier: miq_cloud_networks_view
+        :identifier: cloud_network_show_list
       :post:
       - :name: query
-        :identifier: miq_cloud_networks_view
+        :identifier: cloud_network_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: cloud_network_show
     :subcollection_actions:
       :get:
       - :name: read
-        :identifier: miq_cloud_networks_view
+        :identifier: cloud_network_show_list
     :subresource_actions:
       :get:
       - :name: read
-        :identifier: miq_cloud_networks_view
+        :identifier: cloud_network_show
   :cloud_subnets:
     :description: Cloud Subnets
     :identifier: cloud_subnet

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -274,6 +274,33 @@ describe "Custom Actions API" do
     end
   end
 
+  describe "Cloud Network" do
+    before do
+      @resource = FactoryGirl.create(:cloud_network)
+      @button = define_custom_button1(@resource)
+    end
+
+    it "queries return custom actions defined" do
+      api_basic_authorize(action_identifier(:cloud_networks, :read, :resource_actions, :get))
+
+      get api_cloud_network_url(nil, @resource)
+
+      expect(response.parsed_body).to include(
+        "id"      => @resource.id.to_s,
+        "href"    => api_cloud_network_url(nil, @resource),
+        "actions" => a_collection_including(a_hash_including("name" => @button.name))
+      )
+    end
+
+    it "accept custom actions" do
+      api_basic_authorize
+
+      post api_cloud_network_url(nil, @resource), :params => gen_request(@button.name, "key1" => "value1")
+
+      expect_single_action_result(:success => true, :message => /.*/, :href => api_cloud_network_url(nil, @resource))
+    end
+  end
+
   describe "CloudTenant" do
     before do
       @resource = FactoryGirl.create(:cloud_tenant)


### PR DESCRIPTION
Adding custom_actions support for /api/cloud_networks

- Added missing resource actions
- Added custom_actions collection option
- Fixed up role identifier for cloud_networks