### PR TITLE
Tasks: delete support

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2780,7 +2780,7 @@
     :identifier: tasks
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: MiqTask
     :collection_actions:
       :get:
@@ -2793,6 +2793,12 @@
       :get:
       - :name: read
         :identifier: tasks_view
+      :post:
+      - :name: delete
+        :identifier: miq_task_delete
+      :delete:
+      - :name: delete
+        :identifier: miq_task_delete
   :templates:
     :description: Templates
     :identifier: miq_template

--- a/config/api.yml
+++ b/config/api.yml
@@ -2789,6 +2789,8 @@
       :post:
       - :name: query
         :identifier: tasks_view
+      - :name: delete
+        :identifier: miq_task_delete
     :resource_actions:
       :get:
       - :name: read

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -20,38 +20,42 @@ describe 'TasksController' do
   it 'deletes on POST' do
     api_basic_authorize resource_action_identifier(:tasks, :delete)
 
-    post(api_task_url(nil, task.id), :params => {
+    data = {
       :action => 'delete'
-    })
+    }
+    post(api_task_url(nil, task.id), :params => data)
 
     expect(response).to have_http_status(:ok) # 200
     expect_deleted(task)
 
-    expect(response.parsed_body).to include({
+    expected = {
       'success' => true,
       'message' => "tasks id: #{task.id} deleting"
-    })
+    }
+    expect(response.parsed_body).to include(expected)
   end
 
   it 'bulk deletes' do
     api_basic_authorize collection_action_identifier(:tasks, :delete)
 
-    post(api_tasks_url, :params => {
+    data = {
       :action    => 'delete',
       :resources => [
         {:href => api_task_url(nil, task.id)},
         {:href => api_task_url(nil, task2.id)}
       ]
-    })
+    }
+    post(api_tasks_url, :params => data)
 
     expect(response).to have_http_status(:ok) # 200
     expect_deleted(task, task2)
 
-    expect(response.parsed_body).to include({
+    expected = {
       'results' => a_collection_including(
         a_hash_including('success' => true, 'message' => "tasks id: #{task.id} deleting"),
         a_hash_including('success' => true, 'message' => "tasks id: #{task2.id} deleting")
       )
-    })
+    }
+    expect(response.parsed_body).to include(expected)
   end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -11,7 +11,7 @@ describe 'TasksController' do
   it 'deletes on DELETE' do
     api_basic_authorize resource_action_identifier(:tasks, :delete, :delete)
 
-    delete(api_task_url(nil, task.id))
+    delete(api_task_url(nil, task))
 
     expect(response).to have_http_status(:no_content) # 204
     expect_deleted(task)
@@ -23,7 +23,7 @@ describe 'TasksController' do
     data = {
       :action => 'delete'
     }
-    post(api_task_url(nil, task.id), :params => data)
+    post(api_task_url(nil, task), :params => data)
 
     expect(response).to have_http_status(:ok) # 200
     expect_deleted(task)
@@ -41,8 +41,8 @@ describe 'TasksController' do
     data = {
       :action    => 'delete',
       :resources => [
-        {:href => api_task_url(nil, task.id)},
-        {:href => api_task_url(nil, task2.id)}
+        {:href => api_task_url(nil, task)},
+        {:href => api_task_url(nil, task2)}
       ]
     }
     post(api_tasks_url, :params => data)

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -1,0 +1,57 @@
+describe 'TasksController' do
+  let(:task) { FactoryGirl.create(:miq_task, :state => MiqTask::STATE_FINISHED) }
+  let(:task2) { FactoryGirl.create(:miq_task, :state => MiqTask::STATE_FINISHED) }
+
+  def expect_deleted(*args)
+    args.each do |arg|
+      expect(MiqTask.find_by(:id => arg.id)).to be_nil
+    end
+  end
+
+  it 'deletes on DELETE' do
+    api_basic_authorize resource_action_identifier(:tasks, :delete, :delete)
+
+    delete(api_task_url(nil, task.id))
+
+    expect(response).to have_http_status(:no_content) # 204
+    expect_deleted(task)
+  end
+
+  it 'deletes on POST' do
+    api_basic_authorize resource_action_identifier(:tasks, :delete)
+
+    post(api_task_url(nil, task.id), :params => {
+      :action => 'delete'
+    })
+
+    expect(response).to have_http_status(:ok) # 200
+    expect_deleted(task)
+
+    expect(response.parsed_body).to include({
+      'success' => true,
+      'message' => "tasks id: #{task.id} deleting"
+    })
+  end
+
+  it 'bulk deletes' do
+    api_basic_authorize collection_action_identifier(:tasks, :delete)
+
+    post(api_tasks_url, :params => {
+      :action    => 'delete',
+      :resources => [
+        {:href => api_task_url(nil, task.id)},
+        {:href => api_task_url(nil, task2.id)}
+      ]
+    })
+
+    expect(response).to have_http_status(:ok) # 200
+    expect_deleted(task, task2)
+
+    expect(response.parsed_body).to include({
+      'results' => a_collection_including(
+        a_hash_including('success' => true, 'message' => "tasks id: #{task.id} deleting"),
+        a_hash_including('success' => true, 'message' => "tasks id: #{task2.id} deleting")
+      )
+    })
+  end
+end

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -47,6 +47,10 @@ module Spec
           action_identifier(type, action, :collection_actions, method)
         end
 
+        def resource_action_identifier(type, action, method = :post)
+          action_identifier(type, action, :resource_actions, method)
+        end
+
         def subcollection_action_identifier(type, subtype, action, method = :post)
           subtype_actions = "#{subtype}_subcollection_actions".to_sym
           if ::Api::ApiConfig.collections[type][subtype_actions]


### PR DESCRIPTION
This adds deletion for `MiqTask`, both via `DELETE` and via `POST {action:"delete"}`, *and* bulk deletion (`POST {action:"delete", resources: [...]}`).

Closes #203 

(Needed for https://github.com/ManageIQ/manageiq-ui-classic/pull/2708.)

---

Is it OK to reuse existing identifiers (`miq_task_delete`) or is that frowned upon? :)