### PR TITLE
Generic Object Definition OPTIONS: send hashes rather than arrays

### DIFF
--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -98,13 +98,13 @@ module Api
     end
 
     def self.allowed_association_types
-      GenericObjectDefinition::ALLOWED_ASSOCIATION_TYPES.collect do |association_type|
-        [Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :plural => false, :translate => false), association_type]
-      end.sort
+      GenericObjectDefinition::ALLOWED_ASSOCIATION_TYPES.sort.each_with_object({}) do |association_type, result|
+        result[association_type] = Dictionary.gettext(association_type, :type => :model, :notfound => :titleize, :translate => false)
+      end
     end
 
     def self.allowed_types
-      GenericObjectDefinition::TYPE_NAMES.stringify_keys.invert.to_a.sort
+      GenericObjectDefinition::TYPE_NAMES
     end
 
     def options

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -828,7 +828,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
       options(api_generic_object_definitions_url)
 
       expected_data = {'allowed_association_types' => Api::GenericObjectDefinitionsController.allowed_association_types,
-                       'allowed_types'             => Api::GenericObjectDefinitionsController.allowed_types}
+                       'allowed_types'             => Api::GenericObjectDefinitionsController.allowed_types.stringify_keys}
 
       expect_options_results(:generic_object_definitions, expected_data)
     end


### PR DESCRIPTION
It's unnecessary to transform the hash obtained directly from model into an array, since on the client side, we'd have to do another transformation anyway.

Let's send the hash as it is.

Gaprindashvili/no