### PR TITLE
Delete of search filters

### DIFF
--- a/app/controllers/api/search_filters_controller.rb
+++ b/app/controllers/api/search_filters_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class SearchFiltersController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2236,6 +2236,33 @@
       :get:
       - :name: read
         :identifier: miq_report_view
+  :search_filters:
+    :description: Filters
+    :verbs: *gpd
+    :klass: MiqSearch
+    :identifying_attrs: description
+    :options:
+    - :collection
+    - :show
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: my_settings_default_filters
+      :post:
+      - :name: query
+        :identifier: my_settings_default_filters
+      - :name: delete
+        :identifier: my_settings_default_filters
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: my_settings_default_filters
+      :post:
+      - :name: delete
+        :identifier: my_settings_default_filters
+      :delete:
+      - :name: delete
+        :identifier: my_settings_default_filters
   :security_groups:
     :description: Security Groups
     :identifier: security_group

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -381,6 +381,11 @@ describe "Rest API Collections" do
       FactoryGirl.create(:orchestration_stack)
       test_collection_query(:orchestration_stacks, api_orchestration_stacks_url, OrchestrationStack)
     end
+
+    it 'query search MiqSearch' do
+      FactoryGirl.create(:miq_search)
+      test_collection_query(:search_filters, api_search_filters_url, MiqSearch)
+    end
   end
 
   context "Collections Bulk Queries" do
@@ -711,6 +716,11 @@ describe "Rest API Collections" do
     it 'bulk query orchestration stacks' do
       FactoryGirl.create(:orchestration_stack)
       test_collection_bulk_query(:orchestration_stacks, api_orchestration_stacks_url, OrchestrationStack)
+    end
+
+    it 'bulk query search filters' do
+      FactoryGirl.create(:miq_search)
+      test_collection_bulk_query(:search_filters, api_search_filters_url, MiqSearch)
     end
   end
 end

--- a/spec/requests/search_filters_spec.rb
+++ b/spec/requests/search_filters_spec.rb
@@ -1,0 +1,84 @@
+describe 'Search Filters' do
+  let(:filter) { FactoryGirl.create(:miq_search) }
+
+  describe 'GET /api/search_filters/:id' do
+    it 'cannot get a search filter without an appropriate role' do
+      api_basic_authorize
+
+      get(api_search_filter_url(nil, filter))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can retrieve a search filter with an appropriate role' do
+      api_basic_authorize(action_identifier(:search_filters, :read, :resource_actions, :get))
+
+      get(api_search_filter_url(nil, filter))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('id' => filter.id.to_s)
+    end
+  end
+
+  describe 'POST /api/search_filters' do
+    it 'cannot delete a filter without an appropriate role' do
+      api_basic_authorize
+
+      post(api_search_filters_url, :params => { :action => :delete, :resources => [{:description => filter.description}]})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can delete a filter by description, id, or href with an appropriate role' do
+      filter2, filter3 = FactoryGirl.create_list(:miq_search, 2)
+      api_basic_authorize(collection_action_identifier(:search_filters, :delete, :post))
+
+      post(api_search_filters_url, :params => {
+             :action    => :delete,
+             :resources => [
+               {:description => filter.description},
+               {:id => filter2.id},
+               {:href => api_search_filter_url(nil, filter3)}
+             ]
+           })
+
+      expected = {
+        'results' => [
+          a_hash_including('href' => api_search_filter_url(nil, filter)),
+          a_hash_including('href' => api_search_filter_url(nil, filter2)),
+          a_hash_including('href' => api_search_filter_url(nil, filter3))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'POST /api/search_filters/:id' do
+    it 'cannot delete a filter without an appropriate role' do
+      api_basic_authorize
+
+      post(api_search_filter_url(nil, filter), :params => {:action => 'delete'})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can delete a filter by id with an appropriate role' do
+      api_basic_authorize(action_identifier(:search_filters, :delete, :resource_actions, :post))
+
+      post(api_search_filter_url(nil, filter), :params => {:action => 'delete'})
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'DELETE /api/search_filters/:id' do
+    it 'can delete a filter by id with an appropriate role' do
+      api_basic_authorize(action_identifier(:search_filters, :delete, :resource_actions, :delete))
+
+      delete(api_search_filter_url(nil, filter))
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1530948

Allows deletes by id, href or description
```
POST /api/search_filters
{
  "action": "delete",
  "resources": [
    { "id": ":id" },
    { "href": ":href" },
    { "description": ":description"}
  ]
}
```
or resource delete by ID 
```
POST /api/search_filters/:id
{ "action": "delete" } 
```

or delete via `DELETE`
```
DELETE /api/search_filters/:id
```

cc: @psav