### PR TITLE
Add Settings API for servers, zones, and regions

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -123,10 +123,21 @@ module Api
         resource.remove_settings_path_for_resource(*@req.json_body)
       end
 
-      render :json => resource.settings_for_resource
+      render :json => whitelist_settings(resource.settings_for_resource.to_hash)
     end
 
     private
+
+    def super_admin?
+      User.current_user.super_admin_user?
+    end
+
+    def whitelist_settings(settings)
+      return settings if super_admin?
+
+      whitelisted_categories = ApiConfig.collections[:settings][:categories]
+      settings.with_indifferent_access.slice(*whitelisted_categories)
+    end
 
     def set_gettext_locale
       FastGettext.set_locale(LocaleResolver.resolve(User.current_user, headers))

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -108,6 +108,22 @@ module Api
       render_options(@req.collection)
     end
 
+    def settings
+      id       = @req.collection_id
+      type     = @req.collection
+      klass    = collection_class(@req.collection)
+      resource = resource_search(id, type, klass)
+
+      case @req.method
+      when :patch
+        resource.add_settings_for_resource(@req.json_body)
+      when :delete
+        resource.remove_settings_path_for_resource(*@req.json_body)
+      end
+
+      render :json => resource.settings_for_resource
+    end
+
     private
 
     def set_gettext_locale

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -125,13 +125,21 @@ module Api
         return
       end
 
-      render :json => whitelist_settings(resource.settings_for_resource.to_hash)
+      if super_admin? || current_user.role_allows?(:identifier => 'ops_settings')
+        render :json => whitelist_settings(resource.settings_for_resource.to_hash)
+      else
+        raise ForbiddenError, "You are not authorized to view settings."
+      end
     end
 
     private
 
+    def current_user
+      User.current_user
+    end
+
     def super_admin?
-      User.current_user.super_admin_user?
+      current_user.super_admin_user?
     end
 
     def whitelist_settings(settings)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -116,8 +116,10 @@ module Api
 
       case @req.method
       when :patch
+        raise ForbiddenError, "You are not authorized to edit settings." unless super_admin?
         resource.add_settings_for_resource(@req.json_body)
       when :delete
+        raise ForbiddenError, "You are not authorized to remove settings." unless super_admin?
         resource.remove_settings_path_for_resource(*@req.json_body)
       end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -121,6 +121,8 @@ module Api
       when :delete
         raise ForbiddenError, "You are not authorized to remove settings." unless super_admin?
         resource.remove_settings_path_for_resource(*@req.json_body)
+        head :no_content
+        return
       end
 
       render :json => whitelist_settings(resource.settings_for_resource.to_hash)

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -22,7 +22,7 @@ module Api
         # Method Validation for the collection or sub-collection specified
         if cname && ctype
           mname = @req.method
-          unless collection_config.supports_http_method?(cname, mname) || mname == :options
+          unless collection_config.supports_http_method?(cname, mname) || ignore_http_method_validation?
             raise BadRequestError, "Unsupported HTTP Method #{mname} for the #{ctype} #{cname} specified"
           end
         end
@@ -34,7 +34,7 @@ module Api
       end
 
       def validate_api_action
-        return unless @req.collection
+        return if @req.collection.blank? || ignore_http_method_validation?
         send("validate_#{@req.method}_method")
       end
 
@@ -119,6 +119,12 @@ module Api
       end
 
       private
+
+      def ignore_http_method_validation?
+        settings_request = @req.subcollection == 'settings' && collection_option?(:settings)
+
+        settings_request || @req.method == :options
+      end
 
       #
       # For Posts we need to support actions, let's validate those
@@ -224,6 +230,7 @@ module Api
       def validate_api_request_subcollection(cname, ctype)
         # Sub-Collection Validation for the specified Collection
         if cname && @req.subcollection
+          return [cname, ctype] if @req.subcollection == 'settings' && collection_option?(:settings)
           return [cname, ctype] if collection_option?(:arbitrary_resource_path)
           ctype = "Sub-Collection"
           unless collection_config.subcollection?(cname, @req.subcollection)

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -14,6 +14,8 @@ module Api
     private
 
     def whitelist_settings(settings)
+      return settings if super_admin?
+
       result_hash = {}
       ApiConfig.collections[:settings][:categories].each do |category_path|
         result_hash.deep_merge!(settings_entry_to_hash(category_path, entry_value(settings, category_path)))

--- a/config/api.yml
+++ b/config/api.yml
@@ -1973,6 +1973,7 @@
     :identifier: region
     :options:
     - :collection
+    - :settings
     :verbs: *gp
     :klass: MiqRegion
     :collection_actions:
@@ -2243,6 +2244,7 @@
     :description: EVM Servers
     :options:
     - :collection
+    - :settings
     :verbs: *g
     :klass: MiqServer
   :service_catalogs:
@@ -3071,6 +3073,7 @@
     :identifier: zone
     :options:
     - :collection
