### PR TITLE
ExtManagementSystem#destroy_queue returns a task id

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -54,8 +54,8 @@ module Api
       delete_action_handler do
         raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
         provider = resource_search(id, type, collection_class(type))
-        task = provider.destroy_queue
-        action_result(true, "#{provider_ident(provider)} deleting", :task_id => task.id, :parent_id => id)
+        task_id = provider.destroy_queue
+        action_result(true, "#{provider_ident(provider)} deleting", :task_id => task_id, :parent_id => id)
       end
     end
 


### PR DESCRIPTION
manageiq/b9309e7a8fa7e9b2977ee94cbf0ccc24fbd49749 updated the return
value of this method to be the task id, and the caller was expecting
an object.

This addresses the failing build on master, and is probably also required for https://bugzilla.redhat.com/show_bug.cgi?id=1525498

