### PR TITLE
Added support for deleting data_stores

### DIFF
--- a/app/controllers/api/data_stores_controller.rb
+++ b/app/controllers/api/data_stores_controller.rb
@@ -1,5 +1,21 @@
 module Api
   class DataStoresController < BaseController
     include Subcollections::Tags
+
+    def delete_resource(type, id = nil, _data = nil)
+      delete_action_handler do
+        data_store = resource_search(id, type, collection_class(type))
+        desc = "Deleting #{data_store_ident(data_store)}"
+        api_log_info(desc)
+        task_id = queue_object_action(data_store, desc, :method_name => "destroy")
+        action_result(true, desc, :task_id => task_id, :parent_id => id)
+      end
+    end
+
+    private
+
+    def data_store_ident(data_store)
+      "Data Store id:#{data_store.id} name:'#{data_store.name}'"
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -950,7 +950,7 @@
     :options:
     - :collection
     - :custom_actions
-    :verbs: *gp
+    :verbs: *gpd
     :klass: Storage
     :subcollections:
     - :tags
@@ -963,11 +963,13 @@
         :identifier: storage_show_list
       - :name: delete
         :identifier: storage_delete
-        :disabled: true
     :resource_actions:
       :get:
       - :name: read
         :identifier: storage_show
+      :post:
+      - :name: delete
+        :identifier: storage_delete
       :delete:
       - :name: delete
         :identifier: storage_delete

--- a/spec/requests/data_stores_spec.rb
+++ b/spec/requests/data_stores_spec.rb
@@ -1,0 +1,94 @@
+#
+# REST API Request Tests - Datastores
+#
+# Datastore primary collections:
+#   /api/data_stores
+#
+# Tests for:
+# POST /api/data_stores/:id     - action "delete"
+# POST /api/data_stores         - bulk action "delete"
+# DELETE /api/data_stores/:id
+#
+
+describe "Data Stores API" do
+  it "rejects delete request without appropriate role" do
+    ds = FactoryGirl.create(:storage_nfs)
+
+    api_basic_authorize
+
+    post(api_data_store_url(nil, ds), :params => { :action => 'delete' })
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "can delete a data store" do
+    ds = FactoryGirl.create(:storage_nfs)
+
+    api_basic_authorize action_identifier(:data_stores, :delete, :resource_actions, :post)
+
+    post(api_data_store_url(nil, ds), :params => { :action => "delete" })
+
+    expected = {
+      'message' => a_string_including("Deleting Data Store id:#{ds.id}"),
+      'success' => true,
+      'task_id' => a_kind_of(String)
+    }
+
+    expect(response.parsed_body).to include(expected)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "can delete a data store with DELETE as a resource action" do
+    ds = FactoryGirl.create(:storage_nfs)
+
+    api_basic_authorize action_identifier(:data_stores, :delete, :resource_actions, :delete)
+
+    delete api_data_store_url(nil, ds)
+
+    expect(response).to have_http_status(:no_content)
+  end
+
+  it "rejects delete request with DELETE as a resource action without appropriate role" do
+    ds = FactoryGirl.create(:storage_nfs)
+
+    api_basic_authorize
+
+    delete api_data_store_url(nil, ds)
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it 'DELETE will raise an error if the cloud volume does not exist' do
+    api_basic_authorize action_identifier(:data_stores, :delete, :resource_actions, :delete)
+
+    delete(api_data_store_url(nil, 999_999))
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'can delete data stores through POST' do
+    ds1 = FactoryGirl.create(:storage_vmware)
+    ds2 = FactoryGirl.create(:storage_nfs)
+
+    api_basic_authorize collection_action_identifier(:data_stores, :delete, :post)
+
+    expected = {
+      'results' => a_collection_including(
+        a_hash_including(
+          'success' => true,
+          'message' => a_string_including("Deleting Data Store id:#{ds1.id}"),
+          'task_id' => a_kind_of(String)
+        ),
+        a_hash_including(
+          'success' => true,
+          'message' => a_string_including("Deleting Data Store id:#{ds2.id}"),
+          'task_id' => a_kind_of(String)
+        )
+      )
+    }
+    post(api_data_stores_url, :params => { :action => 'delete', :resources => [{ 'id' => ds1.id }, { 'id' => ds2.id }] })
+
+    expect(response.parsed_body).to include(expected)
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
Added support for deleting data_stores

``` 
 DELETE /api/data_stores/:id
 POST /api/data_stores/:id   - action "delete"
 POST /api/data_stores       - bulk action "delete"
```

https://bugzilla.redhat.com/show_bug.cgi?id=1511376