### PR TITLE
Ensure 'submit_workflow' is true when adding a service to a cart

### DIFF
--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -90,7 +90,7 @@ module Api
         raise BadRequestError, "Must specify a service_template_href for adding a service_request"
       end
       service_template = resource_search(service_template_id, :service_templates, ServiceTemplate)
-      service_template.provision_workflow(User.current_user, service_request)
+      service_template.provision_workflow(User.current_user, service_request, :submit_workflow => true)
     end
 
     def check_validation(validation)

--- a/spec/requests/service_orders_spec.rb
+++ b/spec/requests/service_orders_spec.rb
@@ -85,6 +85,18 @@ RSpec.describe "service orders API" do
     expect(response.parsed_body).to include(expected)
   end
 
+  it "provisions with workflow with the correct options" do
+    dialog = FactoryGirl.create(:dialog, :label => "ServiceDialog1")
+    resource_action = FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog)
+    service_template = FactoryGirl.create(:service_template, :resource_actions => [resource_action])
+
+    expect_any_instance_of(ServiceTemplate).to receive(:provision_workflow).with(@user, {}, :submit_workflow => true)
+
+    api_basic_authorize collection_action_identifier(:service_orders, :create)
+
+    post(api_service_orders_url, :params => { :service_requests => [{ :service_template_href => api_service_template_url(nil, service_template) }] })
+  end
+
   specify "the default state for a service order is 'cart'" do
     api_basic_authorize collection_action_identifier(:service_orders, :create)
 


### PR DESCRIPTION
This is related to https://github.com/ManageIQ/manageiq-api/pull/406 which was meant to remove the automate calls from submit, but the SUI does not directly order the service, it instead adds the service to a cart before ordering. This caused an issue where the dialog field properties weren't being propagated correctly and so the validation was failing.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1601925

@miq-bot add_label gaprindashvili/yes, bug, blocker
@miq-bot assign @gtanzillo 

@d-m-u Can you review?
@gtanzillo Please re-assign if you think someone else should be assigned.

/cc @tinaafitz