### PR TITLE
Add support for a custom controller name on routes

### DIFF
--- a/app/controllers/api/physical_chassis_api_controller.rb
+++ b/app/controllers/api/physical_chassis_api_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class PhysicalChassisController < BaseController
+  class PhysicalChassisApiController < BaseController
     include Subcollections::EventStreams
 
     def refresh_resource(type, id, _data = nil)
@@ -25,7 +25,7 @@ module Api
       role = "ems_operations"
 
       act_refresh(physical_chassis, method_name, role)
-    rescue => err
+    rescue StandardError => err
       action_result(false, err.to_s)
     end
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -1770,6 +1770,7 @@
     - :collection
     :verbs: *gp
     :klass: PhysicalChassis
+    :controller: physical_chassis_api
     :subcollections:
     - :event_streams
     :collection_actions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,11 +9,14 @@ Rails.application.routes.draw do
 
     Api::ApiConfig.collections.each do |collection_name, collection|
       # OPTIONS action for each collection
-      match collection_name.to_s, :controller => collection_name, :action => :options, :via => :options, :as => nil
+      controller = collection.controller
+      controller ||= collection_name
+
+      match collection_name.to_s, :controller => controller, :action => :options, :via => :options, :as => nil
 
       collection_name_pluralized, resource_name = Api::Routing.inflections_for_named_route_helpers(collection_name.to_s)
 
-      scope collection_name, :controller => collection_name do
+      scope collection_name, :controller => controller do
         collection.verbs.each do |verb|
           if collection.options.include?(:primary)
             case verb

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -72,8 +72,13 @@ describe "Authentication API" do
 
       get api_entrypoint_url
 
-      collection_names = Api::ApiConfig.collections.to_h.select { |_, v| v.options.include?(:collection) }.keys
-      hrefs = collection_names.collect { |name| url_for(:controller => name, :action => "index") }
+      collections = Api::ApiConfig.collections.to_h.select { |_, v| v.options.include?(:collection) }
+      hrefs = collections.collect do |collection_name, collection|
+        controller = collection.controller
+        controller ||= collection_name
+        url_for(:controller => controller, :action => "index")
+      end
+
       expected = {
         "collections" => a_collection_containing_exactly(
           *hrefs.collect { |href| a_hash_including("href" => href) }


### PR DESCRIPTION
**What this PR does:**
- Add the support to assign a controller with a custom name to a given collection;
- Changes the controller `PhysicalChassisController` to `PhysicalChassisApiController`.

**Reason:**
Currently, there is the following pattern on ManageIQ:
On the [manageiq-api](https://github.com/ManageIQ/manageiq-api)
```ruby
// app/controllers/api/resources_controller.rb (Plural controller name)
module Api
  class ResourcesController < BaseController
...
```
On the [manageiq-ui-classic](https://github.com/ManageIQ/manageiq-ui-classic)
```ruby
// app/controllers/resource_controller.rb (Singular controller name)
class ResourceController < ApplicationController
...
```

With the current approach, when we try to add a controller on the API and on the UI whose names in plural and singular are the same (ex.: PhysicalChassis), Ruby may have trouble while trying to autoload the classes.

To avoid the overwriting of one of this controllers (by ruby autoload), this PR allows that the controller be named using the option `:controller` on `api.yml`.