### PR TITLE
Update role identifiers for tasks collection

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2716,16 +2716,22 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: tasks_view
+        :identifier:
+        - miq_task_all_ui
+        - miq_task_my_ui
       :post:
       - :name: query
-        :identifier: tasks_view
+        :identifier:
+        - miq_task_all_ui
+        - miq_task_my_ui
       - :name: delete
         :identifier: miq_task_delete
     :resource_actions:
       :get:
       - :name: read
-        :identifier: tasks_view
+        :identifier:
+        - miq_task_all_ui
+        - miq_task_my_ui
       :post:
       - :name: delete
         :identifier: miq_task_delete

--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -23,7 +23,8 @@ describe 'API configuration (config/api.yml)' do
             next unless cfg[action_type]
             cfg[action_type].each do |_, method_cfg|
               method_cfg.each do |action_cfg|
-                set.add(action_cfg[:identifier]) if action_cfg[:identifier]
+                next unless action_cfg[:identifier]
+                Array(action_cfg[:identifier]).each { |id| set.add(id) }
               end
             end
           end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -58,4 +58,66 @@ describe 'TasksController' do
     }
     expect(response.parsed_body).to include(expected)
   end
+
+  describe 'GET /api/tasks' do
+    it 'returns tasks with miq_tasks_all_ui role' do
+      api_basic_authorize('miq_task_all_ui')
+
+      get(api_tasks_url)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns tasks with miq_task_my_ui role' do
+      api_basic_authorize('miq_task_my_ui')
+
+      get(api_tasks_url)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'does not return tasks without an appropriate role' do
+      api_basic_authorize
+
+      get(api_tasks_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/tasks/:id' do
+    it 'returns a task with miq_tasks_all_ui role' do
+      api_basic_authorize('miq_task_all_ui')
+
+      get(api_task_url(nil, task))
+
+      expected = {
+        'href' => api_task_url(nil, task),
+        'name' => task.name
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'returns a task miq_task_my_ui role' do
+      api_basic_authorize('miq_task_my_ui')
+
+      get(api_task_url(nil, task))
+
+      expected = {
+        'href' => api_task_url(nil, task),
+        'name' => task.name
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'does not return a task without an appropriate role' do
+      api_basic_authorize
+
+      get(api_task_url(nil, task))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
 end


### PR DESCRIPTION
When user roles are seeded, they have either the `miq_task_all_ui` feature or `miq_task_my_ui` feature ([or both](https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_user_roles.yml#L67-L68)), which is what the UI also uses to validate that they can view requests. However, the API uses `tasks_view`. This is causing a problem where users that are able to see tasks in the UI are unable to see tasks through the API. This updates the product features used in the API to match what is used in the UI.

Note, no changes were needed for this due to `api_user_role_allows?` method already [accepting arrays](https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/base_controller/renderer.rb#L496), but have updated the api config spec accordingly, since this is the first place we are doing so.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535962