### PR TITLE
Updated container images scan action to fix the action return signature

### DIFF
--- a/app/controllers/api/container_images_controller.rb
+++ b/app/controllers/api/container_images_controller.rb
@@ -1,17 +1,16 @@
 module Api
   class ContainerImagesController < BaseController
     def scan_resource(type, image_id, _payload)
-      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless image_id
-      api_action(type, image_id, :skip_href => true) do |klass|
+      raise BadRequestError, "Must specify an id for scanning a #{type} resource" unless image_id
+      api_action(type, image_id) do |klass|
         image = resource_search(image_id, type, klass)
         begin
-          task_id = image.scan
-          desc = if task_id.present?
-                   "#{container_image_ident(image)} scanning"
-                 else
-                   "#{container_image_ident(image)} failed to start scanning"
-                 end
-          action_result(task_id.present?, desc).merge(:task_id => task_id)
+          task = image.scan
+          if task.present?
+            action_result(true, "#{container_image_ident(image)} scanning", :task_id => task.id)
+          else
+            action_result(false, "#{container_image_ident(image)} failed to start scanning")
+          end
         rescue => err
           action_result(false, err.to_s)
         end

--- a/spec/requests/container_images_spec.rb
+++ b/spec/requests/container_images_spec.rb
@@ -46,7 +46,7 @@ describe "Container Images API" do
     end
   end
 
-  context 'POST /api/container_images/scan' do
+  context 'POST /api/container_images with action scan' do
     let(:provider) { FactoryGirl.create(:ems_kubernetes) }
     let(:container_image) { FactoryGirl.create(:container_image, :ext_management_system => provider) }
     let(:invalid_image_url) { api_container_image_url(nil, container_image.id + 1) }
@@ -85,9 +85,11 @@ describe "Container Images API" do
       post valid_image_url, :params => { :action => "scan" }
 
       expected = {
-        "success" => true,
-        "message" => "ContainerImage id:#{container_image.id} name:'#{container_image.name}' scanning",
-        "task_id" => hash_including("target_id" => container_image.id.to_s)
+        "success"   => true,
+        "message"   => "ContainerImage id:#{container_image.id} name:'#{container_image.name}' scanning",
+        "href"      => api_container_image_url(nil, container_image),
+        "task_id"   => anything,
+        "task_href" => a_string_matching(api_tasks_url)
       }
       expect(response.parsed_body).to include(expected)
     end


### PR DESCRIPTION
Updated container images scan action to fix the action return signature being returned was a hash of the task object, this is not consistent with the action result signature where we have the task_id and task_href of the task just created with the href of the targeted resource.

This is a follow-up to https://github.com/ManageIQ/manageiq-api/pull/245