### PR TITLE
Fix special characters in MIQ_GROUP header

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -44,6 +44,7 @@ module Api
       def authorize_user_group(user_obj)
         group_name = request.headers[HttpHeaders::MIQ_GROUP]
         if group_name.present?
+          group_name = CGI.unescape(group_name)
           group_obj = user_obj.miq_groups.find_by(:description => group_name)
           raise AuthenticationError, "Invalid Authorization Group #{group_name} specified" if group_obj.nil?
           user_obj.current_group_by_description = group_name

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -106,6 +106,19 @@ describe "Authentication API" do
     end
   end
 
+  context "Group Authorization with special characters" do
+    let(:special_char_group) { FactoryGirl.create(:miq_group, :description => "équipe", :miq_user_role => @role) }
+
+    it "permits group headers to be specified with properly escaped descriptions" do
+      @user.miq_groups << special_char_group
+      api_basic_authorize
+
+      get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => CGI.escape(special_char_group.description)}
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   context "Authentication/Authorization Identity" do
     let(:group1) { FactoryGirl.create(:miq_group, :description => "Group1", :miq_user_role => @role) }
     let(:group2) { FactoryGirl.create(:miq_group, :description => "Group2", :miq_user_role => @role) }


### PR DESCRIPTION
Non-ASCII characters are not [permitted in headers](https://www.greenbytes.de/tech/webdav/rfc7230.html#rfc.section.A.2.p.9). In our case, we have an `X_MIQ_GROUP` header that specifies the group description. Our group descriptions allow special characters (as in the case `SR-APP-EPM-Membre-équipe`, which poses an interesting dilemma.

Headers with special characters get encoded incorrectly (ie, `SR-APP-EPM-Membre-\xE9quipe`), causing the following error, which does not allow the SUI to proceed with login if the user's current group contains a special character:
```
ActiveRecord::StatementInvalid: PG::CharacterNotInRepertoire: ERROR:  invalid byte sequence for encoding "UTF8": 0xe9 0x71 0x75
: SELECT  "miq_groups".* FROM "miq_groups" INNER JOIN "miq_groups_users" ON "miq_groups"."id" = "miq_groups_users"."miq_group_id" WHERE "miq_groups_users"."user_id" = $1 AND "miq_groups"."description" = $2 LIMIT $3
```
Gif to demonstrate before behavior (pretty uneventful):
![login_fail_sui](https://user-images.githubusercontent.com/2433314/35047323-945ff15a-fb67-11e7-8cde-725db6b97f3c.gif)

This fix properly encodes it back into UTF8, however, I am on the fence on whether we should allow this, or if group description validation should be changed to not allow special characters (although, may be difficult because groups already exist with special characters). 

The following gif demonstrates login working successfully with a user that belongs to a group with a special character:

![login_success_sui](https://user-images.githubusercontent.com/2433314/35047298-761de4f4-fb67-11e7-8dbc-623be52880f2.gif)

Thoughts? @imtayadeway @abellotti @gtanzillo 
cc: @AllenBW @yrudman 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1531626#c9

@miq-bot add_label bug, blocker, gaprindashvili/yes 