### PR TITLE
Adding 'scan_report_summary' action to container images

### DIFF
--- a/app/controllers/api/container_images_controller.rb
+++ b/app/controllers/api/container_images_controller.rb
@@ -1,5 +1,14 @@
 module Api
   class ContainerImagesController < BaseController
+    def openscap_scan_results_resource(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for getting OpenScap results of a #{type} resource" unless id
+      api_action(type, id) do |klass|
+        cimage = resource_search(id, type, klass)
+        summary = cimage.openscap_rule_results
+        action_result(true, "summary" => summary)
+      end
+    end
+
     def scan_resource(type, image_id, _payload)
       raise BadRequestError, "Must specify an id for starting a #{type} resource" unless image_id
       api_action(type, image_id, :skip_href => true) do |klass|

--- a/config/api.yml
+++ b/config/api.yml
@@ -759,6 +759,8 @@
       :post:
       - :name: scan
         :identifier: container_image_scan
+      - :name: openscap_scan_results
+        :identifier: container_image_scan
   :container_nodes:
     :description: Container Nodes
     :identifier: container_node

--- a/spec/requests/container_images_spec.rb
+++ b/spec/requests/container_images_spec.rb
@@ -92,4 +92,54 @@ describe "Container Images API" do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  context 'POST /api/container_images/<id> with openscap_scan_results action' do
+    let(:provider) { FactoryGirl.create(:ems_kubernetes) }
+    let(:cimage) { FactoryGirl.create(:container_image, :ext_management_system => provider) }
+    let(:unscanned_cimage) { FactoryGirl.create(:container_image, :ext_management_system => provider) }
+    let(:valid_image_url) { api_container_image_url(nil, cimage) }
+    let(:valid_unscanned_image_url) { api_container_image_url(nil, unscanned_cimage) }
+
+    it "returns empty list if the image doesn't have any OpenscapResultRule's" do
+      api_basic_authorize(action_identifier(:container_images, :openscap_scan_results, :resource_actions, :post))
+      post(valid_unscanned_image_url, :params => { :action => "openscap_scan_results" })
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['message']).to include("summary" => [])
+    end
+
+    it "returns a list of openscap_result_summaries" do
+      blob = FactoryGirl.create(:binary_blob,
+                                :binary => "blob",
+                                :name   => "test_blob")
+
+      openscap_result = FactoryGirl.create(:openscap_result_skip_callback,
+                                           :binary_blob        => blob,
+                                           :resource_id        => cimage.id,
+                                           :resource_type      => "ContainerImage",
+                                           :container_image_id => cimage.id)
+
+      rule1 = FactoryGirl.create(:openscap_rule_result,
+                                 :openscap_result => openscap_result,
+                                 :name            => "First Rule",
+                                 :severity        => "High",
+                                 :result          => "success")
+
+      rule2 = FactoryGirl.create(:openscap_rule_result,
+                                 :openscap_result => openscap_result,
+                                 :name            => "Second Rule",
+                                 :severity        => "Medium",
+                                 :result          => "fail")
+
+      cimage.openscap_result = openscap_result
+      cimage.openscap_result.openscap_rule_results << rule1
+      cimage.openscap_result.openscap_rule_results << rule2
+
+      api_basic_authorize(action_identifier(:container_images, :openscap_scan_results, :resource_actions, :post))
+      post(valid_image_url, :params => { :action => "openscap_scan_results" })
+      expect(response).to have_http_status(:ok)
+      summary = [a_hash_including("name" => rule1.name, "severity" => rule1.severity, "result" => rule1.result),
+                 a_hash_including("name" => rule2.name, "severity" => rule2.severity, "result" => rule2.result)]
+      expect(response.parsed_body['message']).to include("summary" => summary)
+    end
+  end
 end


### PR DESCRIPTION
The action `scan_report_summary` will return a list of all the openscap rules  of the image with their result and severity.


BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1446699

This depends on factories from https://github.com/ManageIQ/manageiq/pull/16762