### PR TITLE
Default section to "metadata" across custom attributes add action

### DIFF
--- a/app/controllers/api/subcollections/custom_attributes.rb
+++ b/app/controllers/api/subcollections/custom_attributes.rb
@@ -7,6 +7,7 @@ module Api
 
       def custom_attributes_add_resource(object, _type, _id, data = nil)
         raise BadRequestError, "#{object.class.name} does not support management of custom attributes" unless object.respond_to?(:custom_attributes)
+        data["section"] ||= "metadata"
         add_custom_attribute(object, data)
       rescue => err
         raise BadRequestError, "Could not add custom attributes - #{err}"
@@ -82,7 +83,6 @@ module Api
       end
 
       def new_custom_attribute(data)
-        data["section"] ||= "metadata"
         data["source"] ||= "EVM"
         raise "Must specify a name for a custom attribute to be added" if data["name"].blank?
         data = format_custom_attributes(data)

--- a/spec/requests/custom_attributes_spec.rb
+++ b/spec/requests/custom_attributes_spec.rb
@@ -18,6 +18,26 @@ RSpec.describe "Custom Attributes API" do
     end
   end
 
+  describe "POST /api/<collection>/:cid/custom_attributes/:sid" do
+    it "does not duplicate a custom attribute" do
+      ems = FactoryGirl.create(:ext_management_system)
+      custom_attribute = FactoryGirl.create(:custom_attribute, :name => "foo", :value => "bar", :section => "metadata", :resource => ems)
+      api_basic_authorize(subcollection_action_identifier(:providers, :custom_attributes, :add, :post))
+
+      post(api_provider_custom_attributes_url(nil, ems), :params => {
+             :action    => "add",
+             :resources => [
+               { "name" => "foo", "value" => "bar" }
+             ]
+           })
+
+      expected = {
+        "results" => [a_hash_including("id" => custom_attribute.id.to_s, "name" => "foo", "value" => "bar")]
+      }
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
   it "can delete a custom attribute through its nested URI" do
     vm = FactoryGirl.create(:vm_vmware)
     custom_attribute = FactoryGirl.create(:custom_attribute, :resource => vm)


### PR DESCRIPTION
When a new custom attribute is added, it defaults the `section` to "metadata" if it is not specified. In the same add action, it looks up to see if the custom attribute exists, but it does *not* default the section to metadata, causing it to not be found. This results in a *new* custom attribute with the same name, if the same request is made. Since the behavior is to *edit* instead of add, this is not consistent behavior. Instead of creating a new custom attribute, it should be able to find the custom attribute and edit it. 

example:
```
POST /api/providers/:id/custom_attributes
{
  "action" : "add",
  "resources" : [
    { "name" : "koko", "value" : "loko" }
  ]
}
```
on the first try, would create a new custom attribute "koko", as expected.

Making the same request:
```
POST /api/providers/:id/custom_attributes
{
  "action" : "add",
  "resources" : [
    { "name" : "koko", "value" : "moko" }
  ]
}
```
It would add *another* custom attribute "koko", but it should actually just update the value to "moko".

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544800