### PR TITLE
deep symbolize the options field

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -208,6 +208,7 @@ module Api
     end
 
     def fetch_provider_data(provider_klass, data, options = {})
+      data["options"] = data["options"].deep_symbolize_keys if data.key?("options")
       provider_data = data.except(*RESTRICTED_ATTRS)
       invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys - ENDPOINT_ATTRS - CONNECTION_ATTRS
       raise BadRequestError, "Invalid Provider attributes #{invalid_keys.join(', ')} specified" if invalid_keys.present?

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -638,6 +638,19 @@ describe "Providers API" do
       expect(provider.port).to eq(8080)
     end
 
+    it "supports editing per provider options" do
+      api_basic_authorize collection_action_identifier(:providers, :edit)
+
+      provider = FactoryGirl.create(:ext_management_system, sample_rhevm.except("credentials"))
+
+      options = {"hello" => "world"}
+      options_symbolized = options.deep_symbolize_keys
+      post(api_provider_url(nil, provider), :params => gen_request(:edit,
+                                                                   "options" => options))
+
+      expect(provider.reload.options).to eq(options_symbolized)
+    end
+
     it "only returns real attributes" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 


### PR DESCRIPTION
The keys in the options field should be symbols. This will allow editing the per-provider options from the API.