### PR TITLE
Add settings as a subcollection

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -125,14 +125,22 @@ module Api
         return
       end
 
+      render :json => resource_settings(resource)
+    end
+
+    def settings_query_resource(resource)
+      resource_settings(resource)
+    end
+
+    private
+
+    def resource_settings(resource)
       if super_admin? || current_user.role_allows?(:identifier => 'ops_settings')
-        render :json => whitelist_settings(resource.settings_for_resource.to_hash)
+        whitelist_settings(resource.settings_for_resource.to_hash)
       else
         raise ForbiddenError, "You are not authorized to view settings."
       end
     end
-
-    private
 
     def current_user
       User.current_user

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -121,9 +121,7 @@ module Api
       private
 
       def ignore_http_method_validation?
-        settings_request = @req.subcollection == 'settings' && collection_option?(:settings)
-
-        settings_request || @req.method == :options
+        @req.subcollection == 'settings' || @req.method == :options
       end
 
       #

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -420,6 +420,8 @@ module Api
             :expand_resources => @req.expand?(sc)
           }
           json.set! sc.to_s, collection_to_jbuilder(sc.to_sym, sctype, subresources, copts)
+        elsif subresources.kind_of?(Hash)
+          json.set!(sc, subresources)
         else
           sc_key_id = collection_config.resource_identifier(sctype)
           json.set! sc.to_s do |js|

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -421,7 +421,7 @@ module Api
           }
           json.set! sc.to_s, collection_to_jbuilder(sc.to_sym, sctype, subresources, copts)
         elsif subresources.kind_of?(Hash)
-          json.set!(sc, subresources)
+          json.set!(sc, normalize_hash(sctype, subresources))
         else
           sc_key_id = collection_config.resource_identifier(sctype)
           json.set! sc.to_s do |js|

--- a/config/api.yml
+++ b/config/api.yml
@@ -1975,7 +1975,6 @@
     - :settings
     :options:
     - :collection
-    - :settings
     :verbs: *gp
     :klass: MiqRegion
     :collection_actions:
@@ -2248,7 +2247,6 @@
     - :settings
     :options:
     - :collection
-    - :settings
     :verbs: *g
     :klass: MiqServer
   :service_catalogs:
@@ -3077,7 +3075,6 @@
     :identifier: zone
     :options:
     - :collection
-    - :settings
     :subcollections:
     - :settings
     :verbs: *gp

--- a/config/api.yml
+++ b/config/api.yml
@@ -1971,6 +1971,8 @@
   :regions:
     :description: Regions
     :identifier: region
+    :subcollections:
+    - :settings
     :options:
     - :collection
     - :settings
@@ -2242,6 +2244,8 @@
         :identifier: security_group_show
   :servers:
     :description: EVM Servers
+    :subcollections:
+    - :settings
     :options:
     - :collection
     - :settings
@@ -3073,6 +3077,8 @@
     :identifier: zone
     :options:
     - :collection
+    - :settings
+    :subcollections:
     - :settings
     :verbs: *gp
     :klass: Zone

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
             match(
               "/:c_id/settings",
               :to  => "#{collection_name}#settings",
-              :via => %w[get patch delete],
+              :via => %w(get patch delete),
               :as  => "#{collection_name.to_s.singularize}_settings",
             )
           else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,32 +51,31 @@ Rails.application.routes.draw do
         end
 
         Array(collection.subcollections).each do |subcollection_name|
