### PR TITLE
Assign and Unassign alert definition profiles

### DIFF
--- a/app/controllers/api/alert_definition_profiles_controller.rb
+++ b/app/controllers/api/alert_definition_profiles_controller.rb
@@ -27,9 +27,7 @@ module Api
       data['resources'].each do |resource|
         href = Href.new(resource['href'])
         if resource.key?('tag')
-          tag_id = Href.new(resource['tag']['href']).subject_id
-          tag = resource_search(tag_id, :tags, collection_class(:tags))
-          profile.assign_to_tags([tag.classification], href.subject)
+          profile.assign_to_tags([fetch_tag_classification_resource(resource['tag'])], href.subject)
         else
           assignable_resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
           profile.assign_to_objects([assignable_resource])
@@ -45,9 +43,7 @@ module Api
       data['resources'].each do |resource|
         href = Href.new(resource['href'])
         if resource.key?('tag')
-          tag_id = Href.new(resource['tag']['href']).subject_id
-          tag = resource_search(tag_id, :tags, collection_class(:tags))
-          profile.unassign_tags([tag.classification], href.subject)
+          profile.unassign_tags([fetch_tag_classification_resource(resource['tag'])], href.subject)
         else
           assignable_resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
           profile.unassign_objects([assignable_resource])
@@ -62,6 +58,12 @@ module Api
 
     def alert_definition_profile_ident(profile)
       "Alert Definition Profile id:#{profile.id} name:'#{profile.name}'"
+    end
+
+    def fetch_tag_classification_resource(data)
+      tag_id = Href.new(data['href']).subject_id
+      tag = resource_search(tag_id, :tags, collection_class(:tags))
+      tag.classification
     end
   end
 end

--- a/app/controllers/api/alert_definition_profiles_controller.rb
+++ b/app/controllers/api/alert_definition_profiles_controller.rb
@@ -40,6 +40,24 @@ module Api
       action_result(false, "Could not assign Alert Definition Profile - #{err}")
     end
 
+    def unassign_resource(type, id, data)
+      profile = resource_search(id, type, collection_class(type))
+      data['resources'].each do |resource|
+        href = Href.new(resource['href'])
+        if resource.key?('tag')
+          tag_id = Href.new(resource['tag']['href']).subject_id
+          tag = resource_search(tag_id, :tags, collection_class(:tags))
+          profile.unassign_tags([tag.classification], href.subject)
+        else
+          assignable_resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
+          profile.unassign_objects([assignable_resource])
+        end
+      end
+      action_result(true, "Unassigned resources from #{alert_definition_profile_ident(profile)}")
+    rescue => err
+      action_result(false, "Could not unassign Alert Definition Profile - #{err}")
+    end
+
     private
 
     def alert_definition_profile_ident(profile)

--- a/app/controllers/api/alert_definition_profiles_controller.rb
+++ b/app/controllers/api/alert_definition_profiles_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class AlertDefinitionProfilesController < BaseController
     include Subcollections::AlertDefinitions
+    include Api::Mixins::Tags
 
     REQUIRED_FIELDS = %w(description mode).freeze
 
@@ -25,6 +26,7 @@ module Api
     def assign_resource(type, id, data)
       profile = resource_search(id, type, collection_class(type))
       data['resources'].each do |resource|
+        raise 'Must specify resource href' unless resource.key?('href')
         href = Href.new(resource['href'])
         if resource.key?('tag')
           profile.assign_to_tags([fetch_tag_classification_resource(resource['tag'])], href.subject)
@@ -34,13 +36,14 @@ module Api
         end
       end
       action_result(true, "Assigned resources to #{alert_definition_profile_ident(profile)}")
-    rescue => err
+    rescue StandardError => err
       action_result(false, "Could not assign Alert Definition Profile - #{err}")
     end
 
     def unassign_resource(type, id, data)
       profile = resource_search(id, type, collection_class(type))
       data['resources'].each do |resource|
+        raise 'Must specify resource href' unless resource.key?('href')
         href = Href.new(resource['href'])
         if resource.key?('tag')
           profile.unassign_tags([fetch_tag_classification_resource(resource['tag'])], href.subject)
@@ -50,7 +53,7 @@ module Api
         end
       end
       action_result(true, "Unassigned resources from #{alert_definition_profile_ident(profile)}")
