### PR TITLE
Add pause and resume actions to Providers

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -95,6 +95,14 @@ module Api
       action_result(false, "Could not pause Provider - #{err}")
     end
 
+    def resume_resource(type, id, _data)
+      provider = resource_search(id, type, collection_class(type))
+      provider.enable!
+      action_result(true, "Resumed #{provider_ident(provider)}")
+    rescue => err
+      action_result(false, "Could not resume Provider - #{err}")
+    end
+
     private
 
     def provider_ident(provider)

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -87,6 +87,14 @@ module Api
       render_options(:providers, "provider_settings" => providers_options)
     end
 
+    def pause_resource(type, id, _data)
+      provider = resource_search(id, type, collection_class(type))
+      provider.disable!
+      action_result(true, "Paused #{provider_ident(provider)}")
+    rescue => err
+      action_result(false, "Could not pause Provider - #{err}")
+    end
+
     private
 
     def provider_ident(provider)

--- a/config/api.yml
+++ b/config/api.yml
@@ -1856,6 +1856,8 @@
         :identifier: ems_infra_refresh
       - :name: delete
         :identifier: ems_infra_delete
+      - :name: pause
+        :identifier: ems_infra_edit
     :resource_actions:
       :get:
       - :name: read
@@ -1873,6 +1875,8 @@
         :identifier: ems_infra_import_vm
         :options:
         - :validate_action
+      - :name: pause
+        :identifier: ems_infra_edit
       :delete:
       - :name: delete
         :identifier: ems_infra_delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -1858,6 +1858,8 @@
         :identifier: ems_infra_delete
       - :name: pause
         :identifier: ems_infra_edit
+      - :name: resume
+        :identifier: ems_infra_edit
     :resource_actions:
       :get:
       - :name: read
@@ -1876,6 +1878,8 @@
         :options:
         - :validate_action
       - :name: pause
+        :identifier: ems_infra_edit
+      - :name: resume
         :identifier: ems_infra_edit
       :delete:
       - :name: delete


### PR DESCRIPTION
Actual method names are `enable!` and `disable!`, but actions are "pause" and "resume" to be consistent with the UI

https://bugzilla.redhat.com/show_bug.cgi?id=1507812

