### PR TITLE
Add an option for setting a default scope for collection classes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,12 @@ Below is a breakdown of what some of the above elements mean:
     * Gives more details about the collection and whether it will act as a collection, subcollection
 * **:verbs:**
     * Specifies the [verb set](https://github.com/ManageIQ/manageiq-api/blob/4811ec9fcea2424a585560a761e05d56c53535f8/config/api.yml#L18-L36) that can be used on the collection
-* **:klass:** 
-    * Specifies the base class name of the resources under this collection 
+* **:klass:**
+    * Specifies the base class name of the resources under this collection
+* **:scope:**
+    * Specifies a default scope to be called on the klass defined above
 * **:name:**
-    * Name of the action to be performed 
+    * Name of the action to be performed
 * **:identifier:**
     * Name of the corresponding [product feature](https://github.com/ManageIQ/manageiq/blob/f77c75b4659f97be95f8976ef58abe521085c963/db/fixtures/miq_product_features.yml), which is used to control permissions to resources
 * **:collection_actions:** vs **:resource_actions:**

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -24,7 +24,14 @@ module Api
       end
 
       def collection_class(type)
-        @collection_klasses[type.to_sym] || collection_config.klass(type)
+        if @collection_klasses.key?(type.to_sym)
+          @collection_klasses[type.to_sym]
+        else
+          klass = collection_config.klass(type)
+          # If there's a default scope defined for the collection, call it immediately
+          scope = collection_config.scope(type)
+          scope ? klass.send(:scope) : klass
+        end
       end
 
       def put_resource(type, id)

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -82,6 +82,10 @@ module Api
       end.try(:first)
     end
 
+    def scope(collection_name)
+      self[collection_name][:scope]
+    end
+
     def what_refers_to_feature(product_feature_name)
       referenced_identifiers[product_feature_name]
     end


### PR DESCRIPTION
In certain cases we'd like to hide some records from the collection, so I'd like to introduce a `:scope` key into the config. If this key is set, its value will be sent as a method to the `:klass`.

I would like to use this to hide the `__maintenance__` zone that is being added for the sake of [suspending providers](https://github.com/ManageIQ/manageiq/pull/17452). This is a dummy record and we don't want to expose it for the user.

I would probably need to write some tests for this, but I haven't found any examples in the area and did not wanted to introduce anything new before a review. I could, however, easily create a test in the followup PR where I'd use the `visible` scope on the `zones` collection.

@miq-bot add_reviewer @abellotti 

cc @slemrmartin 