### PR TITLE
Test hrefs on returned resources via collections

### DIFF
--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -17,9 +17,11 @@ describe "Rest API Collections" do
 
     get collection_url, :params => { :expand => "resources" }
 
-    expected_resources = klass.pluck(attr).map do |id|
+    resource_identifier = Api::CollectionConfig.new.resource_identifier(collection)
+    expected_resources = klass.all.map do |record|
       a_hash_including(
-        attr.to_s => id.to_s
+        attr.to_s => record.send(attr).to_s,
+        "href"    => "#{collection_url}/#{record.send(resource_identifier)}"
       )
     end
 
@@ -92,12 +94,12 @@ describe "Rest API Collections" do
 
     it "query Currencies" do
       FactoryGirl.create(:chargeback_rate_detail_currency)
-      test_collection_query(:currencies, "/api/currencies", ChargebackRateDetailCurrency)
+      test_collection_query(:currencies, api_currencies_url, ChargebackRateDetailCurrency)
     end
 
     it "query Measures" do
       FactoryGirl.create(:chargeback_rate_detail_measure)
-      test_collection_query(:measures, "/api/measures", ChargebackRateDetailMeasure)
+      test_collection_query(:measures, api_measures_url, ChargebackRateDetailMeasure)
     end
 
     it "query Clusters" do

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -17,9 +17,20 @@ describe "Rest API Collections" do
 
     get collection_url, :params => { :expand => "resources" }
 
-    expect_query_result(collection, klass.count, klass.count)
-    expected = attr == :id ? klass.pluck(:id).collect(&:to_s) : klass.pluck(attr)
-    expect_result_resources_to_include_data("resources", attr.to_s => expected)
+    expected_resources = klass.pluck(attr).map do |id|
+      a_hash_including(
+        attr.to_s => id.to_s
+      )
+    end
+
+    expected = {
+      "name"      => collection.to_s,
+      "count"     => klass.count,
+      "subcount"  => klass.count,
+      "resources" => match_array(expected_resources)
+    }
+
+    expect(response.parsed_body).to include(expected)
   end
 
   def test_collection_bulk_query(collection, collection_url, klass, id = nil)


### PR DESCRIPTION
This adds testing to ensure that hrefs returned on collections are correct. It's really to ensure we don't break anything while refactoring href logic elsewhere, but I've split it off here to be merged separately.