### PR TITLE
Do not return picture content on create

### DIFF
--- a/app/controllers/api/pictures_controller.rb
+++ b/app/controllers/api/pictures_controller.rb
@@ -3,7 +3,8 @@ module Api
     before_action :set_additional_attributes, :only => [:index, :show]
 
     def create_resource(_type, _id, data)
-      Picture.create_from_base64(data)
+      picture = Picture.create_from_base64(data)
+      picture.attributes.except('content').merge('image_href' => picture.image_href)
     rescue => err
       raise BadRequestError, "Failed to create Picture - #{err}"
     end
@@ -11,7 +12,7 @@ module Api
     private
 
     def set_additional_attributes
-      @additional_attributes = %w(image_href extension)
+      @additional_attributes = %w(image_href)
     end
   end
 end

--- a/app/controllers/api/pictures_controller.rb
+++ b/app/controllers/api/pictures_controller.rb
@@ -12,7 +12,7 @@ module Api
     private
 
     def set_additional_attributes
-      @additional_attributes = %w(image_href)
+      @additional_attributes = %w(image_href extension)
     end
   end
 end

--- a/spec/requests/picture_spec.rb
+++ b/spec/requests/picture_spec.rb
@@ -118,7 +118,7 @@ describe "Pictures" do
       api_basic_authorize collection_action_identifier(:pictures, :create)
 
       expected = {
-        'results' => [a_hash_including('id')]
+        'results' => [a_hash_including('id', 'image_href')]
       }
 
       expect do

--- a/spec/requests/picture_spec.rb
+++ b/spec/requests/picture_spec.rb
@@ -6,90 +6,65 @@
 # - Query picture and image_href of service_requests   /api/service_requests/:id?attributes=picture,picture.image_href
 #
 describe "Pictures" do
