### PR TITLE
Queue chargeback reports of services

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -135,6 +135,14 @@ module Api
       action_result(false, err.to_s)
     end
 
+    def queue_chargeback_report_resource(_type, id, _data)
+      service = resource_search(id, :services, Service)
+      task = service.queue_chargeback_report_generation(:userid => current_user.id)
+      action_result(true, "Queued chargeback report generation for #{service_ident(service)}", :task_id => task.id)
+    rescue StandardError => err
+      action_result(false, "Could not queue chargeback report generation - #{err}")
+    end
+
     private
 
     def validate_resource(data)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2743,6 +2743,8 @@
         :identifier: service_edit
       - :name: add_provider_vms
         :identifier: service_edit
+      - :name: queue_chargeback_report
+        :identifier: service_admin
     :resource_actions:
       :get:
       - :name: read
@@ -2774,6 +2776,8 @@
         :identifier: service_edit
       - :name: add_provider_vms
         :identifier: service_edit
+      - :name: queue_chargeback_report
+        :identifier: service_admin
       :delete:
       - :name: delete
         :identifier: service_delete


### PR DESCRIPTION
This allows queueing of chargeback reports on individual services:
```
POST /api/services/:id
{ "action": "queue_chargeback_report" }
```

or multiple:

```
POST /api/services
{
   "action": "queue_chargeback_report", 
  "resources": [{"id": <svc_id>}, {"href": "api/services/:id"} ]
}
```

@miq-bot add_label enhancement 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1530952