### PR TITLE
Remove groups from editable attributes for users

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,7 +2,7 @@ module Api
   class UsersController < BaseController
     INVALID_USER_ATTRS = %w(id href current_group_id settings).freeze # Cannot update other people's settings
     INVALID_SELF_USER_ATTRS = %w(id href current_group_id).freeze
-    EDITABLE_ATTRS = %w(password email settings group).freeze
+    EDITABLE_ATTRS = %w(password email settings).freeze
 
     include Subcollections::Tags
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:bad_request)
     end
 
+    it "will not allow the user to change their own group" do
+      api_basic_authorize
+
+      expect do
+        post api_user_url(nil, @user), :params => gen_request(:edit, :group => "updated_name")
+      end.not_to change { @user.reload.name }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
     it "cannot change another user's password" do
       api_basic_authorize
       user = FactoryGirl.create(:user)


### PR DESCRIPTION
A user should not be able to update their own group. 

@miq-bot add_label gaprindashvili/yes
@miq-bot assign @abellotti 