### PR TITLE
Return correct subcollection actions

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -413,7 +413,7 @@ module Api
       def gen_action_spec_for_collections(collection, cspec, is_subcollection, href)
         if is_subcollection
           target = :subcollection_actions
-          cspec_target = cspec[target] || collection_config.typed_subcollection_actions(@req.collection, collection)
+          cspec_target = collection_config.typed_subcollection_actions(@req.collection, collection) || cspec[target]
         else
           target = :collection_actions
           cspec_target = cspec[target]

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1182,6 +1182,15 @@ describe "Services API" do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
     end
+
+    it "does not return invalid actions" do
+      api_basic_authorize(subcollection_action_identifier(:services, :generic_objects, :read, :get),
+                          collection_action_identifier(:generic_objects, :create))
+
+      get(api_service_generic_objects_url(nil, svc))
+
+      expect(response.parsed_body.key?('actions')).to be_falsey
+    end
   end
 
   context "service custom_attributes" do


### PR DESCRIPTION
Right now, sub collection actions that are specified on a specific collection (i.e., `:generic_object_subcollection_actions:` specified on `:services:` collection) are not taking precedence to those sub collection actions defined on the collection itself (i.e. `:subcollection_actions:` defined under `:generic_objects:`). This is causing incorrect actions to be returned, causing the users to believe that they have actions that they do not, such as :create: for the generic objects sub collection on services.

This is a reminder to myself that I should probably get around to fixing up https://github.com/ManageIQ/manageiq-api/pull/119 ( new year's resolution 😉 ) 

https://bugzilla.redhat.com/show_bug.cgi?id=1518833

@miq-bot add_label bug, blocker, gaprindashvili/yes 