### PR TITLE
Squish consecutive slashes in the path portion of the URI

### DIFF
--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -74,7 +74,7 @@ module Api
     end
 
     def url
-      @request.original_url # http://target/api/...
+      @request.url # http://target/api/...
     end
 
     def prefix(version = true)

--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -69,4 +69,12 @@ RSpec.describe "API entrypoint" do
       )
     )
   end
+
+  it "will squish consecutive slashes in the path portion of the URI" do
+    api_basic_authorize
+
+    get("http://www.example.com//api")
+
+    expect(response).to have_http_status(:ok)
+  end
 end


### PR DESCRIPTION
It looks like Rails/Rack already does some squishing:

```ruby
request.original_url # => "http://example.com//api"
request.url # => "http://example.com/api"
```

If there's a reason we're using the former over the latter, it's not
obvious and it's not covered by tests. Switching to the latter is
sufficient to resolve the issue below.

Closes https://github.com/ManageIQ/manageiq-api/issues/125