-          next if subcollection_name == :settings
-          Api::ApiConfig.collections[subcollection_name].verbs.each do |verb|
-            case verb
-            when :get
-              get "/:c_id/#{subcollection_name}", :action => :index, :as => "#{collection_name.to_s.singularize}_#{subcollection_name.to_s.pluralize}"
-              get "/:c_id/#{subcollection_name}/:s_id", :action => :show, :as => "#{collection_name.to_s.singularize}_#{subcollection_name.to_s.singularize}"
-            when :put
-              put "/:c_id/#{subcollection_name}/:s_id", :action => :update
-            when :patch
-              patch "/:c_id/#{subcollection_name}/:s_id", :action => :update
-            when :delete
-              delete "/:c_id/#{subcollection_name}/:s_id", :action => :destroy
-            when :post
-              post "/:c_id/#{subcollection_name}", :action => :create, :constraints => Api::CreateConstraint.new
-              post "/:c_id/#{subcollection_name}(/:s_id)", :action => :update
+          if subcollection_name == :settings
+            match(
+              "/:c_id/settings",
+              :to  => "#{collection_name}#settings",
+              :via => %w[get patch delete],
+              :as  => "#{collection_name.to_s.singularize}_settings",
+            )
+          else
+            Api::ApiConfig.collections[subcollection_name].verbs.each do |verb|
+              case verb
+              when :get
+                get "/:c_id/#{subcollection_name}", :action => :index, :as => "#{collection_name.to_s.singularize}_#{subcollection_name.to_s.pluralize}"
+                get "/:c_id/#{subcollection_name}/:s_id", :action => :show, :as => "#{collection_name.to_s.singularize}_#{subcollection_name.to_s.singularize}"
+              when :put
+                put "/:c_id/#{subcollection_name}/:s_id", :action => :update
+              when :patch
+                patch "/:c_id/#{subcollection_name}/:s_id", :action => :update
+              when :delete
+                delete "/:c_id/#{subcollection_name}/:s_id", :action => :destroy
+              when :post
+                post "/:c_id/#{subcollection_name}", :action => :create, :constraints => Api::CreateConstraint.new
+                post "/:c_id/#{subcollection_name}(/:s_id)", :action => :update
+              end
             end
           end
-        end
-
-        if collection.options.include?(:settings)
-          match(
-            "/:c_id/settings",
-            :to  => "#{collection_name}#settings",
-            :via => %w[get patch delete],
-            :as  => "#{collection_name.to_s.singularize}_settings",
-          )
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
         end
 
         Array(collection.subcollections).each do |subcollection_name|
+          next if subcollection_name == :settings
           Api::ApiConfig.collections[subcollection_name].verbs.each do |verb|
             case verb
             when :get

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -41,107 +41,129 @@ describe "Regions API" do
     )
   end
 
-  describe "/api/regions/:id/settings" do
+  describe "Settings" do
     let(:region_number) { ApplicationRecord.my_region_number + 1 }
     let(:id) { ApplicationRecord.id_in_region(1, region_number) }
     let(:region) { FactoryGirl.create(:miq_region, :id => id, :region => region_number) }
-    let(:zone) { FactoryGirl.create(:zone, :id => id) }
-    let!(:server) { EvmSpecHelper.remote_miq_server(:id => id, :zone => zone) }
-    let(:original_timeout) { region.settings_for_resource[:api][:authentication_timeout] }
-    let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
 
-    it "shows the settings to an authenticated user with the proper role" do
-      api_basic_authorize(:ops_settings)
+    context "/api/regions/:id?expand=settings" do
+      it "expands the settings subcollection" do
+        api_basic_authorize(action_identifier(:regions, :read, :resource_actions, :get), :ops_settings)
 
