### PR TITLE
Ignore case of the userid when validating it.

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2615,9 +2615,9 @@
       - :name: delete
         :identifier: dialog_delete
       - :name: create
-        :identifier: dialog_new
+        :identifier: dialog_new_editor
       - :name: edit
-        :identifier: dialog_edit
+        :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
     :resource_actions:
@@ -2632,7 +2632,7 @@
       - :name: delete
         :identifier: dialog_delete
       - :name: edit
-        :identifier: dialog_edit
+        :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
       :delete:

--- a/lib/services/api/user_token_service.rb
+++ b/lib/services/api/user_token_service.rb
@@ -75,7 +75,7 @@ module Api
     end
 
     def validate_userid(userid)
-      raise "Invalid userid #{userid} specified" unless User.where('lower(userid) = ?', userid.downcase).exists?
+      raise "Invalid userid #{userid} specified" unless User.in_my_region.where('lower(userid) = ?', userid.downcase).exists?
     end
   end
 end

--- a/lib/services/api/user_token_service.rb
+++ b/lib/services/api/user_token_service.rb
@@ -75,7 +75,7 @@ module Api
     end
 
     def validate_userid(userid)
-      raise "Invalid userid #{userid} specified" unless User.exists?(:userid => userid)
+      raise "Invalid userid #{userid} specified" unless User.where('lower(userid) = ?', userid.downcase).exists?
     end
   end
 end

--- a/spec/lib/services/api/user_token_service_spec.rb
+++ b/spec/lib/services/api/user_token_service_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Api::UserTokenService do
+  before do
+    @user = FactoryGirl.create(:user_with_group)
+  end
+
+  let(:user_token_service) { described_class.new }
+  let(:token) { user_token_service.generate_token(@user.userid.capitalize, 'api', :token_ttl => token_ttl) }
+  let(:token_info) { user_token_service.token_mgr('api').token_get_info(token) }
+
   describe ".generate_token" do
-    before do
-      @user = FactoryGirl.create(:user_with_group)
-    end
-
-    let(:user_token_service) { described_class.new }
-    let(:token) { user_token_service.generate_token(@user.userid.capitalize, 'api', :token_ttl => token_ttl) }
-    let(:token_info) { user_token_service.token_mgr('api').token_get_info(token) }
-
     context "without token_ttl set" do
       let(:token_ttl) { nil }
 
@@ -22,6 +22,12 @@ RSpec.describe Api::UserTokenService do
       it "uses the optional token_ttl specified" do
         expect(token_info).to include(:userid => @user.userid, :token_ttl => 5599)
       end
+    end
+  end
+
+  describe ".validate_userid" do
+    it "ignores the case of the userid" do
+      expect { user_token_service.send(:validate_userid, @user.userid.capitalize) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
The authentication code ignores the case of the userid. The PR ensures the API user validation
code does also.

All userids are created by the authentication code in lowercase. Users can be manually created with the UI in mixed case. However the UI will not allow a second user to be created with a mismatching case.

If **_User_** exists and one attempts to create **_user_** the UI will report: _**Userid is not unique**_

### To test:

1. Set authentication mode to: **Database**
2. From the UI create a new user with at least one uppercase letter in **Username**. e.g.: **_User_**
3. Try to login with this user.

**Note:** The case of the value specified for **Username** on the login screen is ignored. So if **_User_** was create one could log in with **_User_** or **_user_**

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1590398