### PR TITLE
ActionsBuilder

### DIFF
--- a/lib/api/actions_builder.rb
+++ b/lib/api/actions_builder.rb
@@ -1,0 +1,98 @@
+module Api
+  class ActionsBuilder
+    attr_reader :config, :href, :type, :cspec, :collection, :subcollection, :resource, :user
+
+    def initialize(request, href, type, config, user, resource = nil)
+      @config = config
+      @href = href
+      @type = type
+      @cspec = config[type]
+      @collection = request.collection
+      @subcollection = request.subcollection || (type.to_s if collection != type.to_s)
+      @user = user
+      @resource = resource
+    end
+
+    def actions
+      return unless cspec
+      fetch_targets.each.collect do |method, actions|
+        next unless render_actions_for_method?(method)
+        action_definitions(method, actions).each.collect do |action|
+          next unless enabled_action?(action)
+          generate_actions_hash(method, action)
+        end
+      end.flatten.compact
+    end
+
+    private
+
+    def generate_actions_hash(method, action)
+      actions = [{ 'name' => action[:name], 'method' => method, 'href' => href }]
+      if action[:name] == 'edit' && !collection?
+        actions << { 'name' => 'edit', 'method' => :patch, 'href' => href } if cspec[:verbs].include?(:patch)
+        actions << { 'name' => 'edit', 'method' => :put, 'href' => href } if cspec[:verbs].include?(:put)
+      end
+      actions
+    end
+
+    def fetch_targets
+      targets = collection? ? collection_targets : subcollection_targets
+      targets || []
+    end
+
+    def collection?
+      @is_collection ||= resource.nil?
+    end
+
+    def action_definitions(method, action_definitions)
+      if collection?
+        typed_subcollection_actions(method) || action_definitions
+      else
+        action_definitions || typed_subcollection_actions(method)
+      end
+    end
+
+    def enabled_action?(action)
+      !action[:disabled] && user_role_allows?(action[:identifier]) && action_validated?(action)
+    end
+
+    def collection_targets
+      subcollection.nil? ? cspec[:collection_actions] : subcollection_actions
+    end
+
+    def subcollection_targets
+      subcollection.nil? ? cspec[:resource_actions] : subresource_actions
+    end
+
+    def action_validated?(action_spec)
+      return true if collection?
+      if action_spec[:options].try(:include?, :validate_action)
+        validate_method = "validate_#{action_spec[:name]}"
+        return resource.respond_to?(validate_method) && resource.public_send(validate_method)
+      end
+      true
+    end
+
+    def typed_subcollection_actions(method)
+      return if subcollection.nil?
+      config.typed_subcollection_action(collection, subcollection, method)
+    end
+
+    def subresource_actions
+      cspec[:subresource_actions] || config.typed_subcollection_actions(collection, subcollection, :subresource)
+    end
+
+    def subcollection_actions
+      config.typed_subcollection_actions(collection, subcollection) || cspec[:subcollection_actions]
+    end
+
+    def render_actions_for_method?(method)
+      method != :get && cspec[:verbs].include?(method)
+    end
+
+    def user_role_allows?(action_identifier)
+      return true unless action_identifier
+      user.role_allows?(:identifier => action_identifier)
+    end
+  end
+end

