### PR TITLE
EMS Cloud Refresh is missing

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2120,6 +2120,7 @@
         :identifier: ems_infra_edit
       - :name: refresh
         :identifier: ems_infra_refresh
+        :identifier: ems_cloud_refresh
       - :name: delete
         :identifier: ems_infra_delete
       - :name: pause
@@ -2139,6 +2140,7 @@
         :identifier: ems_infra_edit
       - :name: refresh
         :identifier: ems_infra_refresh
+        :identifier: ems_cloud_refresh
       - :name: delete
         :identifier: ems_infra_delete
       - :name: import_vm

--- a/config/api.yml
+++ b/config/api.yml
@@ -2119,8 +2119,9 @@
       - :name: edit
         :identifier: ems_infra_edit
       - :name: refresh
-        :identifier: ems_infra_refresh
-        :identifier: ems_cloud_refresh
+        :identifier:
+        - ems_infra_refresh
+        - ems_cloud_refresh
       - :name: delete
         :identifier: ems_infra_delete
       - :name: pause
@@ -2139,8 +2140,9 @@
       - :name: edit
         :identifier: ems_infra_edit
       - :name: refresh
-        :identifier: ems_infra_refresh
-        :identifier: ems_cloud_refresh
+        :identifier:
+        - ems_infra_refresh
+        - ems_cloud_refresh
       - :name: delete
         :identifier: ems_infra_delete
       - :name: import_vm

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -949,7 +949,7 @@ describe "Providers API" do
     end
 
     it "supports cloud provider refresh" do
-      api_basic_authorize collection_action_identifier(:providers, :refresh)
+      api_basic_authorize 'ems_cloud_refresh'
 
       provider = FactoryGirl.create(:ext_management_system, sample_amazon.symbolize_keys.except(:type, :credentials))
       provider.update_authentication(:default => default_credentials.symbolize_keys)

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -175,6 +175,19 @@ describe "Providers API" do
     }
   end
 
+  let(:sample_amazon) do
+    {
+      "type"        => "ManageIQ::Providers::Amazon::CloudManager",
+      "name"        => "sample amazon",
+      "hostname"    => "sample-amazon.provider.com",
+      "ipaddress"   => "100.200.300.4",
+      "credentials" => {
+        "userid"   => "uname",
+        "password" => "pword"
+      }
+    }
+  end
+
   def have_endpoint_attributes(expected_hash)
     h = expected_hash.slice(*ENDPOINT_ATTRS)
     h["port"] = h["port"].to_i if h.key?("port")
@@ -928,6 +941,17 @@ describe "Providers API" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
       provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type, :credentials))
+      provider.update_authentication(:default => default_credentials.symbolize_keys)
+
+      post(api_provider_url(nil, provider), :params => gen_request(:refresh))
+
+      expect_single_action_result(failed_auth_action(provider.id.to_s).symbolize_keys)
+    end
+
+    it "supports cloud provider refresh" do
+      api_basic_authorize collection_action_identifier(:providers, :refresh)
+
+      provider = FactoryGirl.create(:ext_management_system, sample_amazon.symbolize_keys.except(:type, :credentials))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       post(api_provider_url(nil, provider), :params => gen_request(:refresh))


### PR DESCRIPTION
When a user role only allows cloud and not infra refresh, that user
is denied refreshing as we only check for infra refresh.

Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1602413

This shows the roles defined:
<img width="401" alt="screen shot 2018-07-23 at 17 50 39" src="https://user-images.githubusercontent.com/63991/43091022-f2d81006-8ea0-11e8-839a-dcc47b6aad73.png">
