### PR TITLE
Specify a target and resource action when retrieving a service dialog

### DIFF
--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -50,6 +50,31 @@ describe "Service Dialogs API" do
       expect_result_to_have_keys(%w(content))
     end
 
+    it "query single dialog to include content with target and resource action specified" do
+      api_basic_authorize action_identifier(:service_dialogs, :read, :resource_actions, :get)
+      service_template = FactoryGirl.create(:service_template)
+      get(api_service_dialog_url(nil, dialog1), :params => { :resource_action_id => ra1.id, :target_id => service_template.id, :target_type => 'service_template' })
+
+      expect_single_resource_query(
+        "id"    => dialog1.id.to_s,
+        "href"  => api_service_dialog_url(nil, dialog1),
+        "label" => dialog1.label
+      )
+      expect_result_to_have_keys(%w(content))
+    end
+
+    it "requires both target_id, target_type, and resource_action" do
+      api_basic_authorize action_identifier(:service_dialogs, :read, :resource_actions, :get)
+
+      get(api_service_dialog_url(nil, dialog1), :params => { :target_id => 'id' })
+
+      expected = {
+        'error' => a_hash_including('message' => a_string_including('Must specify all of'))
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "query single dialog to exclude content when attributes are asked for" do
       api_basic_authorize action_identifier(:service_dialogs, :read, :resource_actions, :get)
 


### PR DESCRIPTION
Fetching the content from a resource sometimes requires both a target and resource_action (ie for custom buttons), where we are currently passing in nil values. By accepting resource_action_id, target_type, and target_id, we are able to use resource search to pass in the applicable values. 

Please verify @eclarizio 

@miq-bot add_label bug, blocker
@miq-bot add_label gaprindashvili/yes 

https://bugzilla.redhat.com/show_bug.cgi?id=1518390