### PR TITLE
Adding support of basic PATCH signatures for API resources

### DIFF
--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -45,6 +45,7 @@ module Api
       #
       def patch_resource(type, id)
         patched_attrs = {}
+        return edit_resource(type, id, @req.json_body) if @req.json_body.kind_of?(Hash)
         @req.json_body.each do |patch_cmd|
           action = patch_cmd["action"]
           path   = patch_cmd["path"]

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -194,6 +194,17 @@ describe "Services API" do
       expect(svc.display).to be_truthy
     end
 
+    it "supports edits of single resource via a standard PATCH" do
+      api_basic_authorize collection_action_identifier(:services, :edit)
+
+      updated_service_attributes = { "name" => "updated svc1", "description" => nil, "display" => true }
+
+      patch(api_service_url(nil, svc), :params => updated_service_attributes)
+
+      expect_single_resource_query("id" => svc.id.to_s)
+      expect(svc.reload.attributes).to include(updated_service_attributes)
+    end
+
     it "supports edits of multiple resources" do
       api_basic_authorize collection_action_identifier(:services, :edit)
 


### PR DESCRIPTION
Adding support of basic PATCH signatures for API resources addition to the attribute action list signature.

    PATCH /api/services/:id
    {
      "name" : "updated_name",
      "description" : "updated description",
      "display" : true
    }

This is equivalent to the current edit POST signature:

    POST /api/services/:id
    {
      "action" : "edit",
      "resource" : {
        "name" : "updated_name",
        "description" : "updated description",
        "display" : true
      }
    }