+    - :settings
     :verbs: *gp
     :klass: Zone
     :collection_actions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,12 @@ Rails.application.routes.draw do
               post "/", :action => :create, :constraints => Api::CreateConstraint.new
               post "(/:c_id)", :action => :update
             end
+
+            if collection.options.include?(:settings)
+              %w(get patch delete).each do |verb|
+                send(verb, "/:c_id/settings", :to => "#{collection_name}#settings")
+              end
+            end
           end
         end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,12 +47,6 @@ Rails.application.routes.draw do
               post "/", :action => :create, :constraints => Api::CreateConstraint.new
               post "(/:c_id)", :action => :update
             end
-
-            if collection.options.include?(:settings)
-              %w(get patch delete).each do |verb|
-                send(verb, "/:c_id/settings", :to => "#{collection_name}#settings")
-              end
-            end
           end
         end
 
@@ -73,6 +67,15 @@ Rails.application.routes.draw do
               post "/:c_id/#{subcollection_name}(/:s_id)", :action => :update
             end
           end
+        end
+
+        if collection.options.include?(:settings)
+          match(
+            "/:c_id/settings",
+            :to  => "#{collection_name}#settings",
+            :via => %w[get patch delete],
+            :as  => "#{collection_name.to_s.singularize}_settings",
+          )
         end
       end
     end

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -42,16 +42,13 @@ describe "Regions API" do
   end
 
   describe "/api/regions/:id/settings" do
-    # let(:server) { FactoryGirl.create(:miq_server) }
-    # let(:region) { FactoryGirl.create(:miq_region, :region => FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number)) }
-    let(:region) { @region }
-
+    let(:region_number) { ApplicationRecord.my_region_number + 1 }
+    let(:id) { ApplicationRecord.id_in_region(1, region_number) }
+    let(:region) { FactoryGirl.create(:miq_region, :id => id, :region => region_number) }
+    let(:zone) { FactoryGirl.create(:zone, :id => id) }
+    let!(:server) { EvmSpecHelper.remote_miq_server(:id => id, :zone => zone) }
     let(:original_timeout) { region.settings_for_resource[:api][:authentication_timeout] }
     let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
-
-    # before do
-    #   allow(MiqServer).to receive(:in_region).with(ApplicationRecord.my_region_number).and_return(MiqServer.where(:id => server.id))
-    # end
 
     it "shows the settings to an authenticated user with the proper role" do
       api_basic_authorize(:ops_settings)

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -3,12 +3,20 @@ RSpec.describe "Servers" do
     let(:server) { FactoryGirl.create(:miq_server) }
     let(:original_timeout) { server.settings_for_resource[:api][:authentication_timeout] }
 
-    it "shows the settings to an authenticated user" do
-      api_basic_authorize
+    it "shows the settings to an authenticated user with the proper role" do
+      api_basic_authorize(:ops_settings)
 
       get(api_server_settings_url(nil, server))
 
       expect(response).to have_http_status(:ok)
