### PR TITLE
Do not expand custom actions on collection searches

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -48,11 +48,12 @@ module Api
       klass = collection_class(@req.subject)
       res, subquery_count = collection_search(@req.subcollection?, @req.subject, klass)
       opts = {
-        :name             => @req.subject,
-        :is_subcollection => @req.subcollection?,
-        :expand_actions   => true,
-        :expand_resources => @req.expand?(:resources),
-        :counts           => Api::QueryCounts.new(klass.count, res.count, subquery_count)
+        :name                  => @req.subject,
+        :is_subcollection      => @req.subcollection?,
+        :expand_actions        => true,
+        :expand_custom_actions => false,
+        :expand_resources      => @req.expand?(:resources),
+        :counts                => Api::QueryCounts.new(klass.count, res.count, subquery_count)
       }
       render_collection(@req.subject, res, opts)
     end
@@ -81,7 +82,12 @@ module Api
 
     def show
       klass = collection_class(@req.subject)
-      opts  = {:name => @req.subject, :is_subcollection => @req.subcollection?, :expand_actions => true}
+      opts  = {
+        :name                  => @req.subject,
+        :is_subcollection      => @req.subcollection?,
+        :expand_actions        => true,
+        :expand_custom_actions => true
+      }
       render_resource(@req.subject, resource_search(@req.subject_id, @req.subject, klass), opts)
     end
 

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -38,10 +38,11 @@ module Api
         end
         resource = resource_search(id, type, collection_class(type))
         opts = {
-          :name             => type.to_s,
-          :is_subcollection => false,
-          :expand_resources => true,
-          :expand_actions   => true
+          :name                  => type.to_s,
+          :is_subcollection      => false,
+          :expand_resources      => true,
+          :expand_actions        => true,
+          :expand_custom_actions => true
         }
         resource_to_jbuilder(type, type, resource, opts).attributes!
       end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -45,7 +45,6 @@ module Api
 
           unless @req.hide?("resources") || collection_option?(:hide_resources)
             key_id = collection_config.resource_identifier(type)
-            opts[:collection_search] = true
             json.resources resources.collect do |resource|
               if opts[:expand_resources]
                 add_hash json, resource_to_jbuilder(type, reftype, resource, opts).attributes!
@@ -83,7 +82,7 @@ module Api
         expand_subcollections(json, type, resource) if resource.respond_to?(:attributes)
 
         expand_actions(resource, json, type, opts, physical_attrs) if opts[:expand_actions]
-        expand_resource_custom_actions(resource, json, type, physical_attrs) if opts[:expand_actions] && !opts[:collection_search]
+        expand_resource_custom_actions(resource, json, type, physical_attrs) if opts[:expand_custom_actions]
         json
       end
 

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -45,6 +45,7 @@ module Api
 
           unless @req.hide?("resources") || collection_option?(:hide_resources)
             key_id = collection_config.resource_identifier(type)
+            opts[:collection_search] = true
             json.resources resources.collect do |resource|
               if opts[:expand_resources]
                 add_hash json, resource_to_jbuilder(type, reftype, resource, opts).attributes!
@@ -82,7 +83,7 @@ module Api
         expand_subcollections(json, type, resource) if resource.respond_to?(:attributes)
 
         expand_actions(resource, json, type, opts, physical_attrs) if opts[:expand_actions]
-        expand_resource_custom_actions(resource, json, type, physical_attrs)
+        expand_resource_custom_actions(resource, json, type, physical_attrs) if opts[:expand_actions] && !opts[:collection_search]
         json
       end
 


### PR DESCRIPTION
Do not expand custom actions if the user is querying a collection. Only show custom actions if an individual resource is fetched.