### PR TITLE
Added support for fetching configuration scripts

### DIFF
--- a/app/controllers/api/configuration_scripts_controller.rb
+++ b/app/controllers/api/configuration_scripts_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ConfigurationScriptsController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -688,20 +688,6 @@
       :delete:
       - :name: delete
         :identifier: condition_delete
-  :configuration_scripts:
-    :description: Configuration Scripts
-    :options:
-    - :collection
-    :verbs: *g
-    :klass: ConfigurationScript
-    :collection_actions:
-      :get:
-      - :name: read
-        :identifier: configuration_script_view
-    :resource_actions:
-      :get:
-      - :name: read
-        :identifier: configuration_script_view
   :configuration_script_payloads:
     :description: Configuration Script Payloads
     :options:
@@ -765,6 +751,20 @@
       :delete:
       - :name: delete
         :identifier: embedded_configuration_script_source_delete
+  :configuration_scripts:
+    :description: Configuration Scripts
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: ConfigurationScript
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: configuration_script_view
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: configuration_script_view
   :container_deployments:
     :description: Container Provider Deployment
     :identifier: container_deployment

--- a/config/api.yml
+++ b/config/api.yml
@@ -688,6 +688,20 @@
       :delete:
       - :name: delete
         :identifier: condition_delete
+  :configuration_scripts:
+    :description: Configuration Scripts
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: ConfigurationScript
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: configuration_script_view
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: configuration_script_view
   :configuration_script_payloads:
     :description: Configuration Script Payloads
     :options:

--- a/spec/requests/configuration_scripts_spec.rb
+++ b/spec/requests/configuration_scripts_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe 'Configuration Scripts API' do
+  describe 'GET /api/configuration_scripts' do
+    it 'lists all the configuration scripts with an appropriate role' do
+      script = FactoryGirl.create(:configuration_script)
+      api_basic_authorize collection_action_identifier(:configuration_scripts, :read, :get)
+
+      get(api_configuration_scripts_url)
+
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'configuration_scripts',
+        'resources' => [
+          hash_including('href' => api_configuration_script_url(nil, script))
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access to configuration scripts without an appropriate role' do
+      api_basic_authorize
+
+      get(api_configuration_scripts_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/configuration_scripts/:id' do
+    it 'will show an ansible script with an appropriate role' do
+      script = FactoryGirl.create(:configuration_script)
+      api_basic_authorize action_identifier(:configuration_scripts, :read, :resource_actions, :get)
+
+      get(api_configuration_script_url(nil, script))
+
+      expect(response.parsed_body)
+        .to include('href' => api_configuration_script_url(nil, script))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access to an ansible script without an appropriate role' do
+      script = FactoryGirl.create(:configuration_script)
+      api_basic_authorize
+
+      get(api_configuration_script_url(nil, script))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
The Ansible Tower Job Template and Ansible Workflows can now be fetched
using the REST API.

This was added for the Service Catalog project so that the Job Template can be accessed using the REST API.