### PR TITLE
Deep symbolize keys when parsing options

### DIFF
--- a/lib/services/api/request_parser.rb
+++ b/lib/services/api/request_parser.rb
@@ -10,7 +10,7 @@ module Api
 
     def self.parse_options(data)
       raise BadRequestError, "Request is missing options" if data["options"].blank?
-      data["options"].symbolize_keys
+      data["options"].deep_symbolize_keys
     end
 
     def self.parse_auto_approve(data)

--- a/spec/lib/services/api/request_parser_spec.rb
+++ b/spec/lib/services/api/request_parser_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Api::RequestParser do
       expect { described_class.parse_options({}) }.to raise_error(Api::BadRequestError, /missing options/)
     end
 
-    it "symbolizes keys" do
-      actual = described_class.parse_options("options" => {"foo" => "bar"})
-      expected = {:foo => "bar"}
+    it "deep symbolizes keys" do
+      actual = described_class.parse_options("options" => {"foo" => "bar", "foobar" => {"bazz" => "foo"}})
+      expected = {:foo => "bar", :foobar => {:bazz => "foo"}}
       expect(actual).to eq(expected)
     end
   end


### PR DESCRIPTION
When parsing the options for creating / updating a request, only `:symbolize_keys` is being called. However, all of the keys must be symbolized via `:deep_symbolize_keys`

Related: https://github.com/ManageIQ/manageiq/pull/16891
Fixes https://github.com/ManageIQ/manageiq-api/issues/260

cc: @lfu @evertmulder

