### PR TITLE
Adding support to apply_config_pattern operation via the REST API

### DIFF
--- a/app/controllers/api/physical_servers_controller.rb
+++ b/app/controllers/api/physical_servers_controller.rb
@@ -52,49 +52,39 @@ module Api
       end
     end
 
+    # Process apply config pattern operation for single and multi-resources
+    #
+    # Even the request for multi-resources isn't completed successfully, return a HTTP Status 200
     def apply_config_pattern_resource(type, id, data)
-      change_resource_state(:apply_config_pattern, type, id, data)
+      ensure_resource_exists(:customization_scripts, data["pattern_id"])
+      change_resource_state(:apply_config_pattern, type, id, [data["pattern_id"]])
+    rescue => err
+      raise err if single_resource?
+      action_result(false, err.to_s)
     end
 
     private
 
-    def change_resource_state(state, type, id, data = {})
-      validate_resource(state, type, id, data)
+    def change_resource_state(state, type, id, data = [])
+      raise BadRequestError, "Must specify an id for changing a #{type} resource" unless id
+
+      ensure_resource_exists(type, id) if single_resource?
+
       api_action(type, id) do |klass|
         begin
           server = resource_search(id, type, klass)
-          ensure_customization_script_exists(data["pattern_id"]) if apply_config_action(state)
           desc = "Requested server state #{state} for #{server_ident(server)}"
           api_log_info(desc)
-          task_id = queue_object_action(server, desc, :method_name => state, :role => :ems_operations)
+          task_id = queue_object_action(server, desc, :method_name => state, :role => :ems_operations, :args => data)
           action_result(true, desc, :task_id => task_id)
-        rescue StandardError => err
+        rescue => err
           action_result(false, err.to_s)
         end
       end
     end
 
-    def validate_resource(state, type, id, data = {})
-      raise BadRequestError, "Must specify an id for changing a #{type} resource" unless id
-      if single_resource?
-        ensure_resource_exists(type, id)
-        # Verify the configuration pattern resource if the operation is apply_config_pattern
-        ensure_customization_script_exists(data["pattern_id"]) if apply_config_action(state)
-      end
-    end
-
-    def apply_config_action(state)
-      state == :apply_config_pattern
-    end
-
-    def ensure_customization_script_exists(id)
-      ensure_resource_exists(:customization_scripts, id)
-    rescue NotFoundError
-      raise NotFoundError, "Customization script not found"
-    end
-
     def ensure_resource_exists(type, id)
-      raise NotFoundError unless collection_class(type).exists?(id)
+      raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
     end
 
     def server_ident(server)

--- a/config/api.yml
+++ b/config/api.yml
@@ -1635,6 +1635,8 @@
         :identifier: physical_server_turn_on_loc_led
       - :name: turn_off_loc_led
         :identifier: physical_server_turn_off_loc_led
+      - :name: apply_config_pattern
+        :identifier: physical_server_apply_config_pattern
     :resource_actions:
       :get:
       - :name: read
@@ -1662,6 +1664,8 @@
         :identifier: physical_server_turn_on_loc_led
       - :name: turn_off_loc_led
         :identifier: physical_server_turn_off_loc_led
+      - :name: apply_config_pattern
+        :identifier: physical_server_apply_config_pattern
   :pictures:
     :description: Pictures
     :options:

--- a/spec/requests/physical_servers_spec.rb
+++ b/spec/requests/physical_servers_spec.rb
@@ -485,9 +485,15 @@ RSpec.describe "physical_servers API" do
   end
 
   describe "Apply config pattern action" do
+    let(:config_pattern) { FactoryGirl.create(:customization_script) }
+    let(:config_pattern2) { FactoryGirl.create(:customization_script) }
+    let(:ps) { FactoryGirl.create(:physical_server) }
+    let(:href_ps) { api_physical_server_url(nil, ps) }
+    let(:ps2) { FactoryGirl.create(:physical_server) }
+    let(:href_ps2) { api_physical_server_url(nil, ps2) }
+
     context "with an invalid physical server id and a valid config pattern id" do
       it "it responds with 404 Not Found" do
-        config_pattern = FactoryGirl.create(:customization_script)
         api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
 
         post(api_physical_server_url(nil, 999_999), :params => gen_request(:apply_config_pattern, "pattern_id" => config_pattern.id, "uuid" => 999_999))
@@ -498,21 +504,16 @@ RSpec.describe "physical_servers API" do
 
     context "with a valid physical server id and an invalid config pattern id" do
       it "it responds with 404 Not Found" do
-        ps = FactoryGirl.create(:physical_server)
         api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
 
         post(api_physical_server_url(nil, ps), :params => gen_request(:apply_config_pattern, "pattern_id" => 999_999, "uuid" => ps.ems_ref))
 
         expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body["error"]).to include("message" => "customization_scripts with id:999999 not found")
       end
 
       it "apply config pattern of multiple Physical servers" do
-        config_pattern = FactoryGirl.create(:customization_script)
-        ps = FactoryGirl.create(:physical_server)
-        ps2 = FactoryGirl.create(:physical_server)
         api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
