### PR TITLE
Only require read priviliges to show cloud volumes

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -551,7 +551,7 @@
     :resource_actions:
       :get:
       - :name: read
-        :identifier: cloud_volume
+        :identifier: cloud_volume_show
       :post:
       - :name: delete
         :identifier: cloud_volume_delete


### PR DESCRIPTION
It looks like the RBAC identifier needed for `CloudVolumes#show` has
been configured incorrectly as `cloud_volume` - the parent of all
cloud volumes. Hence, it requires a user to have all priviliges just
to view individual cloud volumes. Changing this to `cloud_volume_show`
should allow read-only access for users that don't have full
privileges.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1462269

/cc @gtanzillo 