### PR TITLE
Rename dialog_edit and dialog_new to *_editor

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2615,9 +2615,9 @@
       - :name: delete
         :identifier: dialog_delete
       - :name: create
-        :identifier: dialog_new
+        :identifier: dialog_new_editor
       - :name: edit
-        :identifier: dialog_edit
+        :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
     :resource_actions:
@@ -2632,7 +2632,7 @@
       - :name: delete
         :identifier: dialog_delete
       - :name: edit
-        :identifier: dialog_edit
+        :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
       :delete:


### PR DESCRIPTION
The `dialog_edit` and `dialog_new` features were removed in https://github.com/ManageIQ/manageiq/pull/17550.

The new features to do the same thing seem to be called `dialog_new_editor` and `dialog_edit_editor` - renaming.

Cc @skateman , @abellotti 