### PR TITLE
[RFE] Use Vmdb::Appliance.PRODUCT_NAME instead of calling i18n

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -71,7 +71,7 @@ module Api
 
     def product_info
       {
-        :name                 => I18n.t("product.name"),
+        :name                 => Vmdb::Appliance.PRODUCT_NAME,
         :name_full            => I18n.t("product.name_full"),
         :copyright            => I18n.t("product.copyright"),
         :support_website      => I18n.t("product.support_website"),

--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "API entrypoint" do
 
     expect(response.parsed_body).to include(
       "product_info" => a_hash_including(
-        "name"                 => I18n.t("product.name"),
+        "name"                 => Vmdb::Appliance.PRODUCT_NAME,
         "name_full"            => I18n.t("product.name_full"),
         "copyright"            => I18n.t("product.copyright"),
         "support_website"      => I18n.t("product.support_website"),


### PR DESCRIPTION
This [constant](https://github.com/ManageIQ/manageiq/pull/17773/files#diff-b37e88904167347189bb2e4a9a143876R24) allows product name customization for the SUI.

@miq-bot assign @abellotti 

Backend part: https://github.com/ManageIQ/manageiq/pull/17773 (not dependent)
RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1471301