### PR TITLE
Adding tagging support for additional collections

### DIFF
--- a/app/controllers/api/availability_zones_controller.rb
+++ b/app/controllers/api/availability_zones_controller.rb
@@ -1,4 +1,5 @@
 module Api
   class AvailabilityZonesController < BaseController
+    include Subcollections::Tags
   end
 end

--- a/app/controllers/api/cloud_networks_controller.rb
+++ b/app/controllers/api/cloud_networks_controller.rb
@@ -1,4 +1,5 @@
 module Api
   class CloudNetworksController < BaseController
+    include Subcollections::Tags
   end
 end

--- a/app/controllers/api/cloud_subnets_controller.rb
+++ b/app/controllers/api/cloud_subnets_controller.rb
@@ -1,4 +1,5 @@
 module Api
   class CloudSubnetsController < BaseController
+    include Subcollections::Tags
   end
 end

--- a/app/controllers/api/flavors_controller.rb
+++ b/app/controllers/api/flavors_controller.rb
@@ -1,4 +1,5 @@
 module Api
   class FlavorsController < BaseController
+    include Subcollections::Tags
   end
 end

--- a/app/controllers/api/network_routers_controller.rb
+++ b/app/controllers/api/network_routers_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class NetworkRoutersController < BaseController
+    include Subcollections::Tags
+
     def delete_resource(type, id, _data = {})
       delete_action_handler do
         network_router = resource_search(id, type, collection_class(:network_routers))

--- a/app/controllers/api/security_groups_controller.rb
+++ b/app/controllers/api/security_groups_controller.rb
@@ -1,4 +1,5 @@
 module Api
   class SecurityGroupsController < BaseController
+    include Subcollections::Tags
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -322,6 +322,8 @@
     - :custom_actions
     :verbs: *gp
     :klass: AvailabilityZone
+    :subcollections:
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -333,6 +335,12 @@
       :get:
       - :name: read
         :identifier: availability_zone_show
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: availability_zone_tag
+      - :name: unassign
+        :identifier: availability_zone_tag
   :categories:
     :description: Categories
     :identifier: ops_settings
@@ -416,6 +424,8 @@
     - :custom_actions
     :verbs: *gp
     :klass: CloudNetwork
+    :subcollections:
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -435,6 +445,12 @@
       :get:
       - :name: read
         :identifier: cloud_network_show
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: cloud_network_tag
+      - :name: unassign
+        :identifier: cloud_network_tag
   :cloud_object_store_containers:
     :description: Cloud Object Store Containers
     :identifier: cloud_object_store_container
@@ -463,6 +479,8 @@
     - :custom_actions
     :verbs: *gp
     :klass: CloudSubnet
+    :subcollections:
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -482,6 +500,12 @@
       :get:
       - :name: read
         :identifier: cloud_subnet_show
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: cloud_subnet_tag
+      - :name: unassign
+        :identifier: cloud_subnet_tag
   :cloud_templates:
     :description: Cloud Templates
     :identifier: image
@@ -1103,6 +1127,8 @@
     - :subcollection
     :verbs: *gpd
     :klass: Flavor
+    :subcollections:
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -1135,6 +1161,12 @@
       :delete:
       - :name: delete
         :identifier: flavor_delete
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: flavor_tag
+      - :name: unassign
+        :identifier: flavor_tag
   :floating_ips:
     :description: Floating IPs
     :identifier: floating_ip
@@ -1593,6 +1625,8 @@
     - :custom_actions
     :verbs: *gpd
     :klass: NetworkRouter
+    :subcollections:
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -1612,6 +1646,12 @@
       :delete:
       - :name: delete
         :identifier: network_router_delete
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: network_router_tag
+      - :name: unassign
+        :identifier: network_router_tag
   :networks:
     :description: Networks
     :options:
@@ -2418,6 +2458,8 @@
     - :custom_actions
     :verbs: *gp
     :klass: SecurityGroup
+    :subcollections:
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -2442,6 +2484,12 @@
       :get:
       - :name: read
         :identifier: security_group_show
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: security_group_tag
+      - :name: unassign
+        :identifier: security_group_tag
   :servers:
     :description: EVM Servers
     :subcollections:

--- a/spec/requests/tag_collections_spec.rb
+++ b/spec/requests/tag_collections_spec.rb
@@ -30,6 +30,246 @@ describe "Tag Collections API" do
     FactoryGirl.create(:classification_cost_center_with_tags)
   end
 
