### PR TITLE
Transformation Mappings Read and Create

### DIFF
--- a/app/controllers/api/transformation_mappings_controller.rb
+++ b/app/controllers/api/transformation_mappings_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  class TransformationMappingsController < BaseController
+    def create_resource(_type, _id, data = {})
+      raise "Must specify transformation_mapping_items" unless data["transformation_mapping_items"]
+      TransformationMapping.new(data.except("transformation_mapping_items")).tap do |mapping|
+        mapping.transformation_mapping_items = create_mapping_items(data["transformation_mapping_items"])
+        mapping.save!
+      end
+    rescue StandardError => err
+      raise BadRequestError, "Could not create Transformation Mapping - #{err}"
+    end
+
+    private
+
+    def create_mapping_items(items)
+      items.collect do |item|
+        raise "Must specify source and destination hrefs" unless item["source"] && item["destination"]
+        TransformationMappingItem.new(:source => fetch_mapping_resource(item["source"]), :destination => fetch_mapping_resource(item["destination"]))
+      end
+    end
+
+    def fetch_mapping_resource(href)
+      resource_href = Api::Href.new(href)
+      raise "Invalid source or destination type #{resource_href.subject}" unless collection_config.collection?(resource_href.subject)
+      resource_search(resource_href.subject_id, resource_href.subject, collection_class(resource_href.subject.to_sym))
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2903,6 +2903,24 @@
       :delete:
       - :name: delete
         :identifier: rbac_tenant_manage_quotas
+  :transformation_mappings:
+    :description: Transformation Mappings
+    :identifier: transformation_mapping
+    :verbs: *gp
+    :klass: TransformationMapping
+    :options:
+    - :collection
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: transformation_mapping_show_list
+      :post:
+      - :name: create
+        :identifier: transformation_mapping_new
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: transformation_mapping_show
   :users:
     :description: Users
     :identifier: rbac_user

