### PR TITLE
Validate section values for adding new custom attributes via the API

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -59,16 +59,6 @@ module Api
       end
     end
 
-    def custom_attributes_edit_resource(object, type, id, data = nil)
-      formatted_data = format_provider_custom_attributes(data)
-      super(object, type, id, formatted_data)
-    end
-
-    def custom_attributes_add_resource(object, type, id, data = nil)
-      formatted_data = format_provider_custom_attributes(data)
-      super(object, type, id, formatted_data)
-    end
-
     def import_vm_resource(type, id = nil, data = {})
       raise BadRequestError, "Must specify an id for import of VM to a #{type} resource" unless id
 
@@ -98,19 +88,6 @@ module Api
     end
 
     private
-
-    def format_provider_custom_attributes(attribute)
-      if CustomAttribute::ALLOWED_API_VALUE_TYPES.include? attribute["field_type"]
-        attribute["value"] = attribute.delete("field_type").safe_constantize.parse(attribute["value"])
-      end
-      attribute["section"] ||= "metadata" unless @req.action == "edit"
-      if attribute["section"].present? && !CustomAttribute::ALLOWED_API_SECTIONS.include?(attribute["section"])
-        raise "Invalid attribute section specified: #{attribute["section"]}"
-      end
-      attribute
-    rescue => err
-      raise BadRequestError, "Invalid provider custom attributes specified - #{err}"
-    end
 
     def provider_ident(provider)
       "Provider id:#{provider.id} name:'#{provider.name}'"

--- a/app/controllers/api/subcollections/custom_attributes.rb
+++ b/app/controllers/api/subcollections/custom_attributes.rb
@@ -6,16 +6,17 @@ module Api
       end
 
       def custom_attributes_add_resource(object, _type, _id, data = nil)
-        if object.respond_to?(:custom_attributes)
-          add_custom_attribute(object, data)
-        else
-          raise BadRequestError, "#{object.class.name} does not support management of custom attributes"
-        end
+        raise BadRequestError, "#{object.class.name} does not support management of custom attributes" unless object.respond_to?(:custom_attributes)
+        add_custom_attribute(object, data)
+      rescue => err
+        raise BadRequestError, "Could not add custom attributes - #{err}"
       end
 
       def custom_attributes_edit_resource(object, _type, id = nil, data = nil)
         ca = find_custom_attribute(object, id, data)
         edit_custom_attribute(object, ca, data)
+      rescue => err
+        raise BadRequestError, "Could not edit custom attributes - #{err}"
       end
 
       def custom_attributes_delete_resource(object, _type, id = nil, data = nil)
@@ -44,6 +45,7 @@ module Api
 
       def edit_custom_attribute(object, ca, data)
         return if ca.blank?
+        data = format_custom_attributes(data)
         update_custom_attributes(ca, data)
         update_custom_field(object, ca)
         ca
@@ -57,6 +59,7 @@ module Api
       end
 
       def update_custom_attributes(ca, data)
+        data = format_custom_attributes(data)
         ca.update_attributes(data.slice("name", "value", "section"))
       end
 
@@ -79,12 +82,21 @@ module Api
       end
 
       def new_custom_attribute(data)
-        name = data["name"].to_s.strip
-        raise BadRequestError, "Must specify a name for a custom attribute to be added" if name.blank?
-        CustomAttribute.new(:name    => name,
-                            :value   => data["value"],
-                            :source  => data["source"].blank? ? "EVM" : data["source"],
-                            :section => data["section"])
+        data["section"] ||= "metadata"
+        data["source"] ||= "EVM"
+        raise "Must specify a name for a custom attribute to be added" if data["name"].blank?
+        data = format_custom_attributes(data)
+        CustomAttribute.new(data)
+      end
+
+      def format_custom_attributes(attribute)
+        if CustomAttribute::ALLOWED_API_VALUE_TYPES.include?(attribute["field_type"])
+          attribute["value"] = attribute.delete("field_type").safe_constantize.parse(attribute["value"])
+        end
+        if attribute["section"].present? && !CustomAttribute::ALLOWED_API_SECTIONS.include?(attribute["section"])
+          raise "Invalid attribute section specified: #{attribute["section"]}"
+        end
+        attribute
       end
     end
   end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -276,8 +276,7 @@ describe "Providers API" do
       post(provider_ca_url, :params => gen_request(:add, [{"name" => "name3", "value" => "value3",
                                                     "section" => "bad_section"}]))
 
-      expect_bad_request("Invalid provider custom attributes specified - " \
-                         "Invalid attribute section specified: bad_section")
+      expect_bad_request("Could not add custom attributes - Invalid attribute section specified: bad_section")
     end
 
     it "add custom attributes to a provider" do


### PR DESCRIPTION
Custom Attributes have [restrictions](https://github.com/ManageIQ/manageiq/blob/master/app/models/custom_attribute.rb#L2-L3) for the sections that are allowed to be added via the API. Currently validation only occurs for providers, but should be consistent throughout for other types. This change essentially updates the code to remove it from providers and make it accessible to all new custom attribute types.

@miq-bot add_label bug, blocker, gaprindsahvili/yes 

https://bugzilla.redhat.com/show_bug.cgi?id=1516762