### PR TITLE
Adding Physical Chassis Location LED actions

### DIFF
--- a/app/controllers/api/physical_chassis_controller.rb
+++ b/app/controllers/api/physical_chassis_controller.rb
@@ -1,42 +1,22 @@
 module Api
   class PhysicalChassisController < BaseController
     include Subcollections::EventStreams
+    include Api::Mixins::Operations
+
+    def blink_loc_led_resource(type, id, _data)
+      perform_action(:blink_loc_led, type, id)
+    end
+
+    def turn_on_loc_led_resource(type, id, _data)
+      perform_action(:turn_on_loc_led, type, id)
+    end
+
+    def turn_off_loc_led_resource(type, id, _data)
+      perform_action(:turn_off_loc_led, type, id)
+    end
 
     def refresh_resource(type, id, _data = nil)
-      raise BadRequestError, "Must specify an id for refreshing a #{type} resource" if id.blank?
-
-      ensure_resource_exists(type, id) if single_resource?
-
-      api_action(type, id) do |klass|
-        physical_chassis = resource_search(id, type, klass)
-        api_log_info("Refreshing #{physical_chassis_ident(physical_chassis)}")
-        refresh_physical_chassis(physical_chassis)
-      end
-    end
-
-    private
-
-    def ensure_resource_exists(type, id)
-      raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
-    end
-
-    def refresh_physical_chassis(physical_chassis)
-      method_name = "refresh_ems"
-      role = "ems_operations"
-
-      act_refresh(physical_chassis, method_name, role)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def physical_chassis_ident(physical_chassis)
-      "Physical Chassis id:#{physical_chassis.id} name:'#{physical_chassis.name}'"
-    end
-
-    def act_refresh(physical_chassis, method_name, role)
-      desc = "#{physical_chassis_ident(physical_chassis)} refreshing"
-      task_id = queue_object_action(physical_chassis, desc, :method_name => method_name, :role => role)
-      action_result(true, desc, :task_id => task_id)
+      perform_action(:refresh_ems, type, id)
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1779,6 +1779,12 @@
       :post:
       - :name: refresh
         :identifier: physical_chassis_refresh
+      - :name: blink_loc_led
+        :identifier: physical_chassis_blink_loc_led
+      - :name: turn_on_loc_led
+        :identifier: physical_chassis_turn_on_loc_led
+      - :name: turn_off_loc_led
+        :identifier: physical_chassis_turn_off_loc_led
     :resource_actions:
       :get:
       - :name: read
@@ -1786,6 +1792,12 @@
       :post:
       - :name: refresh
         :identifier: physical_chassis_refresh
+      - :name: blink_loc_led
+        :identifier: physical_chassis_blink_loc_led
+      - :name: turn_on_loc_led
+        :identifier: physical_chassis_turn_on_loc_led
+      - :name: turn_off_loc_led
+        :identifier: physical_chassis_turn_off_loc_led
   :physical_racks:
     :description: Physical Racks
     :identifier: physical_rack


### PR DESCRIPTION
__This PR is able to__
- Add Location LED actions for Physical Chassis:
  - blink_loc_led;
  - turn_on_loc_led;
  - turn_off_loc_led.
- Adapt `physical_chassis_controller` to the strategy added on https://github.com/ManageIQ/manageiq-api/pull/409

__Depends on__
- ~https://github.com/ManageIQ/manageiq-api/pull/409~ - Merged