### PR TITLE
Do not return task ID on provider delete

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -54,8 +54,8 @@ module Api
       delete_action_handler do
         raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
         provider = resource_search(id, type, collection_class(type))
-        task = provider.destroy_queue
-        action_result(true, "#{provider_ident(provider)} deleting", :task_id => task.id, :parent_id => id)
+        provider.destroy_queue
+        action_result(true, "#{provider_ident(provider)} has been queued for deletion", :parent_id => id)
       end
     end
 

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -803,9 +803,7 @@ describe "Providers API" do
       post(api_provider_url(nil, provider), :params => gen_request(:delete))
 
       expect_single_action_result(:success   => true,
-                                  :message   => "deleting",
-                                  :task_href => api_tasks_url,
-                                  :task      => true,
+                                  :message   => "queued for deletion",
                                   :href      => api_provider_url(nil, provider))
     end
 
@@ -820,11 +818,11 @@ describe "Providers API" do
                                                       {"href" => api_provider_url(nil, p2)}]))
       expected = {
         "results" => [
-          a_hash_including('task_href' => a_string_including(api_tasks_url)),
-          a_hash_including('task_href' => a_string_including(api_tasks_url))
+          a_hash_including('message' => a_string_including("queued for deletion")),
+          a_hash_including('message' => a_string_including("queued for deletion"))
         ]
       }
-      expect_multiple_action_result(2, :task => true)
+      expect_multiple_action_result(2)
       expect(response.parsed_body).to include(expected)
     end
   end


### PR DESCRIPTION
Destroying a provider uses destroy_queue, however, that method does not create a task, but rather returns an [MiqQueue object](https://github.com/ManageIQ/manageiq/blob/master/app/models/ext_management_system.rb#L452). We are currently returning a task href with non-existent task id. This PR updates the returned task message and removes the task href reference.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525498

More context into the way providers are deleted can be found [here](https://github.com/ManageIQ/manageiq/pull/14848) and [here](https://github.com/ManageIQ/manageiq-api/pull/217). I am not certain of the precedent of this as I do not see anything else like it in the API, or if we should be returning other information to the user. However, for the time being, I think the best course of action is to remove the improper task reference. 

@miq-bot add_label gaprindashvili/yes, bug, blocker 
@miq-bot assign @abellotti 