--- a/spec/lib/api/actions_builder_spec.rb
+++ b/spec/lib/api/actions_builder_spec.rb
@@ -1,0 +1,167 @@
+RSpec.describe Api::ActionsBuilder do
+  let(:user) { instance_double('User') }
+  let(:request) { instance_double('Api::RequestAdapter') }
+  let(:config) { Api::CollectionConfig.new }
+  let(:collection_config) do
+    {
+      :services => {
+        :options                    => %i(collection),
+        :verbs                      => %i(get put post patch delete),
+        :klass                      => 'Service',
+        :subcollections             => %i(tags vms),
+        :collection_actions         => {
+          :post => [
+            {:name => 'create', :identifier => 'service_create'},
+            {:name => 'edit', :identifier => 'service_edit'},
+            {:name => 'delete', :identifier => 'service_delete'}
+          ]
+        },
+        :resource_actions           => {
+          :post   => [
+            {:name => 'reconfigure', :identifier => 'service_reconfigure', :options => [:validate_action]},
+            {:name => 'edit', :identifier => 'service_edit'}
+          ],
+          :delete => [
+            {:name => 'delete', :identifier => 'service_delete'}
+          ]
+        },
+        :tags_subcollection_actions => {
+          :post => [
+            {:name => 'assign', :identifier => 'service_tag'},
+            {:name => 'unassign', :identifier => 'service_tag'}
+          ]
+        },
+        :tags_subresource_actions   => {
+          :post => [
+            {:name => 'create', :identifier => 'tag_create'}
+          ]
+        }
+      },
+      :tags     => {
+        :options => %i(subcollection),
+        :verbs   => %i(get post delete)
+      },
+      :vms      => {
+        :options               => %i(subcollection),
+        :verbs                 => %i(post),
+        :subcollection_actions => {
+          :post => [
+            {:name => 'restart', :identifier => 'vm_restart'}
+          ]
+        }
+      }
+    }
+  end
+
+  before do
+    allow(Api::ApiConfig).to receive(:collections).and_return(collection_config)
+  end
+
+  describe '#actions' do
+    context 'collections' do
+      it 'returns the permitted collection actions' do
+        allow(request).to receive(:subcollection).and_return(nil)
+        allow(request).to receive(:collection).and_return('services')
+        allow_user_roles('service_edit', 'service_create', 'service_delete')
+        href = '/api/services'
+
+        expected = [
+          {'name' => 'create', 'method' => :post, 'href' => href},
+          {'name' => 'edit', 'method' => :post, 'href' => href},
+          {'name' => 'delete', 'method' => :post, 'href' => href}
+        ]
+        expect(described_class.new(request, href, :services, config, user).actions).to match(expected)
+      end
+    end
+
+    context 'subcollections' do
+      it 'returns the permitted subcollection actions defined under the collection' do
+        allow(request).to receive(:subcollection).and_return('tags')
+        allow(request).to receive(:collection).and_return('services')
+        allow_user_roles('service_tag')
+        href = '/api/services/:id/tags'
+
+        expected = [
+          {'name' => 'assign', 'method' => :post, 'href' => href},
+          {'name' => 'unassign', 'method' => :post, 'href' => href}
+        ]
+        expect(described_class.new(request, href, :tags, config, user).actions).to match(expected)
+      end
+
+      it 'returns the permitted subcollection actions defined under the subcollection' do
+        allow(request).to receive(:subcollection).and_return('vms')
+        allow(request).to receive(:collection).and_return('services')
+        allow_user_roles('vm_restart')
+        href = '/api/services/:id/vms'
+
+        expected = [
+          {'name' => 'restart', 'method' => :post, 'href' => href}
+        ]
+        expect(described_class.new(request, href, :vms, config, user).actions).to match(expected)
+      end
+    end
+
+    context 'resources' do
+      let(:href) { '/api/services/:id' }
+      let(:service) { instance_double(Service) }
+      before do
+        allow(request).to receive(:subcollection).and_return(nil)
+        allow(request).to receive(:collection).and_return('services')
+      end
+
+      it 'returns the permitted resource actions' do
+        allow(service).to receive(:validate_reconfigure).and_return(true)
+        allow_user_roles('service_reconfigure', 'service_edit', 'service_delete')
+
+        expected = [
+          {'name' => 'reconfigure', 'method' => :post, 'href' => href},
+          {'name' => 'edit', 'method' => :post, 'href' => href},
+          {'name' => 'edit', 'method' => :patch, 'href' => href},
+          {'name' => 'edit', 'method' => :put, 'href' => href},
+          {'name' => 'delete', 'method' => :delete, 'href' => href}
+        ]
+        expect(described_class.new(request, href, :services, config, user, service).actions).to match(expected)
+      end
+
+      it 'only returns validated actions' do
+        allow_user_roles('service_reconfigure', 'service_delete')
+        action_builder = described_class.new(request, href, :services, config, user, service)
+
+        allow(service).to receive(:validate_reconfigure).and_return(false)
+        expect(action_builder.actions).to eq([{'name' => 'delete', 'method' => :delete, 'href' => href}])
+      end
+
+      it 'returns put and patch actions when specified' do
+        allow_user_roles('service_edit')
+
+        expected = [
+          {'name' => 'edit', 'method' => :post, 'href' => href},
+          {'name' => 'edit', 'method' => :patch, 'href' => href},
+          {'name' => 'edit', 'method' => :put, 'href' => href}
+        ]
+        expect(described_class.new(request, href, :services, config, user, service).actions).to include(*expected)
+      end
+    end
+
+    context 'subresources' do
+      it 'returns the permitted subresource actions' do
+        tag = instance_double('Tag')
+        allow(request).to receive(:subcollection).and_return('tags')
+        allow(request).to receive(:collection).and_return('services')
+        allow_user_roles('tag_create')
+        href = '/services/:id/tags/:id'
+
+        expected = [
+          {'name' => 'create', 'method' => :post, 'href' => href}
+        ]
+        expect(described_class.new(request, href, :tags, config, user, tag).actions).to match(expected)
+      end
+    end
+  end
+
+  def allow_user_roles(*identifiers)
+    allow(user).to receive(:role_allows?) do |arg|
+      identifiers.flatten.include?(arg[:identifier])
+    end
+  end
+end

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -823,62 +823,6 @@ describe "Querying" do
       expect(actions.first["name"]).to eq("suspend")
     end
 
