### PR TITLE
Allow additional provider parameters to be specified on create

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -177,7 +177,7 @@ module Api
     def fetch_provider_data(provider_klass, data, options = {})
       data["options"] = data["options"].deep_symbolize_keys if data.key?("options")
       provider_data = data.except(*RESTRICTED_ATTRS)
-      invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys - ENDPOINT_ATTRS - CONNECTION_ATTRS
+      invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys - ENDPOINT_ATTRS - CONNECTION_ATTRS - provider_klass.api_allowed_attributes
       raise BadRequestError, "Invalid Provider attributes #{invalid_keys.join(', ')} specified" if invalid_keys.present?
       specify_zone(provider_data, data, options)
       provider_data

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -455,6 +455,25 @@ describe "Providers API" do
         .and_return([OvirtSDK4::ProbeResult.new(:version => '3')])
     end
 
+    it 'allows provider specific attributes to be specified' do
+      allow(ManageIQ::Providers::Azure::CloudManager).to receive(:api_allowed_attributes).and_return(%w(azure_tenant_id))
+      tenant = FactoryGirl.create(:cloud_tenant)
+      api_basic_authorize collection_action_identifier(:providers, :create)
+
+      post(api_providers_url, :params => { "type"            => "ManageIQ::Providers::Azure::CloudManager",
+                                           "name"            => "sample azure provider",
+                                           "hostname"        => "hostname",
+                                           "zone"            => @zone,
+                                           "azure_tenant_id" => tenant.id,
+                                           "credentials"     => {}})
+
+      expected = {
+        "results" => [a_hash_including("uid_ems" => tenant.id.to_s, "name" => "sample azure provider")]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "rejects creation without appropriate role" do
       api_basic_authorize
 


### PR DESCRIPTION
This update will allow individual providers to have more control over the parameters that are allowed when creating a new manager. This will also be a good transition starting point to move a lot of the validation inside of the providers themselves, rather than having it all within the API controller.

As an example, the Azure provider would like users to provide `azure_tenant_id`, which is not possible under the current API validation. By updating `.api_allowed_attributes` on the `Azure::CloudManager` to return `azure_tenant_id`, users will be allowed to specify that attribute for Azure Cloud Managers.

@miq-bot add_label wip, enhancement 
cc: @juliancheal @bronaghs 

Dependent on https://github.com/ManageIQ/manageiq/pull/16802