+  context "Availability Zone Tag subcollection" do
+    let(:availability_zone) { FactoryGirl.create(:availability_zone) }
+
+    it "query all tags of an Availability Zone and verify tag category and names" do
+      api_basic_authorize
+      classify_resource(availability_zone)
+
+      get api_availability_zone_tags_url(nil, availability_zone), :params => { :expand => "resources" }
+
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
+    end
+
+    it "does not assign a tag to an Availability Zone without appropriate role" do
+      api_basic_authorize
+
+      post(api_availability_zone_tags_url(nil, availability_zone), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "assigns a tag to an Availability Zone" do
+      api_basic_authorize subcollection_action_identifier(:availability_zones, :tags, :assign)
+
+      post(api_availability_zone_tags_url(nil, availability_zone), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_availability_zone_url(nil, availability_zone)))
+    end
+
+    it "does not unassign a tag from an Availability Zone without appropriate role" do
+      api_basic_authorize
+
+      post(api_availability_zone_tags_url(nil, availability_zone), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "unassigns a tag from an Availability Zone" do
+      api_basic_authorize subcollection_action_identifier(:availability_zones, :tags, :unassign)
+      classify_resource(availability_zone)
+
+      post(api_availability_zone_tags_url(nil, availability_zone), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_availability_zone_url(nil, availability_zone)))
+      expect_resource_has_tags(availability_zone, tag2[:path])
+    end
+  end
+
+  context "Cloud Network Tag subcollection" do
+    let(:cloud_network) { FactoryGirl.create(:cloud_network) }
+
+    it "query all tags of an Cloud Network and verify tag category and names" do
+      api_basic_authorize
+      classify_resource(cloud_network)
+
+      get api_cloud_network_tags_url(nil, cloud_network), :params => { :expand => "resources" }
+
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
+    end
+
+    it "does not assign a tag to an Cloud Network without appropriate role" do
+      api_basic_authorize
+
+      post(api_cloud_network_tags_url(nil, cloud_network), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "assigns a tag to an Cloud Network" do
+      api_basic_authorize subcollection_action_identifier(:cloud_networks, :tags, :assign)
+
+      post(api_cloud_network_tags_url(nil, cloud_network), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_cloud_network_url(nil, cloud_network)))
+    end
+
+    it "does not unassign a tag from an Cloud Network without appropriate role" do
+      api_basic_authorize
+
+      post(api_cloud_network_tags_url(nil, cloud_network), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "unassigns a tag from an Cloud Network" do
+      api_basic_authorize subcollection_action_identifier(:cloud_networks, :tags, :unassign)
+      classify_resource(cloud_network)
+
+      post(api_cloud_network_tags_url(nil, cloud_network), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_cloud_network_url(nil, cloud_network)))
+      expect_resource_has_tags(cloud_network, tag2[:path])
+    end
+  end
+
+  context "Cloud Subnet Tag subcollection" do
+    let(:cloud_subnet) { FactoryGirl.create(:cloud_subnet) }
+
+    it "query all tags of a Cloud Subnet and verify tag category and names" do
+      api_basic_authorize
+      classify_resource(cloud_subnet)
+
+      get api_cloud_subnet_tags_url(nil, cloud_subnet), :params => { :expand => "resources" }
+
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
+    end
+
+    it "does not assign a tag to a Cloud Subnet without appropriate role" do
+      api_basic_authorize
+
+      post(api_cloud_subnet_tags_url(nil, cloud_subnet), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "assigns a tag to a Cloud Subnet" do
+      api_basic_authorize subcollection_action_identifier(:cloud_subnets, :tags, :assign)
+
+      post(api_cloud_subnet_tags_url(nil, cloud_subnet), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_cloud_subnet_url(nil, cloud_subnet)))
+    end
+
+    it "does not unassign a tag from a Cloud Subnet without appropriate role" do
+      api_basic_authorize
+
+      post(api_cloud_subnet_tags_url(nil, cloud_subnet), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "unassigns a tag from a Cloud Subnet" do
+      api_basic_authorize subcollection_action_identifier(:cloud_subnets, :tags, :unassign)
+      classify_resource(cloud_subnet)
+
+      post(api_cloud_subnet_tags_url(nil, cloud_subnet), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_cloud_subnet_url(nil, cloud_subnet)))
+      expect_resource_has_tags(cloud_subnet, tag2[:path])
+    end
+  end
+
+  context "Flavor Tag subcollection" do
+    let(:flavor) { FactoryGirl.create(:flavor) }
+
+    it "query all tags of a Flavor and verify tag category and names" do
+      api_basic_authorize
+      classify_resource(flavor)
+
+      get api_flavor_tags_url(nil, flavor), :params => { :expand => "resources" }
+
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
+    end
+
+    it "does not assign a tag to a Flavor without appropriate role" do
+      api_basic_authorize
+
+      post(api_flavor_tags_url(nil, flavor), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "assigns a tag to a Flavor" do
+      api_basic_authorize subcollection_action_identifier(:flavors, :tags, :assign)
+
+      post(api_flavor_tags_url(nil, flavor), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_flavor_url(nil, flavor)))
+    end
+
+    it "does not unassign a tag from a Flavor without appropriate role" do
+      api_basic_authorize
+
+      post(api_flavor_tags_url(nil, flavor), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "unassigns a tag from a Flavor" do
+      api_basic_authorize subcollection_action_identifier(:flavors, :tags, :unassign)
+      classify_resource(flavor)
+
+      post(api_flavor_tags_url(nil, flavor), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_flavor_url(nil, flavor)))
+      expect_resource_has_tags(flavor, tag2[:path])
+    end
+  end
+
+  context "Network Router Tag subcollection" do
+    let(:network_router) { FactoryGirl.create(:network_router) }
+
+    it "query all tags of a Network Router and verify tag category and names" do
+      api_basic_authorize
+      classify_resource(network_router)
+
+      get api_network_router_tags_url(nil, network_router), :params => { :expand => "resources" }
+
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
+    end
+
+    it "does not assign a tag to a Network Router without appropriate role" do
+      api_basic_authorize
+
+      post(api_network_router_tags_url(nil, network_router), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "assigns a tag to a Network Router" do
+      api_basic_authorize subcollection_action_identifier(:network_routers, :tags, :assign)
+
+      post(api_network_router_tags_url(nil, network_router), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_network_router_url(nil, network_router)))
+    end
+
+    it "does not unassign a tag from a Network Router without appropriate role" do
+      api_basic_authorize
+
+      post(api_network_router_tags_url(nil, network_router), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "unassigns a tag from a Network Router" do
+      api_basic_authorize subcollection_action_identifier(:network_routers, :tags, :unassign)
+      classify_resource(network_router)
+
+      post(api_network_router_tags_url(nil, network_router), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_network_router_url(nil, network_router)))
+      expect_resource_has_tags(network_router, tag2[:path])
+    end
+  end
+
   context "Provider Tag subcollection" do
     let(:provider)          { ems }
 
