### PR TITLE
Add event_streams as subcollection of the physical resources

### DIFF
--- a/app/controllers/api/physical_chassis_controller.rb
+++ b/app/controllers/api/physical_chassis_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class PhysicalChassisController < BaseController
+    include Subcollections::EventStreams
+
     def refresh_resource(type, id, _data = nil)
       raise BadRequestError, "Must specify an id for refreshing a #{type} resource" if id.blank?
 

--- a/app/controllers/api/physical_servers_controller.rb
+++ b/app/controllers/api/physical_servers_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class PhysicalServersController < BaseController
+    include Subcollections::EventStreams
+
     def blink_loc_led_resource(type, id, _data)
       change_resource_state(:blink_loc_led, type, id)
     end

--- a/app/controllers/api/physical_switches_controller.rb
+++ b/app/controllers/api/physical_switches_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class PhysicalSwitchesController < BaseController
     include Api::Mixins::Operations
+    include Subcollections::EventStreams
 
     def refresh_resource(type, id, _data = nil)
       perform_action(:refresh_ems, type, id)

--- a/app/controllers/api/subcollections/event_streams.rb
+++ b/app/controllers/api/subcollections/event_streams.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module EventStreams
+      def event_streams_query_resource(object)
+        object.respond_to?(:event_where_clause) ? EventStream.where(object.event_where_clause) : []
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1063,6 +1063,7 @@
     :description: Event Streams
     :options:
     - :collection
+    - :subcollection
     :verbs: *gp
     :klass: EventStream
     :collection_actions:
@@ -1073,6 +1074,14 @@
       - :name: query
         identifier: event_streams_show_list
     :resource_actions:
+      :get:
+      - :name: read
+        :identifier: event_streams_show
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: event_streams_show_list
+    :subresource_actions:
       :get:
       - :name: read
         :identifier: event_streams_show
@@ -1748,6 +1757,7 @@
     :verbs: *gp
     :klass: PhysicalChassis
     :subcollections:
+    - :event_streams
     :collection_actions:
       :get:
       - :name: read
@@ -1794,6 +1804,7 @@
     :verbs: *gp
     :klass: PhysicalServer
     :subcollections:
+    - :event_streams
     :collection_actions:
       :get:
       - :name: read
@@ -1884,6 +1895,7 @@
     :verbs: *gp
     :klass: PhysicalSwitch
     :subcollections:
+    - :event_streams
     :collection_actions:
       :get:
       - :name: read

--- a/spec/requests/physical_chassis_spec.rb
+++ b/spec/requests/physical_chassis_spec.rb
@@ -97,4 +97,53 @@ describe "Physical Chassis API" do
       end
     end
   end
+
+  describe "Subcollections" do
+    let(:physical_chassis) { FactoryGirl.create(:physical_chassis) }
+    let(:event_stream) { FactoryGirl.create(:event_stream, :physical_chassis_id => physical_chassis.id, :event_type => "Some Event") }
+
+    context 'Events subcollection' do
+      context 'GET /api/physical_chassis/:id/event_streams' do
+        it 'returns the event_streams with an appropriate role' do
+          api_basic_authorize(collection_action_identifier(:event_streams, :read, :get))
+
+          expected = {
+            'resources' => [
+              { 'href' => api_one_physical_chassis_event_stream_url(nil, physical_chassis, event_stream) }
+            ]
+          }
+          get(api_one_physical_chassis_event_streams_url(nil, physical_chassis))
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
+        end
+
+        it 'does not return the event_streams without an appropriate role' do
+          api_basic_authorize
+          get(api_one_physical_chassis_event_streams_url(nil, physical_chassis))
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'GET /api/physical_chassis/:id/event_streams/:id' do
+        it 'returns the event_stream with an appropriate role' do
+          api_basic_authorize(action_identifier(:event_streams, :read, :resource_actions, :get))
+          url = api_one_physical_chassis_event_stream_url(nil, physical_chassis, event_stream)
+          expected = { 'href' => url }
+          get(url)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
+        end
+
+        it 'does not return the event_stream without an appropriate role' do
+          api_basic_authorize
+          get(api_one_physical_chassis_event_stream_url(nil, physical_chassis, event_stream))
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/physical_servers_spec.rb
+++ b/spec/requests/physical_servers_spec.rb
@@ -575,4 +575,52 @@ RSpec.describe "physical_servers API" do
       end
     end
   end
