### PR TITLE
Add option to reuse dialog values for great justice on master

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -4,7 +4,7 @@ module Api
       def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
         raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered" unless service_template.orderable?
-        request_result = service_template.order(User.current_user, (data || {}), nil, scheduled_time)
+        request_result = service_template.order(User.current_user, (data || {}), {:submit_workflow => true}, scheduled_time)
         errors = request_result[:errors]
         if errors.present?
           raise BadRequestError, "Failed to order #{service_template_ident(service_template)} - #{errors.join(", ")}"

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -485,7 +485,8 @@ describe "Service Templates API" do
         post(api_service_templates_url, :params => { :action => "order", :resources => [{:href => api_service_template_url(nil, service_template)}] })
 
         expected = {
-          "results" => [a_hash_including("href" => a_string_including(api_service_requests_url))]
+          "results" => [a_hash_including("href"    => a_string_including(api_service_requests_url),
+                                         "options" => a_hash_including("request_options" => a_hash_including("submit_workflow"=>true)))]
         }
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)


### PR DESCRIPTION
Dialogs are being run twice, once on load, once on submit, this lets us reuse the values we picked so they don't rerun on submit.

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1584355

There's a related main PR.

It's eclarizio's code.

## related to
https://github.com/ManageIQ/manageiq/pull/17642