### PR TITLE
Adding Chassis and Racks as PhysicalStorages subcollections

### DIFF
--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -1,5 +1,8 @@
 module Api
   class PhysicalStoragesController < BaseController
+    include Subcollections::PhysicalRacks
+    include Subcollections::PhysicalChassis
+
     def refresh_resource(type, id, _data = nil)
       raise BadRequestError, "Must specify an id for refreshing a #{type} resource" if id.blank?
 

--- a/app/controllers/api/subcollections/physical_chassis.rb
+++ b/app/controllers/api/subcollections/physical_chassis.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module PhysicalChassis
+      def physical_chassis_query_resource(object)
+        object.respond_to?(:physical_chassis) ? ManageIQ::Providers::PhysicalInfraManager::PhysicalChassis.where(:id => object.physical_chassis_id) : []
+      end
+    end
+  end
+end

--- a/app/controllers/api/subcollections/physical_racks.rb
+++ b/app/controllers/api/subcollections/physical_racks.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module PhysicalRacks
+      def physical_racks_query_resource(object)
+        object.respond_to?(:physical_rack) ? PhysicalRack.where(:id => object.physical_rack_id) : []
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1772,6 +1772,7 @@
     :identifier: physical_chassis
     :options:
     - :collection
+    - :subcollection
     :verbs: *gp
     :klass: PhysicalChassis
     :subcollections:
@@ -1789,6 +1790,10 @@
         :identifier: physical_chassis_turn_on_loc_led
       - :name: turn_off_loc_led
         :identifier: physical_chassis_turn_off_loc_led
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: physical_chassis_show_list
     :resource_actions:
       :get:
       - :name: read
@@ -1802,11 +1807,16 @@
         :identifier: physical_chassis_turn_on_loc_led
       - :name: turn_off_loc_led
         :identifier: physical_chassis_turn_off_loc_led
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: physical_chassis_show
   :physical_racks:
     :description: Physical Racks
     :identifier: physical_rack
     :options:
     - :collection
+    - :subcollection
     :verbs: *gp
     :klass: PhysicalRack
     :subcollections:
@@ -1819,6 +1829,10 @@
         :identifier: physical_rack_show_list
       - :name: refresh
         :identifier: physical_rack_refresh
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: physical_rack_show_list
     :resource_actions:
       :get:
       - :name: read
@@ -1826,6 +1840,10 @@
       :post:
       - :name: refresh
         :identifier: physical_rack_refresh
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: physical_rack_show
   :physical_servers:
     :description: Physical Servers
     :identifier: physical_server
@@ -1903,6 +1921,8 @@
     :verbs: *gp
     :klass: PhysicalStorage
     :subcollections:
+    - :physical_racks
+    - :physical_chassis
     :collection_actions:
       :get:
       - :name: read

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -97,4 +97,102 @@ describe "Physical Storages API" do
       end
     end
   end
+
+  context 'Physical Racks subcollection' do
+    let(:physical_rack) { FactoryGirl.create(:physical_rack) }
+    let(:physical_storage) { FactoryGirl.create(:physical_storage, :physical_rack_id => physical_rack.id) }
+
+    context 'GET /api/physical_storages/:id/physical_racks' do
+      it 'returns the physical racks with an appropriate role' do
+        api_basic_authorize(collection_action_identifier(:physical_racks, :read, :get))
+
+        url_get = api_physical_storage_physical_racks_url(nil, physical_storage)
+        url_resource = api_physical_storage_physical_rack_url(nil, physical_storage, physical_rack)
+
+        expected = {
+          'resources' => [{'href' => url_resource}]
+        }
+        get(url_get)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+
+      it 'does not return the physical racks without an appropriate role' do
+        api_basic_authorize
+
+        get(api_physical_storage_physical_rack_url(nil, physical_storage, physical_rack))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'GET /api/physical_storages/:id/physical_racks/:s_id' do
+      it 'returns the physical rack with an appropriate role' do
+        api_basic_authorize action_identifier(:physical_racks, :read, :resource_actions, :get)
+
+        get(api_physical_storage_physical_rack_url(nil, physical_storage, physical_rack))
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include('id' => physical_rack.id.to_s)
+      end
+
+      it 'does not return the physical rack without an appropriate role' do
+        api_basic_authorize
+
+        get(api_physical_storage_physical_rack_url(nil, physical_storage, physical_rack))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  context 'Physical Chassis subcollection' do
+    let(:physical_chassis) { FactoryGirl.create(:physical_chassis) }
+    let(:physical_storage) { FactoryGirl.create(:physical_storage, :physical_chassis_id => physical_chassis.id) }
+
+    context 'GET /api/physical_storages/:id/physical_chassis' do
+      it 'returns the physical chassis with an appropriate role' do
+        api_basic_authorize(collection_action_identifier(:physical_chassis, :read, :get))
+
+        url_get = api_physical_storage_physical_chassis_url(nil, physical_storage)
+        url_resource = api_physical_storage_one_physical_chassis_url(nil, physical_storage, physical_chassis)
+
+        expected = {
+          'resources' => [{'href' => url_resource}]
+        }
+        get(url_get)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+
+      it 'does not return the physical chassis without an appropriate role' do
+        api_basic_authorize
+
+        get(api_physical_storage_one_physical_chassis_url(nil, physical_storage, physical_chassis))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'GET /api/physical_storages/:id/physical_chassis/:s_id' do
+      it 'returns the physical chassis with an appropriate role' do
+        api_basic_authorize action_identifier(:physical_chassis, :read, :resource_actions, :get)
+
+        get(api_physical_storage_one_physical_chassis_url(nil, physical_storage, physical_chassis))
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include('id' => physical_chassis.id.to_s)
+      end
+
+      it 'does not return the physical chassis without an appropriate role' do
+        api_basic_authorize
+
+        get(api_physical_storage_one_physical_chassis_url(nil, physical_storage, physical_chassis))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is able to add:
- `GET /api/physical_storages/:c_id/physical_chassis`
- `GET /api/physical_storages/:c_id/physical_chassis/:s_id`
- `GET /api/physical_storages/:c_id/physical_racks`
- `GET /api/physical_storages/:c_id/physical_racks/:s_id`

Depends on:
- ~[ManageIQ/manageiq-schema#224](https://github.com/ManageIQ/manageiq-schema/pull/224)~ [Merged]
- ~[ManageIQ/manageiq#17616](https://github.com/ManageIQ/manageiq/pull/17616)~ [Merged]
- ~[ManageIQ/manageiq-providers-lenovo#201](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/201)~ [Merged]