### PR TITLE
Adding support for /api/containers primary collection.

### DIFF
--- a/app/controllers/api/containers_controller.rb
+++ b/app/controllers/api/containers_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ContainersController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -835,6 +835,24 @@
       :get:
       - :name: read
         :identifier: persistent_volume_show
+  :containers:
+    :description: Containers
+    :identifier: container
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: Container
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: container_show_list
+      :post:
+      - :name: query
+        :identifier: container_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: container_show
   :currencies:
     :description: Currencies
     :identifier: currency

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -82,6 +82,11 @@ describe "Rest API Collections" do
       test_collection_query(:chargebacks, api_chargebacks_url, ChargebackRate)
     end
 
+    it "query Containers" do
+      FactoryGirl.create(:container)
+      test_collection_query(:containers, api_containers_url, Container)
+    end
+
     it "query ContainerGroups" do
       FactoryGirl.create(:container_group)
       test_collection_query(:container_groups, api_container_groups_url, ContainerGroup)
@@ -661,6 +666,11 @@ describe "Rest API Collections" do
     it 'bulk query CloudVolumes' do
       FactoryGirl.create(:cloud_volume)
       test_collection_bulk_query(:cloud_volumes, api_cloud_volumes_url, CloudVolume)
+    end
+
+    it 'bulk query Container' do
+      FactoryGirl.create(:container)
+      test_collection_bulk_query(:containers, api_containers_url, Container)
     end
 
     it 'bulk query Firmwares' do


### PR DESCRIPTION
Adding support for /api/containers primary collection

  GET /api/containers
  GET /api/containers/:id
  POST /api/containers      - bulk action "query"

Requires: https://github.com/ManageIQ/manageiq/pull/17074

https://bugzilla.redhat.com/show_bug.cgi?id=1549661