### PR TITLE
Create API validator module 

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -24,7 +24,8 @@ module Api
     before_action :require_api_user_or_token, :except => [:options]
     before_action :set_gettext_locale, :set_access_control_headers, :parse_api_request, :log_api_request,
                   :validate_optional_collection_classes, :validate_api_version, :validate_request_method,
-                  :validate_api_request_collection, :validate_api_request_subcollection, :validate_post_method
+                  :validate_api_request_collection, :validate_api_request_subcollection
+    before_action :validate_post_method, :validate_post_api_action_as_subcollection, :only => [:create, :update]
     before_action :validate_api_action, :except => [:options]
     before_action :validate_response_format, :except => [:destroy]
     before_action :ensure_pagination, :only => :index

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -23,11 +23,11 @@ module Api
     before_action :log_request_initiated
     before_action :require_api_user_or_token, :except => [:options]
     before_action :set_gettext_locale, :set_access_control_headers, :parse_api_request, :log_api_request,
-                  :validate_optional_collection_classes, :validate_api_version, :validate_api_action,
+                  :validate_optional_collection_classes, :validate_api_version,
                   :validate_api_request_collection, :validate_api_request_subcollection
     before_action :validate_post_method, :validate_post_api_action_as_subcollection,
                   :validate_resources_specified, :only => [:create, :update]
-    before_action :validate_request_method, :except => :options
+    before_action :validate_request_method, :validate_api_action, :unless => :ignore_http_method_validation?
     before_action :validate_response_format, :except => [:destroy]
     before_action :ensure_pagination, :only => :index
     after_action :log_api_response

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -23,10 +23,11 @@ module Api
     before_action :log_request_initiated
     before_action :require_api_user_or_token, :except => [:options]
     before_action :set_gettext_locale, :set_access_control_headers, :parse_api_request, :log_api_request,
-                  :validate_optional_collection_classes, :validate_api_version, :validate_request_method,
+                  :validate_optional_collection_classes, :validate_api_version, :validate_api_action,
                   :validate_api_request_collection, :validate_api_request_subcollection
-    before_action :validate_post_method, :validate_post_api_action_as_subcollection, :only => [:create, :update]
-    before_action :validate_api_action, :except => [:options]
+    before_action :validate_post_method, :validate_post_api_action_as_subcollection,
+                  :validate_resources_specified, :only => [:create, :update]
+    before_action :validate_request_method, :except => :options
     before_action :validate_response_format, :except => [:destroy]
     before_action :ensure_pagination, :only => :index
     after_action :log_api_response

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -9,6 +9,7 @@ module Api
 
     include_concern 'Parameters'
     include_concern 'Parser'
+    include_concern 'Validator'
     include_concern 'Manager'
     include_concern 'Action'
     include_concern 'Logger'
@@ -22,7 +23,8 @@ module Api
     before_action :log_request_initiated
     before_action :require_api_user_or_token, :except => [:options]
     before_action :set_gettext_locale, :set_access_control_headers, :parse_api_request, :log_api_request,
-                  :validate_api_request
+                  :validate_optional_collection_classes, :validate_api_version, :validate_request_method,
+                  :validate_api_request_collection, :validate_api_request_subcollection, :validate_post_method
     before_action :validate_api_action, :except => [:options]
     before_action :validate_response_format, :except => [:destroy]
     before_action :ensure_pagination, :only => :index

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -108,7 +108,6 @@ module Api
       def update_multiple_collections(is_subcollection, target, type, resources)
         action = @req.action
 
-        processed = 0
         results = resources.each.collect do |r|
           next if r.blank?
 
@@ -120,10 +119,9 @@ module Api
             rid = parse_by_attr(r, type)
           end
           r.except!(*ID_ATTRS) if rid
-          processed += 1
           update_one_collection(is_subcollection, target, type, rid, r)
         end.flatten
-        raise BadRequestError, "No #{type} resources were specified for the #{action} action" if processed == 0
+
         {"results" => results}
       end
     end

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -87,12 +87,6 @@ module Api
 
       private
 
-      def ignore_http_method_validation?
-        settings_request = @req.subcollection == 'settings' && collection_option?(:settings)
-
-        settings_request || @req.method == :options
-      end
-
       def collection_option?(option)
         collection_config.option?(@req.collection, option) if @req.collection
       end

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -5,39 +5,6 @@ module Api
         @req = RequestAdapter.new(request, params)
       end
 
