### PR TITLE
Dialog field/tab deletion

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -30,8 +30,8 @@ module Api
     def edit_resource(type, id, data)
       service_dialog = resource_search(id, type, Dialog)
       begin
-        service_dialog.update!(data.except('content'))
         service_dialog.update_tabs(data['content']['dialog_tabs']) if data['content']
+        service_dialog.update!(data.except('content'))
       rescue => err
         raise BadRequestError, "Failed to update service dialog - #{err}"
       end


### PR DESCRIPTION
Currently dialog fields or tabs are not being deleted because validation is being called before updating them, rather than after. This fix simply switches the update_tabs method to place it before the update! method so that validation is performed in the correct order. Also adds in a spec to test the removal of a field.

https://bugzilla.redhat.com/show_bug.cgi?id=1522870

@miq-bot add_label bug, gaprindashvili/yes, blocker