### PR TITLE
Rolling back system token OTP logic

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -1,8 +1,6 @@
 module Api
   class BaseController
     module Authentication
-      SYSTEM_TOKEN_ALLOWED_TIME_SKEW = 5.minutes
-
       #
       # REST APIs Authenticator and Redirector
       #
@@ -80,8 +78,6 @@ module Api
       end
 
       def authenticate_with_system_token(x_miq_token)
-        validate_system_token_otp(x_miq_token)
-
         @miq_token_hash = YAML.load(MiqPassword.decrypt(x_miq_token))
 
         validate_system_token_server(@miq_token_hash[:server_guid])
@@ -106,14 +102,7 @@ module Api
 
       def validate_system_token_timestamp(timestamp)
         raise "Missing timestamp" if timestamp.blank?
-        raise "Invalid timestamp #{timestamp} specified" if SYSTEM_TOKEN_ALLOWED_TIME_SKEW.ago.utc > timestamp
-      end
-
-      def validate_system_token_otp(x_miq_token)
-        token_store = TokenStore.acquire("api_system_token_otp", SYSTEM_TOKEN_ALLOWED_TIME_SKEW)
-        token_used_timestamp = token_store.read(x_miq_token)
-        raise "System Token was already used at #{token_used_timestamp}" if token_used_timestamp
-        token_store.write(x_miq_token, Time.now.getlocal)
+        raise "Invalid timestamp #{timestamp} specified" if 5.minutes.ago.utc > timestamp
       end
     end
   end

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -1,6 +1,8 @@
 module Api
   class BaseController
     module Authentication
+      SYSTEM_TOKEN_TTL = 30.seconds
+
       #
       # REST APIs Authenticator and Redirector
       #
@@ -102,7 +104,7 @@ module Api
 
       def validate_system_token_timestamp(timestamp)
         raise "Missing timestamp" if timestamp.blank?
-        raise "Invalid timestamp #{timestamp} specified" if 5.minutes.ago.utc > timestamp
+        raise "Invalid timestamp #{timestamp} specified" if SYSTEM_TOKEN_TTL.ago.utc > timestamp
       end
     end
   end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -342,22 +342,6 @@ describe "Authentication API" do
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
     end
-
-    it "authentication using a valid token succeeds only once" do
-      miq_token = systoken(MiqServer.first.guid, @user.userid, Time.now.utc)
-
-      get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
-
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(ENTRYPOINT_KEYS)
-
-      get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
-
-      expect(response).to have_http_status(:unauthorized)
-      expect(response.parsed_body).to include(
-        "error" => a_hash_including("kind" => "unauthorized", "message" => AUTHENTICATION_ERROR)
-      )
-    end
   end
 
   context "Role Based Authorization" do


### PR DESCRIPTION
- This was breaking central admin functionality.
- Preferring a short-term token of 30 seconds instead.

/cc @carbonin @gtanzillo 