-    rescue => err
+    rescue StandardError => err
       action_result(false, "Could not unassign Alert Definition Profile - #{err}")
     end
 
@@ -60,10 +63,13 @@ module Api
       "Alert Definition Profile id:#{profile.id} name:'#{profile.name}'"
     end
 
+    # rubocop:disable Rails/DynamicFindBy
     def fetch_tag_classification_resource(data)
-      tag_id = Href.new(data['href']).subject_id
-      tag = resource_search(tag_id, :tags, collection_class(:tags))
-      tag.classification
+      tag_spec = tag_specified(data["id"], data)
+      raise BadRequestError, "Must specify tag id, href, or name of classification" if tag_spec.empty?
+      classification = Classification.find_by_name(tag_spec[:category])
+      classification.find_entry_by_name(tag_spec[:name])
     end
+    # rubocop:enable Rails/DynamicFindBy
   end
 end

--- a/app/controllers/api/mixins/tags.rb
+++ b/app/controllers/api/mixins/tags.rb
@@ -1,0 +1,41 @@
+module Api
+  module Mixins
+    module Tags
+      def tag_specified(id, data)
+        if id.to_i > 0
+          klass  = collection_class(:tags)
+          tagobj = klass.find(id)
+          return tag_path_to_spec(tagobj.name).merge(:id => tagobj.id)
+        end
+
+        parse_tag(data)
+      end
+
+      def parse_tag(data)
+        return {} if data.blank?
+
+        category = data["category"]
+        name     = data["name"]
+        return {:category => category, :name => name} if category && name
+        return tag_path_to_spec(name) if name && name[0] == '/'
+
+        parse_tag_from_href(data)
+      end
+
+      def parse_tag_from_href(data)
+        href = data["href"]
+        tag  = if href&.match(%r{^.*/tags/\d+$})
+                 klass = collection_class(:tags)
+                 klass.find(href.split('/').last)
+               end
+        tag.present? ? tag_path_to_spec(tag.name).merge(:id => tag.id) : {}
+      end
+
+      def tag_path_to_spec(path)
+        tag_path = path[0..7] == Api::BaseController::TAG_NAMESPACE ? path[8..-1] : path
+        parts    = tag_path.split('/')
+        {:category => parts[1], :name => parts[2]}
+      end
+    end
+  end
+end

--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -1,6 +1,8 @@
 module Api
   module Subcollections
     module Tags
+      include Api::Mixins::Tags
+
       def assign_tags_resource(type, id, data)
         resource = resource_search(id, type, collection_class(type))
         data['tags'].collect do |tag|
@@ -77,42 +79,6 @@ module Api
         add_tag_to_result(result, tag_spec)
         log_result(result)
         result
-      end
-
-      def tag_specified(id, data)
-        if id.to_i > 0
-          klass  = collection_class(:tags)
-          tagobj = klass.find(id)
-          return tag_path_to_spec(tagobj.name).merge(:id => tagobj.id)
-        end
-
-        parse_tag(data)
-      end
-
-      def parse_tag(data)
-        return {} if data.blank?
-
-        category = data["category"]
-        name     = data["name"]
-        return {:category => category, :name => name} if category && name
-        return tag_path_to_spec(name) if name && name[0] == '/'
-
-        parse_tag_from_href(data)
-      end
-
-      def parse_tag_from_href(data)
-        href = data["href"]
-        tag  = if href && href.match(%r{^.*/tags/\d+$})
-                 klass = collection_class(:tags)
-                 klass.find(href.split('/').last)
-               end
-        tag.present? ? tag_path_to_spec(tag.name).merge(:id => tag.id) : {}
-      end
-
-      def tag_path_to_spec(path)
-        tag_path = (path[0..7] == Api::BaseController::TAG_NAMESPACE) ? path[8..-1] : path
-        parts    = tag_path.split('/')
-        {:category => parts[1], :name => parts[2]}
       end
 
       def ci_set_tag(ci, tag_spec)

--- a/config/api.yml
+++ b/config/api.yml
@@ -106,6 +106,8 @@
         :identifier: alert_definition_profile_delete
       - :name: assign
         :identifier: alert_definition_profile_edit
+      - :name: unassign
+        :identifier: alert_definition_profile_edit
     :resource_actions:
       :get:
       - :name: read
@@ -116,6 +118,8 @@
       - :name: delete
         :identifier: alert_definition_profile_delete
       - :name: assign
