### PR TITLE
Update role identifiers for cloud subnets subcollection

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -469,11 +469,11 @@
     :subcollection_actions:
       :get:
       - :name: read
-        :identifier: cloud_tenant_show_list
+        :identifier: cloud_subnet_show_list
     :subresource_actions:
       :get:
       - :name: read
-        :identifier: cloud_tenant_show
+        :identifier: cloud_subnet_show
   :cloud_templates:
     :description: Cloud Templates
     :identifier: image


### PR DESCRIPTION
The role identifiers for cloud subnets refer to cloud tenants, but should be the cloud subnet identifiers. This change makes them consistent with the collection.

Resolves https://github.com/ManageIQ/manageiq-api/issues/276

@miq-bot add_label bug, gaprindashvili/yes 
@miq-bot assign @abellotti 

cc: @gtanzillo - do we need a BZ for a backport to gaprindashvili? 