### PR TITLE
Added verify_ssl to the list of valid attributes

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -6,7 +6,7 @@ module Api
     AUTH_TYPE_ATTR    = "auth_type".freeze
     DEFAULT_AUTH_TYPE = "default".freeze
     CONNECTION_ATTRS  = %w(connection_configurations).freeze
-    ENDPOINT_ATTRS    = %w(hostname url ipaddress port security_protocol certificate_authority).freeze
+    ENDPOINT_ATTRS    = %w(verify_ssl hostname url ipaddress port security_protocol certificate_authority).freeze
     RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"].freeze
 
     include Subcollections::Policies


### PR DESCRIPTION
When we add a provider it might be using self signed certs
We need a way to disable the certificate check with verify_ssl.
The UI provides a check box to disable certifcate check we would
need something similar for REST API