### PR TITLE
Remove unused create_vm_attributes_hash method

### DIFF
--- a/app/controllers/api/subcollections/vms.rb
+++ b/app/controllers/api/subcollections/vms.rb
@@ -12,14 +12,6 @@ module Api
           vm.as_json.merge(attributes_hash)
         end
       end
-
-      private
-
-      def create_vm_attributes_hash(vm_attrs, vm)
-        vm_attrs.each_with_object({}) do |attr, hash|
-          hash[attr] = vm.public_send(attr.to_sym) if vm.respond_to?(attr.to_sym)
-        end.compact
-      end
     end
   end
 end


### PR DESCRIPTION
Noticed that this is not used anymore, and `create_resource_attributes_hash` is instead ✂️ 