### PR TITLE
Remove product feature needed to access automate workspace

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -271,18 +271,13 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: miq_ae_domain_view
     :resource_actions:
       :get:
       - :name: read
-        :identifier: miq_ae_domain_view
       :post:
       - :name: edit
-        :identifier: miq_ae_domain_view
       - :name: encrypt
-        :identifier: miq_ae_domain_view
       - :name: decrypt
-        :identifier: miq_ae_domain_view
   :automation_requests:
     :description: Automation Requests
     :options:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1598464

Each automate workspace is identified with a unique guid
and it is only available for the lifetime of the method.
When this feature was initially added we use 'miq_ae_domain_view'
product feature, which is only available for admin user and
for non admin users we get a 403 Forbidden error because they dont
have the miq_ae_domain_view feature enabled. This PR does away
with the miq_ae_domain_view feature to be enabled for each user
to access the workspace.