### PR TITLE
Do not return duplicate "edit" action entries

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -469,7 +469,7 @@ module Api
             next unless !action[:disabled] && api_user_role_allows?(action[:identifier]) && action_validated?(resource, action)
             build_resource_actions(action, method, href, cspec[:verbs])
           end
-        end.flatten.compact
+        end.flatten.uniq.compact
       end
 
       def build_resource_actions(action, method, href, verbs)

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -45,6 +45,23 @@ RSpec.describe 'CustomButtons API' do
 
         expect(response).to have_http_status(:forbidden)
       end
+
+      it 'returns the correct actions' do
+        api_basic_authorize(collection_action_identifier(:custom_buttons, :edit),
+                            action_identifier(:custom_buttons, :read, :resource_actions, :get))
+
+        get(api_custom_button_url(nil, cb))
+
+        expected = {
+          'actions' => [
+            a_hash_including('name' => 'edit', 'method' => 'post'),
+            a_hash_including('name' => 'edit', 'method' => 'patch'),
+            a_hash_including('name' => 'edit', 'method' => 'put')
+          ]
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
     end
 
     context 'with an appropriate role' do


### PR DESCRIPTION
In the api.yml, some collections define the put and patch methods, while others do not although they are allowed by default due to the verb specification. In the case where the put and/or patch methods are defined, the edit actions were being duplicated. This ensures they are only present once each.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540894