### PR TITLE
Ensure refresh => true option gets passed for service_template refresh

### DIFF
--- a/app/controllers/api/subcollections/service_templates.rb
+++ b/app/controllers/api/subcollections/service_templates.rb
@@ -97,7 +97,7 @@ module Api
         refresh_fields = data["fields"]
         return action_result(false, "Must specify fields to refresh") if refresh_fields.blank?
 
-        dialog = define_service_template_dialog(st, dialog_fields)
+        dialog = define_service_template_dialog(st, dialog_fields, :refresh => true)
         return action_result(false, "Service Template has no provision dialog defined") unless dialog
 
         refresh_dialog_fields_action(dialog, refresh_fields, service_template_ident(st))
@@ -105,9 +105,9 @@ module Api
         action_result(false, err.to_s)
       end
 
-      def define_service_template_dialog(st, dialog_fields)
+      def define_service_template_dialog(st, dialog_fields, options = {})
         resource_action = st.resource_actions.find_by(:action => "Provision")
-        workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => st)
+        workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, {:target => st}.merge(options))
         dialog_fields.each { |key, value| workflow.set_value(key, value) }
         workflow.dialog
       end

--- a/spec/requests/service_catalogs_spec.rb
+++ b/spec/requests/service_catalogs_spec.rb
@@ -525,5 +525,17 @@ describe "Service Catalogs API" do
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
+
+    it "creates a ResourceActionWorkflow by passing in a true refresh option" do
+      allow(ResourceActionWorkflow).to receive(:new).and_call_original
+      expect(ResourceActionWorkflow).to receive(:new).with(
+        {}, instance_of(User), instance_of(ResourceAction), hash_including(:refresh => true)
+      )
+
+      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :refresh_dialog_fields)
+      init_st_dialog
+
+      post(sc_template_url(sc.id, st1.id), :params => gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
+    end
   end
 end


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-api/pull/365, but the Service UI was using this endpoint instead for its refreshes. The Service UI is going to be changed to use the same endpoint as the Classic UI in https://github.com/ManageIQ/manageiq-ui-service/pull/1438, but this will need to be updated anyway in case anyone decides they want to use the API call outside of either the SUI or CUI.

https://bugzilla.redhat.com/show_bug.cgi?id=1578080

/cc @d-m-u 

@miq-bot add_label gaprindashvili/yes
@miq-bot assign @abellotti 