### PR TITLE
Creating PhysicalChassis controller and adding endpoint configuration

### DIFF
--- a/app/controllers/api/physical_chassis_controller.rb
+++ b/app/controllers/api/physical_chassis_controller.rb
@@ -1,4 +1,40 @@
 module Api
   class PhysicalChassisController < BaseController
+    def refresh_resource(type, id, _data = nil)
+      raise BadRequestError, "Must specify an id for refreshing a #{type} resource" if id.blank?
+
+      ensure_resource_exists(type, id) if single_resource?
+
+      api_action(type, id) do |klass|
+        physical_chassis = resource_search(id, type, klass)
+        api_log_info("Refreshing #{physical_chassis_ident(physical_chassis)}")
+        refresh_physical_chassis(physical_chassis)
+      end
+    end
+
+    private
+
+    def ensure_resource_exists(type, id)
+      raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
+    end
+
+    def refresh_physical_chassis(physical_chassis)
+      method_name = "refresh_ems"
+      role = "ems_operations"
+
+      act_refresh(physical_chassis, method_name, role)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def physical_chassis_ident(physical_chassis)
+      "Physical Chassis id:#{physical_chassis.id} name:'#{physical_chassis.name}'"
+    end
+
+    def act_refresh(physical_chassis, method_name, role)
+      desc = "#{physical_chassis_ident(physical_chassis)} refreshing"
+      task_id = queue_object_action(physical_chassis, desc, :method_name => method_name, :role => role)
+      action_result(true, desc, :task_id => task_id)
+    end
   end
 end

--- a/app/controllers/api/physical_chassis_controller.rb
+++ b/app/controllers/api/physical_chassis_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class PhysicalChassisController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1808,6 +1808,18 @@
         :identifier: physical_server_turn_off_loc_led
       - :name: apply_config_pattern
         :identifier: physical_server_apply_config_pattern
+  :physical_chassis:
+    :description: Physical Chassis
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: PhysicalChassis
+    :collection_actions:
+      :get:
+      - :name: read
+    :resource_actions:
+      :get:
+      - :name: read
   :pictures:
     :description: Pictures
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -1740,6 +1740,28 @@
       :delete:
       - :name: delete
         :identifier: orchestration_template_remove
+  :physical_chassis:
+    :description: Physical Chassis
+    :identifier: physical_chassis
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: PhysicalChassis
+    :subcollections:
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: physical_chassis_show_list
+      :post:
+      - :name: refresh
+        :identifier: physical_chassis_refresh
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: physical_chassis_show
+      :post:
+      - :name: refresh
+        :identifier: physical_chassis_refresh
   :physical_servers:
     :description: Physical Servers
     :identifier: physical_server
@@ -1808,18 +1830,6 @@
         :identifier: physical_server_turn_off_loc_led
       - :name: apply_config_pattern
         :identifier: physical_server_apply_config_pattern
-  :physical_chassis:
-    :description: Physical Chassis
-    :options:
-    - :collection
-    :verbs: *g
-    :klass: PhysicalChassis
-    :collection_actions:
-      :get:
-      - :name: read
-    :resource_actions:
-      :get:
-      - :name: read
   :pictures:
     :description: Pictures
     :options:

--- a/spec/requests/physical_chassis_spec.rb
+++ b/spec/requests/physical_chassis_spec.rb
@@ -1,0 +1,100 @@
+describe "Physical Chassis API" do
+  context "GET /api/physical_chassis" do
+    it "returns all physical_chassis" do
+      physical_chassis = FactoryGirl.create(:physical_chassis)
+      api_basic_authorize('physical_chassis_show_list')
+
+      get(api_physical_chassis_url)
+
+      expected = {
+        "name"      => "physical_chassis",
+        "resources" => [{"href" => api_one_physical_chassis_url(nil, physical_chassis)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "GET /api/physical_chassis/:id" do
+    it "returns one physical_chassis" do
+      physical_chassis = FactoryGirl.create(:physical_chassis)
+      api_basic_authorize('physical_chassis_show')
+
+      get(api_one_physical_chassis_url(nil, physical_chassis))
+
+      expected = {
+        "name" => physical_chassis.name,
+        "href" => api_one_physical_chassis_url(nil, physical_chassis)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe "Physical Chassis refresh action" do
+    context "with an invalid id" do
+      it "it responds with 404 Not Found" do
+        api_basic_authorize(action_identifier(:physical_chassis, :refresh, :resource_actions, :post))
+
+        post(api_one_physical_chassis_url(nil, 999_999), :params => gen_request(:refresh))
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "without an appropriate role" do
+      it "it responds with 403 Forbidden" do
+        physical_chassis = FactoryGirl.create(:physical_chassis)
+        api_basic_authorize
+
+        post(api_one_physical_chassis_url(nil, physical_chassis), :params => gen_request(:refresh))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with an appropriate role" do
+      it "rejects refresh for unspecified physical chassis" do
+        api_basic_authorize(action_identifier(:physical_chassis, :refresh, :resource_actions, :post))
+
+        post(api_physical_chassis_url, :params => gen_request(:refresh, [{"href" => "/api/physical_chassis/"}, {"href" => "/api/physical_chassis/"}]))
+
+        expect_bad_request(/Must specify an id/i)
+      end
+
+      it "refresh of a single Physical Chassis" do
+        physical_chassis = FactoryGirl.create(:physical_chassis)
+        api_basic_authorize('physical_chassis_refresh')
+
+        post(api_one_physical_chassis_url(nil, physical_chassis), :params => gen_request(:refresh))
+
+        expect_single_action_result(:success => true, :message => /#{physical_chassis.id}.* refreshing/i, :href => api_one_physical_chassis_url(nil, physical_chassis))
+      end
+
+      it "refresh of multiple Physical Chassis" do
+        physical_chassis = FactoryGirl.create(:physical_chassis)
+        physical_chassis_two = FactoryGirl.create(:physical_chassis)
+        api_basic_authorize('physical_chassis_refresh')
+
+        post(api_physical_chassis_url, :params => gen_request(:refresh, [{"href" => api_one_physical_chassis_url(nil, physical_chassis)}, {"href" => api_one_physical_chassis_url(nil, physical_chassis_two)}]))
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including(
+              "message" => a_string_matching(/#{physical_chassis.id}.* refreshing/i),
+              "success" => true,
+              "href"    => api_one_physical_chassis_url(nil, physical_chassis)
+            ),
+            a_hash_including(
+              "message" => a_string_matching(/#{physical_chassis_two.id}.* refreshing/i),
+              "success" => true,
+              "href"    => api_one_physical_chassis_url(nil, physical_chassis_two)
+            )
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**This PR adds:**
- GET /api/physical_chassis
- GET /api/physical_chassis/:id
- POST /api/physical_chassis (action: refresh)
- POST /api/physical_chassis/:id (action: refresh)

**Depends on:**
[ManageIQ/manageiq#17320](https://github.com/ManageIQ/manageiq/pull/17320) [Merged]
[ManageIQ/manageiq-api#364](https://github.com/ManageIQ/manageiq-api/pull/364) [Merged]