### PR TITLE
Implementing change password action for providers endpoint

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1920,6 +1920,8 @@
         - ems_infra_show_list
         - ems_block_storage_show_list
       :post:
+      - :name: change_password
+        :identifier: ems_infra_change_password
       - :name: query
         :identifier:
         - ems_infra_show_list
@@ -1943,6 +1945,8 @@
         - ems_infra_show
         - ems_block_storage_show
       :post:
+      - :name: change_password
+        :identifier: ems_infra_change_password
       - :name: edit
         :identifier: ems_infra_edit
       - :name: refresh


### PR DESCRIPTION
**This PR adds:**
* `change_password` action for `/providers` endpoint

**This PR depends on:**
~https://github.com/ManageIQ/manageiq/pull/16895~ - Merged
~https://github.com/ManageIQ/manageiq-providers-lenovo/pull/130~ - Merged
~https://github.com/ManageIQ/manageiq/pull/16883~ - Merged
~https://github.com/lenovo/xclarity_client/pull/81~ - Merged
~https://github.com/ManageIQ/manageiq/pull/17323~ - Merged