### PR TITLE
Fix specifying of additional attributes on pictures

### DIFF
--- a/app/controllers/api/mixins/pictures.rb
+++ b/app/controllers/api/mixins/pictures.rb
@@ -7,7 +7,9 @@ module Api
 
       def format_picture_response(picture)
         return unless picture
-        picture.attributes.except('content').merge('image_href' => picture.image_href)
+        picture_hash = picture.attributes.except('content').merge('image_href' => picture.image_href,
+                                                                  'href'       => picture.href_slug)
+        normalize_hash(:picture, picture_hash)
       end
     end
   end

--- a/app/controllers/api/pictures_controller.rb
+++ b/app/controllers/api/pictures_controller.rb
@@ -16,5 +16,13 @@ module Api
     def set_additional_attributes
       @additional_attributes = %w(image_href extension)
     end
+
+    def attribute_selection
+      if !@req.attributes.empty? || @additional_attributes
+        @req.attributes | Array(@additional_attributes) | ID_ATTRS
+      else
+        Picture.attribute_names - %w(content)
+      end
+    end
   end
 end

--- a/spec/requests/pictures_spec.rb
+++ b/spec/requests/pictures_spec.rb
@@ -98,6 +98,29 @@ describe "Pictures" do
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)
       end
+
+      it 'allows specifying of additional attributes' do
+        api_basic_authorize
+
+        expected = {
+          'resources' => [
+            a_hash_including('href_slug'     => @picture.href_slug,
+                             'region_number' => @picture.region_number)
+          ]
+        }
+        get(api_pictures_url, :params => { :expand => 'resources', :attributes => 'href_slug,region_number'})
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+
+      it 'only allows specifying of valid attributes' do
+        api_basic_authorize
+
+        get(api_pictures_url, :params => { :expand => 'resources', :attributes => 'bad_attr'})
+
+        expect(response).to have_http_status(:bad_request)
+      end
     end
 
     describe 'GET /api/pictures/:id' do
@@ -108,6 +131,25 @@ describe "Pictures" do
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include('image_href' => a_string_including(@picture.image_href), 'extension' => @picture.extension)
+      end
+
+      it 'allows specifying of additional attributes' do
+        api_basic_authorize
+
+        get(api_picture_url(nil, @picture), :params => { :attributes => 'href_slug,region_number' })
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include('href_slug'     => @picture.href_slug,
+                                                'region_number' => @picture.region_number)
+      end
+
+      it 'will return only the requested physical attribute with the set additional attributes' do
+        api_basic_authorize
+
+        get(api_picture_url(nil, @picture), :params => { :attributes => 'md5' })
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.keys).to match_array(%w(md5 href id extension image_href))
       end
     end
 


### PR DESCRIPTION
### Encoding errors strike again!

Requesting any additional attributes for a picture results in:
```
error:
{
    "error": {
        "kind": "internal_server_error",
        "message": "\"\\x89\" from ASCII-8BIT to UTF-8",
        "klass": "Encoding::UndefinedConversionError"
    }
}
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1547852