+    end
+
+    it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
+      api_basic_authorize
+
+      get(api_server_settings_url(nil, server))
+
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "does not allow an unauthenticated user to view the settings" do

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe "Servers" do
+  describe "/api/servers/:id/settings" do
+    let(:server) { FactoryGirl.create(:miq_server) }
+    let(:original_timeout) { server.settings_for_resource[:api][:authentication_timeout] }
+
+    it "shows the settings to an authenticated user" do
+      api_basic_authorize
+
+      get(api_server_settings_url(nil, server))
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not allow an unauthenticated user to view the settings" do
+      get(api_server_settings_url(nil, server))
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "permits updates to settings for an authenticated super-admin user" do
+      user = create_super_admin_user
+      api_basic_authorize(:user => user.userid, :password => user.password)
+
+      expect {
+        patch(api_server_settings_url(nil, server), :params => {:api => {:authentication_timeout => "1337.minutes"}})
+      }.to change { server.settings_for_resource[:api][:authentication_timeout] }.from(original_timeout).to("1337.minutes")
+
+      expect(response.parsed_body).to include("api" => a_hash_including("authentication_timeout" => "1337.minutes"))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not allow an authenticated non-super-admin user to update settings" do
+      api_basic_authorize
+
+      expect {
+        patch(api_server_settings_url(nil, server), :params => {:api => {:authentication_timeout => "10.minutes"}})
+      }.not_to change { server.settings_for_resource[:api][:authentication_timeout] }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "does not allow an unauthenticated user to update the settings" do
+      expect {
+        patch(api_server_settings_url(nil, server), :params => {:api => {:authentication_timeout => "10.minutes"}})
+      }.not_to change { server.settings_for_resource[:api][:authentication_timeout] }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    context "with an existing settings change" do
+      before do
+        server.add_settings_for_resource("api" => {"authentication_timeout" => "7331.minutes"})
+      end
+
+      it "allows an authenticated super-admin user to delete settings" do
+        user = create_super_admin_user
+        api_basic_authorize(:user => user.userid, :password => user.password)
+        expect(server.settings_for_resource["api"]["authentication_timeout"]).to eq("7331.minutes")
+
+        expect {
+          delete(
+            api_server_settings_url(nil, server),
+            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+          )
+        }.to change { server.settings_for_resource["api"]["authentication_timeout"] }.from("7331.minutes").to("30.seconds")
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "does not allow an authenticated non-super-admin user to delete settings" do
+        api_basic_authorize
+
+        expect {
+          delete(
+            api_server_settings_url(nil, server),
+            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+          )
+        }.not_to change { server.settings_for_resource["api"]["authentication_timeout"] }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not allow an unauthenticated user to delete settings`" do
+        expect {
+          delete(
+            api_server_settings_url(nil, server),
+            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+          )
+        }.not_to change { server.settings_for_resource["api"]["authentication_timeout"] }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    def create_super_admin_user(userid = "alice", password = "alicepassword")
+      super_admin_role  = FactoryGirl.create(:miq_user_role, :name => "EvmRole-super_administrator")
+      super_admin_group = FactoryGirl.create(:miq_group, :miq_user_role => super_admin_role)
+      FactoryGirl.create(:user, :userid => userid, :password => password, :miq_groups => [super_admin_group])
+    end
+  end
+end

--- a/spec/requests/zones_spec.rb
+++ b/spec/requests/zones_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe "Zones" do
+  describe "/api/zones/:id/settings" do
+    let(:zone) { FactoryGirl.create(:zone) }
+    let(:original_timeout) { zone.settings_for_resource[:api][:authentication_timeout] }
+    let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
+
+    it "shows the settings to an authenticated user with the proper role" do
+      api_basic_authorize(:ops_settings)
+
+      get(api_zone_settings_url(nil, zone))
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
+      api_basic_authorize
+
+      get(api_zone_settings_url(nil, zone))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "does not allow an unauthenticated user to view the settings" do
+      get(api_zone_settings_url(nil, zone))
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "permits updates to settings for an authenticated super-admin user" do
+      api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
+
+      expect {
+        patch(api_zone_settings_url(nil, zone), :params => {:api => {:authentication_timeout => "1337.minutes"}})
+      }.to change { zone.settings_for_resource[:api][:authentication_timeout] }.from(original_timeout).to("1337.minutes")
+
+      expect(response.parsed_body).to include("api" => a_hash_including("authentication_timeout" => "1337.minutes"))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not allow an authenticated non-super-admin user to update settings" do
+      api_basic_authorize
+
+      expect {
+        patch(api_zone_settings_url(nil, zone), :params => {:api => {:authentication_timeout => "10.minutes"}})
+      }.not_to change { zone.settings_for_resource[:api][:authentication_timeout] }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "does not allow an unauthenticated user to update the settings" do
+      expect {
+        patch(api_zone_settings_url(nil, zone), :params => {:api => {:authentication_timeout => "10.minutes"}})
+      }.not_to change { zone.settings_for_resource[:api][:authentication_timeout] }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    context "with an existing settings change" do
+      before do
+        zone.add_settings_for_resource("api" => {"authentication_timeout" => "7331.minutes"})
+      end
+
+      it "allows an authenticated super-admin user to delete settings" do
+        api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
+        expect(zone.settings_for_resource["api"]["authentication_timeout"]).to eq("7331.minutes")
+
+        expect {
+          delete(
+            api_zone_settings_url(nil, zone),
+            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+          )
+        }.to change { zone.settings_for_resource["api"]["authentication_timeout"] }.from("7331.minutes").to("30.seconds")
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "does not allow an authenticated non-super-admin user to delete settings" do
+        api_basic_authorize
+
+        expect {
+          delete(
+            api_zone_settings_url(nil, zone),
+            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+          )
+        }.not_to change { zone.settings_for_resource["api"]["authentication_timeout"] }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not allow an unauthenticated user to delete settings`" do
+        expect {
+          delete(
+            api_zone_settings_url(nil, zone),
+            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+          )
+        }.not_to change { zone.settings_for_resource["api"]["authentication_timeout"] }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This adds manipulation of all settings on servers, zones, and regions via the API in core's `ConfigurationManagementMixin` in the form of a new base controller method, `settings`, which routes to these three collections using the `settings` options keyword in the YAML.

* `GET /servers/:id/settings`
  Renders the server settings as provided by the settings API.

* `PATCH /zones/:id/settings`, body: `{"ems": { "ems_ansible_tower": "blacklisted_event_names": ["EventName1"] } }`
  Sets the ems.ems_ansible_tower.blacklisted_event_names to ["EventName1"] This action serves as both create and update.

* `DELETE /zones/:id/settings`, body: `["ems", "ems_ansible_tower"]`
  This deletes the settings change for this zone under this key path. All changes underneath this key path would be reset and the settings for this zone's ems.ems_ansible_tower subtree would revert to whatever is higher up the settings tree for this zone.

The interface here is very simplistic and just follows the API provided by the core mixin. It emulates the existing `/settings` endpoint.

Additionally,

* Only super admins can read, edit, and delete all settings
* All other users are read only and settings are scoped to only those set as categories in the settings collection.

https://bugzilla.redhat.com/show_bug.cgi?id=1486634
  