### PR TITLE
[GAPRINDASHVILI] Fixed up role identifiers  for cloud_networks

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -399,7 +399,7 @@
         :identifier: chargeback_rates_delete
   :cloud_networks:
     :description: Cloud Networks
-    :identifier: miq_cloud_networks
+    :identifier: cloud_network
     :options:
     - :collection
     - :subcollection
@@ -408,18 +408,22 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: miq_cloud_networks_view
+        :identifier: cloud_network_show_list
       :post:
       - :name: query
-        :identifier: miq_cloud_networks_view
+        :identifier: cloud_network_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: cloud_network_show
     :subcollection_actions:
       :get:
       - :name: read
-        :identifier: miq_cloud_networks_view
+        :identifier: cloud_network_show_list
     :subresource_actions:
       :get:
       - :name: read
-        :identifier: miq_cloud_networks_view
+        :identifier: cloud_network_show
   :cloud_subnets:
     :description: Cloud Subnets
     :identifier: cloud_subnet


### PR DESCRIPTION
pulled out from https://github.com/ManageIQ/manageiq-api/pull/200

these identifiers didn't fit identifiers from https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_product_features.yml#L4389-L4432

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1535479