### PR TITLE
Fix picture fetching as an attribute

### DIFF
--- a/app/controllers/api/mixins/pictures.rb
+++ b/app/controllers/api/mixins/pictures.rb
@@ -1,0 +1,14 @@
+module Api
+  module Mixins
+    module Pictures
+      def fetch_picture(resource)
+        format_picture_response(resource.picture)
+      end
+
+      def format_picture_response(picture)
+        return unless picture
+        picture.attributes.except('content').merge('image_href' => picture.image_href)
+      end
+    end
+  end
+end

--- a/app/controllers/api/pictures_controller.rb
+++ b/app/controllers/api/pictures_controller.rb
@@ -1,10 +1,12 @@
 module Api
   class PicturesController < BaseController
+    include Api::Mixins::Pictures
+
     before_action :set_additional_attributes, :only => [:index, :show]
 
     def create_resource(_type, _id, data)
       picture = Picture.create_from_base64(data)
-      picture.attributes.except('content').merge('image_href' => picture.image_href)
+      format_picture_response(picture)
     rescue => err
       raise BadRequestError, "Failed to create Picture - #{err}"
     end

--- a/app/controllers/api/service_requests_controller.rb
+++ b/app/controllers/api/service_requests_controller.rb
@@ -1,6 +1,9 @@
 module Api
   class ServiceRequestsController < BaseController
     include Subcollections::RequestTasks
+    include Api::Mixins::Pictures
+
+    alias fetch_service_requests_picture fetch_picture
 
     def approve_resource(type, id, data)
       raise "Must specify a reason for approving a service request" unless data["reason"].present?

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -4,8 +4,11 @@ module Api
     include Subcollections::Tags
     include Subcollections::ResourceActions
     include Subcollections::ServiceRequests
+    include Api::Mixins::Pictures
 
     before_action :set_additional_attributes, :only => [:show]
+
+    alias fetch_service_templates_picture fetch_picture
 
     def create_resource(_type, _id, data)
       catalog_item_type = ServiceTemplate.class_from_request_data(data)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -7,7 +7,9 @@ module Api
     include Subcollections::MetricRollups
     include Subcollections::GenericObjects
     include Subcollections::CustomAttributes
+    include Api::Mixins::Pictures
 
+    alias fetch_services_picture fetch_picture
 
     def create_resource(_type, _id, data)
       validate_service_data(data)

--- a/app/controllers/api/subcollections/generic_objects.rb
+++ b/app/controllers/api/subcollections/generic_objects.rb
@@ -1,6 +1,8 @@
 module Api
   module Subcollections
     module GenericObjects
+      include Api::Mixins::Pictures
+
       def generic_objects_query_resource(object_definition)
         generic_objects = object_definition.generic_objects
         go_attrs = attribute_selection_for('generic_objects')
@@ -12,7 +14,7 @@ module Api
 
           if attributes_hash['picture']
             picture = attributes_hash['picture']
-            attributes_hash['picture'] = picture.attributes.merge('image_href' => picture.image_href, 'extension' => picture.extension)
+            attributes_hash['picture'] = format_picture_response(picture)
           end
 
           go.as_json.merge(attributes_hash)

--- a/spec/requests/pictures_spec.rb
+++ b/spec/requests/pictures_spec.rb
@@ -6,15 +6,34 @@
 # - Query picture and image_href of service_requests   /api/service_requests/:id?attributes=picture,picture.image_href
 #
 describe "Pictures" do
