### PR TITLE
[WIP] Add validate_vms resource action to transformation mappings

### DIFF
--- a/app/controllers/api/transformation_mappings_controller.rb
+++ b/app/controllers/api/transformation_mappings_controller.rb
@@ -10,6 +10,13 @@ module Api
       raise BadRequestError, "Could not create Transformation Mapping - #{err}"
     end
 
+    def validate_vms_resource(type, id, data = {})
+      transformation_mapping = resource_search(id, type, collection_class(type))
+      transformation_mapping.validate_vms(data["import"]) || {}
+    rescue StandardError => err
+      raise BadRequestError, "Could not validate vms - #{err}"
+    end
+
     private
 
     def create_mapping_items(items)

--- a/config/api.yml
+++ b/config/api.yml
@@ -3101,6 +3101,9 @@
       :get:
       - :name: read
         :identifier: transformation_mapping_show
+      :post:
+      - :name: validate_vms
+        :identifier: transformation_mapping_new
   :users:
     :description: Users
     :identifier: rbac_user


### PR DESCRIPTION
Dependent on https://github.com/ManageIQ/manageiq/pull/17177

Supports import from csv or without any data at all

```
POST /api/transformation_mappings/:id
{
   "action": "validate_vms"
}
```

```
POST /api/transformation_mappings/:id
{
   "action": "validate_vms",
   "import": [
      { "name": "vm_name", "uid": "vm_uid" } 
    ]
}
```

cc: @bzwei 