### PR TITLE
Downcase userid to match how it is stored in the DB.

### DIFF
--- a/lib/services/api/user_token_service.rb
+++ b/lib/services/api/user_token_service.rb
@@ -24,6 +24,7 @@ module Api
     end
 
     def generate_token(userid, requester_type, token_ttl: nil)
+      userid = userid.downcase
       validate_userid(userid)
       validate_requester_type(requester_type)
 

--- a/spec/lib/services/api/user_token_service_spec.rb
+++ b/spec/lib/services/api/user_token_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::UserTokenService do
     end
 
     let(:user_token_service) { described_class.new }
-    let(:token) { user_token_service.generate_token(@user.userid, 'api', token_ttl: token_ttl) }
+    let(:token) { user_token_service.generate_token(@user.userid.capitalize, 'api', :token_ttl => token_ttl) }
     let(:token_info) { user_token_service.token_mgr('api').token_get_info(token) }
 
     context "without token_ttl set" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1562403

If the authentication directory returns mixed case for the userid it
needs to be downcased to match the way userids are stored in the DB.

IBM Tivoli SAML can report usernames in mixed case. Most SAML servers do not.
This PR will ensure mixed case usernames are downcased before comparing them
to how they are stored in the DB.