### PR TITLE
Union edit service_dialog API call with other calls

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -30,8 +30,8 @@ module Api
     def edit_resource(type, id, data)
       service_dialog = resource_search(id, type, Dialog)
       begin
-        service_dialog.update_tabs(data['content']['dialog_tabs']) if data['content']
-        service_dialog.update!(data.except('content'))
+        service_dialog.update_tabs(data['dialog_tabs'] || data['content']['dialog_tabs']) if data['dialog_tabs'] || data['content']
+        service_dialog.update!(data.except('dialog_tabs', 'content'))
       rescue => err
         raise BadRequestError, "Failed to update service dialog - #{err}"
       end

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -30,6 +30,7 @@ module Api
     def edit_resource(type, id, data)
       service_dialog = resource_search(id, type, Dialog)
       begin
+        $api_log.warn("Both 'dialog_tabs':[...] and 'content':{'dialog_tabs':[...]} were specified. 'content':{'dialog_tabs':[...]} will be ignored.")
         service_dialog.update_tabs(data['dialog_tabs'] || data['content']['dialog_tabs']) if data['dialog_tabs'] || data['content']
         service_dialog.update!(data.except('dialog_tabs', 'content'))
       rescue => err


### PR DESCRIPTION
This change is communicated with @simaishi at https://github.com/ManageIQ/manageiq/pull/16747. 
This change should be backported to fine. Follow the same link as above to find the change. 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1532200