### PR TITLE
Return 404 error if perform an action against a non existent Physical Server

### DIFF
--- a/app/controllers/api/physical_servers_controller.rb
+++ b/app/controllers/api/physical_servers_controller.rb
@@ -43,6 +43,8 @@ module Api
     def refresh_resource(type, id, _data = nil)
       raise BadRequestError, "Must specify an id for refreshing a #{type} resource" unless id
 
+      ensure_resource_exists(type, id) if single_resource?
+
       api_action(type, id) do |klass|
         physical_server = resource_search(id, type, klass)
         api_log_info("Refreshing #{physical_server_ident(physical_server)}")
@@ -55,6 +57,8 @@ module Api
     def change_resource_state(state, type, id)
       raise BadRequestError, "Must specify an id for changing a #{type} resource" unless id
 
+      ensure_resource_exists(type, id) if single_resource?
+
       api_action(type, id) do |klass|
         begin
           server = resource_search(id, type, klass)
@@ -66,6 +70,10 @@ module Api
           action_result(false, err.to_s)
         end
       end
+    end
+
+    def ensure_resource_exists(type, id)
+      raise NotFoundError unless collection_class(type).exists?(id)
     end
 
     def server_ident(server)


### PR DESCRIPTION
This PR is able to:
- Fix the error that returns a 200 code if try to perform an action against a non existent PH;
- Return 404 if the ID of the Physical Server doesn't exist.