### PR TITLE
OPTIONS for Custom Button Sets

### DIFF
--- a/app/controllers/api/custom_button_sets_controller.rb
+++ b/app/controllers/api/custom_button_sets_controller.rb
@@ -7,5 +7,18 @@ module Api
     def edit_resource(type, id, data)
       super(type, id, data.deep_symbolize_keys)
     end
+
+    def options
+      render_options(:custom_button_sets, build_custom_button_sets_options)
+    end
+
+    def build_custom_button_sets_options
+      {
+        :custom_button_sets => {
+          :generic_object_definitions => CustomButtonSet.find_all_by_class_name('GenericObjectDefinition'),
+          :service_templates          => CustomButtonSet.find_all_by_class_name('ServiceTemplate')
+        }
+      }
+    end
   end
 end

--- a/spec/requests/custom_button_sets_spec.rb
+++ b/spec/requests/custom_button_sets_spec.rb
@@ -199,4 +199,19 @@ RSpec.describe 'CustomButtonSets API' do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  describe 'OPTIONS /api/custom_button_sets' do
+    it 'returns custom_button_sets for Generic Object Definitions and Service Templates' do
+      options(api_custom_button_sets_url)
+
+      expected_data = {
+        'custom_button_sets' => {
+          'generic_object_definitions' => CustomButtonSet.find_all_by_class_name('GenericObjectDefinition'),
+          'service_templates'          => CustomButtonSet.find_all_by_class_name('ServiceTemplate')
+        }
+      }
+
+      expect_options_results(:custom_button_sets, expected_data)
+    end
+  end
 end


### PR DESCRIPTION
Added `OPTIONS` for `Custom Button Sets`

To retrieve the CustomButtonSets for `GenericObjectDefinition` and `ServiceTemplate`

The `OPTIONS` call is required by this PR - https://github.com/ManageIQ/manageiq-ui-classic/pull/2733