### PR TITLE
Use type names directly from GenericObjectDefinition object

### DIFF
--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -104,9 +104,7 @@ module Api
     end
 
     def self.allowed_types
-      GenericObjectDefinition::TYPE_MAP.keys.collect do |type|
-        [Dictionary.gettext(type.to_s, :type => :data_type, :notfound => :titleize, :plural => false), type.to_s]
-      end.sort
+      GenericObjectDefinition::TYPE_NAMES.stringify_keys.invert.to_a.sort
     end
 
     def options


### PR DESCRIPTION
This change is to make sure API uses pretty (i.e. human readable) type names directly from the `GenericObjectDefinition` object, rather than from the `locale/en.yml` file. 

This PR depends on https://github.com/ManageIQ/manageiq/pull/16563