### PR TITLE
Moving the operations routine to a mixin

### DIFF
--- a/app/controllers/api/mixins/operations.rb
+++ b/app/controllers/api/mixins/operations.rb
@@ -1,0 +1,65 @@
+module Api
+  module Mixins
+    #
+    # Contains the routines to enqueue operations for resources
+    #
+    module Operations
+      def perform_action(action, type, id)
+        if single_resource?
+          enqueue_action_single_resource(action, type, id)
+        else
+          enqueue_action_multiple_resources(action, type, id)
+        end
+      end
+
+      #
+      # Enqueues the action for a single resource.
+      #
+      # @param [symbol] action - action to be enqueued
+      # @param [symbol] type   - type of the resource
+      # @param [number] id     - id of the resource
+      #
+      def enqueue_action_single_resource(action, type, id)
+        raise BadRequestError, "Must specify an id for changing a #{type} resource" unless id
+
+        resource = resource_search(id, type, collection_class(type))
+
+        api_action(type, id) do
+          begin
+            desc = "Performing #{action} for #{resource_identify(resource)}"
+            api_log_info(desc)
+            task_id = queue_object_action(resource, desc, :method_name => action, :role => :ems_operations)
+            action_result(true, desc, :task_id => task_id)
+          rescue StandardError => err
+            action_result(false, err.to_s)
+          end
+        end
+      end
+
+      #
+      # Enqueues the action for multiple resources.
+      #   For multiple resources, when an error occurs, the error messages must
+      #   be built individually for each resource. Always responding with status 200.
+      #
+      # @param [symbol] action - action to be enqueued
+      # @param [symbol] type   - type of the resource
+      # @param [number] id     - id of the resource
+      #
+      def enqueue_action_multiple_resources(action, type, id)
+        enqueue_action_single_resource(action, type, id)
+      rescue ActiveRecord::RecordNotFound => err
+        action_result(false, _(err.message))
+      end
+
+      #
+      # Mounts a string to identify the resource that is
+      #   performing the operation.
+      #
+      # @param resource - resource that is performing the operation.
+      #
+      def resource_identify(resource)
+        "#{resource.class.name.demodulize.underscore.humanize} id:#{resource.id} name: '#{resource.name}'"
+      end
+    end
+  end
+end

--- a/app/controllers/api/physical_switches_controller.rb
+++ b/app/controllers/api/physical_switches_controller.rb
@@ -1,84 +1,13 @@
 module Api
   class PhysicalSwitchesController < BaseController
+    include Api::Mixins::Operations
+
     def refresh_resource(type, id, _data = nil)
-      raise BadRequestError, "Must specify an id for refreshing a #{type} resource" unless id
-
-      ensure_resource_exists(type, id) if single_resource?
-
-      api_action(type, id) do |klass|
-        physical_switch = resource_search(id, type, klass)
-        api_log_info("Refreshing #{physical_switch_ident(physical_switch)}")
-        refresh_physical_switch(physical_switch)
-      end
+      perform_action(:refresh_ems, type, id)
     end
 
     def restart_resource(type, id, _data = nil)
       perform_action(:restart, type, id)
-    end
-
-    private
-
-    def perform_action(action, type, id)
-      if single_resource?
-        enqueue_action_single_resource(action, type, id)
-      else
-        enqueue_action_multiple_resources(action, type, id)
-      end
-    end
-
-    #
-    # Enqueues the action for a single resource.
-    #
-    # @param [symbol] action - action to be enqueued
-    # @param [symbol] type   - type of the resource
-    # @param [number] id     - id of the resource
-    #
-    def enqueue_action_single_resource(action, type, id)
-      raise BadRequestError, "Must specify an id for changing a #{type} resource" unless id
-
-      physical_switch = resource_search(id, type, collection_class(type))
-
-      api_action(type, id) do
-        begin
-          desc = "Performing #{action} for #{physical_switch_ident(physical_switch)}"
-          api_log_info(desc)
-          task_id = queue_object_action(physical_switch, desc, :method_name => action, :role => :ems_operations)
-          action_result(true, desc, :task_id => task_id)
-        rescue StandardError => err
-          action_result(false, err.to_s)
-        end
-      end
-    end
-
-    #
-    # Enqueues the action for multiple resources.
-    #   For multiple resources, when an error occurs, the error messages must
-    #   be built individually for each resource. Always responding with status 200.
-    #
-    # @param [symbol] action - action to be enqueued
-    # @param [symbol] type   - type of the resource
-    # @param [number] id     - id of the resource
-    #
-    def enqueue_action_multiple_resources(action, type, id)
-      enqueue_action_single_resource(action, type, id)
-    rescue ActiveRecord::RecordNotFound => err
-      action_result(false, _(err.message))
-    end
-
-    def ensure_resource_exists(type, id)
-      raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
-    end
-
-    def refresh_physical_switch(physical_switch)
-      desc = "#{physical_switch_ident(physical_switch)} refreshing"
-      task_id = queue_object_action(physical_switch, desc, :method_name => "refresh_ems", :role => "ems_operations")
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def physical_switch_ident(physical_switch)
-      "Physical Switch id:#{physical_switch.id} name: '#{physical_switch.name}'"
     end
   end
 end