-        href_ps = api_physical_server_url(nil, ps)
-        href_ps2 = api_physical_server_url(nil, ps2)
 
         resources = [
           {"pattern_id" => config_pattern.id, "uuid" => ps.ems_ref, "href" => href_ps},
@@ -529,7 +530,7 @@ RSpec.describe "physical_servers API" do
             ),
             a_hash_including(
               "success" => false,
-              "href"    => href_ps2
+              "message" => "customization_scripts with id:999999 not found"
             )
           )
         }
@@ -540,8 +541,6 @@ RSpec.describe "physical_servers API" do
 
     context "with a valid physical server id and config pattern id" do
       it "apply config pattern of a single Physical server" do
-        config_pattern = FactoryGirl.create(:customization_script)
-        ps = FactoryGirl.create(:physical_server)
         api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
 
         post(api_physical_server_url(nil, ps), :params => gen_request(:apply_config_pattern, "pattern_id" => config_pattern.id, "uuid" => ps.ems_ref))
@@ -550,13 +549,7 @@ RSpec.describe "physical_servers API" do
       end
 
       it "apply config pattern of multiple Physical servers" do
-        config_pattern = FactoryGirl.create(:customization_script)
-        config_pattern2 = FactoryGirl.create(:customization_script)
-        ps = FactoryGirl.create(:physical_server)
-        ps2 = FactoryGirl.create(:physical_server)
         api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
-        href_ps = api_physical_server_url(nil, ps)
-        href_ps2 = api_physical_server_url(nil, ps2)
 
         resources = [
           {"pattern_id" => config_pattern.id, "uuid" => ps.ems_ref, "href" => href_ps},

--- a/spec/requests/physical_servers_spec.rb
+++ b/spec/requests/physical_servers_spec.rb
@@ -483,4 +483,103 @@ RSpec.describe "physical_servers API" do
       end
     end
   end
+
+  describe "Apply config pattern action" do
+    context "with an invalid physical server id and a valid config pattern id" do
+      it "it responds with 404 Not Found" do
+        config_pattern = FactoryGirl.create(:customization_script)
+        api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
+
+        post(api_physical_server_url(nil, 999_999), :params => gen_request(:apply_config_pattern, "pattern_id" => config_pattern.id, "uuid" => 999_999))
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "with a valid physical server id and an invalid config pattern id" do
+      it "it responds with 404 Not Found" do
+        ps = FactoryGirl.create(:physical_server)
+        api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
+
+        post(api_physical_server_url(nil, ps), :params => gen_request(:apply_config_pattern, "pattern_id" => 999_999, "uuid" => ps.ems_ref))
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "apply config pattern of multiple Physical servers" do
+        config_pattern = FactoryGirl.create(:customization_script)
+        ps = FactoryGirl.create(:physical_server)
+        ps2 = FactoryGirl.create(:physical_server)
+        api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
+        href_ps = api_physical_server_url(nil, ps)
+        href_ps2 = api_physical_server_url(nil, ps2)
+
+        resources = [
+          {"pattern_id" => config_pattern.id, "uuid" => ps.ems_ref, "href" => href_ps},
+          {"pattern_id" => 999_999, "uuid" => ps2.ems_ref, "href" => href_ps2}
+        ]
+
+        post(api_physical_servers_url, :params => gen_request(:apply_config_pattern, resources))
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including(
+              "success" => true,
+              "href"    => href_ps
+            ),
+            a_hash_including(
+              "success" => false,
+              "href"    => href_ps2
+            )
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with a valid physical server id and config pattern id" do
+      it "apply config pattern of a single Physical server" do
+        config_pattern = FactoryGirl.create(:customization_script)
+        ps = FactoryGirl.create(:physical_server)
+        api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
+
+        post(api_physical_server_url(nil, ps), :params => gen_request(:apply_config_pattern, "pattern_id" => config_pattern.id, "uuid" => ps.ems_ref))
+
+        expect_single_action_result(:success => true, :href => api_physical_server_url(nil, ps))
+      end
+
+      it "apply config pattern of multiple Physical servers" do
+        config_pattern = FactoryGirl.create(:customization_script)
+        config_pattern2 = FactoryGirl.create(:customization_script)
+        ps = FactoryGirl.create(:physical_server)
+        ps2 = FactoryGirl.create(:physical_server)
+        api_basic_authorize(action_identifier(:physical_servers, :apply_config_pattern, :resource_actions, :post))
+        href_ps = api_physical_server_url(nil, ps)
+        href_ps2 = api_physical_server_url(nil, ps2)
+
+        resources = [
+          {"pattern_id" => config_pattern.id, "uuid" => ps.ems_ref, "href" => href_ps},
+          {"pattern_id" => config_pattern2.id, "uuid" => ps2.ems_ref, "href" => href_ps2}
+        ]
+
+        post(api_physical_servers_url, :params => gen_request(:apply_config_pattern, resources))
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including(
+              "success" => true,
+              "href"    => href_ps
+            ),
+            a_hash_including(
+              "success" => true,
+              "href"    => href_ps2
+            )
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is able to:
* Add a new operation to apply a config pattern to a physical server via REST API.

Depends on: https://github.com/ManageIQ/manageiq/pull/16796
Depends on: https://github.com/ManageIQ/manageiq-api/pull/300
