### PR TITLE
Don't translate model names sent over API

### DIFF
--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -99,7 +99,7 @@ module Api
 
     def self.allowed_association_types
       GenericObjectDefinition::ALLOWED_ASSOCIATION_TYPES.collect do |association_type|
-        [Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :plural => false), association_type]
+        [Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :plural => false, :translate => false), association_type]
       end.sort
     end
 


### PR DESCRIPTION
This fix is to make sure the model names sent over API will remain in English and won't be translated.

The translation will happen on client side, in this particular case, with this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/2962

Also, I think this change should land in Gaprindashvili, unless we want to introduce this non-standard behavior in a released project / product version.