### PR TITLE
Make cloud_tenants and flavors subcollections consistent with others

### DIFF
--- a/app/controllers/api/subcollections/cloud_tenants.rb
+++ b/app/controllers/api/subcollections/cloud_tenants.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module CloudTenants
       def cloud_tenants_query_resource(object)
-        object.cloud_tenants
+        object.respond_to?(:cloud_tenants) ? object.cloud_tenants : []
       end
     end
   end

--- a/app/controllers/api/subcollections/flavors.rb
+++ b/app/controllers/api/subcollections/flavors.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module Flavors
       def flavors_query_resource(object)
-        object.flavors
+        object.respond_to?(:flavors) ? object.flavors : []
       end
 
       def flavors_create_resource(parent, _type, _id, data)

--- a/spec/requests/cloud_tenants_spec.rb
+++ b/spec/requests/cloud_tenants_spec.rb
@@ -93,4 +93,16 @@ RSpec.describe 'CloudTenants API' do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  context 'As a subcollection' do
+    it 'returns an empty array for collections that do not have cloud tenants' do
+      ems_infra = FactoryGirl.create(:ems_infra)
+      api_basic_authorize(subcollection_action_identifier(:providers, :cloud_tenants, :read, :get))
+
+      get(api_provider_cloud_tenants_url(nil, ems_infra))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('resources' => [])
+    end
+  end
 end

--- a/spec/requests/flavors_spec.rb
+++ b/spec/requests/flavors_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe "Flavors API" do
 
         expect(response).to have_http_status(:forbidden)
       end
+
+      it 'returns an empty array for collections that do not have flavors' do
+        ems_infra = FactoryGirl.create(:ems_infra)
+        api_basic_authorize(subcollection_action_identifier(:providers, :flavors, :read, :get))
+
+        get(api_provider_flavors_url(nil, ems_infra))
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include('resources' => [])
+      end
     end
 
     describe "GET /api/providers/:c_id/flavors/:id" do


### PR DESCRIPTION
Infra providers do not have `cloud_tenants` or `flavors`, causing a 500 error to be returned when they are requested. This makes the behavior consistent with other subcollections, checking to see if the object responds to the subcollection. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1545240