### PR TITLE
Fix specs after recent changes to RBAC

### DIFF
--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -154,7 +154,7 @@ describe "Rest API Collections" do
 
     it "query Groups" do
       expect(Tenant.exists?).to be_truthy
-      FactoryGirl.create(:miq_group)
+      @user.miq_groups << FactoryGirl.create(:miq_group)
       api_basic_authorize collection_action_identifier(:groups, :read, :get)
       get api_groups_url, :params => { :expand => 'resources' }
       expect_query_result(:groups, MiqGroup.non_tenant_groups.count, MiqGroup.count)
@@ -298,7 +298,8 @@ describe "Rest API Collections" do
     end
 
     it "query Users" do
-      FactoryGirl.create(:user)
+      user = FactoryGirl.create(:user)
+      user.miq_groups << @user.current_group
       test_collection_query(:users, api_users_url, User)
     end
 
@@ -471,6 +472,7 @@ describe "Rest API Collections" do
 
     it "bulk query Groups" do
       group = FactoryGirl.create(:miq_group)
+      @user.miq_groups << group
       test_collection_bulk_query(:groups, api_groups_url, MiqGroup, group.id)
     end
 

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -618,6 +618,7 @@ describe "Custom Actions API" do
     before do
       @resource = FactoryGirl.create(:miq_group)
       @button1 = define_custom_button1(@resource)
+      @user.miq_groups << @resource
     end
 
     it "queries return custom actions defined" do
@@ -942,6 +943,7 @@ describe "Custom Actions API" do
     before do
       @resource = FactoryGirl.create(:user)
       @button1 = define_custom_button1(@resource)
+      @resource.miq_groups << @user.current_group
     end
 
     it "queries return custom actions defined" do

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -756,6 +756,7 @@ describe "Services API" do
 
     it 'returns individual success and failures' do
       user = FactoryGirl.create(:user)
+      user.miq_groups << @user.current_group
       api_basic_authorize(collection_action_identifier(:services, :add_resource))
       request = {
         'action'    => 'add_resource',
@@ -796,6 +797,7 @@ describe "Services API" do
 
     it 'requires the resource to respond to add_to_service' do
       user = FactoryGirl.create(:user)
+      user.miq_groups << @user.current_group
       api_basic_authorize(collection_action_identifier(:services, :add_resource))
       request = {
         'action'   => 'add_resource',


### PR DESCRIPTION
This recently merged PR https://github.com/ManageIQ/manageiq/pull/17061 fixed an issue with RBAC that was exposed: a user was able to see all groups and all other users

After the fix, users can only see groups or users from their own groups, which broke many of our specs.

One concern is - this slightly changes the behavior of our API. Should we leave this to be in sync with the new change to RBAC, or should we adapt the User functionality to remain as currently is (previous to this change)? (FWIW, seems like we should be in sync with RBAC, but I am worried about what else this might break)

cc: @lpichler @gtanzillo 