### PR TITLE
Adds request_retirement start

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -61,6 +61,22 @@ module Api
         delete_resource_action(klass, type, id)
       end
 
+      def request_retire_resource(type, id, _data = nil)
+        if api_user_role_allows?('miq_request_approval')
+          klass = collection_class(type)
+          if id
+            msg = "Retiring #{type} id #{id} immediately as a request."
+            resource = resource_search(id, type, klass)
+            api_log_info(msg)
+            klass.make_retire_request(resource.id)
+          else
+            raise BadRequestError, "Must specify an id for retiring a #{type} resource"
+          end
+        else
+          raise ForbiddenError, "User lacking correct permissions to approve a #{type} retire as a request."
+        end
+      end
+
       def retire_resource(type, id, data = nil)
         klass = collection_class(type)
         if id

--- a/config/api.yml
+++ b/config/api.yml
@@ -2811,6 +2811,8 @@
         :identifier: service_edit
       - :name: retire
         :identifier: service_retire
+      - :name: request_retire
+        :identifier: service_retire
       - :name: set_ownership
         :identifier: service_ownership
       - :name: delete
@@ -2843,6 +2845,8 @@
       - :name: edit
         :identifier: service_edit
       - :name: retire
+        :identifier: service_retire
+      - :name: request_retire
         :identifier: service_retire
       - :name: set_ownership
         :identifier: service_ownership
@@ -3275,6 +3279,8 @@
         :identifier: vm_reset
       - :name: retire
         :identifier: vm_retire_now
+      - :name: request_retire
+        :identifier: vm_retire_now
       - :name: set_owner
         :identifier: vm_edit
       - :name: set_ownership
@@ -3323,6 +3329,8 @@
       - :name: reset
         :identifier: vm_reset
       - :name: retire
+        :identifier: vm_retire_now
+      - :name: request_retire
         :identifier: vm_retire_now
       - :name: delete
         :identifier: vm_delete


### PR DESCRIPTION
The New And Improved https://github.com/ManageIQ/manageiq-api/pull/375. 

WIP cause needs specs that pass

New retire as a request uses new make_retire_request this api change is necessary because we must continue to have retire_now for backward compatibility reasons.

https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/retirement_mixin.rb#L13 is new, we're calling make_request for retirement as well. make_require_request is available for both Vm and Service and OrchStack classes and is immediate (replaces old retire_now except it doesn't replace it, we're not taking the retire_now out for those who still use it). The identifier in miq_product_features isn't changing. Everything should be similar to retire_now, it's just bimodal now.