### PR TITLE
Allow multiple role identifiers for cloud volume

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1795,10 +1795,14 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: ems_infra_show_list
+        :identifier:
+        - ems_infra_show_list
+        - ems_block_storage_show_list
       :post:
       - :name: query
-        :identifier: ems_infra_show_list
+        :identifier:
+        - ems_infra_show_list
+        - ems_block_storage_show_list
       - :name: create
         :identifier: ems_infra_new
       - :name: edit
@@ -1810,7 +1814,9 @@
     :resource_actions:
       :get:
       - :name: read
-        :identifier: ems_infra_show
+        :identifier:
+        - ems_infra_show
+        - ems_block_storage_show
       :post:
       - :name: edit
         :identifier: ems_infra_edit

--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -19,7 +19,7 @@ describe 'API configuration (config/api.yml)' do
 
       let(:api_feature_identifiers) do
         collection_settings.each_with_object(Set.new) do |(_, cfg), set|
-          set.add(cfg[:identifier]) if cfg[:identifier]
+          Array(cfg[:identifier]).each { |id| set.add(id) }
           keys = [:collection_actions, :resource_actions, :subcollection_actions, :subresource_actions]
           Array(cfg[:subcollections]).each do |s|
             keys << "#{s}_subcollection_actions" << "#{s}_subresource_actions"


### PR DESCRIPTION
pulled out from https://github.com/ManageIQ/manageiq/pull/15249 - there is description
but the problem is solved only for storage managers.

@miq-bot add_label gaprindashvili/yes, blocker

# links
https://bugzilla.redhat.com/show_bug.cgi?id=1538003

cc @gtanzillo 

@miq-bot assign @abellotti 