### PR TITLE
Add Lans subcollection to Hosts / Providers

### DIFF
--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -4,6 +4,7 @@ module Api
     AUTH_TYPE_ATTR = "auth_type".freeze
     DEFAULT_AUTH_TYPE = "default".freeze
 
+    include Subcollections::Lans
     include Subcollections::Policies
     include Subcollections::PolicyProfiles
     include Subcollections::Tags

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -23,6 +23,7 @@ module Api
     include Subcollections::CloudTemplates
     include Subcollections::Folders
     include Subcollections::Networks
+    include Subcollections::Lans
 
     before_action :validate_provider_class
 

--- a/app/controllers/api/subcollections/lans.rb
+++ b/app/controllers/api/subcollections/lans.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module Lans
+      def lans_query_resource(object)
+        object.respond_to?(:lans) ? object.lans : []
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1881,6 +1881,7 @@
     - :cloud_templates
     - :folders
     - :networks
+    - :lans
     :collection_actions:
       :get:
       - :name: read
@@ -1973,6 +1974,18 @@
         - ems_infra_show_list
         - ems_block_storage_show_list
     :networks_subresource_actions:
+      :get:
+      - :name: read
+        :identifier:
+        - ems_infra_show
+        - ems_block_storage_show
+    :lans_subcollection_actions:
+      :get:
+      - :name: read
+        :identifier:
+        - ems_infra_show_list
+        - ems_block_storage_show_list
+    :lans_subresource_actions:
       :get:
       - :name: read
         :identifier:

--- a/config/api.yml
+++ b/config/api.yml
@@ -1304,6 +1304,7 @@
     - :tags
     - :policies
     - :policy_profiles
+    - :lans
     :collection_actions:
       :get:
       - :name: read
@@ -1389,6 +1390,14 @@
         :identifier: host_protect
       - :name: unassign
         :identifier: host_protect
+    :lans_subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: host_show_list
+    :lans_subresource_actions:
+      :get:
+      - :name: read
+        :identifier: host_show
   :instances:
     :description: Instances
     :identifier: instance
@@ -1476,6 +1485,7 @@
     :description: Lans
     :options:
     - :collection
+    - :subcollection
     :verbs: *g
     :klass: Lan
     :collection_actions:

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1571,6 +1571,58 @@ describe "Providers API" do
     end
   end
 
+  context 'Lans subcollection' do
+    let(:lan) { FactoryGirl.create(:lan) }
+    let(:switch) { FactoryGirl.create(:switch, :lans => [lan]) }
+    let(:host) { FactoryGirl.create(:host, :switches => [switch]) }
+    let(:ems) { FactoryGirl.create(:ext_management_system) }
+
+    before do
+      ems.hosts << host
+    end
+
+    context 'GET /api/providers/:id/lans' do
+      it 'returns the lans with an appropriate role' do
+        api_basic_authorize(collection_action_identifier(:providers, :read, :get))
+
+        expected = {
+          'resources' => [{'href' => api_provider_lan_url(nil, ems, lan)}]
+        }
+        get(api_provider_lans_url(nil, ems))
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+
+      it 'does not return the lans without an appropriate role' do
+        api_basic_authorize
+
+        get(api_provider_lans_url(nil, ems))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'GET /api/providers/:id/lans/:s_id' do
+      it 'returns the lan with an appropriate role' do
+        api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
+
+        get(api_provider_lan_url(nil, ems, lan))
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include('id' => lan.id.to_s)
+      end
+
+      it 'does not return the lans without an appropriate role' do
+        api_basic_authorize
+
+        get(api_provider_lan_url(nil, ems, lan))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
   context "Cloud networks subcollection" do
     it "returns an empty array for providers that return nil" do
       api_basic_authorize subcollection_action_identifier(:providers, :cloud_networks, :read, :get)


### PR DESCRIPTION
Adds the following:
`GET /api/hosts/:c_id/lans`
`GET /api/hosts/:c_id/lans/:s_id`
`GET /api/providers/:c_id/lans`
`GET /api/providers/:c_id/lans/:s_id`

Another for https://bugzilla.redhat.com/show_bug.cgi?id=1472279