### PR TITLE
Return product features for all of a user's groups on the API entrypoint

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -32,19 +32,17 @@ module Api
     end
 
     def auth_identity
-      user  = User.current_user
-      group = user.current_group
       {
-        :userid     => user.userid,
-        :name       => user.name,
-        :user_href  => "#{@req.api_prefix}/users/#{user.id}",
-        :group      => group.description,
-        :group_href => "#{@req.api_prefix}/groups/#{group.id}",
-        :role       => group.miq_user_role_name,
-        :role_href  => "#{@req.api_prefix}/roles/#{group.miq_user_role.id}",
-        :tenant     => group.tenant.name,
-        :groups     => user.miq_groups.pluck(:description),
-        :miq_groups => normalize_array(user.miq_groups, :groups)
+        :userid     => current_user.userid,
+        :name       => current_user.name,
+        :user_href  => "#{@req.api_prefix}/users/#{current_user.id}",
+        :group      => current_group.description,
+        :group_href => "#{@req.api_prefix}/groups/#{current_group.id}",
+        :role       => current_group.miq_user_role_name,
+        :role_href  => "#{@req.api_prefix}/roles/#{current_group.miq_user_role.id}",
+        :tenant     => current_group.tenant.name,
+        :groups     => current_user.miq_groups.pluck(:description),
+        :miq_groups => normalize_array(miq_groups, :groups)
       }
     end
 
@@ -80,11 +78,19 @@ module Api
       }
     end
 
+    def miq_groups
+      current_user.miq_groups.collect do |group|
+        group.attributes.merge(:sui_product_features => group.sui_product_features)
+      end
+    end
+
+    def current_group
+      @group ||= current_user.current_group
+    end
+
     def auth_authorization
-      user  = User.current_user
-      group = user.current_group
       {
-        :product_features => product_features(group.miq_user_role)
+        :product_features => product_features(current_group.miq_user_role)
       }
     end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -135,7 +135,7 @@ module Api
     private
 
     def current_user
-      User.current_user
+      @current_user ||= User.current_user
     end
 
     def super_admin?

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -159,7 +159,11 @@ describe "Authentication API" do
       get api_entrypoint_url, :params => { :attributes => "authorization" }
 
       expect(response).to have_http_status(:ok)
-      expected = {"authorization" => hash_including("product_features")}
+
+      expected = {"authorization" => hash_including("product_features"),
+                  "identity"      => a_hash_including("miq_groups" => a_collection_including(
+                    hash_including("sui_product_features" => a_kind_of(Hash))
+                  ))}
       ENTRYPOINT_KEYS.each { |k| expected[k] = anything }
       expect(response.parsed_body).to include(expected)
     end


### PR DESCRIPTION
This is needed so that the users can know what features they will have before changing groups. When they are a part of multiple groups, the current way of getting groups `/api/groups?attributes=miq_product_features` may not be available to them based off of their current groups permissions. This will allow them to see them.

It also refactors a bit as was necessary to use memoization and not have to create the product features for the current group multiple times.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1540733

cc: @AllenBW 
