### PR TITLE
Symbolize schedule data

### DIFF
--- a/app/controllers/api/subcollections/schedules.rb
+++ b/app/controllers/api/subcollections/schedules.rb
@@ -12,7 +12,7 @@ module Api
 
       def schedules_edit_resource(_parent, _type, id, data)
         # We need to hit #edit_resource from the BaseController, not any of the override methods in child controllers
-        BaseController.instance_method(:edit_resource).bind(self).call(:schedules, id, data)
+        BaseController.instance_method(:edit_resource).bind(self).call(:schedules, id, data.deep_symbolize_keys)
       rescue => err
         raise BadRequestError, "Could not update Schedule - #{err}"
       end

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -805,6 +805,17 @@ describe "Service Templates API" do
           expect(schedule_1.reload.name).to eq("Updated Schedule Name")
         end
 
+        it "can edit a single schedule run_at" do
+          api_basic_authorize(subresource_action_identifier(:service_templates, :schedules, :edit))
+
+          t = Time.zone.now.utc
+          post(api_service_template_schedule_url(nil, service_template, schedule_1), :params => gen_request(:edit, "run_at" => {"start_time" => t.to_s, "interval" => {"unit" => "daily", "value" => "12"}}))
+
+          schedule_1.reload
+          expect(schedule_1.run_at[:interval]).to eq(:unit => "daily", :value => "12")
+          expect(schedule_1.run_at[:start_time]).to be_within(1).of(t)
+        end
+
         it "will not delete a schedule unless authorized" do
           api_basic_authorize
 

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -796,7 +796,7 @@ describe "Service Templates API" do
       end
 
       describe "POST /api/service_templates/:id/schedules/:id with edit action" do
-        it "can queue a flavor for deletion" do
+        it "can edit a single schedule" do
           api_basic_authorize(subresource_action_identifier(:service_templates, :schedules, :edit))
 
           post(api_service_template_schedule_url(nil, service_template, schedule_1), :params => gen_request(:edit, "name" => "Updated Schedule Name"))
@@ -816,7 +816,7 @@ describe "Service Templates API" do
           expect(schedule_1.run_at[:start_time]).to be_within(1).of(t)
         end
 
-        it "will not delete a schedule unless authorized" do
+        it "will not edit a schedule unless authorized" do
           api_basic_authorize
 
           post(api_service_template_schedule_url(nil, service_template, schedule_1), :params => gen_request(:edit, "name" => "Updated Schedule Name"))
@@ -826,7 +826,7 @@ describe "Service Templates API" do
       end
 
       describe "POST /api/service_templates/:id/schedules/ with edit action" do
-        it "can delete multiple schedules" do
+        it "can edit multiple schedules" do
           api_basic_authorize(subcollection_action_identifier(:service_templates, :schedules, :edit))
 
           post(api_service_template_schedules_url(nil, service_template), :params => gen_request(:edit, [{:id => schedule_1.id, :name => "Schedule1"}, {:id => schedule_2.id, :name => "Schedule2"}]))
@@ -836,7 +836,7 @@ describe "Service Templates API" do
           expect(MiqSchedule.pluck(:name)).to match_array(%w(Schedule1 Schedule2))
         end
 
-        it "forbids multiple schedule deletion without an appropriate role" do
+        it "forbids multiple schedule edit without an appropriate role" do
           api_basic_authorize
 
           post(api_service_template_schedules_url(nil, service_template), :params => gen_request(:edit, [{:id => schedule_1.id, :name => "Schedule1"}, {:id => schedule_2.id, :name => "Schedule2"}]))


### PR DESCRIPTION
Ensure the hash keys are symbolized before sending them to the model.

https://bugzilla.redhat.com/show_bug.cgi?id=1564255