### PR TITLE
Remove useless expand_paths

### DIFF
--- a/lib/manageiq/api/engine.rb
+++ b/lib/manageiq/api/engine.rb
@@ -3,9 +3,9 @@ module ManageIQ
   module Api
     class Engine < ::Rails::Engine
       isolate_namespace ManageIQ::Api
-      config.autoload_paths << root.join('app', 'controllers', 'api').expand_path
-      config.autoload_paths << root.join('lib', 'services').expand_path
-      config.autoload_paths << root.join('lib').expand_path
+      config.autoload_paths << root.join('app', 'controllers', 'api')
+      config.autoload_paths << root.join('lib', 'services')
+      config.autoload_paths << root.join('lib')
 
       config.after_initialize do
         $api_log.info("Initializing Environment for #{::Api::ApiConfig.base[:name]}")


### PR DESCRIPTION
These do literally nothing.

root.join('lib') == root.join('lib').expand_path #=> true

I'm sure it's a relic from before Rails.root was a Pathname

@bdunne Please review (and take note for all the other plugins/generator/whatever)