### PR TITLE
Add Yamllint config

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+ignore: |
+  /spec/manageiq/**
+  /vendor/**
+
+extends: relaxed
+
+rules:
+  indentation:
+    indent-sequences: false
+  line-length:
+    max: 120

--- a/config/api.yml
+++ b/config/api.yml
@@ -446,8 +446,8 @@
     :description: Cloud Templates
     :identifier: image
     :options:
-      - :collection
-      - :subcollection
+    - :collection
+    - :subcollection
     :verbs: *gp
     :klass: ManageIQ::Providers::CloudManager::Template
     :collection_actions:


### PR DESCRIPTION
Adds a .yamllint config file and appeases an indentation violation making master free of yamllint violations

