### PR TITLE
API support for updating and deleting `service_template` schedules

### DIFF
--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -22,7 +22,11 @@ module Api
       catalog_item = resource_search(id, type, collection_class(:service_templates))
       if data.key?("schedule_time")
         schedule_time = data&.delete("schedule_time")
-        catalog_item.update_schedule(schedule_time)
+        if schedule_time.nil?
+          catalog_item.delete_schedule
+        else
+          catalog_item.update_schedule(schedule_time)
+        end
       end
       catalog_item.update_catalog_item(data.deep_symbolize_keys, User.current_user.userid)
     rescue => err

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -20,6 +20,10 @@ module Api
 
     def edit_resource(type, id, data)
       catalog_item = resource_search(id, type, collection_class(:service_templates))
+      if data.key?("schedule_time")
+        schedule_time = data&.delete("schedule_time")
+        catalog_item.update_schedule(schedule_time)
+      end
       catalog_item.update_catalog_item(data.deep_symbolize_keys, User.current_user.userid)
     rescue => err
       raise BadRequestError, "Could not update Service Template - #{err}"

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -15,7 +15,7 @@ module Api
     end
 
     def self.time_attributes
-      @time_attributes ||= ApiConfig.collections.each.with_object(Set.new(%w(expires_on))) do |(_, cspec), result|
+      @time_attributes ||= ApiConfig.collections.each.with_object(Set.new(%w(expires_on schedule_time))) do |(_, cspec), result|
         next if cspec[:klass].blank?
         klass = cspec[:klass].constantize
         klass.columns_hash.each do |name, typeobj|


### PR DESCRIPTION
**Get schedule**
`GET /api/service_templates/5?attributes=miq_schedule`

**Get scheduled time**
`GET /api/service_templates/58?attributes=schedule_time`

**Update scheduled time**
```
POST /api/service_templates/59
{
  "action" : "edit",
  "schedule_time" : "20180704T100000Z"
}
```

**Delete schedule**
```
POST /api/service_templates/59
{ 
  "action" : "edit",
  "schedule_time" : null
}
```

Depends on https://github.com/ManageIQ/manageiq/pull/17645

Paired with @abellotti 


