### PR TITLE
Allow read-only access to quotas subcollection

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2844,12 +2844,27 @@
     :quotas_subcollection_actions:
       :get:
       - :name: read
-        :identifier: rbac_tenant_manage_quotas
+        :identifier: rbac_tenant_view
       :post:
       - :name: create
         :identifier: rbac_tenant_manage_quotas
       - :name: edit
         :identifier: rbac_tenant_manage_quotas
+      - :name: delete
+        :identifier: rbac_tenant_manage_quotas
+    :quotas_subresource_actions:
+      :get:
+      - :name: read
+        :identifier: rbac_tenant_view
+      :post:
+      - :name: edit
+        :identifier: rbac_tenant_manage_quotas
+      - :name: delete
+        :identifier: rbac_tenant_manage_quotas
+      :put:
+      - :name: edit
+        :identifier: rbac_tenant_manage_quotas
+      :delete:
       - :name: delete
         :identifier: rbac_tenant_manage_quotas
   :users:

--- a/spec/requests/tenant_quotas_spec.rb
+++ b/spec/requests/tenant_quotas_spec.rb
@@ -3,7 +3,7 @@ describe "tenant quotas API" do
 
   context "with an appropriate role" do
     it "can list all the quotas form a tenant" do
-      api_basic_authorize action_identifier(:quotas, :read, :subcollection_actions, :get)
+      api_basic_authorize subcollection_action_identifier(:tenants, :quotas, :read, :get)
 
       quota_1 = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
       quota_2 = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :mem_allocated, :value => 20)
@@ -22,7 +22,7 @@ describe "tenant quotas API" do
     end
 
     it "can show a single quota from a tenant" do
-      api_basic_authorize action_identifier(:quotas, :read, :subresource_actions, :get)
+      api_basic_authorize subcollection_action_identifier(:tenants, :quotas, :read, :get)
 
       quota = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
 


### PR DESCRIPTION
This change allows read-only access to the quotas subcollection on tenants 

@miq-bot add_label gaprindashvili/yes 
@miq-bot assign @abellotti 