### PR TITLE
Fix links in the case when there are no incoming query params

### DIFF
--- a/lib/api/links_builder.rb
+++ b/lib/api/links_builder.rb
@@ -42,7 +42,9 @@ module Api
       if href.include?("offset")
         href.sub("offset=#{offset}", "offset=#{new_offset}")
       else
-        href + "&offset=#{new_offset}"
+        result = URI.parse(href)
+        result.query = [result.query, "offset=#{new_offset}"].compact.join("&")
+        result.to_s
       end
     end
 

--- a/spec/lib/api/links_builder_spec.rb
+++ b/spec/lib/api/links_builder_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe Api::LinksBuilder do
 
       expect(links[:previous]).to eq(links[:first])
     end
+
+    it "will construct a valid URI when there are no incoming query params" do
+      builder = Api::LinksBuilder.new(
+        {"offset" => 0, "limit" => 1000},
+        "http://example.com/api/features",
+        double(Api::QueryCounts, :subquery_count => 1)
+      )
+
+      expected = {
+        :first => "http://example.com/api/features?offset=0",
+        :last  => "http://example.com/api/features?offset=0",
+        :self  => "http://example.com/api/features?offset=0"
+      }
+      expect(builder.links).to match(expected)
+    end
   end
 
   describe "#pages" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514097

IMO the surrounding code could benefit from some more sophisticated URI parsing, but I wanted to focus on fixing the bug first and leave that as a follow up.

@miq-bot add-label bug, gaprindashvili/yes
@miq-bot assign @abellotti 

/cc @jntullo 