### PR TITLE
Creating PhysicalStorage controller and adding endpoint configuration

### DIFF
--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -1,0 +1,40 @@
+module Api
+  class PhysicalStoragesController < BaseController
+    def refresh_resource(type, id, _data = nil)
+      raise BadRequestError, "Must specify an id for refreshing a #{type} resource" if id.blank?
+
+      ensure_resource_exists(type, id) if single_resource?
+
+      api_action(type, id) do |klass|
+        physical_storage = resource_search(id, type, klass)
+        api_log_info("Refreshing #{physical_storage_ident(physical_storage)}")
+        refresh_physical_storage(physical_storage)
+      end
+    end
+
+    private
+
+    def ensure_resource_exists(type, id)
+      raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
+    end
+
+    def refresh_physical_storage(physical_storage)
+      method_name = "refresh_ems"
+      role = "ems_operations"
+
+      act_refresh(physical_storage, method_name, role)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def physical_storage_ident(physical_storage)
+      "Physical Storage id:#{physical_storage.id} name:'#{physical_storage.name}'"
+    end
+
+    def act_refresh(physical_storage, method_name, role)
+      desc = "#{physical_storage_ident(physical_storage)} refreshing"
+      task_id = queue_object_action(physical_storage, desc, :method_name => method_name, :role => role)
+      action_result(true, desc, :task_id => task_id)
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1830,6 +1830,28 @@
         :identifier: physical_server_turn_off_loc_led
       - :name: apply_config_pattern
         :identifier: physical_server_apply_config_pattern
+  :physical_storages:
+    :description: Physical Storages
+    :identifier: physical_storage
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: PhysicalStorage
+    :subcollections:
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: physical_storage_show_list
+      :post:
+      - :name: refresh
+        :identifier: physical_storage_refresh
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: physical_storage_show
+      :post:
+      - :name: refresh
+        :identifier: physical_storage_refresh
   :physical_switches:
     :description: Physical Switches
     :identifier: physical_switch

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -1,0 +1,100 @@
+describe "Physical Storages API" do
+  context "GET /api/physical_storages" do
+    it "returns all physical_storages" do
+      physical_storage = FactoryGirl.create(:physical_storage)
+      api_basic_authorize('physical_storage_show_list')
+
+      get(api_physical_storages_url)
+
+      expected = {
+        "name"      => "physical_storages",
+        "resources" => [{"href" => api_physical_storage_url(nil, physical_storage)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "GET /api/physical_storages/:id" do
+    it "returns one physical_storage" do
+      physical_storage = FactoryGirl.create(:physical_storage)
+      api_basic_authorize('physical_storage_show')
+
+      get(api_physical_storage_url(nil, physical_storage))
+
+      expected = {
+        "name" => physical_storage.name,
+        "href" => api_physical_storage_url(nil, physical_storage)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe "Physical Storages refresh action" do
+    context "with an invalid id" do
+      it "it responds with 404 Not Found" do
+        api_basic_authorize(action_identifier(:physical_storages, :refresh, :resource_actions, :post))
+
+        post(api_physical_storage_url(nil, 999_999), :params => gen_request(:refresh))
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "without an appropriate role" do
+      it "it responds with 403 Forbidden" do
+        physical_storage = FactoryGirl.create(:physical_storage)
+        api_basic_authorize
+
+        post(api_physical_storage_url(nil, physical_storage), :params => gen_request(:refresh))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with an appropriate role" do
+      it "rejects refresh for unspecified physical storage" do
+        api_basic_authorize(action_identifier(:physical_storages, :refresh, :resource_actions, :post))
+
+        post(api_physical_storages_url, :params => gen_request(:refresh, [{"href" => "/api/physical_storages/"}, {"href" => "/api/physical_storages/"}]))
+
+        expect_bad_request(/Must specify an id/i)
+      end
+
+      it "refresh of a single Physical Storage" do
+        physical_storage = FactoryGirl.create(:physical_storage)
+        api_basic_authorize('physical_storage_refresh')
+
+        post(api_physical_storage_url(nil, physical_storage), :params => gen_request(:refresh))
+
+        expect_single_action_result(:success => true, :message => /#{physical_storage.id}.* refreshing/i, :href => api_physical_storage_url(nil, physical_storage))
+      end
+
+      it "refresh of multiple Physical Storages" do
+        physical_storage = FactoryGirl.create(:physical_storage)
+        physical_storage_two = FactoryGirl.create(:physical_storage)
+        api_basic_authorize('physical_storage_refresh')
+
+        post(api_physical_storages_url, :params => gen_request(:refresh, [{"href" => api_physical_storage_url(nil, physical_storage)}, {"href" => api_physical_storage_url(nil, physical_storage_two)}]))
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including(
+              "message" => a_string_matching(/#{physical_storage.id}.* refreshing/i),
+              "success" => true,
+              "href"    => api_physical_storage_url(nil, physical_storage)
+            ),
+            a_hash_including(
+              "message" => a_string_matching(/#{physical_storage_two.id}.* refreshing/i),
+              "success" => true,
+              "href"    => api_physical_storage_url(nil, physical_storage_two)
+            )
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**This PR adds:**
- GET /api/physical_storages
- GET /api/physical_storages/:id
- POST /api/physical_storages (action: refresh)
- POST /api/physical_storages/:id (action: refresh)

Depends on:
- [ManageIQ/manageiq#17586](https://github.com/ManageIQ/manageiq/pull/17586)