-  let(:dialog1)  { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
-  let(:ra1)      { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
-  let(:picture)  { FactoryGirl.create(:picture, :extension => "jpg") }
-  let(:template) do
-    FactoryGirl.create(:service_template,
-                       :name             => "ServiceTemplate",
-                       :resource_actions => [ra1],
-                       :picture          => picture)
-  end
-  let(:service) { FactoryGirl.create(:service, :service_template_id => template.id) }
-  let(:service_request) do
-    FactoryGirl.create(:service_template_provision_request,
-                       :description => 'Service Request',
-                       :requester   => @user,
-                       :source_id   => template.id)
-  end
+  context "As an attribute" do
+    let(:dialog1)  { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
+    let(:ra1)      { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
+    let(:picture) { FactoryGirl.create(:picture, :extension => "jpg") }
+    let(:template) do
+      FactoryGirl.create(:service_template,
+                         :name             => "ServiceTemplate",
+                         :resource_actions => [ra1],
+                         :picture          => picture)
+    end
+    let(:service) { FactoryGirl.create(:service, :service_template_id => template.id) }
+    let(:service_request) do
+      FactoryGirl.create(:service_template_provision_request,
+                         :description => 'Service Request',
+                         :requester   => @user,
+                         :source_id   => template.id)
+    end
 
-  def expect_result_to_include_picture_href(source_id)
-    expect_result_to_match_hash(response.parsed_body, "id" => source_id)
-    expect_result_to_have_keys(%w(id href picture))
-    expect_result_to_match_hash(response.parsed_body["picture"],
-                                "id"          => picture.id.to_s,
-                                "resource_id" => template.id.to_s,
-                                "image_href"  => /^http:.*#{picture.image_href}$/)
-  end
+    def expect_result_to_include_picture_href(source_id)
+      expect_result_to_match_hash(response.parsed_body, "id" => source_id)
+      expect_result_to_have_keys(%w(id href picture))
+      expect_result_to_match_hash(response.parsed_body["picture"],
+                                  "id"          => picture.id.to_s,
+                                  "resource_id" => template.id.to_s,
+                                  "image_href"  => /^http:.*#{picture.image_href}$/)
+    end
 
-  describe "Queries of Service Templates" do
-    it "allows queries of the related picture and image_href" do
-      api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
+    describe "Queries of Service Templates" do
+      it "allows queries of the related picture and image_href" do
+        api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
 
-      get api_service_template_url(nil, template), :params => { :attributes => "picture,picture.image_href" }
+        get api_service_template_url(nil, template), :params => { :attributes => "picture,picture.image_href" }
 
-      expect_result_to_include_picture_href(template.id.to_s)
+        expect_result_to_include_picture_href(template.id.to_s)
+      end
+    end
+
+    describe "Queries of Services" do
+      it "allows queries of the related picture and image_href" do
+        api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
+
+        get api_service_url(nil, service), :params => { :attributes => "picture,picture.image_href" }
+
+        expect_result_to_include_picture_href(service.id.to_s)
+      end
+    end
+
+    describe "Queries of Service Requests" do
+      it "allows queries of the related picture and image_href" do
+        api_basic_authorize action_identifier(:service_requests, :read, :resource_actions, :get)
+
+        get api_service_request_url(nil, service_request), :params => { :attributes => "picture,picture.image_href" }
+
+        expect_result_to_include_picture_href(service_request.id.to_s)
+      end
     end
   end
 
-  describe "Queries of Services" do
-    it "allows queries of the related picture and image_href" do
-      api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
-
-      get api_service_url(nil, service), :params => { :attributes => "picture,picture.image_href" }
-
-      expect_result_to_include_picture_href(service.id.to_s)
-    end
-  end
-
-  describe "Queries of Service Requests" do
-    it "allows queries of the related picture and image_href" do
-      api_basic_authorize action_identifier(:service_requests, :read, :resource_actions, :get)
-
-      get api_service_request_url(nil, service_request), :params => { :attributes => "picture,picture.image_href" }
-
-      expect_result_to_include_picture_href(service_request.id.to_s)
-    end
-  end
-
-  describe 'GET /api/pictures' do
-    it 'returns image_href, extension when resources are expanded' do
-      api_basic_authorize
-
-      expected = {
-        'resources' => [
-          a_hash_including('image_href' => a_string_including(picture.image_href), 'extension' => picture.extension)
-        ]
-      }
-      get(api_pictures_url, :params => { :expand => 'resources' })
-
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include(expected)
-    end
-  end
-
-  describe 'GET /api/pictures/:id' do
-    it 'returns image_href, extension by default' do
-      api_basic_authorize
-
-      get(api_picture_url(nil, picture))
-
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('image_href' => a_string_including(picture.image_href), 'extension' => picture.extension)
-    end
-  end
-
-  describe 'POST /api/pictures' do
+  context 'As a collection' do
     # Valid base64 image
     let(:content) do
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGP"\
@@ -106,83 +81,116 @@ describe "Pictures" do
       "xQAAAABJRU5ErkJggg=="
     end
 
-    it 'rejects create without an appropriate role' do
-      api_basic_authorize
-
-      post api_pictures_url, :params => { :extension => 'png', :content => content }
-
-      expect(response).to have_http_status(:forbidden)
+    before do
+      @picture = Picture.create_from_base64(:extension => "jpg", :content => content)
     end
 
-    it 'creates a new picture' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+    describe 'GET /api/pictures' do
+      it 'returns image_href, extension when resources are expanded' do
+        api_basic_authorize
 
-      expected = {
-        'results' => [a_hash_including('id', 'image_href')]
-      }
+        expected = {
+          'resources' => [
+            a_hash_including('image_href' => a_string_including(@picture.image_href), 'extension' => @picture.extension)
+          ]
+        }
+        get(api_pictures_url, :params => { :expand => 'resources' })
 
-      expect do
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+    end
+
+    describe 'GET /api/pictures/:id' do
+      it 'returns image_href, extension by default' do
+        api_basic_authorize
+
+        get(api_picture_url(nil, @picture))
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include('image_href' => a_string_including(@picture.image_href), 'extension' => @picture.extension)
+      end
+    end
+
+    describe 'POST /api/pictures' do
+      it 'rejects create without an appropriate role' do
+        api_basic_authorize
+
         post api_pictures_url, :params => { :extension => 'png', :content => content }
-      end.to change(Picture, :count).by(1)
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
-    end
 
-    it 'creates multiple pictures' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+        expect(response).to have_http_status(:forbidden)
+      end
 
-      expected = {
-        'results' => [a_hash_including('id'), a_hash_including('id')]
-      }
+      it 'creates a new picture' do
+        api_basic_authorize collection_action_identifier(:pictures, :create)
 
-      expect do
-        post(api_pictures_url, :params => gen_request(:create, [{:extension => 'png', :content => content},
-                                                                {:extension => 'jpg', :content => content}]))
-      end.to change(Picture, :count).by(2)
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
-    end
+        expected = {
+          'results' => [a_hash_including('id', 'image_href')]
+        }
 
-    it 'requires an extension' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+        expect do
+          post api_pictures_url, :params => { :extension => 'png', :content => content }
+        end.to change(Picture, :count).by(1)
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
 
-      post api_pictures_url, :params => { :content => content }
+      it 'creates multiple pictures' do
+        api_basic_authorize collection_action_identifier(:pictures, :create)
 
-      expected = {
-        'error' => a_hash_including(
-          'message' => a_string_including("Extension can't be blank")
-        )
-      }
-      expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to include(expected)
-    end
+        expected = {
+          'results' => [a_hash_including('id'), a_hash_including('id')]
+        }
 
-    it 'requires content' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+        expect do
+          post(api_pictures_url, :params => gen_request(:create, [{:extension => 'png', :content => content},
+                                                                  {:extension => 'jpg', :content => content}]))
+        end.to change(Picture, :count).by(2)
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
 
-      post api_pictures_url, :params => { :extension => 'png' }
+      it 'requires an extension' do
+        api_basic_authorize collection_action_identifier(:pictures, :create)
 
-      expected = {
-        'error' => a_hash_including(
-          'message' => a_string_including("Content can't be blank")
-        )
-      }
-      expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to include(expected)
-    end
+        post api_pictures_url, :params => { :content => content }
 
-    it 'requires content with valid base64' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+        expected = {
+          'error' => a_hash_including(
+            'message' => a_string_including("Extension can't be blank")
+          )
+        }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to include(expected)
+      end
 
-      post api_pictures_url, :params => { :content => 'not base64', :extension => 'png' }
+      it 'requires content' do
+        api_basic_authorize collection_action_identifier(:pictures, :create)
 
-      expected = {
-        'error' => a_hash_including(
-          'message' => a_string_including('invalid base64')
-        )
-      }
-      expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to include(expected)
+        post api_pictures_url, :params => { :extension => 'png' }
+
+        expected = {
+          'error' => a_hash_including(
+            'message' => a_string_including("Content can't be blank")
+          )
+        }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to include(expected)
+      end
+
+      it 'requires content with valid base64' do
+        api_basic_authorize collection_action_identifier(:pictures, :create)
+
+        post api_pictures_url, :params => { :content => 'not base64', :extension => 'png' }
+
+        expected = {
+          'error' => a_hash_including(
+            'message' => a_string_including('invalid base64')
+          )
+        }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to include(expected)
+      end
     end
   end
 end


### PR DESCRIPTION
Do not return picture content on create, which will resolve broken specs introduced by https://github.com/ManageIQ/manageiq/pull/16810

Since we are not returning picture content, this now returns `image_href` on create, which is how images can be returned.

@miq-bot add_label bug, gaprindashvili/yes 