### PR TITLE
Add delete action for templates

### DIFF
--- a/app/controllers/api/subcollections/cloud_templates.rb
+++ b/app/controllers/api/subcollections/cloud_templates.rb
@@ -4,6 +4,21 @@ module Api
       def cloud_templates_query_resource(object)
         object.vms_and_templates.where(:template => true)
       end
+
+      def cloud_templates_delete_resource(_parent, type, id, _data)
+        image = resource_search(id, type, collection_class(type))
+        task_id = image.delete_image_queue(User.current_user.id)
+        action_result(true, "Deleting #{image_ident(image)}", :task_id => task_id)
+      rescue => err
+        action_result(false, err.to_s)
+      end
+      alias delete_resource_cloud_templates cloud_templates_delete_resource
+
+      private
+
+      def image_ident(image)
+        "Image id:#{image.id} name: '#{image.name}'"
+      end
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -480,7 +480,7 @@
     :options:
     - :collection
     - :subcollection
-    :verbs: *gp
+    :verbs: *gpppd
     :klass: ManageIQ::Providers::CloudManager::Template
     :collection_actions:
       :get:
@@ -497,10 +497,19 @@
       :get:
       - :name: read
         :identifier: image_show_list
+      :post:
+      - :name: delete
+        :identifier: image_delete
     :subresource_actions:
       :get:
       - :name: read
         :identifier: image_show
+      :post:
+      - :name: delete
+        :identifier: image_delete
+      :delete:
+      - :name: delete
+        :identifier: image_delete
   :cloud_tenants:
     :description: Cloud Tenants
     :identifier: cloud_tenant

--- a/spec/requests/cloud_templates_spec.rb
+++ b/spec/requests/cloud_templates_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Cloud Templates API" do
   describe "as a subcollection of providers" do
     it "can list images of a provider" do
       api_basic_authorize(action_identifier(:cloud_templates, :read, :subcollection_actions, :get))
-      ems = FactoryGirl.create(:ems_cloud)
+      ems = FactoryGirl.create(:ems_openstack)
       image = FactoryGirl.create(:template_cloud, :ext_management_system => ems)
 
       get(api_provider_cloud_templates_url(nil, ems))
@@ -20,7 +20,7 @@ RSpec.describe "Cloud Templates API" do
 
     it "will not list images unless authorized" do
       api_basic_authorize
-      ems = FactoryGirl.create(:ems_cloud)
+      ems = FactoryGirl.create(:ems_openstack)
       FactoryGirl.create(:template_cloud, :ext_management_system => ems)
 
       get(api_provider_cloud_templates_url(nil, ems))
@@ -32,7 +32,7 @@ RSpec.describe "Cloud Templates API" do
   describe "GET /api/providers/:c_id/cloud_templates/:id" do
     it "can show a provider's image" do
       api_basic_authorize(action_identifier(:cloud_templates, :read, :subresource_actions, :get))
-      ems = FactoryGirl.create(:ems_cloud)
+      ems = FactoryGirl.create(:ems_openstack)
       image = FactoryGirl.create(:template_cloud, :ext_management_system => ems)
 
       get(api_provider_cloud_template_url(nil, ems, image))
@@ -47,10 +47,97 @@ RSpec.describe "Cloud Templates API" do
 
     it "will not show an image unless authorized" do
       api_basic_authorize
-      ems = FactoryGirl.create(:ems_cloud)
+      ems = FactoryGirl.create(:ems_openstack)
       image = FactoryGirl.create(:template_cloud, :ext_management_system => ems)
 
       get(api_provider_cloud_template_url(nil, ems, image))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "DELETE /api/providers/:c_id/cloud_templates/:id" do
+    it "can delete an image" do
+      api_basic_authorize(action_identifier(:cloud_templates, :delete, :subresource_actions, :delete))
+      ems = FactoryGirl.create(:ems_openstack)
+      image = FactoryGirl.create(:template_cloud, :ext_management_system => ems)
+
+      delete(api_provider_cloud_template_url(nil, ems, image))
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "will not delete image unless authorized" do
+      api_basic_authorize
+      ems = FactoryGirl.create(:ems_openstack)
+      image = FactoryGirl.create(:template_cloud, :ext_management_system => ems)
+
+      delete(api_provider_cloud_template_url(nil, ems, image))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "POST /api/providers/:c_id/cloud_templates/:id with delete action" do
+    it "can delete an image" do
+      ems = FactoryGirl.create(:ems_openstack)
+      image = FactoryGirl.create(:template_openstack, :ext_management_system => ems)
+      api_basic_authorize(action_identifier(:cloud_templates, :delete, :subresource_actions, :delete))
+
+      post(api_provider_cloud_template_url(nil, ems, image), :params => gen_request(:delete))
+
+      expected = {
+        'success' => true,
+        'message' => a_string_including('Deleting Image')
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it "will not delete an image unless authorized" do
+      ems = FactoryGirl.create(:ems_openstack)
+      image = FactoryGirl.create(:template_openstack, :ext_management_system => ems)
+      api_basic_authorize
+
+      post(api_provider_cloud_template_url(nil, ems, image), :params => gen_request(:delete))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "can delete multiple images" do
+      ems = FactoryGirl.create(:ems_openstack)
+      image1, image2 = FactoryGirl.create_list(:template_openstack, 2, :ext_management_system => ems)
+      api_basic_authorize(action_identifier(:cloud_templates, :delete, :subresource_actions))
+
+      post(
+        api_provider_cloud_templates_url(nil, ems),
+        :params => {
+          :action    => "delete",
+          :resources => [
+            {:href => api_provider_cloud_template_url(nil, ems, image1)},
+            {:href => api_provider_cloud_template_url(nil, ems, image2)}
+          ]
+        }
+      )
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "will not delete multiple images unless authorized" do
+      ems = FactoryGirl.create(:ems_openstack)
+      image1, image2 = FactoryGirl.create_list(:template_openstack, 2, :ext_management_system => ems)
+      api_basic_authorize
+
+      post(
+        api_provider_cloud_templates_url(nil, ems),
+        :params => {
+          :action    => "delete",
+          :resources => [
+            {:href => api_provider_cloud_template_url(nil, ems, image1)},
+            {:href => api_provider_cloud_template_url(nil, ems, image2)}
+          ]
+        }
+      )
 
       expect(response).to have_http_status(:forbidden)
     end


### PR DESCRIPTION
Added `delete` action for Openstack images to API
https://bugzilla.redhat.com/show_bug.cgi?id=1487114
https://github.com/ManageIQ/manageiq-providers-openstack/pull/236