--- a/spec/requests/transformation_mappings_spec.rb
+++ b/spec/requests/transformation_mappings_spec.rb
@@ -1,0 +1,146 @@
+describe "Transformation Mappings" do
+  let(:transformation_mapping) { FactoryGirl.create(:transformation_mapping) }
+
+  describe "GET /api/transformation_mappings" do
+    context "with an appropriate role" do
+      it "retrieves transformation mappings with an appropriate role" do
+        api_basic_authorize(collection_action_identifier(:transformation_mappings, :read, :get))
+
+        get(api_transformation_mappings_url)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "without an appropriate role" do
+      it "is forbidden" do
+        api_basic_authorize
+
+        get(api_transformation_mappings_url)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "GET /api/transformation_mappings/:id" do
+    context "with an appropriate role" do
+      it "returns the transformation mapping" do
+        api_basic_authorize(action_identifier(:transformation_mappings, :read, :resource_actions, :get))
+
+        get(api_transformation_mapping_url(nil, transformation_mapping))
+
+        expect(response.parsed_body).to include('id' => transformation_mapping.id.to_s)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "without an appropriate role" do
+      it "is forbidden" do
+        api_basic_authorize
+
+        get(api_transformation_mapping_url(nil, transformation_mapping))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST /api/transformation_mappings" do
+    let(:cluster) { FactoryGirl.create(:ems_cluster) }
+    let(:cluster2) { FactoryGirl.create(:ems_cluster) }
+
+    context "with an appropriate role" do
+      it "can create a new transformation mapping" do
+        api_basic_authorize(collection_action_identifier(:transformation_mappings, :create))
+
+        new_mapping = {"name"                         => "new transformation mapping",
+                       "transformation_mapping_items" => [
+                         { "source" => api_cluster_url(nil, cluster), "destination" => api_cluster_url(nil, cluster2) }
+                       ]}
+        post(api_transformation_mappings_url, :params => new_mapping)
+
+        expected = {
+          "results" => [a_hash_including("href" => a_string_including(api_transformation_mappings_url),
+                                         "name" => "new transformation mapping")]
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will raise a bad request if mappings are not specified" do
+        api_basic_authorize(collection_action_identifier(:transformation_mappings, :create))
+
+        new_mapping = {"name" => "new transformation mapping"}
+        post(api_transformation_mappings_url, :params => new_mapping)
+
+        expected = {
+          "error" => a_hash_including(
+            "kind"    => "bad_request",
+            "message" => /Must specify transformation_mapping_items/
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it "will raise a bad request if source and destination are not specified for mappings" do
+        api_basic_authorize(collection_action_identifier(:transformation_mappings, :create))
+
+        new_mapping = {"name" => "new transformation mapping", "transformation_mapping_items" => [{}]}
+        post(api_transformation_mappings_url, :params => new_mapping)
+
+        expected = {
+          "error" => a_hash_including(
+            "kind"    => "bad_request",
+            "message" => /Must specify source and destination hrefs/
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it "will raise a bad request for a bad source or destination" do
+        api_basic_authorize(collection_action_identifier(:transformation_mappings, :create))
+
+        new_mapping = {"name" => "new transformation mapping", "transformation_mapping_items" => [{ "source" => "/api/bogus/:id", "destination" => api_cluster_url(nil, cluster2) }]}
+        post(api_transformation_mappings_url, :params => new_mapping)
+
+        expected = {
+          "error" => a_hash_including(
+            "kind"    => "bad_request",
+            "message" => /Invalid source or destination type bogus/
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it "will raise a bad request for a nonexistent source or destination" do
+        api_basic_authorize(collection_action_identifier(:transformation_mappings, :create))
+
+        new_mapping = {"name" => "new transformation mapping", "transformation_mapping_items" => [{ "source" => api_cluster_url(nil, cluster2), "destination" => api_cluster_url(nil, 999_999) }]}
+        post(api_transformation_mappings_url, :params => new_mapping)
+
+        expected = {
+          "error" => a_hash_including(
+            "kind"    => "bad_request",
+            "message" => /Couldn't find EmsCluster with 'id'=999999/
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "without an appropriate role" do
+      it "is forbidden" do
+        api_basic_authorize
+
+        get(api_transformation_mapping_url(nil, transformation_mapping))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds reads and creates of Transformation Mappings to the API:

Sample create:
```
POST /api/transformation_mappings
{"name": "new transformation mapping",
 "description": "clusters to clusters",
 "state": "draft",
 "transformation_mapping_items": [
     { "source": "/api/clusters/10", "destination": "/api/clusters/1" },
     { "source": "/api/clusters/11", "destination": "/api/clusters/1" },
     { "source": "/api/date_stores/12", "destination": "/api/data_stores/13" },
     { "source": "/api/data_stores/2", "destination": "/api/data_stores/13" },
     { "source": "/api/lans/2", "destination": "/api/lans/13" } 
     { "source": "/api/lans/3", "destination": "/api/lans/13" } 
   ]
}
```

Create will accept `transformation_mapping_items` as part of the request with href references to the source and destination. 

A call to
```
GET /api/transformation_mappings
```
Will return all of the transformation mappings.

```
GET /api/transformation_mappings/:id
```
Will return a particular transformation mapping.

Transformation Mapping Items may be retrieved via:
```
GET /api/transformation_mappings/:id?attributes=transformation_mapping_items
```
which will return
```
{  
   "href":"http://localhost:3000/api/transformation_mappings/10000000000001",
   "id":"10000000000001",
   "name":"Cluster and Datastores",
   "description":"Cluster and Datastores Mapping",
   "comments":null,
   "state":"draft",
   "options":{  

   },
   "tenant_id":null,
   "created_at":"2018-02-07T16:02:39Z",
   "updated_at":"2018-02-07T16:02:39Z",
   "transformation_mapping_items":[  
      {  
         "id":"10000000000001",
         "source_id":"10000000000002",
         "source_type":"EmsCluster",
         "destination_id":"10000000000005",
         "destination_type":"EmsCluster",
         "transformation_mapping_id":"10000000000001",
         "options":{  

         },
         "created_at":"2018-02-07T16:01:44Z",
         "updated_at":"2018-02-07T16:02:39Z"
      },
      {  
         "id":"10000000000002",
         "source_id":"10000000000001",
         "source_type":"Storage",
         "destination_id":"10000000000018",
         "destination_type":"Storage",
         "transformation_mapping_id":"10000000000001",
         "options":{  

         },
         "created_at":"2018-02-07T16:05:04Z",
         "updated_at":"2018-02-07T16:05:04Z"
      }
   ]
}
```

Dependent upon:
https://github.com/ManageIQ/manageiq/pull/16787
https://github.com/ManageIQ/manageiq/pull/16947
~~and needs a factory~~

cc: @bzwei @gmcculloug 