@@ -271,6 +511,54 @@ describe "Tag Collections API" do
 
       expect_tagging_result(tag1_results(api_cluster_url(nil, cluster)))
       expect_resource_has_tags(cluster, tag2[:path])
+    end
+  end
+
+  context "Security Group Tag subcollection" do
+    let(:security_group) { FactoryGirl.create(:security_group) }
+
+    it "query all tags of a Security Group and verify tag category and names" do
+      api_basic_authorize
+      classify_resource(security_group)
+
+      get api_security_group_tags_url(nil, security_group), :params => { :expand => "resources" }
+
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
+    end
+
+    it "does not assign a tag to a Security Group without appropriate role" do
+      api_basic_authorize
+
+      post(api_security_group_tags_url(nil, security_group), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "assigns a tag to a Security Group" do
+      api_basic_authorize subcollection_action_identifier(:security_groups, :tags, :assign)
+
+      post(api_security_group_tags_url(nil, security_group), :params => gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_security_group_url(nil, security_group)))
+    end
+
+    it "does not unassign a tag from a Security Group without appropriate role" do
+      api_basic_authorize
+
+      post(api_security_group_tags_url(nil, security_group), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "unassigns a tag from a Security Group" do
+      api_basic_authorize subcollection_action_identifier(:security_groups, :tags, :unassign)
+      classify_resource(security_group)
+
+      post(api_security_group_tags_url(nil, security_group), :params => gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(tag1_results(api_security_group_url(nil, security_group)))
+      expect_resource_has_tags(security_group, tag2[:path])
     end
   end
 


### PR DESCRIPTION
Adding tagging support for resources of the following collections:

  - /api/availability_zones
  - /api/cloud_networks
  - /api/cloud_subnets
  - /api/flavors
  - /api/network_routers
  - /api/security_groups

Standard tagging subcollection signature as follows:

  - /api/availability_zones/:id/tags
  - /api/cloud_networks/:id/tags
  - /api/cloud_subnets/:id/tags
  - /api/flavors/:id/tags
  - /api/network_routers/:id/tags
  - /api/security_groups/:id/tags

supporting regular queries as well as the assign and unassign actions.

Fixes: #77 

https://bugzilla.redhat.com/show_bug.cgi?id=1497061