### PR TITLE
Added the enterprise_href in the server_info section of the entrypoint

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -58,13 +58,14 @@ module Api
 
     def server_info
       {
-        :version     => Vmdb::Appliance.VERSION,
-        :build       => Vmdb::Appliance.BUILD,
-        :appliance   => MiqServer.my_server.name,
-        :time        => Time.now.utc.iso8601,
-        :server_href => "#{@req.api_prefix}/servers/#{MiqServer.my_server.id}",
-        :zone_href   => "#{@req.api_prefix}/zones/#{MiqServer.my_server.zone.id}",
-        :region_href => "#{@req.api_prefix}/regions/#{MiqRegion.my_region.id}"
+        :version         => Vmdb::Appliance.VERSION,
+        :build           => Vmdb::Appliance.BUILD,
+        :appliance       => MiqServer.my_server.name,
+        :time            => Time.now.utc.iso8601,
+        :server_href     => "#{@req.api_prefix}/servers/#{MiqServer.my_server.id}",
+        :zone_href       => "#{@req.api_prefix}/zones/#{MiqServer.my_server.zone.id}",
+        :region_href     => "#{@req.api_prefix}/regions/#{MiqRegion.my_region.id}",
+        :enterprise_href => "#{@req.api_prefix}/enterprises/#{MiqEnterprise.my_enterprise.id}"
       }
     end
 

--- a/spec/requests/enterprises_spec.rb
+++ b/spec/requests/enterprises_spec.rb
@@ -1,7 +1,7 @@
 describe "Enterprises API" do
   context "GET /api/enterprises" do
     it "returns the enterprises" do
-      enterprise = FactoryGirl.create(:miq_enterprise)
+      enterprise = MiqEnterprise.first
       api_basic_authorize
 
       get(api_enterprises_url)

--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -45,13 +45,14 @@ RSpec.describe "API entrypoint" do
 
       expect(response.parsed_body).to include(
         "server_info" => a_hash_including(
-          "version"     => Vmdb::Appliance.VERSION,
-          "build"       => Vmdb::Appliance.BUILD,
-          "appliance"   => MiqServer.my_server.name,
-          "time"        => "2018-01-01T00:00:00Z",
-          "server_href" => api_server_url(nil, MiqServer.my_server),
-          "zone_href"   => api_zone_url(nil, MiqServer.my_server.zone),
-          "region_href" => api_region_url(nil, MiqRegion.my_region)
+          "version"         => Vmdb::Appliance.VERSION,
+          "build"           => Vmdb::Appliance.BUILD,
+          "appliance"       => MiqServer.my_server.name,
+          "time"            => "2018-01-01T00:00:00Z",
+          "server_href"     => api_server_url(nil, MiqServer.my_server),
+          "zone_href"       => api_zone_url(nil, MiqServer.my_server.zone),
+          "region_href"     => api_region_url(nil, MiqRegion.my_region),
+          "enterprise_href" => api_enterprise_url(nil, MiqEnterprise.my_enterprise)
         )
       )
     end

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -7,6 +7,7 @@ module Spec
     module Api
       module Helpers
         def init_api_spec_env
+          @enterprise = FactoryGirl.create(:miq_enterprise)
           @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
           @region = FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number)
           @role  = FactoryGirl.create(:miq_user_role, :name => "Api User Role")


### PR DESCRIPTION
Completing the Enterprise story, adding an enterprise_href in the section in the API entrypoint.

Followup to https://github.com/ManageIQ/manageiq-api/pull/346
