### PR TITLE
Update dialog copy product feature

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2305,7 +2305,7 @@
       - :name: edit
         :identifier: dialog_edit
       - :name: copy
-        :identifier: dialog_copy
+        :identifier: dialog_copy_editor
     :resource_actions:
       :get:
       - :name: read
@@ -2318,7 +2318,7 @@
       - :name: edit
         :identifier: dialog_edit
       - :name: copy
-        :identifier: dialog_copy
+        :identifier: dialog_copy_editor
       :delete:
       - :name: delete
         :identifier: dialog_delete


### PR DESCRIPTION
1f460c4628a4dcac0803e306c31d63c2055934e7 in the main repository
changed the name of this product feature, breaking the contract
between product features and the API. This PR updates the API to be
back in sync.

This should restore the failing master build.

/cc @romanblanco @dclarizio @himdel 

Links: https://github.com/ManageIQ/manageiq/pull/16623