### PR TITLE
Use destroy_queue for provider delete

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -803,10 +803,11 @@ describe "Providers API" do
 
       post(api_provider_url(nil, provider), :params => gen_request(:delete))
 
-      expect_single_action_result(:success => true,
-                                  :message => "deleting",
-                                  :href    => api_provider_url(nil, provider),
-                                  :task    => true)
+      expect_single_action_result(:success   => true,
+                                  :message   => "deleting",
+                                  :task_href => api_tasks_url,
+                                  :task      => true,
+                                  :href      => api_provider_url(nil, provider))
     end
 
     it "supports multiple provider deletes" do
@@ -818,9 +819,14 @@ describe "Providers API" do
       post(api_providers_url, :params => gen_request(:delete,
                                                      [{"href" => api_provider_url(nil, p1)},
                                                       {"href" => api_provider_url(nil, p2)}]))
-
+      expected = {
+        "results" => [
+          a_hash_including('task_href' => a_string_including(api_tasks_url)),
+          a_hash_including('task_href' => a_string_including(api_tasks_url))
+        ]
+      }
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", [api_provider_url(nil, p1), api_provider_url(nil, p2)])
+      expect(response.parsed_body).to include(expected)
     end
   end
 


### PR DESCRIPTION
Changes to ExtManagementSystem now require the use of schedule_destroy_queue to queue the deletion of the provider. Without this change, provider deletion is silently failing due to a before_hook on destroy that checks if there are any active queues for the provider. The orchestrate_delete method that will now be called will resolve this.

https://bugzilla.redhat.com/show_bug.cgi?id=1501941

@miq-bot add_label bug, gaprindashvili/yes, blocker 

cc: @gtanzillo @zeari 