### PR TITLE
Allow the PUT/PATCH editing of templates and add a test for it

### DIFF
--- a/app/controllers/api/templates_controller.rb
+++ b/app/controllers/api/templates_controller.rb
@@ -3,5 +3,9 @@ module Api
     include Subcollections::Policies
     include Subcollections::PolicyProfiles
     include Subcollections::Tags
+
+    def edit_resource(type, id = nil, data = {})
+      super(type, id, data.extract!('name', 'description'))
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -3138,7 +3138,7 @@
     :options:
     - :collection
     - :custom_actions
-    :verbs: *gpd
+    :verbs: *gpppd
     :klass: MiqTemplate
     :subcollections:
     - :tags
@@ -3171,7 +3171,6 @@
         :disabled: true
       - :name: edit
         :identifier: miq_template_edit
-        :disabled: true
       - :name: set_ownership
         :identifier: miq_template_ownership
       - :name: delete

--- a/spec/requests/templates_spec.rb
+++ b/spec/requests/templates_spec.rb
@@ -29,6 +29,32 @@ RSpec.describe "Templates API" do
     end
   end
 
+  context "editing a template" do
+    let!(:template) { FactoryGirl.create(:template, :name => 'foo', :description => 'bar') }
+    before { api_basic_authorize(action_identifier(:templates, :edit)) }
+    subject { send(req, api_template_url(nil, template), :params => params) }
+
+    describe "PUT /api/templates/:c_id" do
+      let(:req) { :put }
+      let(:params) { {:name => 'baz'} }
+
+      it 'edits the template name' do
+        expect { subject }.to change { template.reload.name }.to('baz')
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "PATCH /api/templates/:c_id" do
+      let(:req) { :patch }
+      let(:params) { {:description => 'baz'} }
+
+      it 'edits the template description' do
+        expect { subject }.to change { template.reload.description }.to('baz')
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
   describe "tags subcollection" do
     it "can list a template's tags" do
       template = FactoryGirl.create(:template)


### PR DESCRIPTION
This will enable to edit the name/description of `MiqTemplate` entities through the API. The final goal is to join this with the OpenStack-related `CloudTemplate` controller somehow.

Related issue: #381

@miq-bot assign @abellotti 