+        :identifier: alert_definition_profile_edit
+      - :name: unassign
         :identifier: alert_definition_profile_edit
       :delete:
       - :name: delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -104,6 +104,8 @@
         :identifier: alert_definition_profile_edit
       - :name: delete
         :identifier: alert_definition_profile_delete
+      - :name: assign
+        :identifier: alert_definition_profile_edit
     :resource_actions:
       :get:
       - :name: read
@@ -113,6 +115,8 @@
         :identifier: alert_definition_profile_edit
       - :name: delete
         :identifier: alert_definition_profile_delete
+      - :name: assign
+        :identifier: alert_definition_profile_edit
       :delete:
       - :name: delete
         :identifier: alert_definition_profile_delete

--- a/spec/requests/alert_definition_profiles_spec.rb
+++ b/spec/requests/alert_definition_profiles_spec.rb
@@ -1,0 +1,54 @@
+describe "Alert Definition Profiles API" do
+  describe "POST /api/alert_definition_profiles" do
+    context "assign" do
+      it "assigns alert profiles with an appropriate role" do
+        api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
+        alert_definition_profile = FactoryGirl.create(:miq_alert_set)
+        cluster = FactoryGirl.create(:ems_cluster)
+        dept = FactoryGirl.create(:classification_department)
+        tag = FactoryGirl.create(:classification_tag, :name => "foo", :parent => dept).tag
+
+        request = {
+          "action"    => "assign",
+          "resources" => [
+            { "id" => alert_definition_profile.id, "resources" => [
+              {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, tag) }},
+              {"href" => api_cluster_url(nil, cluster) }
+            ]}
+          ]
+        }
+        post(api_alert_definition_profiles_url, :params => request)
+
+        expected = {
+          "results" => [{"success" => true, "message" => /Assigned resources to Alert Definition Profile/}]
+        }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+    end
+  end
+
+  describe "POST /api/alert_definition_profiles" do
+    context "assign" do
+      it "assigns alert profiles with an appropriate role" do
+        api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
+        alert_definition_profile = FactoryGirl.create(:miq_alert_set)
+        cluster = FactoryGirl.create(:ems_cluster)
+        dept = FactoryGirl.create(:classification_department)
+        tag = FactoryGirl.create(:classification_tag, :name => "foo", :parent => dept).tag
+
+        request = {
+          "action"    => "assign",
+          "resources" => [
+            {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, tag) }},
+            {"href" => api_cluster_url(nil, cluster) }
+          ]
+        }
+        post(api_alert_definition_profile_url(nil, alert_definition_profile), :params => request)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include("success" => true, "message" => /Assigned resources to Alert Definition Profile/)
+      end
+    end
+  end
+end

--- a/spec/requests/alert_definition_profiles_spec.rb
+++ b/spec/requests/alert_definition_profiles_spec.rb
@@ -1,18 +1,60 @@
 describe "Alert Definition Profiles API" do
+  let(:alert_definition_profile) { FactoryGirl.create(:miq_alert_set) }
+  let(:cluster) { FactoryGirl.create(:ems_cluster) }
+  let(:department_classification) { FactoryGirl.create(:classification_department) }
+  let(:classification_tag) { FactoryGirl.create(:classification_tag, :name => "foo", :parent => department_classification) }
+
   describe "POST /api/alert_definition_profiles" do
     context "assign" do
-      it "assigns alert profiles with an appropriate role" do
+      it "requires a tag id, href, or classification name" do
         api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
