### PR TITLE
Ensure array is returned for subcollections

### DIFF
--- a/app/controllers/api/subcollections/cloud_networks.rb
+++ b/app/controllers/api/subcollections/cloud_networks.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module CloudNetworks
       def cloud_networks_query_resource(object)
-        object.respond_to?(:cloud_networks) ? object.cloud_networks : []
+        object.respond_to?(:cloud_networks) ? Array(object.cloud_networks) : []
       end
     end
   end

--- a/app/controllers/api/subcollections/cloud_subnets.rb
+++ b/app/controllers/api/subcollections/cloud_subnets.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module CloudSubnets
       def cloud_subnets_query_resource(object)
-        object.cloud_subnets
+        object.respond_to?(:cloud_subnets) ? Array(object.cloud_subnets) : []
       end
     end
   end

--- a/app/controllers/api/subcollections/security_groups.rb
+++ b/app/controllers/api/subcollections/security_groups.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module SecurityGroups
       def security_groups_query_resource(object)
-        object.respond_to?(:security_groups) ? object.security_groups : []
+        object.respond_to?(:security_groups) ? Array(object.security_groups) : []
       end
 
       def security_groups_add_resource(parent, _type, _id, data)

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1173,6 +1173,16 @@ describe "Providers API" do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it "returns an empty array for providers that return nil" do
+      api_basic_authorize subcollection_action_identifier(:providers, :cloud_subnets, :read, :get)
+      provider = FactoryGirl.create(:ems_redhat)
+
+      get(api_provider_cloud_subnets_url(nil, provider))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("resources" => [])
+    end
   end
 
   context 'cloud tenants subcollection' do
@@ -1281,6 +1291,16 @@ describe "Providers API" do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it "returns an empty array for providers that return nil" do
+      api_basic_authorize subcollection_action_identifier(:providers, :security_groups, :read, :get)
+      provider = FactoryGirl.create(:ems_redhat)
+
+      get(api_provider_security_groups_url(nil, provider))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("resources" => [])
+    end
   end
 
   describe 'edit custom_attributes on providers' do
@@ -1353,6 +1373,18 @@ describe "Providers API" do
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "Cloud networks subcollection" do
+    it "returns an empty array for providers that return nil" do
+      api_basic_authorize subcollection_action_identifier(:providers, :cloud_networks, :read, :get)
+      provider = FactoryGirl.create(:ems_redhat)
+
+      get(api_provider_cloud_networks_url(nil, provider))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("resources" => [])
     end
   end
 end


### PR DESCRIPTION
Some providers return nil for cloud_networks, cloud_subnets, and security_groups, causing an internal server error to be raised. This ensures an array is returned rather than a nil

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1546112