-    it 'returns correct actions on a collection' do
-      api_basic_authorize(collection_action_identifier(:vms, :read, :get),
-                          action_identifier(:vms, :start),
-                          action_identifier(:vms, :stop))
-
-      get(api_vms_url)
-
-      actions = response.parsed_body['actions']
-      expect(actions.size).to eq(3)
-      expect(actions.collect { |a| a['name'] }).to match_array(%w(start stop query))
-      expect_result_to_have_keys(%w(name count subcount resources actions))
-    end
-
-    it 'returns correct actions on a subcollection' do
-      api_basic_authorize subcollection_action_identifier(:vms, :snapshots, :read, :get),
-                          subcollection_action_identifier(:vms, :snapshots, :delete, :post),
-                          subcollection_action_identifier(:vms, :snapshots, :create, :post)
-      vm = FactoryGirl.create(:vm)
-      FactoryGirl.create(:snapshot, :vm_or_template => vm)
-
-      get(api_vm_snapshots_url(nil, vm))
-
-      actions = response.parsed_body['actions']
-      expect(actions.size).to eq(2)
-      expect(actions.collect { |a| a['name'] }).to match_array(%w(create delete))
-      expect_result_to_have_keys(%w(name count subcount resources actions))
-    end
-
-    it 'returns the correct actions on a subresource' do
-      api_basic_authorize subcollection_action_identifier(:vms, :snapshots, :delete, :post),
-                          subcollection_action_identifier(:vms, :snapshots, :read, :get),
-                          subcollection_action_identifier(:vms, :snapshots, :create, :post)
-
-      vm = FactoryGirl.create(:vm)
-      snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
-
-      get(api_vm_snapshot_url(nil, vm, snapshot))
-
-      actions = response.parsed_body['actions']
-      expect(actions.size).to eq(2)
-      expect(actions.collect { |a| a['name'] }).to match_array(%w(delete delete))
-      expect_result_to_have_keys(%w(href id actions))
-    end
-
-    it "returns multiple actions if authorized as such" do
-      api_basic_authorize(action_identifier(:vms, :start),
-                          action_identifier(:vms, :stop),
-                          action_identifier(:vms, :read, :resource_actions, :get))
-
-      get api_vm_url(nil, vm1)
-
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(id href name vendor actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(start stop))
-    end
-
     it "returns actions if asked for with physical attributes" do
       api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
 


### PR DESCRIPTION
Re-creation of https://github.com/ManageIQ/manageiq-api/pull/119 since that one is now from an "unknown repository" 😛 

Breaking out a lot of the action logic that is held in the renderer into an ActionsBuilder. We have a lot of tests in random places for actions, so this will allow us to centralize those tests as well as reduce what the renderer does.

@miq-bot add_label refactoring
@miq-bot assign @imtayadeway 