-        alert_definition_profile = FactoryGirl.create(:miq_alert_set)
-        cluster = FactoryGirl.create(:ems_cluster)
-        dept = FactoryGirl.create(:classification_department)
-        tag = FactoryGirl.create(:classification_tag, :name => "foo", :parent => dept).tag
 
         request = {
           "action"    => "assign",
           "resources" => [
             { "id" => alert_definition_profile.id, "resources" => [
-              {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, tag) }},
+              {"href" => api_hosts_url, "tag" => {}}
+            ]}
+          ]
+        }
+        post(api_alert_definition_profiles_url, :params => request)
+
+        expected = {
+          "results" => [{"success" => false, "message" => /Must specify tag id, href, or name/}]
+        }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+
+      it "requires a resource href" do
+        api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
+
+        request = {
+          "action"    => "assign",
+          "resources" => [
+            { "id" => alert_definition_profile.id, "resources" => [{}]}
+          ]
+        }
+        post(api_alert_definition_profiles_url, :params => request)
+
+        expected = {
+          "results" => [{"success" => false, "message" => /Must specify resource href/}]
+        }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+
+      it "assigns alert profiles with an appropriate role via tag href or classification name" do
+        api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
+        cc_classification = FactoryGirl.create(:classification_cost_center)
+        FactoryGirl.create(:classification_tag, :name => "bar", :parent => cc_classification)
+
+        request = {
+          "action"    => "assign",
+          "resources" => [
+            { "id" => alert_definition_profile.id, "resources" => [
+              {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, classification_tag.tag) }},
+              {"href" => api_hosts_url, "tag" => { "category" => cc_classification.name, "name" => "bar" }},
               {"href" => api_cluster_url(nil, cluster) }
             ]}
           ]
@@ -28,19 +70,37 @@ describe "Alert Definition Profiles API" do
     end
 
     context "unassign" do
-      it "assigns alert profiles with an appropriate role" do
+      it "requires a resource href" do
         api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
-        alert_definition_profile = FactoryGirl.create(:miq_alert_set)
-        cluster = FactoryGirl.create(:ems_cluster)
-        dept = FactoryGirl.create(:classification_department)
-        classification = FactoryGirl.create(:classification_tag, :name => "foo", :parent => dept)
-        alert_definition_profile.assign_to_tags([classification], "host")
+
+        request = {
+          "action"    => "unassign",
+          "resources" => [
+            { "id" => alert_definition_profile.id, "resources" => [{}]}
+          ]
+        }
+        post(api_alert_definition_profiles_url, :params => request)
+
+        expected = {
+          "results" => [{"success" => false, "message" => /Must specify resource href/}]
+        }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+
+      it "unassigns alert profiles with an appropriate role via tag href or classification name" do
+        api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
+        cc_classification = FactoryGirl.create(:classification_cost_center)
+        classification_tag2 = FactoryGirl.create(:classification_tag, :name => "bar", :parent => cc_classification)
+        alert_definition_profile.assign_to_tags([classification_tag], "host")
+        alert_definition_profile.assign_to_tags([classification_tag2], "host")
 
         request = {
           "action"    => "unassign",
           "resources" => [
             { "id" => alert_definition_profile.id, "resources" => [
-              {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, classification.tag) }},
+              {"href" => api_hosts_url, "tag" => { "id" => classification_tag.tag.id }},
+              {"href" => api_hosts_url, "tag" => { "category" => cc_classification.name, "name" => "bar" }},
               {"href" => api_cluster_url(nil, cluster) }
             ]}
           ]
@@ -60,15 +120,11 @@ describe "Alert Definition Profiles API" do
     context "assign" do
       it "assigns alert profiles with an appropriate role" do
         api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
-        alert_definition_profile = FactoryGirl.create(:miq_alert_set)
-        cluster = FactoryGirl.create(:ems_cluster)
-        dept = FactoryGirl.create(:classification_department)
-        tag = FactoryGirl.create(:classification_tag, :name => "foo", :parent => dept).tag
 
         request = {
           "action"    => "assign",
           "resources" => [
-            {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, tag) }},
+            {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, classification_tag.tag) }},
             {"href" => api_cluster_url(nil, cluster) }
           ]
         }
@@ -82,17 +138,13 @@ describe "Alert Definition Profiles API" do
     context "unassign" do
       it "unassigns objects and tags with an appropriate role" do
         api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
-        alert_definition_profile = FactoryGirl.create(:miq_alert_set)
-        cluster = FactoryGirl.create(:ems_cluster)
         alert_definition_profile.assign_to_objects([cluster])
-        dept = FactoryGirl.create(:classification_department)
-        classification = FactoryGirl.create(:classification_tag, :name => "foo", :parent => dept)
-        alert_definition_profile.assign_to_tags([classification], "host")
+        alert_definition_profile.assign_to_tags([classification_tag], "host")
 
         request = {
           "action"    => "unassign",
           "resources" => [
-            {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, classification.tag) }},
+            {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, classification_tag.tag) }},
             {"href" => api_cluster_url(nil, cluster) }
           ]
         }

