### PR TITLE
Adding the customization_script retrieve operation via the REST API

### DIFF
--- a/app/controllers/api/customization_scripts_controller.rb
+++ b/app/controllers/api/customization_scripts_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class CustomizationScriptsController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -922,6 +922,22 @@
       :delete:
       - :name: delete
         :identifier: ab_group_delete
+  :customization_scripts:
+    :description: Customization Script
+    :identifier: customization_script
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: CustomizationScript
+    :subcollections:
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: customization_script_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: customization_script_show
   :data_stores:
     :description: Datastores
     :identifier: storage

--- a/config/api.yml
+++ b/config/api.yml
@@ -927,12 +927,15 @@
     :identifier: customization_script
     :options:
     - :collection
-    :verbs: *g
+    :verbs: *gp
     :klass: CustomizationScript
     :subcollections:
     :collection_actions:
       :get:
       - :name: read
+        :identifier: customization_script_show_list
+      :post:
+      - :name: query
         :identifier: customization_script_show_list
     :resource_actions:
       :get:

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -668,6 +668,11 @@ describe "Rest API Collections" do
       test_collection_bulk_query(:physical_servers, api_physical_servers_url, PhysicalServer)
     end
 
+    it 'bulk query CustomizationScripts' do
+      FactoryGirl.create(:customization_script)
+      test_collection_bulk_query(:customization_scripts, api_customization_scripts_url, CustomizationScript)
+    end
+
     it 'bulk query GuestDevices' do
       FactoryGirl.create(:guest_device)
       test_collection_bulk_query(:guest_devices, api_guest_devices_url, GuestDevice)

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -352,6 +352,11 @@ describe "Rest API Collections" do
       test_collection_query(:physical_servers, api_physical_servers_url, PhysicalServer)
     end
 
+    it 'query CustomizationScripts' do
+      FactoryGirl.create(:customization_script)
+      test_collection_query(:customization_scripts, api_customization_scripts_url, CustomizationScript)
+    end
+
     it 'query GuestDevices' do
       FactoryGirl.create(:guest_device)
       test_collection_query(:guest_devices, api_guest_devices_url, GuestDevice)

--- a/spec/requests/customization_script_spec.rb
+++ b/spec/requests/customization_script_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Customization Scripts" do
     end
 
     context "with valid id" do
-      it "returns both id and href" do
+      it "shows all of its properties" do
         config_pattern = FactoryGirl.create(:customization_script)
 
         api_basic_authorize action_identifier(:customization_scripts, :read, :resource_actions, :get)

--- a/spec/requests/customization_script_spec.rb
+++ b/spec/requests/customization_script_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "Customization Scripts" do
+  describe "display a config pattern's details" do
+    context "without an appropriate role" do
+      it "forbids access to read config pattern" do
+        config_pattern = FactoryGirl.create(:customization_script)
+
+        api_basic_authorize
+        get api_customization_script_url(nil, config_pattern)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body["error"]).to include("kind" => "forbidden")
+      end
+    end
+
+    context "with valid id" do
+      it "returns both id and href" do
+        config_pattern = FactoryGirl.create(:customization_script)
+
+        api_basic_authorize action_identifier(:customization_scripts, :read, :resource_actions, :get)
+        get api_customization_script_url(nil, config_pattern)
+
+        expect_single_resource_query("id" => config_pattern.id.to_s, "href" => api_customization_script_url(nil, config_pattern))
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with an invalid id" do
+      it "fails to retrieve config pattern" do
+        api_basic_authorize action_identifier(:customization_scripts, :read, :resource_actions, :get)
+
+        get api_customization_script_url(nil, 999_999)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is able to:
* Add a new operation to retrieving a configuration pattern from customization scripts endpoint