### PR TITLE
[WIP] Caches the calls to user_role_allows? for the currently authenticated

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -494,7 +494,9 @@ module Api
 
       def api_user_role_allows?(action_identifier)
         return true unless action_identifier
-        Array(action_identifier).any? { |identifier| User.current_user.role_allows?(:identifier => identifier) }
+        @cached_allowed_user_roles ||= {}
+        key = Array(action_identifier).sort.join(',')
+        @cached_allowed_user_roles[key] ||= Array(action_identifier).any? { |identifier| User.current_user.role_allows?(:identifier => identifier) }
       end
 
       def render_actions(physical_attrs)


### PR DESCRIPTION
API user.  While this PR eliminates a fair amount of DEBUG lines seen
as follows in the logs:

  D, [2018-03-21T19:51:26.328222 #7831] DEBUG -- :   CACHE (0.0ms)  SELECT "miq_product_features"."identifier" FROM "miq_product_features" INNER JOIN "miq_roles_features" ON "miq_product_features"."id" = "miq_roles_features"."miq_product_feature_id" WHERE "miq_roles_features"."miq_user_role_id" = $1  [["miq_user_role_id", 1]]

There is no performance gain since the resultant data above is already cached.