--- a/spec/requests/alert_definition_profiles_spec.rb
+++ b/spec/requests/alert_definition_profiles_spec.rb
@@ -26,6 +26,34 @@ describe "Alert Definition Profiles API" do
         expect(response.parsed_body).to include(expected)
       end
     end
+
+    context "unassign" do
+      it "assigns alert profiles with an appropriate role" do
+        api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
+        alert_definition_profile = FactoryGirl.create(:miq_alert_set)
+        cluster = FactoryGirl.create(:ems_cluster)
+        dept = FactoryGirl.create(:classification_department)
+        classification = FactoryGirl.create(:classification_tag, :name => "foo", :parent => dept)
+        alert_definition_profile.assign_to_tags([classification], "host")
+
+        request = {
+          "action"    => "unassign",
+          "resources" => [
+            { "id" => alert_definition_profile.id, "resources" => [
+              {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, classification.tag) }},
+              {"href" => api_cluster_url(nil, cluster) }
+            ]}
+          ]
+        }
+        post(api_alert_definition_profiles_url, :params => request)
+
+        expected = {
+          "results" => [{"success" => true, "message" => /Unassigned resources from Alert Definition Profile/}]
+        }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+    end
   end
 
   describe "POST /api/alert_definition_profiles" do
@@ -48,6 +76,30 @@ describe "Alert Definition Profiles API" do
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include("success" => true, "message" => /Assigned resources to Alert Definition Profile/)
+      end
+    end
+
+    context "unassign" do
+      it "unassigns objects and tags with an appropriate role" do
+        api_basic_authorize(collection_action_identifier(:alert_definition_profiles, :edit))
+        alert_definition_profile = FactoryGirl.create(:miq_alert_set)
+        cluster = FactoryGirl.create(:ems_cluster)
+        alert_definition_profile.assign_to_objects([cluster])
+        dept = FactoryGirl.create(:classification_department)
+        classification = FactoryGirl.create(:classification_tag, :name => "foo", :parent => dept)
+        alert_definition_profile.assign_to_tags([classification], "host")
+
+        request = {
+          "action"    => "unassign",
+          "resources" => [
+            {"href" => api_hosts_url, "tag" => { "href" => api_tag_url(nil, classification.tag) }},
+            {"href" => api_cluster_url(nil, cluster) }
+          ]
+        }
+        post(api_alert_definition_profile_url(nil, alert_definition_profile), :params => request)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include("success" => true, "message" => /Unassigned resources from Alert Definition Profile/)
       end
     end
   end


### PR DESCRIPTION
Had to deviate slightly from the signature defined [here](https://github.com/ManageIQ/manageiq-api/pull/177#issuecomment-361722583) because it was not taking into account the alert definition profile resource. Tag references accept both `href` and `name` (name of the classification)

```
POST /api/alert_definition_profiles
{  
   "action":"assign",
   "resources":[  
      {  
         "id":"<alert_definition_profile_id>",
         "resources":[  
            {  
               "href":"/api/hosts",
               "tag":{  
                  "href":"/api/tags/:id"
               }
            },
            {  
               "href":"/api/hosts",
               "tag":{ 
                   "category":"<category name>",
                  "name":"<tag name>"
               }
            },
            {  
               "href":"/api/clusters/:id"
            }
         ]
      }
   ]
}
```

```
POST /api/alert_definition_profiles/:id
{  
   "action":"assign",
   "resources":[  
      {  
         "href":"/api/hosts",
         "tag":{  
            "href":"/api/tags/:id"
         }
      },
      {  
         "href":"/api/clusters/:id"
      }
   ]
}
```

```
POST /api/alert_definition_profiles
{  
   "action":"unassign",
   "resources":[  
      {  
         "id":"<alert_definition_profile_id>",
         "resources":[  
            {  
               "href":"/api/hosts",
               "tag":{  
                  "href":"/api/tags/:id"
               }
            },
            {  
               "href":"/api/hosts",
               "tag":{  
                   "category":"<category name>",
                  "name":"<tag name>"
               }
            },
            {  
               "href":"/api/clusters/:id"
            }
         ]
      }
   ]
}
```

```
POST /api/alert_definition_profiles/:id
{  
   "action":"unassign",
   "resources":[  
      {  
         "href":"/api/hosts",
         "tag":{  
            "href":"/api/tags/:id"
         }
      },
      {  
         "href":"/api/clusters/:id"
      }
   ]
}
```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1539379