### PR TITLE
Fixes an issue where no userid gets retrieved for the token

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -67,7 +67,10 @@ module Api
         if !api_token_mgr.token_valid?(auth_token)
           raise AuthenticationError, "Invalid Authentication Token #{auth_token} specified"
         else
-          auth_user_obj = userid_to_userobj(api_token_mgr.token_get_info(auth_token, :userid))
+          userid = api_token_mgr.token_get_info(auth_token, :userid)
+          raise AuthenticationError, "Invalid Authentication Token #{auth_token} specified" unless userid
+
+          auth_user_obj = userid_to_userobj(userid)
 
           unless request.headers['X-Auth-Skip-Token-Renewal'] == 'true'
             api_token_mgr.reset_token(auth_token)

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -188,6 +188,16 @@ describe "Authentication API" do
           expect_result_to_have_keys(ENTRYPOINT_KEYS)
         end
 
+        it "authentication with an initial valid token that expired midstream" do
+          expired_token = "bogus_expired_token"
+
+          allow_any_instance_of(TokenManager).to receive(:token_valid?).with(expired_token).and_return(true)
+
+          get api_entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => expired_token}
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+
         it "authentication using a valid token updates the token's expiration time" do
           api_basic_authorize
 


### PR DESCRIPTION
Fixes an issue where no token info was retrieved from the token as it gets invalidated after its initial existence check.

- Depends on https://github.com/ManageIQ/manageiq/pull/16520
- Added rspec