-      def validate_api_request
-        validate_optional_collection_classes
-
-        # API Version Validation
-        if @req.version
-          vname = @req.version
-          unless Api::SUPPORTED_VERSIONS.include?(vname)
-            raise BadRequestError, "Unsupported API Version #{vname} specified"
-          end
-        end
-
-        cname, ctype = validate_api_request_collection
-        cname, ctype = validate_api_request_subcollection(cname, ctype)
-
-        # Method Validation for the collection or sub-collection specified
-        if cname && ctype
-          mname = @req.method
-          unless collection_config.supports_http_method?(cname, mname) || ignore_http_method_validation?
-            raise BadRequestError, "Unsupported HTTP Method #{mname} for the #{ctype} #{cname} specified"
-          end
-        end
-      end
-
-      def validate_optional_collection_classes
-        @collection_klasses = {} # Default all to config classes
-        validate_collection_class
-      end
-
-      def validate_api_action
-        return if @req.collection.blank? || ignore_http_method_validation?
-        send("validate_#{@req.method}_method")
-      end
-
       def parse_id(resource, collection)
         return nil if !resource.kind_of?(Hash) || resource.blank?
 
@@ -126,141 +93,6 @@ module Api
         settings_request || @req.method == :options
       end
 
-      #
-      # For Posts we need to support actions, let's validate those
-      #
-      def validate_post_method
-        cname = @req.subject
-        type, target = request_type_target
-        validate_post_api_action(cname, @req.method, type, target)
-      end
-
-      #
-      # For Get, Delete, Patch and Put, we need to make sure we're entitled for them.
-      #
-      def validate_get_method
-        validate_method_action(:get, "read")
-      end
-
-      def validate_patch_method
-        validate_method_action(:post, "edit")
-      end
-
-      def validate_put_method
-        validate_method_action(:post, "edit")
-      end
-
-      def validate_delete_method
-        validate_method_action(:delete, "delete")
-      end
-
-      def validate_method_action(method_name, action_name)
-        cname, target = if collection_option?(:arbitrary_resource_path)
-                          [@req.collection, (@req.collection_id ? :resource : :collection)]
-                        else
-                          [@req.subject, request_type_target.last]
-                        end
-        aspec = if @req.subcollection?
-                  collection_config.typed_subcollection_actions(@req.collection, cname, target) ||
-                    collection_config.typed_collection_actions(cname, target)
-                else
-                  collection_config.typed_collection_actions(cname, target)
-                end
-        return if method_name == :get && aspec.nil?
-        action_hash = fetch_action_hash(aspec, method_name, action_name)
-        raise BadRequestError, "Disabled action #{action_name}" if action_hash[:disabled]
-        unless api_user_role_allows?(action_hash[:identifier])
-          raise ForbiddenError, "Use of the #{action_name} action is forbidden"
-        end
-      end
-
-      def request_type_target
-        if @req.subcollection
-          @req.subcollection_id ? [:resource, :subresource] : [:collection, :subcollection]
-        else
-          @req.collection_id ? [:resource, :resource] : [:collection, :collection]
-        end
-      end
-
-      def validate_post_api_action(cname, mname, type, target)
-        aname = @req.action
-
-        aspec = if @req.subcollection?
-                  collection_config.typed_subcollection_actions(@req.collection, cname, target) ||
-                    collection_config.typed_collection_actions(cname, target)
-                else
-                  collection_config.typed_collection_actions(cname, target)
-                end
-        raise BadRequestError, "No actions are supported for #{cname} #{type}" unless aspec
-
-        action_hash = fetch_action_hash(aspec, mname, aname)
-        if action_hash.blank?
-          unless type == :resource && collection_config.custom_actions?(cname)
-            raise BadRequestError, "Unsupported Action #{aname} for the #{cname} #{type} specified"
-          end
-        end
-
-        if action_hash.present?
-          raise BadRequestError, "Disabled Action #{aname} for the #{cname} #{type} specified" if action_hash[:disabled]
-          unless api_user_role_allows?(action_hash[:identifier])
-            raise ForbiddenError, "Use of Action #{aname} is forbidden"
-          end
-        end
-
-        validate_post_api_action_as_subcollection(cname, mname, aname)
-      end
-
-      def validate_api_request_collection
-        # Collection Validation
-        if @req.collection
-          cname = @req.collection
-          ctype = "Collection"
-          raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config[cname]
-          if collection_config.primary?(cname)
-            if "#{@req.collection_id}#{@req.subcollection}#{@req.subcollection_id}".present?
-              raise BadRequestError, "Invalid request for #{ctype} #{cname} specified"
-            end
-          else
-            raise BadRequestError, "Unsupported #{ctype} #{cname} specified" unless collection_config.collection?(cname)
-          end
-          [cname, ctype]
-        end
-      end
-
-      def validate_api_request_subcollection(cname, ctype)
-        # Sub-Collection Validation for the specified Collection
-        if cname && @req.subcollection
-          return [cname, ctype] if @req.subcollection == 'settings' && collection_option?(:settings)
-          return [cname, ctype] if collection_option?(:arbitrary_resource_path)
-          ctype = "Sub-Collection"
-          unless collection_config.subcollection?(cname, @req.subcollection)
-            raise BadRequestError, "Unsupported #{ctype} #{@req.subcollection} specified"
-          end
-          cname = @req.subcollection
-        end
-        [cname, ctype]
-      end
-
-      def validate_post_api_action_as_subcollection(cname, mname, aname)
-        return if cname == @req.collection
-        return if collection_config.subcollection_denied?(@req.collection, cname)
-
-        aspec = collection_config.typed_subcollection_actions(@req.collection, cname, @req.subcollection_id ? :subresource : :subcollection)
-        return unless aspec
-
-        action_hash = fetch_action_hash(aspec, mname, aname)
-        raise BadRequestError, "Unsupported Action #{aname} for the #{cname} sub-collection" if action_hash.blank?
-        raise BadRequestError, "Disabled Action #{aname} for the #{cname} sub-collection" if action_hash[:disabled]
-
-        unless api_user_role_allows?(action_hash[:identifier])
-          raise ForbiddenError, "Use of Action #{aname} for the #{cname} sub-collection is forbidden"
-        end
-      end
-
-      def fetch_action_hash(aspec, method_name, action_name)
-        Array(aspec[method_name]).detect { |h| h[:name] == action_name } || {}
-      end
-
       def collection_option?(option)
         collection_config.option?(@req.collection, option) if @req.collection
       end
