### PR TITLE
Allow region to be queried by the region number

### DIFF
--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,4 +1,11 @@
 module Api
   class RegionsController < BaseController
+    private
+
+    def resource_search(id, type, klass)
+      region = MiqRegion.find_by(:region => id)
+      return region unless region.nil?
+      super(id, type, klass)
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2114,6 +2114,7 @@
   :regions:
     :description: Regions
     :identifier: region
+    :identifying_attrs: region
     :subcollections:
     - :settings
     :options:

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -41,6 +41,19 @@ describe "Regions API" do
     )
   end
 
+  it "allows GET of a region by region number" do
+    api_basic_authorize action_identifier(:regions, :read, :resource_actions, :get)
+    region = FactoryGirl.create(:miq_region, :region => "2")
+
+    get(api_region_url(nil, region.region))
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to include(
+      "href" => api_region_url(nil, region),
+      "id"   => region.id.to_s
+    )
+  end
+
   describe "Settings" do
     let(:region_number) { ApplicationRecord.my_region_number + 1 }
     let(:id) { ApplicationRecord.id_in_region(1, region_number) }


### PR DESCRIPTION
Add in the ability to look up a region by its region number, ie `10` rather than its actual id from the database `10000000000001`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552899