-      get(api_region_settings_url(nil, region))
+        get(api_region_url(nil, region), :params => {:expand => 'settings'})
 
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
-      api_basic_authorize
-
-      get(api_region_settings_url(nil, region))
-
-      expect(response).to have_http_status(:forbidden)
-    end
-
-    it "does not allow an unauthenticated user to view the settings" do
-      get(api_region_settings_url(nil, region))
-
-      expect(response).to have_http_status(:unauthorized)
-    end
-
-    it "permits updates to settings for an authenticated super-admin user" do
-      api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
-
-      expect {
-        patch(api_region_settings_url(nil, region), :params => {:api => {:authentication_timeout => "1337.minutes"}})
-      }.to change { region.settings_for_resource[:api][:authentication_timeout] }.from(original_timeout).to("1337.minutes")
-
-      expect(response.parsed_body).to include("api" => a_hash_including("authentication_timeout" => "1337.minutes"))
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "does not allow an authenticated non-super-admin user to update settings" do
-      api_basic_authorize
-
-      expect {
-        patch(api_region_settings_url(nil, region), :params => {:api => {:authentication_timeout => "10.minutes"}})
-      }.not_to change { region.settings_for_resource[:api][:authentication_timeout] }
-
-      expect(response).to have_http_status(:forbidden)
-    end
-
-    it "does not allow an unauthenticated user to update the settings" do
-      expect {
-        patch(api_region_settings_url(nil, region), :params => {:api => {:authentication_timeout => "10.minutes"}})
-      }.not_to change { region.settings_for_resource[:api][:authentication_timeout] }
-
-      expect(response).to have_http_status(:unauthorized)
-    end
-
-    context "with an existing settings change" do
-      before do
-        region.add_settings_for_resource("api" => {"authentication_timeout" => "7331.minutes"})
+        expect(response.parsed_body).to include('settings' => a_kind_of(Hash))
+        expect(response).to have_http_status(:ok)
       end
 
-      it "allows an authenticated super-admin user to delete settings" do
-        api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
-        expect(region.settings_for_resource["api"]["authentication_timeout"]).to eq("7331.minutes")
+      it "does not expand settings without an appropriate role" do
+        api_basic_authorize(action_identifier(:regions, :read, :resource_actions, :get))
 
-        expect {
-          delete(
-            api_region_settings_url(nil, region),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
-          )
-        }.to change { region.settings_for_resource["api"]["authentication_timeout"] }.from("7331.minutes").to("30.seconds")
+        get(api_region_url(nil, region), :params => {:expand => 'settings'})
 
-        expect(response).to have_http_status(:no_content)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "/api/regions/:id/settings" do
+      let(:zone) { FactoryGirl.create(:zone, :id => id) }
+      let!(:server) { EvmSpecHelper.remote_miq_server(:id => id, :zone => zone) }
+      let(:original_timeout) { region.settings_for_resource[:api][:authentication_timeout] }
+      let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
+
+      it "shows the settings to an authenticated user with the proper role" do
+        api_basic_authorize(:ops_settings)
+
+        get(api_region_settings_url(nil, region))
+
+        expect(response).to have_http_status(:ok)
       end
 
-      it "does not allow an authenticated non-super-admin user to delete settings" do
+      it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
         api_basic_authorize
 
-        expect {
-          delete(
-            api_region_settings_url(nil, region),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
-          )
-        }.not_to change { region.settings_for_resource["api"]["authentication_timeout"] }
+        get(api_region_settings_url(nil, region))
 
         expect(response).to have_http_status(:forbidden)
       end
 
-      it "does not allow an unauthenticated user to delete settings`" do
-        expect {
-          delete(
-            api_region_settings_url(nil, region),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
-          )
-        }.not_to change { region.settings_for_resource["api"]["authentication_timeout"] }
+      it "does not allow an unauthenticated user to view the settings" do
+        get(api_region_settings_url(nil, region))
 
         expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "permits updates to settings for an authenticated super-admin user" do
