### PR TITLE
[DEPENDS ON ManageIQ/manageiq#17672] Add ServiceTemplate#schedules subcollection

### DIFF
--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -46,6 +46,10 @@ module Api
       action_result(false, "Could not unarchive Service Template - #{err}")
     end
 
+    def schedules_query_resource(object)
+      object.miq_schedules
+    end
+
     private
 
     def set_additional_attributes

--- a/config/api.yml
+++ b/config/api.yml
@@ -2806,6 +2806,7 @@
     :subcollections:
     - :resource_actions
     - :tags
+    - :schedules
     - :service_requests
     - :service_dialogs
     :collection_actions:


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/17672
Enables viewing schedules for ServiceTemplates for V2V
https://bugzilla.redhat.com/show_bug.cgi?id=1564255
