### PR TITLE
Allow ordering ServiceTemplates with a schedule_time

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -1,16 +1,15 @@
 module Api
   module Mixins
     module ServiceTemplates
-      def order_service_template(id, data)
+      def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
         raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered" unless service_template.orderable?
-        workflow = service_template.provision_workflow(User.current_user, data || {})
-        request_result = workflow.submit_request
+        request_result = service_template.order(User.current_user, (data || {}), nil, scheduled_time)
         errors = request_result[:errors]
         if errors.present?
           raise BadRequestError, "Failed to order #{service_template_ident(service_template)} - #{errors.join(", ")}"
         end
-        request_result[:request]
+        request_result[:request] || request_result[:schedule]
       end
 
       private

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -26,7 +26,8 @@ module Api
     end
 
     def order_resource(_type, id, data)
-      order_service_template(id, data)
+      schedule_time = data&.delete("schedule_time")
+      order_service_template(id, data, schedule_time)
     end
 
     def archive_resource(type, id, _data)

--- a/app/controllers/api/subcollections/service_templates.rb
+++ b/app/controllers/api/subcollections/service_templates.rb
@@ -29,7 +29,8 @@ module Api
       end
 
       def service_templates_order_resource(_object, _type, id = nil, data = nil)
-        order_service_template(id, data)
+        schedule_time = data&.delete(:schedule_time)
+        order_service_template(id, data, schedule_time)
       end
 
       def service_templates_refresh_dialog_fields_resource(object, type, id = nil, data = nil)

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -516,6 +516,29 @@ describe "Service Templates API" do
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)
       end
+
+      context "with a schedule_time" do
+        it "can be ordered as a resource action" do
+          api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
+
+          post(api_service_template_url(nil, service_template), :params => { :action => "order", :schedule_time => Time.now.utc.to_s })
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include("name"=>"Order ServiceTemplate #{ServiceTemplate.first.id}")
+        end
+
+        it "can be ordered as an action on the collection" do
+          api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
+
+          post(api_service_templates_url, :params => { :action => "order", :resources => [{:href => api_service_template_url(nil, service_template), :schedule_time => Time.now.utc.to_s}] })
+
+          expected = {
+            "results" => [a_hash_including("name"=>"Order ServiceTemplate #{ServiceTemplate.first.id}")]
+          }
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
+        end
+      end
     end
 
     context "with an unorderable template" do


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/17594

@AllenBW With this change, you can order now or schedule with `{ :action => "order", :schedule_time => "2018-06-15 21:26:43 UTC" }`