### PR TITLE
Add svc_catalog_provision product feature to service dialog queries

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2466,10 +2466,14 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: miq_ae_customization_explorer
+        :identifier:
+        - miq_ae_customization_explorer
+        - svc_catalog_provision
       :post:
       - :name: query
-        :identifier: miq_ae_customization_explorer
+        :identifier:
+        - miq_ae_customization_explorer
+        - svc_catalog_provision
       - :name: refresh_dialog_fields
         :identifier: svc_catalog_provision
       - :name: delete
@@ -2483,7 +2487,9 @@
     :resource_actions:
       :get:
       - :name: read
-        :identifier: miq_ae_customization_explorer
+        :identifier:
+        - miq_ae_customization_explorer
+        - svc_catalog_provision
       :post:
       - :name: refresh_dialog_fields
         :identifier: svc_catalog_provision

--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -30,6 +30,22 @@ describe "Service Dialogs API" do
       expect(response).to have_http_status(:ok)
     end
 
+    it "allows read of service dialogs with the service catalog provision role" do
+      api_basic_authorize("svc_catalog_provision")
+
+      get api_service_dialogs_url
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "allows read of a single service dialog with the service catalog provision role" do
+      api_basic_authorize("svc_catalog_provision")
+
+      get api_service_dialog_url(nil, dialog1)
+
+      expect(response).to have_http_status(:ok)
+    end
+
     it "query with expanded resources to include content" do
       api_basic_authorize collection_action_identifier(:service_dialogs, :read, :get)
       get api_service_dialogs_url, :params => { :expand => "resources" }


### PR DESCRIPTION
If a user is attempting to order a service catalog and have permissions to do so, they may not have permissions to view the associated dialog, resulting in a failure to order. This gives the correct permissions to complete the ordering process by keeping the product features consistent across ordering and dialogs.

cc: @gtanzillo @gmcculloug 
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1546944