### PR TITLE
[GAPRINDASHVILI] Pass option to retain dialog values so they're not rerun

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -4,7 +4,7 @@ module Api
       def order_service_template(id, data)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
         raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered" unless service_template.orderable?
-        workflow = service_template.provision_workflow(User.current_user, data || {})
+        workflow = service_template.provision_workflow(User.current_user, data || {}, :submit_workflow => true)
         request_result = workflow.submit_request
         errors = request_result[:errors]
         if errors.present?

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -473,7 +473,8 @@ describe "Service Templates API" do
         post(api_service_templates_url, :params => { :action => "order", :resources => [{:href => api_service_template_url(nil, service_template)}] })
 
         expected = {
-          "results" => [a_hash_including("href" => a_string_including(api_service_requests_url))]
+          "results" => [a_hash_including("href"    => a_string_including(api_service_requests_url),
+                                         "options" => a_hash_including("request_options" => a_hash_including("submit_workflow"=>true)))]
         }
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)


### PR DESCRIPTION
Dialogs are being run twice, once on load, once on submit, this lets us reuse the values we picked so they don't rerun on submit. 

Master PR: https://github.com/ManageIQ/manageiq-api/pull/407
Fix for ~~https://bugzilla.redhat.com/show_bug.cgi?id=1591427~~
https://bugzilla.redhat.com/show_bug.cgi?id=1595776

There's a related main PR.

It's eclarizio's code. 

Also it's WIP cause it needs tests. 

## Related to:
https://github.com/ManageIQ/manageiq/pull/17641