### PR TITLE
Ensure request task options are keyed with symbols

### DIFF
--- a/app/controllers/api/subcollections/request_tasks.rb
+++ b/app/controllers/api/subcollections/request_tasks.rb
@@ -9,7 +9,10 @@ module Api
       def request_tasks_edit_resource(_object, type, id = nil, data = {})
         raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
         request_task = resource_search(id, type, collection_class(:request_tasks))
-        request_task.update_attributes(:options => request_task.options.merge(data['options'] || {}))
+        if data.key?("options")
+          updated_options = request_task.options.merge(Hash(data.fetch("options")).deep_symbolize_keys)
+          request_task.update!(:options => updated_options)
+        end
         request_task
       end
     end

--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -290,6 +290,7 @@ describe "Automation Requests API" do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['options']).to match(hash_including(options))
+      expect(task.reload.options.keys).to all(be_kind_of(Symbol))
     end
   end
 end

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -480,6 +480,7 @@ describe "Provision Requests API" do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['options']).to match(hash_including(options))
+      expect(task.reload.options.keys).to all(be_kind_of(Symbol))
     end
   end
 end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -517,6 +517,7 @@ RSpec.describe "Requests API" do
       post(tasks_url, :params => params)
 
       expect(response).to have_http_status(:ok)
+      expect(task.reload.options.keys).to all(be_kind_of(Symbol))
     end
   end
 end

--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -629,6 +629,7 @@ describe "Service Requests API" do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['options']).to match(hash_including(options))
+      expect(task.reload.options.keys).to all(be_kind_of(Symbol))
     end
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1542661

Replaces https://github.com/ManageIQ/manageiq/issues/16966

