### PR TITLE
Add deep symbolization to CustomButton `visibility` field

### DIFF
--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -4,6 +4,7 @@ module Api
       custom_button = CustomButton.new(data.except("resource_action", "options"))
       custom_button.userid = User.current_user.userid
       custom_button.options = data["options"].deep_symbolize_keys if data["options"]
+      custom_button.visibility = data["visibility"].deep_symbolize_keys if data["visibility"]
       custom_button.resource_action = find_or_create_resource_action(data["resource_action"]) if data.key?("resource_action")
       if custom_button.save
         custom_button

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -69,13 +69,15 @@ RSpec.describe 'CustomButtons API' do
         'resource_action'  => {
           'ae_namespace' => 'SYSTEM',
           'ae_class'     => 'PROCESS'
-        }
+        },
+        'visibility'     => {'roles' => ['_ALL_']}
       }
       post(api_custom_buttons_url, :params => cb_rec)
 
       expect(response).to have_http_status(:ok)
       custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
       expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")
+      expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
       expect(response.parsed_body['results'].first).to include(cb_rec.except('resource_action'))
     end
 
@@ -85,18 +87,20 @@ RSpec.describe 'CustomButtons API' do
       request = {
         'action'    => 'edit',
         'resources' => [
-          { 'id' => cb.id.to_s, 'resource' => {'name' => 'updated 1', 'resource_action' => {'ae_namespace' => 'SYSTEM2'}}},
+          { 'id' => cb.id.to_s, 'resource' => {'name' => 'updated 1', 'resource_action' => {'ae_namespace' => 'SYSTEM2'}, 'visibility' => {'roles' => ['_ALL_']}}},
         ]
       }
       post(api_custom_buttons_url, :params => request)
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => cb.id.to_s, 'name' => 'updated 1'),
+          a_hash_including('id' => cb.id.to_s, 'name' => 'updated 1', 'visibility' => {'roles' => ['_ALL_']}),
         )
       }
+      custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
+      expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
     end
   end
 

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'CustomButtons API' do
           'ae_namespace' => 'SYSTEM',
           'ae_class'     => 'PROCESS'
         },
-        'visibility'     => {'roles' => ['_ALL_']}
+        'visibility'       => {'roles' => ['_ALL_']}
       }
       post(api_custom_buttons_url, :params => cb_rec)
 
@@ -97,10 +97,9 @@ RSpec.describe 'CustomButtons API' do
           a_hash_including('id' => cb.id.to_s, 'name' => 'updated 1', 'visibility' => {'roles' => ['_ALL_']}),
         )
       }
-      custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
-      expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
+      expect(cb.reload.visibility[:roles]).to eq(['_ALL_'])
     end
   end
 


### PR DESCRIPTION
The backend expects the `CustomButton` `visibility` field to be deep symbolized in order to perform Custom Button related operations.

Hence appropriate adjustment had to be made in the API as well.