### PR TITLE
Fix regression for expansion of subcollection on a resource

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -228,7 +228,7 @@ module Api
 
       # Expand if: expand='resources' && no attributes specified && subcollection is configured
       def expand_resources?(sc)
-        @req.expand?('resources') && @req.attributes.empty? && collection_config.show?(sc)
+        collection_config.show?(sc) && (@req.collection_id || @req.expand?('resources')) && @req.attributes.empty?
       end
 
       # Expand if: resource is being returned and subcollection is configured


### PR DESCRIPTION
This fixes a regression where subcollections are not being returned for a resource even when it is [configured](https://github.com/ManageIQ/manageiq-api/blob/f4f2ca76db3584f5e5a665c708c2d8bff169479c/config/api.yml#L999) to be returned within the api.yml via the `:show` option. Two tests were added to ensure the regression does not return.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1529299

@miq-bot add_label blocker, bug 