+  # Valid base64 image
+  let(:content) do
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGP"\
+      "C/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3Cc"\
+      "ulE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2Jl"\
+      "LnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIg"\
+      "eDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpy"\
+      "ZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1u"\
+      "cyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAg"\
+      "ICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYv"\
+      "MS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3Jp"\
+      "ZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpS"\
+      "REY+CjwveDp4bXBtZXRhPgpMwidZAAAADUlEQVQIHWNgYGCwBQAAQgA+3N0+"\
+      "xQAAAABJRU5ErkJggg=="
+  end
+
+  before do
+    @picture = Picture.create_from_base64(:extension => "jpg", :content => content)
+  end
+
   context "As an attribute" do
     let(:dialog1)  { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
     let(:ra1)      { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
-    let(:picture) { FactoryGirl.create(:picture, :extension => "jpg") }
     let(:template) do
       FactoryGirl.create(:service_template,
                          :name             => "ServiceTemplate",
                          :resource_actions => [ra1],
-                         :picture          => picture)
+                         :picture          => @picture)
     end
     let(:service) { FactoryGirl.create(:service, :service_template_id => template.id) }
     let(:service_request) do
@@ -28,9 +47,9 @@ describe "Pictures" do
       expect_result_to_match_hash(response.parsed_body, "id" => source_id)
       expect_result_to_have_keys(%w(id href picture))
       expect_result_to_match_hash(response.parsed_body["picture"],
-                                  "id"          => picture.id.to_s,
+                                  "id"          => @picture.id.to_s,
                                   "resource_id" => template.id.to_s,
-                                  "image_href"  => /^http:.*#{picture.image_href}$/)
+                                  "image_href"  => /^http:.*#{@picture.image_href}$/)
     end
 
     describe "Queries of Service Templates" do
@@ -65,26 +84,6 @@ describe "Pictures" do
   end
 
   context 'As a collection' do
-    # Valid base64 image
-    let(:content) do
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGP"\
-      "C/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3Cc"\
-      "ulE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2Jl"\
-      "LnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIg"\
-      "eDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpy"\
-      "ZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1u"\
-      "cyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAg"\
-      "ICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYv"\
-      "MS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3Jp"\
-      "ZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpS"\
-      "REY+CjwveDp4bXBtZXRhPgpMwidZAAAADUlEQVQIHWNgYGCwBQAAQgA+3N0+"\
-      "xQAAAABJRU5ErkJggg=="
-    end
-
-    before do
-      @picture = Picture.create_from_base64(:extension => "jpg", :content => content)
-    end
-
     describe 'GET /api/pictures' do
       it 'returns image_href, extension when resources are expanded' do
         api_basic_authorize

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1124,7 +1124,21 @@ describe "Services API" do
   end
 
   describe "Generic Objects Subcollection" do
-    let(:picture) { FactoryGirl.create(:picture) }
+    let(:content) do
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGP"\
+      "C/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3Cc"\
+      "ulE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2Jl"\
+      "LnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIg"\
+      "eDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpy"\
+      "ZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1u"\
+      "cyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAg"\
+      "ICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYv"\
+      "MS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3Jp"\
+      "ZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpS"\
+      "REY+CjwveDp4bXBtZXRhPgpMwidZAAAADUlEQVQIHWNgYGCwBQAAQgA+3N0+"\
+      "xQAAAABJRU5ErkJggg=="
+    end
+    let(:picture) { FactoryGirl.create(:picture, :content => content) }
     let(:generic_object_definition) { FactoryGirl.create(:generic_object_definition, :picture => picture) }
     let(:generic_object) { FactoryGirl.create(:generic_object, :generic_object_definition => generic_object_definition) }
 


### PR DESCRIPTION
Fetching a picture as an attribute is causing the same error that we saw https://github.com/ManageIQ/manageiq-api/pull/292, where it returns:
```
"kind": "internal_server_error",
"message": "\"\\x89\" from ASCII-8BIT to UTF-8",
"klass": "Encoding::UndefinedConversionError"
```
due to the changes in picture content.

This change creates a picture mixin to both format the way a picture object will now be returned, as well as provide a fetch method for collections with picture attributes.

Note, that I only added the module to collections that we were testing picture attribute selection on. We may need to add it to more in the future, or consider other options such as a picture serializer. 

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @abellotti 