### PR TITLE
Specify a target and resource when refreshing a dialog field

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -11,12 +11,12 @@ module Api
         service_dialog = resource_search(id, type, klass)
         api_log_info("Refreshing Dialog Fields for #{service_dialog_ident(service_dialog)}")
 
-        refresh_dialog_fields_service_dialog(service_dialog, data)
+        refresh_dialog_fields_service_dialog(data)
       end
     end
 
     def fetch_service_dialogs_content(resource)
-      target, resource_action = validate_dialog_content_params
+      target, resource_action = validate_dialog_content_params(params)
       resource.content(target, resource_action, true)
     end
 
@@ -49,8 +49,9 @@ module Api
 
     private
 
-    def validate_dialog_content_params
-      return unless CONTENT_PARAMS.detect { |param| params.include?(param) }
+    def validate_dialog_content_params(params, required = false)
+      return unless CONTENT_PARAMS.detect { |param| params.include?(param) } || required
+
       raise BadRequestError, "Must specify all of #{CONTENT_PARAMS.join(',')}" unless (CONTENT_PARAMS - params.keys).count.zero?
       target_type = params['target_type'].pluralize.to_sym
       target = resource_search(params['target_id'], target_type, collection_class(target_type))
@@ -62,26 +63,26 @@ module Api
       @additional_attributes = %w(content) if attribute_selection == "all"
     end
 
-    def refresh_dialog_fields_service_dialog(service_dialog, data)
+    def refresh_dialog_fields_service_dialog(data)
       data ||= {}
       dialog_fields = Hash(data["dialog_fields"])
       refresh_fields = data["fields"]
       return action_result(false, "Must specify fields to refresh") if refresh_fields.blank?
 
-      define_service_dialog_fields(service_dialog, dialog_fields)
+      service_dialog = define_service_dialog(dialog_fields, data)
 
       refresh_dialog_fields_action(service_dialog, refresh_fields, service_dialog_ident(service_dialog))
     rescue => err
       action_result(false, err.to_s)
     end
 
-    def define_service_dialog_fields(service_dialog, dialog_fields)
-      ident = service_dialog_ident(service_dialog)
-      dialog_fields.each do |key, value|
-        dialog_field = service_dialog.field(key)
-        raise BadRequestError, "Dialog field #{key} specified does not exist in #{ident}" if dialog_field.nil?
-        dialog_field.value = value
-      end
+    def define_service_dialog(dialog_fields, data)
+      target, resource_action = validate_dialog_content_params(data, true)
+
+      workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => target)
+
+      dialog_fields.each { |key, value| workflow.set_value(key, value) }
+      workflow.dialog
     end
 
     def service_dialog_ident(service_dialog)

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -11,7 +11,7 @@ module Api
         service_dialog = resource_search(id, type, klass)
         api_log_info("Refreshing Dialog Fields for #{service_dialog_ident(service_dialog)}")
 
-        refresh_dialog_fields_service_dialog(data)
+        refresh_dialog_fields_service_dialog(service_dialog, data)
       end
     end
 
@@ -63,13 +63,20 @@ module Api
       @additional_attributes = %w(content) if attribute_selection == "all"
     end
 
-    def refresh_dialog_fields_service_dialog(data)
+    def refresh_dialog_fields_service_dialog(dialog, data)
       data ||= {}
       dialog_fields = Hash(data["dialog_fields"])
       refresh_fields = data["fields"]
       return action_result(false, "Must specify fields to refresh") if refresh_fields.blank?
 
       service_dialog = define_service_dialog(dialog_fields, data)
+
+      if service_dialog.id != dialog.id
+        return action_result(
+          false,
+          "Dialog from resource action and requested refresh dialog must be the same dialog"
+        )
+      end
 
       refresh_dialog_fields_action(service_dialog, refresh_fields, service_dialog_ident(service_dialog))
     rescue => err

--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -63,7 +63,7 @@ describe "Service Dialogs API" do
       expect_result_to_have_keys(%w(content))
     end
 
-    it "requires both target_id, target_type, and resource_action" do
+    it "requires all of target_id, target_type, and resource_action" do
       api_basic_authorize action_identifier(:service_dialogs, :read, :resource_actions, :get)
 
       get(api_service_dialog_url(nil, dialog1), :params => { :target_id => 'id' })
@@ -360,16 +360,59 @@ describe "Service Dialogs API" do
       api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
       init_dialog
 
-      post(api_service_dialog_url(nil, dialog1), :params => gen_request(:refresh_dialog_fields, "fields" => %w(bad_field)))
-
+      post(api_service_dialog_url(nil, dialog1), :params => gen_request(
+        :refresh_dialog_fields,
+        "fields"             => %w(bad_field),
+        "resource_action_id" => ra1.id,
+        "target_id"          => template.id,
+        "target_type"        => "service_template"
+      ))
       expect_single_action_result(:success => false, :message => /unknown dialog field bad_field/i)
+    end
+
+    it "requires all of resource_action_id, target_id, and target_type" do
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      init_dialog
+
+      post(api_service_dialog_url(nil, dialog1), :params => gen_request(
+        :refresh_dialog_fields,
+        "fields" => %w(text1)
+      ))
+
+      expect_single_action_result(:success => false, :message => a_string_including('Must specify all of'))
+    end
+
+    it "supports refresh when passing in resource_action_id, target_id, and target_type" do
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      init_dialog
+
+      post(api_service_dialog_url(nil, dialog1), :params => gen_request(
+        :refresh_dialog_fields,
+        "fields"             => %w(text1),
+        "resource_action_id" => ra1.id,
+        "target_id"          => template.id,
+        "target_type"        => "service_template"
+      ))
+
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "message" => a_string_matching(/refreshing dialog fields/i),
+        "href"    => api_service_dialog_url(nil, dialog1),
+        "result"  => hash_including("text1")
+      )
     end
 
     it "supports refresh dialog fields of valid fields" do
       api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
       init_dialog
 
-      post(api_service_dialog_url(nil, dialog1), :params => gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
+      post(api_service_dialog_url(nil, dialog1), :params => gen_request(
+        :refresh_dialog_fields,
+        "fields"             => %w(text1),
+        "resource_action_id" => ra1.id,
+        "target_id"          => template.id,
+        "target_type"        => "service_template"
+      ))
 
       expect(response.parsed_body).to include(
         "success" => true,

--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -382,6 +382,21 @@ describe "Service Dialogs API" do
       expect_single_action_result(:success => false, :message => a_string_including('Must specify all of'))
     end
 
+    it "requires that the resource action returns the same dialog as the dialog that we are requesting refresh of" do
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      init_dialog
+
+      post(api_service_dialog_url(nil, dialog1), :params => gen_request(
+        :refresh_dialog_fields,
+        "fields"             => %w(text1),
+        "resource_action_id" => ra2.id,
+        "target_id"          => template.id,
+        "target_type"        => "service_template"
+      ))
+
+      expect_single_action_result(:success => false, :message => a_string_including('must be the same dialog'))
+    end
+
     it "supports refresh when passing in resource_action_id, target_id, and target_type" do
       api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
       init_dialog


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/2885, this needs to be merged first so that the API then supports the parameters that are being passed in for refresh.

https://bugzilla.redhat.com/show_bug.cgi?id=1518390