### PR TITLE
Allow an array to be specified on PATCH for settings

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -117,7 +117,13 @@ module Api
       case @req.method
       when :patch
         raise ForbiddenError, "You are not authorized to edit settings." unless super_admin?
-        resource.add_settings_for_resource(@req.json_body)
+        if @req.json_body.kind_of?(Array)
+          @req.json_body.each do |setting|
+            resource.add_settings_for_resource(setting)
+          end
+        else
+          resource.add_settings_for_resource(@req.json_body)
+        end
       when :delete
         raise ForbiddenError, "You are not authorized to remove settings." unless super_admin?
         resource.remove_settings_path_for_resource(*@req.json_body)


### PR DESCRIPTION
The rest of the API supports an array being passed to PATCH, and this will allow it to remain consistent with what is accepted elsewhere. In addition, it supports multiple updates to the settings at once.

Example:
```
PATCH /api/zone/:id/settings
[
  { "api": {"authentication_timeout": "<new_value>"} },
  { "binary_blob": {"purge_window_size": "<new_value>"} }
]
```
cc: @psav