### PR TITLE
Remove remaining decorators from the API

### DIFF
--- a/app/controllers/api/subcollections/vms.rb
+++ b/app/controllers/api/subcollections/vms.rb
@@ -5,52 +5,20 @@ module Api
         vms = object.try(:vms) || []
 
         vm_attrs = attribute_selection_for("vms")
-        vm_decorators = decorator_selection_for("vms")
-
-        return vms if vm_attrs.blank? && vm_decorators.blank?
+        return vms if vm_attrs.blank?
 
         vms.collect do |vm|
           attributes_hash = create_resource_attributes_hash(vm_attrs, vm)
-          decorators_hash = create_vm_decorators_hash(vm_decorators, vm)
-
-          conflictless_hash = attributes_hash.merge(decorators_hash || {}) do |key, _, _|
-            raise BadRequestError, "Requested both an attribute and a decorator of the same name: #{key}"
-          end
-
-          vm.as_json.merge(conflictless_hash)
+          vm.as_json.merge(attributes_hash)
         end
       end
 
       private
 
-      def decorator_selection
-        params['decorators'].to_s.split(",")
-      end
-
-      def decorator_selection_for(collection)
-        decorator_selection.collect do |attr|
-          /\A#{collection}\.(?<name>.*)\z/.match(attr) { |m| m[:name] }
-        end.compact
-      end
-
       def create_vm_attributes_hash(vm_attrs, vm)
         vm_attrs.each_with_object({}) do |attr, hash|
           hash[attr] = vm.public_send(attr.to_sym) if vm.respond_to?(attr.to_sym)
         end.compact
-      end
-
-      def create_vm_decorators_hash(vm_decorators, vm)
-        hash = {}
-        if vm_decorators.include? 'supports_console?'
-          hash['supports_console?'] = vm.supports_console?
-        end
-        if vm_decorators.include? 'supports_cockpit?'
-          hash['supports_cockpit?'] = vm.supports_launch_cockpit?
-        end
-        if vm_decorators.include?('supports_vnc_console?')
-          hash['supports_vnc_console?'] = vm.console_supported?('VNC')
-        end
-        hash
       end
     end
   end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -487,14 +487,6 @@ describe "Services API" do
                                            {"id" => vm2.id.to_s, "cpu_total_cores" => 4}])
     end
 
-    it "can query vms as subcollection via decorators with additional decorators" do
-      get api_service_url(nil, svc1), :params => { :expand => "vms", :attributes => "", :decorators => "vms.supports_console?,vms.supports_cockpit?,vms.supports_vnc_console?" }
-
-      expect_svc_with_vms
-      expect_results_to_match_hash("vms", [{"id" => vm1.id.to_s, "supports_console?" => true, "supports_cockpit?" => anything, "supports_vnc_console?" => anything},
-                                           {"id" => vm2.id.to_s, "supports_console?" => true, "supports_cockpit?" => anything, "supports_vnc_console?" => anything}])
-    end
-
     it "cannot query vms via both virtual attribute and subcollection" do
       get api_service_url(nil, svc1), :params => { :expand => "vms", :attributes => "vms" }
 


### PR DESCRIPTION
With the addition of the `supported_consoles` virtual attribute on the VMs model, there is no longer a need to maintain the last remaining decorators in the API.

@miq-bot add_label cleanup 