### PR TITLE
[WIP] If a user never logged in, default the current_group

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -52,6 +52,8 @@ module Api
           group_obj = user_obj.miq_groups.find_by(:description => group_name)
           raise AuthenticationError, "Invalid Authorization Group #{group_name} specified" if group_obj.nil?
           user_obj.current_group_by_description = group_name
+        elsif user_obj.current_group.nil? && user_obj.miq_groups.present?
+          user_obj.change_current_group
         end
       end
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -44,6 +44,7 @@ describe "Authentication API" do
     end
 
     it "test basic authentication with a user without a group" do
+      @user.miq_groups = []
       @user.current_group = nil
       @user.save
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -56,6 +56,18 @@ describe "Authentication API" do
       expect(response.headers["WWW-Authenticate"]).to match("Basic")
     end
 
+    it "test basic authentication with a user without a current group" do
+      @user.current_group = nil
+      @user.save
+
+      api_basic_authorize
+
+      get api_entrypoint_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["identity"]["group"]).to eq(@group.description)
+    end
+
     it "returns a correctly formatted versions href" do
       version_ident = "v#{ManageIQ::Api::VERSION}"
       api_basic_authorize


### PR DESCRIPTION
If a user never logged in, the current_group could be nil and issues validating the user in API.

We now default the current_group (usually miq_groups.first) if nil

Fixes https://github.com/ManageIQ/manageiq-api/issues/366
