### PR TITLE
Add create action for templates

### DIFF
--- a/app/controllers/api/subcollections/cloud_templates.rb
+++ b/app/controllers/api/subcollections/cloud_templates.rb
@@ -5,6 +5,13 @@ module Api
         object.vms_and_templates.where(:template => true)
       end
 
+      def cloud_templates_create_resource(parent, _type, _id, data)
+        task_id = ManageIQ::Providers::CloudManager::Template.create_image_queue(User.current_user.id, parent, data)
+        action_result(true, 'Creating Image', :task_id => task_id)
+      rescue => err
+        action_result(false, err.to_s)
+      end
+
       def cloud_templates_delete_resource(_parent, type, id, _data)
         image = resource_search(id, type, collection_class(type))
         task_id = image.delete_image_queue(User.current_user.id)

--- a/config/api.yml
+++ b/config/api.yml
@@ -506,6 +506,8 @@
       - :name: read
         :identifier: image_show_list
       :post:
+      - :name: create
+        :identifier: image_create
       - :name: delete
         :identifier: image_delete
     :subresource_actions:

--- a/spec/requests/cloud_templates_spec.rb
+++ b/spec/requests/cloud_templates_spec.rb
@@ -56,6 +56,37 @@ RSpec.describe "Cloud Templates API" do
     end
   end
 
+  describe "POST /api/providers/:c_id/cloud_templates" do
+    it "can queue the creation of an images" do
+      api_basic_authorize(action_identifier(:cloud_templates, :create, :subcollection_actions))
+      ems = FactoryGirl.create(:ems_cloud)
+
+      post(api_provider_cloud_templates_url(nil, ems), :params => { :name => "test-image", :vendor => "test-cloud", :location => "test-location" })
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "success"   => true,
+            "message"   => "Creating Image",
+            "task_id"   => anything,
+            "task_href" => a_string_matching(api_tasks_url)
+          )
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "will not create an image unless authorized" do
+      api_basic_authorize
+      ems = FactoryGirl.create(:ems_cloud)
+
+      post(api_provider_cloud_templates_url(nil, ems), :params => { :name => "test-image" })
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe "DELETE /api/providers/:c_id/cloud_templates/:id" do
     it "can delete an image" do
       api_basic_authorize(action_identifier(:cloud_templates, :delete, :subresource_actions, :delete))


### PR DESCRIPTION
Added `create` action for images to API
https://bugzilla.redhat.com/show_bug.cgi?id=1487114
Depends on:
https://github.com/ManageIQ/manageiq/pull/17089