+        api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
+
+        expect {
+          patch(api_region_settings_url(nil, region), :params => {:api => {:authentication_timeout => "1337.minutes"}})
+        }.to change { region.settings_for_resource[:api][:authentication_timeout] }.from(original_timeout).to("1337.minutes")
+
+        expect(response.parsed_body).to include("api" => a_hash_including("authentication_timeout" => "1337.minutes"))
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not allow an authenticated non-super-admin user to update settings" do
+        api_basic_authorize
+
+        expect {
+          patch(api_region_settings_url(nil, region), :params => {:api => {:authentication_timeout => "10.minutes"}})
+        }.not_to change { region.settings_for_resource[:api][:authentication_timeout] }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not allow an unauthenticated user to update the settings" do
+        expect {
+          patch(api_region_settings_url(nil, region), :params => {:api => {:authentication_timeout => "10.minutes"}})
+        }.not_to change { region.settings_for_resource[:api][:authentication_timeout] }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      context "with an existing settings change" do
+        before do
+          region.add_settings_for_resource("api" => {"authentication_timeout" => "7331.minutes"})
+        end
+
+        it "allows an authenticated super-admin user to delete settings" do
+          api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
+          expect(region.settings_for_resource["api"]["authentication_timeout"]).to eq("7331.minutes")
+
+          expect {
+            delete(
+              api_region_settings_url(nil, region),
+              :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            )
+          }.to change { region.settings_for_resource["api"]["authentication_timeout"] }.from("7331.minutes").to("30.seconds")
+
+          expect(response).to have_http_status(:no_content)
+        end
+
+        it "does not allow an authenticated non-super-admin user to delete settings" do
+          api_basic_authorize
+
+          expect {
+            delete(
+              api_region_settings_url(nil, region),
+              :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            )
+          }.not_to change { region.settings_for_resource["api"]["authentication_timeout"] }
+
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "does not allow an unauthenticated user to delete settings`" do
+          expect {
+            delete(
+              api_region_settings_url(nil, region),
+              :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            )
+          }.not_to change { region.settings_for_resource["api"]["authentication_timeout"] }
+
+          expect(response).to have_http_status(:unauthorized)
+        end
       end
     end
   end

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -49,10 +49,13 @@ describe "Regions API" do
     context "/api/regions/:id?expand=settings" do
       it "expands the settings subcollection" do
         api_basic_authorize(action_identifier(:regions, :read, :resource_actions, :get), :ops_settings)
+        allow(Vmdb::Settings).to receive(:for_resource).and_return('authentications' => { 'bind_pwd' => 'bad_val'})
+        allow(User).to receive(:current_user).and_return(@user)
+        allow(@user).to receive(:super_admin_user?).and_return(true)
 
         get(api_region_url(nil, region), :params => {:expand => 'settings'})
 
-        expect(response.parsed_body).to include('settings' => a_kind_of(Hash))
+        expect(response.parsed_body).to include('settings' => {'authentications' => {}})
         expect(response).to have_http_status(:ok)
       end
 

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -1,6 +1,26 @@
 RSpec.describe "Servers" do
+  let(:server) { FactoryGirl.create(:miq_server) }
+
+  describe "/api/servers/:id?expand=settings" do
+    it "expands the settings subcollection" do
+      api_basic_authorize(:ops_settings)
+
+      get(api_server_url(nil, server), :params => {:expand => 'settings'})
+
+      expect(response.parsed_body).to include('settings' => a_kind_of(Hash))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not expand settings without an appropriate role" do
+      api_basic_authorize
+
+      get(api_server_url(nil, server), :params => {:expand => 'settings'})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe "/api/servers/:id/settings" do
-    let(:server) { FactoryGirl.create(:miq_server) }
     let(:original_timeout) { server.settings_for_resource[:api][:authentication_timeout] }
     let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
 

--- a/spec/requests/zones_spec.rb
+++ b/spec/requests/zones_spec.rb
@@ -1,6 +1,26 @@
 RSpec.describe "Zones" do
+  let(:zone) { FactoryGirl.create(:zone) }
+
+  describe "/api/zones/:id?expand=settings" do
+    it "expands the settings subcollection" do
+      api_basic_authorize(action_identifier(:zones, :read, :resource_actions, :get), :ops_settings)
+
+      get(api_zone_url(nil, zone), :params => {:expand => 'settings'})
+
+      expect(response.parsed_body).to include('settings' => a_kind_of(Hash))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not expand settings without an appropriate role" do
+      api_basic_authorize(action_identifier(:zones, :read, :resource_actions, :get))
+
+      get(api_zone_url(nil, zone), :params => {:expand => 'settings'})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe "/api/zones/:id/settings" do
-    let(:zone) { FactoryGirl.create(:zone) }
     let(:original_timeout) { zone.settings_for_resource[:api][:authentication_timeout] }
     let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
 
@@ -99,5 +119,4 @@ RSpec.describe "Zones" do
       end
     end
   end
-
 end


### PR DESCRIPTION
This allows settings to be returned as a subcollection via `?expand=settings`
