### PR TITLE
Always challenge a user with no/bad credentials

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -37,8 +37,6 @@ module Api
     rescue_from(ActiveRecord::StatementInvalid) { |e| api_error(:bad_request, e) }
     rescue_from(JSON::ParserError)              { |e| api_error(:bad_request, e) }
     rescue_from(MultiJson::LoadError)           { |e| api_error(:bad_request, e) }
-    rescue_from(MiqException::MiqEVMLoginError) { |e| api_error(:unauthorized, e) }
-    rescue_from(AuthenticationError)            { |e| api_error(:unauthorized, e) }
     rescue_from(ForbiddenError)                 { |e| api_error(:forbidden, e) }
     rescue_from(BadRequestError)                { |e| api_error(:bad_request, e) }
     rescue_from(NotFoundError)                  { |e| api_error(:not_found, e) }

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -31,6 +31,7 @@ module Api
         api_log_error("AuthenticationError: #{e.message}")
         response.headers["Content-Type"] = "application/json"
         request_http_basic_authentication("Application", ErrorSerializer.new(:unauthorized, e).serialize.to_json)
+        log_api_response
       end
 
       def user_settings

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -14,11 +14,8 @@ module Api
         else
           success = authenticate_with_http_basic do |u, p|
             begin
-              user = User.authenticate(
-                u, p, request,
-                :require_user => true,
-                :timeout      => ::Settings.api.authentication_timeout.to_i_with_method
-              )
+              timeout = ::Settings.api.authentication_timeout.to_i_with_method
+              user = User.authenticate(u, p, request, :require_user => true, :timeout => timeout)
               auth_user_obj = userid_to_userobj(user.userid)
               authorize_user_group(auth_user_obj)
               validate_user_identity(auth_user_obj)

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -31,6 +31,7 @@ module Api
         end
         log_api_auth
       rescue AuthenticationError => e
+        api_log_error("AuthenticationError: #{e.message}")
         response.headers["Content-Type"] = "application/json"
         request_http_basic_authentication("Application", ErrorSerializer.new(:unauthorized, e).serialize.to_json)
       end

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -12,7 +12,7 @@ module Api
         elsif request.headers[HttpHeaders::AUTH_TOKEN]
           authenticate_with_user_token(request.headers[HttpHeaders::AUTH_TOKEN])
         else
-          authenticate_with_http_basic do |u, p|
+          success = authenticate_with_http_basic do |u, p|
             begin
               user = User.authenticate(
                 u, p, request,
@@ -26,7 +26,8 @@ module Api
             rescue MiqException::MiqEVMLoginError => e
               raise AuthenticationError, e.message
             end
-          end or raise AuthenticationError
+          end
+          raise AuthenticationError unless success
         end
         log_api_auth
       rescue AuthenticationError => e

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -5,12 +5,20 @@ describe "Authentication API" do
   ENTRYPOINT_KEYS = %w(name description version versions identity collections)
 
   context "Basic Authentication" do
+    example "the user is challenged to use Basic Authentication when no credentials are provided" do
+      get api_entrypoint_url
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to match("Basic")
+    end
+
     it "test basic authentication with bad credentials" do
       api_basic_authorize :user => 'baduser', :password => 'badpassword'
 
       get api_entrypoint_url
 
       expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to match("Basic")
     end
 
     it "test basic authentication with correct credentials" do
@@ -30,7 +38,9 @@ describe "Authentication API" do
 
       get api_entrypoint_url
 
+      expect(response.parsed_body).to include_error_with_message("User's Role is missing")
       expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to match("Basic")
     end
 
     it "test basic authentication with a user without a group" do
@@ -42,6 +52,7 @@ describe "Authentication API" do
       get api_entrypoint_url
 
       expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to match("Basic")
     end
 
     it "returns a correctly formatted versions href" do
@@ -86,7 +97,9 @@ describe "Authentication API" do
 
       get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => "bogus_group"}
 
+      expect(response.parsed_body).to include_error_with_message("Invalid Authorization Group bogus_group specified")
       expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to match("Basic")
     end
 
     it "test basic authentication with a primary group" do


### PR DESCRIPTION
According to RFC 2617:

> The 401 (Unauthorized) response message is used by an origin server
  to challenge the authorization of a user agent. This response MUST
  include a WWW-Authenticate header field containing at least one
  challenge applicable to the requested resource.

We currently only issue a challenge when no credentials are provided -
if a user fails authentication they are not challenged again. This
broken implementation can cause some frustration for instance when
using the web browser, which will cache a mis-typed user/password
combination and not challenge the user again.

This is somewhat problematic as we only use the `Authorization` header
for Basic Authentication. It seems like a safe compromise for the user
to be challenged to use Basic Authentication if authentication fails
for whatever reason.