--- a/spec/requests/physical_switches_spec.rb
+++ b/spec/requests/physical_switches_spec.rb
@@ -68,7 +68,7 @@ describe "Physical Switches API" do
 
         post(api_physical_switch_url(nil, physical_switch), :params => gen_request(:refresh))
 
-        expect_single_action_result(:success => true, :message => /#{physical_switch.id}.* refreshing/i, :href => api_physical_switch_url(nil, physical_switch))
+        expect_single_action_result(:success => true, :message => "Performing refresh_ems for Physical switch id:#{physical_switch.id} name: '#{physical_switch.name}'", :href => api_physical_switch_url(nil, physical_switch))
       end
 
       it "refresh of multiple Physical Switches" do
@@ -81,12 +81,12 @@ describe "Physical Switches API" do
         expected = {
           "results" => a_collection_containing_exactly(
             a_hash_including(
-              "message" => a_string_matching(/#{first_physical_switch.id}.* refreshing/i),
+              "message" => a_string_matching("Performing refresh_ems for Physical switch id:#{first_physical_switch.id} name: '#{first_physical_switch.name}'"),
               "success" => true,
               "href"    => api_physical_switch_url(nil, first_physical_switch)
             ),
             a_hash_including(
-              "message" => a_string_matching(/#{second_physical_switch.id}.* refreshing/i),
+              "message" => a_string_matching("Performing refresh_ems for Physical switch id:#{second_physical_switch.id} name: '#{second_physical_switch.name}'"),
               "success" => true,
               "href"    => api_physical_switch_url(nil, second_physical_switch)
             )
@@ -111,7 +111,7 @@ describe "Physical Switches API" do
           expected = {
             "results" => a_collection_containing_exactly(
               a_hash_including(
-                "message" => a_string_matching("Performing #{action} for Physical Switch id:#{physical_switch.id} name: '#{physical_switch.name}'"),
+                "message" => a_string_matching("Performing #{action} for Physical switch id:#{physical_switch.id} name: '#{physical_switch.name}'"),
                 "success" => true,
                 "href"    => api_physical_switch_url(nil, physical_switch)
               ),
@@ -134,7 +134,7 @@ describe "Physical Switches API" do
           expected = {
             "results" => a_collection_containing_exactly(
               a_hash_including(
-                "message" => a_string_matching("Performing #{action} for Physical Switch id:#{physical_switch.id} name: '#{physical_switch.name}'"),
+                "message" => a_string_matching("Performing #{action} for Physical switch id:#{physical_switch.id} name: '#{physical_switch.name}'"),
                 "success" => true,
                 "href"    => api_physical_switch_url(nil, physical_switch)
               )
@@ -165,7 +165,7 @@ describe "Physical Switches API" do
 
           expect_single_action_result(
             :success => true,
-            :message => a_string_matching("Performing #{action} for Physical Switch id:#{physical_switch.id} name: '#{physical_switch.name}'"),
+            :message => a_string_matching("Performing #{action} for Physical switch id:#{physical_switch.id} name: '#{physical_switch.name}'"),
             :href    => api_physical_switch_url(nil, physical_switch)
           )
         end


### PR DESCRIPTION
__This PR is able to__
- create `Api::Mixins::Operations` to share the operations routine with others controllers;

__Main goal__
The enqueue of operations for physical components could be shared, so would be good have a mixin with those routines, as a first step, the `physical_switches_controller` was refactored to this new approach and then the `physical_chassis_controller` and `physical_servers_controller` will be refactored in upcoming PRs