### PR TITLE
Fix error message for required params on metric rollups subcollection

### DIFF
--- a/lib/services/api/metric_rollups_service.rb
+++ b/lib/services/api/metric_rollups_service.rb
@@ -1,11 +1,12 @@
 module Api
   class MetricRollupsService
     REQUIRED_PARAMS = %w(resource_type capture_interval start_date).freeze
+    QUERY_PARAMS = %w(resource_ids).freeze
 
     attr_reader :params
 
     def initialize(params)
-      @params = params
+      @params = params.slice(*(REQUIRED_PARAMS + QUERY_PARAMS))
       validate_required_params
       validate_capture_interval
     end
@@ -20,9 +21,8 @@ module Api
     private
 
     def validate_required_params
-      REQUIRED_PARAMS.each do |key|
-        raise BadRequestError, "Must specify #{REQUIRED_PARAMS.join(', ')}" unless params[key.to_sym]
-      end
+      not_specified = REQUIRED_PARAMS - params.keys
+      raise BadRequestError, "Must specify #{not_specified.join(', ')}" unless not_specified.empty?
     end
 
     def validate_capture_interval

--- a/spec/lib/services/api/metric_rollups_service_spec.rb
+++ b/spec/lib/services/api/metric_rollups_service_spec.rb
@@ -8,9 +8,9 @@ describe Api::MetricRollupsService do
 
     it 'validates the capture interval' do
       expect do
-        described_class.new(:resource_type    => 'Service',
-                            :start_date       => Time.zone.today.to_s,
-                            :capture_interval => 'bad_interval')
+        described_class.new('resource_type'    => 'Service',
+                            'start_date'       => Time.zone.today.to_s,
+                            'capture_interval' => 'bad_interval')
       end.to raise_error(Api::BadRequestError, a_string_including('Capture interval must be one of '))
     end
   end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1055,6 +1055,20 @@ describe "Services API" do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'does not require resource_type for a subcollection' do
+      api_basic_authorize(subcollection_action_identifier(:services, :metric_rollups, :read, :get))
+
+      get(url)
+
+      expected = {
+        'error' => a_hash_including(
+          'message' => 'Must specify capture_interval, start_date'
+        )
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   describe 'add_provider_vms_resource' do


### PR DESCRIPTION
resource_type is set by the controller when the request is made based off of the collection that has been specified. Currently the error message informs the user that all three of `resource_type`, `capture_interval`, and `start_date` are required. This returns a more appropriate error message based off of the missing parameters.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540254