### PR TITLE
Raise bad request when current_group is specified on edit

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class UsersController < BaseController
-    INVALID_USER_ATTRS = %w(id href current_group_id settings).freeze # Cannot update other people's settings
-    INVALID_SELF_USER_ATTRS = %w(id href current_group_id).freeze
+    INVALID_USER_ATTRS = %w(id href current_group_id settings current_group).freeze # Cannot update other people's settings
+    INVALID_SELF_USER_ATTRS = %w(id href current_group_id current_group).freeze
     EDITABLE_ATTRS = %w(password email settings).freeze
 
     include Subcollections::Tags

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -217,6 +217,27 @@ RSpec.describe "users API" do
       expect(user1.reload.miq_groups).to match_array([group2, group3])
     end
 
+    it "does not allow edits of current_user" do
+      api_basic_authorize collection_action_identifier(:users, :edit)
+
+      request = {
+        "action"    => "edit",
+        "resources" => [{
+          "href"          => api_user_url(nil, user1),
+          "current_group" => {}
+        }]
+      }
+      post(api_users_url, :params => request)
+
+      expected = {
+        'error' => a_hash_including(
+          'message' => "Invalid attribute(s) current_group specified for a user"
+        )
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "does not allow setting of empty miq_groups" do
       api_basic_authorize collection_action_identifier(:users, :edit)
 


### PR DESCRIPTION
Editing of a current_group is allowed only on on the set_current_group action.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1549086