+  describe "Subcollections" do
+    let(:physical_server) { FactoryGirl.create(:physical_server) }
+    let(:event_stream) { FactoryGirl.create(:event_stream, :physical_server_id => physical_server.id, :event_type => "Some Event") }
+
+    context 'Events subcollection' do
+      context 'GET /api/physical_servers/:id/event_streams' do
+        it 'returns the event_streams with an appropriate role' do
+          api_basic_authorize(collection_action_identifier(:event_streams, :read, :get))
+
+          expected = {
+            'resources' => [
+              { 'href' => api_physical_server_event_stream_url(nil, physical_server, event_stream) }
+            ]
+          }
+          get(api_physical_server_event_streams_url(nil, physical_server))
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
+        end
+
+        it 'does not return the event_streams without an appropriate role' do
+          api_basic_authorize
+          get(api_physical_server_event_streams_url(nil, physical_server))
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'GET /api/physical_servers/:id/event_streams/:id' do
+        it 'returns the event_stream with an appropriate role' do
+          api_basic_authorize(action_identifier(:event_streams, :read, :resource_actions, :get))
+          url = api_physical_server_event_stream_url(nil, physical_server, event_stream)
+          expected = { 'href' => url }
+          get(url)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
+        end
+
+        it 'does not return the event_stream without an appropriate role' do
+          api_basic_authorize
+          get(api_physical_server_event_stream_url(nil, physical_server, event_stream))
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/physical_switches_spec.rb
+++ b/spec/requests/physical_switches_spec.rb
@@ -172,4 +172,53 @@ describe "Physical Switches API" do
       end
     end
   end
+
+  describe "Subcollections" do
+    let(:physical_switch) { FactoryGirl.create(:physical_switch) }
+    let(:event_stream) { FactoryGirl.create(:event_stream, :physical_switch_id => physical_switch.id, :event_type => "Some Event") }
+
+    context 'Events subcollection' do
+      context 'GET /api/physical_switches/:id/event_streams' do
+        it 'returns the event_streams with an appropriate role' do
+          api_basic_authorize(collection_action_identifier(:event_streams, :read, :get))
+
+          expected = {
+            'resources' => [
+              { 'href' => api_physical_switch_event_stream_url(nil, physical_switch, event_stream) }
+            ]
+          }
+          get(api_physical_switch_event_streams_url(nil, physical_switch))
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
+        end
+
+        it 'does not return the event_streams without an appropriate role' do
+          api_basic_authorize
+          get(api_physical_switch_event_streams_url(nil, physical_switch))
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'GET /api/physical_switches/:id/event_streams/:id' do
+        it 'returns the event_stream with an appropriate role' do
+          api_basic_authorize(action_identifier(:event_streams, :read, :resource_actions, :get))
+          url = api_physical_switch_event_stream_url(nil, physical_switch, event_stream)
+          expected = { 'href' => url }
+          get(url)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
+        end
+
+        it 'does not return the event_stream without an appropriate role' do
+          api_basic_authorize
+          get(api_physical_switch_event_stream_url(nil, physical_switch, event_stream))
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is able to:
 - Add event_streams as subcollection of the physical resources as:
   - physical_server endpoint 
    ```
         get /physical_servers/id/event_streams
         get /physical_servers/id/event_streams/id
     ```
   - physical_chassis endpoint
   - physical_switches endpoint

~Dependes on: [ManageIQ - manageiq 17661]( https://github.com/ManageIQ/manageiq/pull/17661)  - MERGED~