### PR TITLE
Add subresource_action_identifier spec helper

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1611,7 +1611,7 @@
     :subcollection_actions:
       :get:
       - :name: read
-        :identifier: orchestration_stack_show
+        :identifier: orchestration_stack_show_list
     :subresource_actions:
       :get:
       - :name: read

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -676,7 +676,7 @@ describe "Services API" do
     end
 
     it 'can query a specific orchestration stack' do
-      api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
+      api_basic_authorize(subresource_action_identifier(:services, :orchestration_stacks, :read, :get))
 
       get(api_service_orchestration_stack_url(nil, svc, os))
 
@@ -686,7 +686,7 @@ describe "Services API" do
     end
 
     it 'can query a specific orchestration stack asking for stdout' do
-      api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
+      api_basic_authorize(subresource_action_identifier(:services, :orchestration_stacks, :read, :get))
 
       allow_any_instance_of(OrchestrationStack).to receive(:stdout).with(nil).and_return("default text stdout")
       get(api_service_orchestration_stack_url(nil, svc, os), :params => { :attributes => "stdout" })
@@ -700,7 +700,7 @@ describe "Services API" do
     end
 
     it 'can query a specific orchestration stack asking for stdout in alternate format' do
-      api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
+      api_basic_authorize(subresource_action_identifier(:services, :orchestration_stacks, :read, :get))
 
       allow_any_instance_of(OrchestrationStack).to receive(:stdout).with("json").and_return("json stdout")
       get(api_service_orchestration_stack_url(nil, svc, os), :params => { :attributes => "stdout", :format_attributes => "stdout=json" })

--- a/spec/requests/snapshots_spec.rb
+++ b/spec/requests/snapshots_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe "Snapshots API" do
 
     describe "GET /api/instances/:c_id/snapshots/:s_id" do
       it "can show an Instance's snapshot" do
-        api_basic_authorize(subcollection_action_identifier(:instances, :snapshots, :read, :get))
+        api_basic_authorize(subresource_action_identifier(:instances, :snapshots, :read, :get))
         instance = FactoryGirl.create(:vm_openstack)
         create_time = Time.zone.parse("2017-01-11T00:00:00Z")
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance, :create_time => create_time)

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -56,6 +56,15 @@ module Spec
           end
         end
 
+        def subresource_action_identifier(type, subtype, action, method = :post)
+          subresource_actions = "#{subtype}_subresource_actions".to_sym
+          if ::Api::ApiConfig.collections[type][subresource_actions]
+            action_identifier(type, action, subresource_actions, method)
+          else
+            action_identifier(subtype, action, :subresource_actions, method)
+          end
+        end
+
         def gen_request(action, data = nil, *hrefs)
           request = {"action" => action.to_s}
           if hrefs.present?


### PR DESCRIPTION
The current `subcollection_action_identifier` spec helper does not account for subresource actions, which means that the subresource action cannot not be tested if they have a different identifier than the subcollection action. This adds in a new `subresource_action_identifier` which takes into account both subresource actions defined on the type and on the subtype. This will now allow the `orchestration_template` sub collection actions to be identified properly. This also adjusts a snapshots spec to ensure that the helper works for both cases of identifiers (on the type and subtype)

Follow up to https://github.com/ManageIQ/manageiq-api/pull/196

@miq-bot assign @abellotti 