### PR TITLE
[WIP] Change retirement call to use make_retire_request

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -1,3 +1,4 @@
+
 module Api
   class BaseController
     module Generic
@@ -76,7 +77,7 @@ module Api
           else
             msg << " immediately."
             api_log_info(msg)
-            resource.retire_now
+            klass.make_retire_request(resource.id)
           end
           resource
         else


### PR DESCRIPTION
New retire as a request uses new make_retire_request and Madhu says that this api change is necessary because we must continue to have retire_now for backward compatibility reasons. 

https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/retirement_mixin.rb#L13 is new, we're calling make_request for retirement as well. make_require_request is available for both Vm and Service classes and is immediate (replaces old retire_now except it doesn't replace it, we're not taking the retire_now out for those who still use it). The identifier in miq_product_features isn't changing. Everything should be similar to retire_now, it's just bimodal now.