### PR TITLE
Return correct href slug on the VMs collection

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -263,6 +263,10 @@ module Api
       action_result(false, "Failed to set miq_server - #{err}")
     end
 
+    def fetch_vms_href_slug(resource)
+      "vms/#{resource.id}"
+    end
+
     private
 
     def miq_server_message(miq_server)

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -28,6 +28,17 @@ describe "Vms API" do
     vms.each { |vm| vm.update_attributes!(:raw_power_state => state) }
   end
 
+  context 'Vm href slug' do
+    it 'returns the correct value for cloud instances' do
+      vm_cloud = FactoryGirl.create(:vm_amazon)
+      api_basic_authorize(action_identifier(:vms, :read, :resource_actions, :get))
+
+      get(api_vm_url(nil, vm_cloud), :params => { :attributes => 'href_slug'})
+
+      expect(response.parsed_body['href_slug']).to eq("vms/#{vm_cloud.id}")
+    end
+  end
+
   context 'Vm edit' do
     let(:new_vms) { FactoryGirl.create_list(:vm_openstack, 2) }
 


### PR DESCRIPTION
For cloud vms, the href_slug returns `instances/:id` instead of `vms/:id`. As per BZ, the href slug is supposed to respect and match the href.

https://bugzilla.redhat.com/show_bug.cgi?id=1510238

@miq-bot add_label bug, gaprindashvili/yes 
@miq-bot assign @abellotti 