### PR TITLE
Do not return hrefs for objects without a collection

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -95,7 +95,7 @@ module Api
         # Ensures hrefs are consistent with those of the collection they were requested from
         return reftype if collection_class == rclass || collection_class.descendants.include?(rclass)
 
-        collection_config.name_for_klass(rclass) || collection_config.name_for_subclass(rclass) || reftype
+        collection_config.name_for_klass(rclass) || collection_config.name_for_subclass(rclass)
       end
 
       #

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -87,6 +87,18 @@ describe "Service Templates API" do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
     end
+
+    it 'does not return hrefs on resources that do not have a collection' do
+      api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
+      vm = FactoryGirl.create(:vm)
+      template.add_resource(vm)
+      template.save
+
+      get(api_service_template_url(nil, template), :params => {:attributes => 'service_resources'})
+
+      expect(response).to have_http_status(:ok)
+      response.parsed_body['service_resources'].each { |resource| expect(resource.keys).to_not include('href') }
+    end
   end
 
   describe "Service Templates edit" do


### PR DESCRIPTION
When expanding "service_resources" on "service_templates", an invalid href is returned for the service resources. The href being returned is "/api/service_templates/<service_resource_id>", which is a nonexistent resource. This is due to always returning the `reftype` instead of a nil, which then allows the normalizer to believe it can generate an href for it. There is no collection for service resources, therefore no href should be present.

cc: @bzwei 