@@ -276,22 +108,6 @@ module Api
         unless missing_fields.empty?
           raise BadRequestError, "Resource #{missing_fields.join(", ")} needs be specified for creating a new #{type}"
         end
-      end
-
-      def validate_collection_class
-        param = params['collection_class']
-        return unless param.present?
-
-        klass = collection_class(@req.collection)
-        return if param == klass.name
-
-        param_klass = klass.descendants.detect { |sub_klass| param == sub_klass.name }
-        if param_klass.present?
-          @collection_klasses[@req.collection.to_sym] = param_klass
-          return
-        end
-
-        raise BadRequestError, "Invalid collection_class #{param} specified for the #{@req.collection} collection"
       end
     end
   end

--- a/app/controllers/api/base_controller/validator.rb
+++ b/app/controllers/api/base_controller/validator.rb
@@ -82,6 +82,12 @@ module Api
         end
       end
 
+      def ignore_http_method_validation?
+        settings_request = @req.subcollection == 'settings' && collection_config[@req.collection].options&.include?(:settings)
+
+        settings_request || @req.method == :options
+      end
+
       private
 
       def target_collection_config

--- a/app/controllers/api/base_controller/validator.rb
+++ b/app/controllers/api/base_controller/validator.rb
@@ -1,0 +1,164 @@
+module Api
+  class BaseController
+    module Validator
+      def validate_api_version
+        if @req.version
+          vname = @req.version
+          unless Api::SUPPORTED_VERSIONS.include?(vname)
+            raise BadRequestError, "Unsupported API Version #{vname} specified"
+          end
+        end
+      end
+
+      def validate_request_method
+        if collection_name && type
+          unless collection_config.supports_http_method?(collection_name, @req.method) || @req.method == :options
+            raise BadRequestError, "Unsupported HTTP Method #{@req.method} for the #{type} #{collection_name} specified"
+          end
+        end
+      end
+
+      def validate_optional_collection_classes
+        @collection_klasses = {} # Default all to config classes
+        param = params['collection_class']
+        return if param.blank?
+
+        klass = collection_class(@req.collection)
+        return if param == klass.name
+
+        param_klass = klass.descendants.detect { |sub_klass| param == sub_klass.name }
+        if param_klass.present?
+          @collection_klasses[@req.collection.to_sym] = param_klass
+          return
+        end
+
+        raise BadRequestError, "Invalid collection_class #{param} specified for the #{@req.collection} collection"
+      end
+
+      def validate_api_action
+        return unless @req.collection
+        return if @req.method == :get && aspec.nil?
+        raise BadRequestError, "Disabled action #{@req.action}" if action_hash[:disabled]
+        unless api_user_role_allows?(action_hash[:identifier])
+          raise ForbiddenError, "Use of the #{@req.action} action is forbidden"
+        end
+      end
+
+      def validate_post_method
+        return unless method == :post
+        raise BadRequestError, "No actions are supported for #{collection_name} #{type}" unless aspec
+
+        if action_hash.blank?
+          unless type == :resource && req_collection_config&.options&.include?(:custom_actions)
+            raise BadRequestError, "Unsupported Action #{@req.action} for the #{collection_name} #{type} specified"
+          end
+        end
+
+        if action_hash.present?
+          raise BadRequestError, "Disabled Action #{@req.action} for the #{collection_name} #{type} specified" if action_hash[:disabled]
+          unless api_user_role_allows?(action_hash[:identifier])
+            raise ForbiddenError, "Use of Action #{@req.action} is forbidden"
+          end
+        end
+
+        validate_post_api_action_as_subcollection
+      end
+
+      def validate_api_request_collection
+        return unless @req.collection
+        raise BadRequestError, "Unsupported Collection #{@req.collection} specified" unless collection_config[@req.collection]
+        if primary_collection?
+          if "#{@req.collection_id}#{@req.subcollection}#{@req.subcollection_id}".present?
+            raise BadRequestError, "Invalid @req for Collection #{@req.collection} specified"
+          end
+        else
+          raise BadRequestError, "Unsupported Collection #{@req.collection} specified" unless collection_config.collection?(@req.collection)
+        end
+      end
+
+      def validate_api_request_subcollection
+        # Sub-Collection Validation for the specified Collection
+        if @req.collection && @req.subcollection && !arbitrary_resource_path?
+          unless collection_config.subcollection?(@req.collection, @req.subcollection)
+            raise BadRequestError, "Unsupported Sub-Collection #{@req.subcollection} specified"
+          end
+        end
+      end
+
+      def validate_post_api_action_as_subcollection
+        return if collection_name == @req.collection
+        return if collection_config.subcollection_denied?(@req.collection, collection_name)
+        return unless aspec
+
+        raise BadRequestError, "Unsupported Action #{@req.action} for the #{collection_name} sub-collection" if action_hash.blank?
+        raise BadRequestError, "Disabled Action #{@req.action} for the #{collection_name} sub-collection" if action_hash[:disabled]
+
+        unless api_user_role_allows?(action_hash[:identifier])
+          raise ForbiddenError, "Use of Action #{@req.action} for the #{collection_name} sub-collection is forbidden"
+        end
+      end
+
+      private
+
+      def req_collection_config
+        @req_collection_config ||= collection_config[@req.collection]
+      end
+
+      def collection_name
+        @collection_name ||= if @req.collection && arbitrary_resource_path?
+                               @req.collection
+                             else
+                               @req.subject
+                             end
+      end
+
+      def arbitrary_resource_path?
+        @arbitrary ||= req_collection_config&.options&.include?(:arbitrary_resource_path)
+      end
+
+      def primary_collection?
+        @primary_collection ||= collection_config.primary?(collection_name)
+      end
+
+      def subcollection
+        @subcollection ||= @req.subcollection
+      end
+
+      def aspec
+        @aspec ||= if @req.subcollection
+                     collection_config.typed_subcollection_actions(@req.collection, collection_name, target) || collection_config.typed_collection_actions(collection_name, target)
+                   else
+                     collection_config.typed_collection_actions(collection_name, target)
+                   end
+      end
+
+      def method
+        @method ||= if @req.method == :put || @req.method == :patch
+                      :post
+                    else
+                      @req.method
+                    end
+      end
+
+      def action_hash
+        @action_hash = Array(aspec[method]).detect { |h| h[:name] == @req.action } || {}
+      end
+
+      def type
+        @type ||= if (@req.collection_id && !@req.subcollection) || (@req.subcollection && @req.subcollection_id)
+                    :resource
+                  else
+                    :collection
+                  end
+      end
+
+      def target
+        @target ||= if @req.subcollection && !req_collection_config.options&.include?(:arbitrary_resource_path)
+                      @req.subcollection_id ? :subresource : :subcollection
+                    else
+                      @req.collection_id ? :resource : :collection
+                    end
+      end
+    end
+  end
+end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -6,7 +6,7 @@ module Api
 
     include Subcollections::Tags
 
-    skip_before_action :validate_api_action, :only => :update
+    skip_before_action :validate_api_action, :validate_post_method, :only => :update
 
     def update
       aname = @req.action

--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -96,7 +96,7 @@ module Api
     end
 
     def resource
-      json_body.fetch("resource", json_body.except("action"))
+      json_body.fetch("resource", json_body.except("action")) || {}
     end
 
     private


### PR DESCRIPTION
The existing parser is overloaded with a lot of responsibilities from configuration to validation. It has very repetitive methods (particularly with retrieving information from the collection config) and it is difficult to follow where particular variables come from and what they are supposed to represent.

This creates a validation module that breaks validation down into smaller, easier to understand methods, as well as breaks down a lot of the underlying logic that was previously passed in as variables into smaller methods which also helps to eliminate repetitive calls. 

@miq-bot add_label wip, refactoring 