### PR TITLE
Ensure that correct target is passed to resource_search on dialog refresh

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -53,8 +53,10 @@ module Api
       return unless CONTENT_PARAMS.detect { |param| params.include?(param) } || required
 
       raise BadRequestError, "Must specify all of #{CONTENT_PARAMS.join(',')}" unless (CONTENT_PARAMS - params.keys).count.zero?
-      target_type = params['target_type'].pluralize.to_sym
-      target = resource_search(params['target_id'], target_type, collection_class(target_type))
+      type = collection_config.name_for_subclass(params['target_type'].camelize)
+      raise BadRequestError, "Invalid target_type #{params['target_type']}" unless type
+
+      target = resource_search(params['target_id'], type, collection_class(type))
       resource_action = resource_search(params['resource_action_id'], :resource_actions, ResourceAction)
       [target, resource_action]
     end

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -75,9 +75,10 @@ module Api
     end
 
     def name_for_subclass(resource_class)
+      resource_class = resource_class.to_s
       @cfg.detect do |collection, _|
         collection_class = klass(collection)
-        collection_class && (collection_class == resource_class || collection_class.descendants.include?(resource_class))
+        collection_class && (collection_class.to_s == resource_class || collection_class.descendants.collect(&:to_s).include?(resource_class))
       end.try(:first)
     end
 

--- a/spec/lib/api/collection_config_spec.rb
+++ b/spec/lib/api/collection_config_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Api::CollectionConfig do
     it "returns nil for classes unknown to the API" do
       expect(subject.name_for_subclass(String)).to be_nil
     end
+
+    it "returns the collection name for a class from a string" do
+      expect(subject.name_for_subclass("ServiceTemplateAnsibleTower")).to eq(:service_templates)
+    end
   end
 
   describe "[]" do

--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -417,6 +417,40 @@ describe "Service Dialogs API" do
       )
     end
 
+    it "supports refresh when passing in a target_type that is not the name of an api collection type" do
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      init_dialog
+
+      post(api_service_dialog_url(nil, dialog1), :params => gen_request(
+        :refresh_dialog_fields,
+        "fields"             => %w(text1),
+        "resource_action_id" => ra1.id,
+        "target_id"          => template.id,
+        "target_type"        => "service_template_ansible_tower"
+      ))
+
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "message" => a_string_matching(/refreshing dialog fields/i),
+        "href"    => api_service_dialog_url(nil, dialog1),
+        "result"  => hash_including("text1")
+      )
+    end
+
+    it "raises a bad request for invalid target_types" do
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+
+      post(api_service_dialog_url(nil, dialog1), :params => gen_request(
+        :refresh_dialog_fields,
+        "fields"             => %w(text1),
+        "resource_action_id" => ra1.id,
+        "target_id"          => template.id,
+        "target_type"        => "bad_type"
+      ))
+
+      expect(response.parsed_body).to include("success" => false, "message" => "Invalid target_type bad_type")
+    end
+
     it "supports refresh dialog fields of valid fields" do
       api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
       init_dialog


### PR DESCRIPTION
Currently, the API assumes that a pluralized target_type will match that of a collection class type. This is not the case, as can be seen from `service_template_ansible_tower`. This ensures that a valid resource class and type is returned from the given target_type. In addition, this will raise a bad request error for invalid target_types rather than raising an internal server error

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1524227

cc: @himdel 
@miq-bot add_label bug, blocker, gaprindashvili/yes 
