### PR TITLE
Return property method actions on Generic Object subresources

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -376,7 +376,7 @@ module Api
       def expand_resource_custom_actions(resource, json, type, physical_attrs)
         return unless render_actions(physical_attrs) && collection_config.custom_actions?(type)
 
-        href = json.attributes!["href"]
+        href = @req.subcollection.present? ? collection_href(@req.subcollection, resource.id) : json.attributes!["href"]
         json.actions do |js|
           resource_custom_action_names(resource).each do |action|
             add_child js, "name" => action, "method" => :post, "href" => href

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -376,7 +376,7 @@ module Api
       def expand_resource_custom_actions(resource, json, type, physical_attrs)
         return unless render_actions(physical_attrs) && collection_config.custom_actions?(type)
 
-        href = @req.subcollection.present? ? collection_href(@req.subcollection, resource.id) : json.attributes!["href"]
+        href = @req.subcollection.present? ? normalize_url("#{@req.subcollection}/#{resource.id}") : json.attributes!["href"]
         json.actions do |js|
           resource_custom_action_names(resource).each do |action|
             add_child js, "name" => action, "method" => :post, "href" => href

--- a/app/controllers/api/generic_objects_controller.rb
+++ b/app/controllers/api/generic_objects_controller.rb
@@ -27,10 +27,6 @@ module Api
 
     private
 
-    def resource_custom_action_names(resource)
-      (property_method_names(resource) << super).flatten
-    end
-
     def invoke_custom_action(type, resource, action, data)
       return super(type, resource.reload, action, data) if resource_custom_action_button(resource, action)
       result = begin
@@ -44,11 +40,6 @@ module Api
       log_result(result)
       result
     end
-
-    def property_method_names(resource)
-      resource.respond_to?(:property_methods) ? Array(resource.property_methods) : []
-    end
-
     def method_description(resource, action)
       "Invoked method #{resource.generic_object_definition.name}##{action} for Generic Object id: #{resource.id} name: #{resource.name}"
     end

--- a/app/controllers/api/mixins/generic_objects.rb
+++ b/app/controllers/api/mixins/generic_objects.rb
@@ -5,6 +5,14 @@ module Api
 
       private
 
+      def resource_custom_action_names(resource)
+        (property_method_names(resource) << super).flatten
+      end
+
+      def property_method_names(resource)
+        resource.respond_to?(:property_methods) ? Array(resource.property_methods) : []
+      end
+
       def create_generic_object(object_definition, data)
         data['generic_object_definition'] = object_definition
         GenericObject.new(data.except(*ADDITIONAL_ATTRS)).tap do |generic_object|

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'id'                  => object.id.to_s,
         'name'                => 'bar',
         'property_attributes' => { 'is_something' => true },
-        'actions'             => [{'name' => 'foo', 'method' => 'post', 'href' => api_generic_object_definition_generic_object_url(nil, object_def.id, object.id)}]
+        'actions'             => [{'name' => 'foo', 'method' => 'post', 'href' => api_generic_object_url(nil, object.id)}]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)

--- a/spec/requests/generic_object_definitions_spec.rb
+++ b/spec/requests/generic_object_definitions_spec.rb
@@ -134,7 +134,8 @@ RSpec.describe 'GenericObjectDefinitions API' do
       object.add_to_property_association('vms', [vm])
     end
 
-    it 'returns the generic object with property attributes by default' do
+    it 'returns the generic object with property attributes and custom method actions by default' do
+      object_def.add_property_method('foo')
       api_basic_authorize subcollection_action_identifier(:generic_object_definitions, :generic_objects, :read, :get)
 
       get(api_generic_object_definition_generic_object_url(nil, object_def.id, object.id))
@@ -143,7 +144,8 @@ RSpec.describe 'GenericObjectDefinitions API' do
         'href'                => api_generic_object_definition_generic_object_url(nil, object_def, object),
         'id'                  => object.id.to_s,
         'name'                => 'bar',
-        'property_attributes' => { 'is_something' => true }
+        'property_attributes' => { 'is_something' => true },
+        'actions'             => [{'name' => 'foo', 'method' => 'post', 'href' => api_generic_object_definition_generic_object_url(nil, object_def.id, object.id)}]
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
Currently when retrieving a generic object subresource, ie:
```
/api/generic_object_definitions/:c_id/generic_objects/:id
```
The custom actions / property method actions are not being returned. This change moves code from the generic objects controller into the shared generic objects mixin so that the actions are returned as they should be.

This also fixes another issue where the href being returned for custom actions specifies the subresource href, ie `POST /api/generic_object_definitions/:c_id/generic_objects/:id`. This is incorrect, because when attempting to call the custom method with this href, it results in:
```
{"error":{"kind":"bad_request","message":"No actions are supported for generic_objects resource","klass":"Api::BadRequestError"}}
```
when attempting to call this action. Generic Objects were not the only resource affected by this problem.

@miq-bot add_label blocker, bug, gaprindashvili/yes 
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1518803

