### PR TITLE
Adding support for collection_names whose plural and singular are the same

### DIFF
--- a/lib/api.rb
+++ b/lib/api.rb
@@ -3,15 +3,6 @@ module Api
   VERSION_CONSTRAINT = /v\d+(\.[\da-zA-Z]+)*(\-[\da-zA-Z\-\.]+)?/
   VERSION_REGEX = /\A#{VERSION_CONSTRAINT}\z/
 
-  VERBS_ACTIONS_MAP = {
-    :get     => "show",
-    :post    => "update",
-    :put     => "update",
-    :patch   => "update",
-    :delete  => "destroy",
-    :options => "options"
-  }.freeze
-
   ApiError = Class.new(StandardError)
   AuthenticationError = Class.new(ApiError)
   ForbiddenError = Class.new(ApiError)

--- a/lib/api/routing.rb
+++ b/lib/api/routing.rb
@@ -1,0 +1,37 @@
+module Api
+  module Routing
+    VERBS_ACTIONS_MAP = {
+      :get     => "show",
+      :post    => "update",
+      :put     => "update",
+      :patch   => "update",
+      :delete  => "destroy",
+      :options => "options"
+    }.freeze
+
+    # Generates plural and singular variants of the default collection_name
+    #
+    # Plural inflection is used on the root routes. e.g.: route => /containers, :as => "containers"
+    # Singular inflection is used on the resource routes. e.g.: route => /containers/:id, :as => "container"
+    #
+    # !IMPORTANT!
+    # One special case happens when singular and plural are the same. The API would not allow two routes
+    # with the same name. This method generates a singular variant with preffix "one_" when this happens.
+    # e.g.:
+    #   route => /physical_chassis,     :as => "physical_chassis"
+    #   route => /physical_chassis/:id, :as => "one_physical_chassis"
+    #
+    # @param [String] name - Default collection_name
+    #
+    # @return [String, String] plural, singular - Values of Plural and Singular inflections
+    def self.inflections_for_named_route_helpers(name)
+      plural   = name.pluralize
+      singular = name.singularize
+
+      if singular == plural
+        singular = "one_#{singular}"
+      end
+      return plural, singular
+    end
+  end
+end

--- a/spec/lib/api/routing_spec.rb
+++ b/spec/lib/api/routing_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Api::Routing do
+  describe ".inflections_for_named_route_helpers" do
+    it "returns plural and singular for regular names" do
+      collection_name = :accounts # first collection_name on the api.yml
+
+      expected_plural    = "accounts"
+      expected_singular  = "account"
+
+      actual = Api::Routing.inflections_for_named_route_helpers(collection_name.to_s)
+      expect(actual).to eq([expected_plural, expected_singular])
+    end
+
+    it "returns a modified singular for names that singular == plural" do
+      collection_name    = :chassis
+      expected_plural    = "chassis"
+      expected_singular  = "one_chassis"
+
+      actual = Api::Routing.inflections_for_named_route_helpers(collection_name.to_s)
+
+      # If the inflection for "chassis" is set on the core this test makes sense
+      # The inflector will retrieve the same value for plural and singular
+      if collection_name.to_s.pluralize == collection_name.to_s.singularize
+        expect(actual).to eq([expected_plural, expected_singular])
+      else
+        expect(actual).to_not eq([expected_plural, expected_singular])
+      end
+    end
+  end
+end


### PR DESCRIPTION
**This PR is able to**:
- Enable that the api.yml parsing accept collection_names whose string values of plural and singular are the same;

**Detailed description**:
Currently, when [routes.rb](https://github.com/ManageIQ/manageiq-api/blob/master/config/routes.rb) reads the ApiConfig collections declared on the [api.yml](https://github.com/ManageIQ/manageiq-api/blob/master/config/api.yml) file, It generates two endpoints for a given collection name: one root endpoint with **:as** option equals to `collection_name.to_s.pluralize` and the resource endpoint using **:as** equals to `collection_name.to_s.singularize`. However, when a new endpoint is added and Its collection_name have the same values for plural and singular, the API breaks on startup because we try to define two routes with the same name.

This PR adds a new logic on the parsing of collections. If the plural is equal to the singular of collection_name, the singular value that is going to be used on the alias of the endpoint will have a value of "one_#{collection_name}".