### PR TITLE
Allow ordering of service templates resource

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -1,0 +1,23 @@
+module Api
+  module Mixins
+    module ServiceTemplates
+      def order_service_template(id, data)
+        service_template = resource_search(id, :service_templates, ServiceTemplate)
+        raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered" unless service_template.orderable?
+        workflow = service_template.provision_workflow(User.current_user, data || {})
+        request_result = workflow.submit_request
+        errors = request_result[:errors]
+        if errors.present?
+          raise BadRequestError, "Failed to order #{service_template_ident(service_template)} - #{errors.join(", ")}"
+        end
+        request_result[:request]
+      end
+
+      private
+
+      def service_template_ident(st)
+        "Service Template id:#{st.id} name:'#{st.name}'"
+      end
+    end
+  end
+end

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -5,6 +5,7 @@ module Api
     include Subcollections::ResourceActions
     include Subcollections::ServiceRequests
     include Api::Mixins::Pictures
+    include Api::Mixins::ServiceTemplates
 
     before_action :set_additional_attributes, :only => [:show]
 
@@ -22,6 +23,10 @@ module Api
       catalog_item.update_catalog_item(data.deep_symbolize_keys, User.current_user.userid)
     rescue => err
       raise BadRequestError, "Could not update Service Template - #{err}"
+    end
+
+    def order_resource(_type, id, data)
+      order_service_template(id, data)
     end
 
     private

--- a/app/controllers/api/subcollections/service_templates.rb
+++ b/app/controllers/api/subcollections/service_templates.rb
@@ -1,6 +1,8 @@
 module Api
   module Subcollections
     module ServiceTemplates
+      include Api::Mixins::ServiceTemplates
+
       def service_templates_query_resource(object)
         klass = collection_class(:service_templates)
         object ? klass.where(:service_template_catalog_id => object.id) : {}
@@ -26,16 +28,8 @@ module Api
         end
       end
 
-      def service_templates_order_resource(_object, type, id = nil, data = nil)
-        klass = collection_class(:service_templates)
-        service_template = resource_search(id, type, klass)
-        workflow = service_template.provision_workflow(User.current_user, data || {})
-        request_result = workflow.submit_request
-        errors = request_result[:errors]
-        if errors.present?
-          raise BadRequestError, "Failed to order #{service_template_ident(service_template)} - #{errors.join(", ")}"
-        end
-        request_result[:request]
+      def service_templates_order_resource(_object, _type, id = nil, data = nil)
+        order_service_template(id, data)
       end
 
       def service_templates_refresh_dialog_fields_resource(object, type, id = nil, data = nil)
@@ -53,10 +47,6 @@ module Api
       end
 
       private
-
-      def service_template_ident(st)
-        "Service Template id:#{st.id} name:'#{st.name}'"
-      end
 
       def service_template_subcollection_action(type, id)
         klass = collection_class(:service_templates)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2487,6 +2487,8 @@
         :identifier: catalogitem_delete
       - :name: create
         :identifier: atomic_catalogitem_new
+      - :name: order
+        :identifier: svc_catalog_provision
     :subcollection_actions:
       :post:
       - :name: edit
@@ -2510,6 +2512,10 @@
         :identifier: catalogitem_edit
       - :name: delete
         :identifier: catalogitem_delete
+      - :name: order
+        :identifier: svc_catalog_provision
+        :options:
+        - :validate_action
       :delete:
       - :name: delete
         :identifier: catalogitem_delete


### PR DESCRIPTION
For the new ServiceTemplateTransformationPlan, ordering must happen directly on the service template. Currently, the API only allows ordering through a service catalog. It was discussed with @bzwei that ordering can be allowed in general for a service template, and no special case is needed for the new `ServiceTemplateTransformationPlan` since there is validation around whether a service template is "orderable".

Sample order without required fields:
```
POST /api/service_templates/:id
{
   "action": "order"
}
```

Sample order with required fields:
```
POST /api/service_templates/:id
{
   "action": "order",
   "required_field_1": "filled in field"
}
```