### PR TITLE
Add lans collection with read and show

### DIFF
--- a/app/controllers/api/lans_controller.rb
+++ b/app/controllers/api/lans_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class LansController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1446,6 +1446,28 @@
         :identifier: instance_edit
       - :name: delete
         :identifier: instance_edit
+  :lans:
+    :description: Lans
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: Lan
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier:
+        - ems_cluster_show_list
+        - host_show_list
+        - instance_show_list
+        - vm_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier:
+        - ems_cluster_show
+        - host_show
+        - instance_show
+        - vm_show
   :load_balancers:
     :description: Load Balancers
     :options:

--- a/spec/requests/lans_spec.rb
+++ b/spec/requests/lans_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe 'Lans API' do
+  describe 'GET /api/lans' do
+    it 'returns all lans with an appropriate role' do
+      lan = FactoryGirl.create(:lan)
+      api_basic_authorize collection_action_identifier(:lans, :read, :get)
+
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'lans',
+        'resources' => [
+          hash_including('href' => api_lan_url(nil, lan))
+        ]
+      }
+      get(api_lans_url)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids access to lans without an appropriate role' do
+      api_basic_authorize
+
+      get(api_lans_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/lans/:id' do
+    let(:lan) { FactoryGirl.create(:lan) }
+
+    it 'will show a lan with an appropriate role' do
+      api_basic_authorize action_identifier(:lans, :read, :resource_actions, :get)
+
+      get(api_lan_url(nil, lan))
+
+      expect(response.parsed_body).to include('href' => api_lan_url(nil, lan))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access to a lan without an appropriate role' do
+      api_basic_authorize
+
+      get(api_lan_url(nil, lan))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
This adds the lans collection that is needed for the creation of transformation mappings.

With this, when a user expands `/api/ems_clusters/:id?attributes=lans`, an `href` will be returned for the lan which can then be specified as either a source or destination for creating a transformation mapping.

Related (but not dependent) https://github.com/ManageIQ/manageiq/pull/17019