### PR TITLE
Allow plugins to bring api.yml extensions

### DIFF
--- a/lib/api/api_config.rb
+++ b/lib/api/api_config.rb
@@ -1,7 +1,9 @@
 require "config"
 
 module Api
+  ::Config.overwrite_arrays = false
   ApiConfig = ::Config::Options.new.tap do |o|
+    Vmdb::Plugins.each { |plugin| o.add_source!(plugin.root.join('config/api.yml').to_s) }
     o.add_source!(ManageIQ::Api::Engine.root.join("config/api.yml").to_s)
     o.load!
   end


### PR DESCRIPTION
This allows Vmdb::Plugins like providers to bring their own api.yml
extensions, enabling for example new operations that those providers
bring to be accessible through the API.