### PR TITLE
[WIP] Add refresh parameter to ResourceActionWorkflow initialization

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -72,7 +72,7 @@ module Api
       refresh_fields = data["fields"]
       return action_result(false, "Must specify fields to refresh") if refresh_fields.blank?
 
-      service_dialog = define_service_dialog(dialog_fields, data)
+      service_dialog = define_service_dialog(dialog_fields, data, {:refresh => true})
 
       if service_dialog.id != dialog.id
         return action_result(
@@ -86,10 +86,10 @@ module Api
       action_result(false, err.to_s)
     end
 
-    def define_service_dialog(dialog_fields, data)
+    def define_service_dialog(dialog_fields, data, options = {})
       target, resource_action = validate_dialog_content_params(data, true)
 
-      workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => target)
+      workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, {:target => target}.merge(options))
 
       dialog_fields.each { |key, value| workflow.set_value(key, value) }
       workflow.dialog

--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -568,6 +568,24 @@ describe "Service Dialogs API" do
         "result"  => hash_including("text1")
       )
     end
+
+    it "creates a ResourceActionWorkflow by passing in a true refresh option" do
+      allow(ResourceActionWorkflow).to receive(:new).and_call_original
+      expect(ResourceActionWorkflow).to receive(:new).with(
+        {}, instance_of(User), instance_of(ResourceAction), hash_including(:refresh => true)
+      )
+
+      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      init_dialog
+
+      post(api_service_dialog_url(nil, dialog1), :params => gen_request(
+        :refresh_dialog_fields,
+        "fields"             => %w(text1),
+        "resource_action_id" => ra1.id,
+        "target_id"          => template.id,
+        "target_type"        => "service_template"
+      ))
+    end
   end
 
   context 'Creates service dialogs' do


### PR DESCRIPTION
This ties in with https://github.com/ManageIQ/manageiq/pull/17329 and will be needed in order to distinguish `ResourceActionWorkflow` initialization calls in the backend.

WIP for now, but I think this is probably how the API change will end up looking.

https://bugzilla.redhat.com/show_bug.cgi?id=1559757