### PR TITLE
Revert "Merge pull request #418 from agrare/allow_plugins_to_bring_api_yml_extensions"

### DIFF
--- a/lib/api/api_config.rb
+++ b/lib/api/api_config.rb
@@ -1,9 +1,7 @@
 require "config"
 
 module Api
-  ::Config.overwrite_arrays = false
   ApiConfig = ::Config::Options.new.tap do |o|
-    Vmdb::Plugins.each { |plugin| o.add_source!(plugin.root.join('config/api.yml').to_s) }
     o.add_source!(ManageIQ::Api::Engine.root.join("config/api.yml").to_s)
     o.load!
   end


### PR DESCRIPTION
This reverts commit 2c1b8d915fe37c7abcf80fd62286277b315cd241, reversing
changes made to 9d146dc4207a3482a60e74e01d227ca46236bf18.

Setting `Config.overwrite_arrays` at the global level breaks Vmdb::Settings on core, https://travis-ci.org/ManageIQ/manageiq/jobs/407590294#L1000-L1047