### PR TITLE
Build href_slug from type 

### DIFF
--- a/app/controllers/api/automate_domains_controller.rb
+++ b/app/controllers/api/automate_domains_controller.rb
@@ -27,10 +27,6 @@ module Api
       end
     end
 
-    def fetch_automate_domains_href_slug(resource)
-      "automate_domains/#{resource.id}"
-    end
-
     private
 
     def automate_domain_ident(domain)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -80,6 +80,7 @@ module Api
 
         expand_virtual_attributes(json, type, resource, virtual_attrs) unless virtual_attrs.empty?
         expand_subcollections(json, type, resource) if resource.respond_to?(:attributes)
+        json.set!('href_slug', "#{type}/#{resource.id}") if virtual_attrs.include?('href_slug')
 
         expand_actions(resource, json, type, opts, physical_attrs) if opts[:expand_actions]
         expand_resource_custom_actions(resource, json, type, physical_attrs)
@@ -249,6 +250,7 @@ module Api
         result = {}
         object_hash = {}
         virtual_attrs.each do |vattr|
+          next if vattr == 'href_slug'
           attr_name, attr_base = split_virtual_attribute(vattr)
           value, value_result = if attr_base.blank?
                                   fetch_direct_virtual_attribute(type, resource, attr_name)

--- a/app/controllers/api/policy_actions_controller.rb
+++ b/app/controllers/api/policy_actions_controller.rb
@@ -1,7 +1,4 @@
 module Api
   class PolicyActionsController < BaseController
-    def fetch_policy_actions_href_slug(resource)
-      "policy_actions/#{resource.id}"
-    end
   end
 end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -474,6 +474,17 @@ RSpec.describe "Requests API" do
     end
   end
 
+  context 'href_slug' do
+    it 'returns the correct slug for a request' do
+      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      request = FactoryGirl.create(:automation_request, :requester => @user)
+
+      get(api_request_url(nil, request), :params => { :attributes => 'href_slug' })
+
+      expect(response.parsed_body['href_slug']).to eq("requests/#{request.id}")
+    end
+  end
+
   context 'Tasks subcollection' do
     let(:request) do
       FactoryGirl.create(:service_template_provision_request,

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1167,7 +1167,7 @@ describe "Services API" do
     it "allows expansion of generic objects and specification of generic object attributes" do
       api_basic_authorize(action_identifier(:services, :read, :resource_actions, :get))
 
-      get api_services_url, :params => { :expand => 'resources,generic_objects', :attributes => 'generic_objects.generic_object_definition,generic_objects.picture' }
+      get api_services_url, :params => { :expand => 'resources,generic_objects', :attributes => 'generic_objects.generic_object_definition,generic_objects.picture,generic_objects.href_slug' }
 
       expected = {
         'name'      => 'services',
@@ -1180,7 +1180,8 @@ describe "Services API" do
               a_hash_including(
                 'href'                      => api_service_generic_object_url(nil, svc, generic_object),
                 'generic_object_definition' => a_hash_including('id' => generic_object_definition.id.to_s),
-                'picture'                   => a_hash_including('image_href' => a_string_including(picture.image_href), 'extension' => picture.extension)
+                'picture'                   => a_hash_including('image_href' => a_string_including(picture.image_href), 'extension' => picture.extension),
+                'href_slug'                 => "generic_objects/#{generic_object.id}"
               )
             ]
           )

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -28,6 +28,17 @@ describe "Vms API" do
     vms.each { |vm| vm.update_attributes!(:raw_power_state => state) }
   end
 
+  context 'href_slug' do
+    it 'returns the correct value for cloud instances' do
+      vm_cloud = FactoryGirl.create(:vm_amazon)
+      api_basic_authorize(action_identifier(:vms, :read, :resource_actions, :get))
+
+      get(api_vm_url(nil, vm_cloud), :params => { :attributes => 'href_slug'})
+
+      expect(response.parsed_body['href_slug']).to eq("vms/#{vm_cloud.id}")
+    end
+  end
+
   context 'Vm edit' do
     let(:new_vms) { FactoryGirl.create_list(:vm_openstack, 2) }
 


### PR DESCRIPTION
This change builds the `href_slug` from the requested `type` rather than the current implementation of fetching the type from the resource class, as discussed in https://github.com/ManageIQ/manageiq-api/issues/208

This will remove the need for any controllers to have a `fetch_<type>_href_slug` method. Also added in a test to ensure that href slugs are returned correctly for indirect virtual attributes. 

Moved tests added in from https://github.com/ManageIQ/manageiq-api/pull/205 and https://github.com/ManageIQ/manageiq-api/pull/145 to close out any outstanding BZs surrounding this issue.

@miq-bot assign @chrisarcand 
@miq-bot add_label gaprindashvili/yes, bug 



