### PR TITLE
[RFE] Add the /api/product_info route with product and branding info

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -6,18 +6,22 @@ module Api
 
     def index
       res = {
-        :name         => ApiConfig.base.name,
-        :description  => ApiConfig.base.description,
-        :version      => ManageIQ::Api::VERSION,
-        :versions     => entrypoint_versions,
-        :settings     => user_settings,
-        :identity     => auth_identity,
-        :server_info  => server_info,
-        :product_info => product_info
+        :name          => ApiConfig.base.name,
+        :description   => ApiConfig.base.description,
+        :version       => ManageIQ::Api::VERSION,
+        :versions      => entrypoint_versions,
+        :settings      => user_settings,
+        :identity      => auth_identity,
+        :server_info   => server_info,
+        :product_info  => product_info_data
       }
       res[:authorization] = auth_authorization if attribute_selection.include?("authorization")
       res[:collections]   = entrypoint_collections
       render_resource :entrypoint, res
+    end
+
+    def product_info
+      render_resource :product_info, product_info_data
     end
 
     private
@@ -70,14 +74,29 @@ module Api
       }
     end
 
-    def product_info
+    def product_info_data
       {
         :name                 => Vmdb::Appliance.PRODUCT_NAME,
         :name_full            => I18n.t("product.name_full"),
         :copyright            => I18n.t("product.copyright"),
         :support_website      => I18n.t("product.support_website"),
         :support_website_text => I18n.t("product.support_website_text"),
+        :branding_info        => branding_info
       }
+    end
+
+    def image_path(image)
+      ActionController::Base.helpers.image_path(image)
+    rescue Sprockets::FileNotFound # UI isn't loaded, we don't want images
+      nil
+    end
+
+    def branding_info
+      {
+        :brand      => Settings.server.custom_brand || image_path('layout/brand.svg'),
+        :logo       => Settings.server.custom_logo || image_path('layout/login-screen-logo.png'),
+        :login_logo => Settings.server.custom_login_logo.presence
+      }.compact
     end
 
     def plugin_info

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -20,10 +20,10 @@ module Api
     include ActionController::HttpAuthentication::Basic::ControllerMethods
 
     before_action :log_request_initiated
-    before_action :require_api_user_or_token, :except => [:options]
-    before_action :set_gettext_locale, :set_access_control_headers, :parse_api_request, :log_api_request,
-                  :validate_api_request
-    before_action :validate_api_action, :except => [:options]
+    before_action :require_api_user_or_token, :except => [:options, :product_info]
+    before_action :set_gettext_locale, :set_access_control_headers, :parse_api_request, :log_api_request
+    before_action :validate_api_request, :except => [:product_info]
+    before_action :validate_api_action, :except => [:options, :product_info]
     before_action :validate_response_format, :except => [:destroy]
     before_action :ensure_pagination, :only => :index
     after_action :log_api_response

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     match "/", :to => "api#options", :via => :options
 
     get "/ping" => "ping#index"
+    get "/product_info" => "api#product_info"
 
     Api::ApiConfig.collections.each do |collection_name, collection|
       # OPTIONS action for each collection

--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -69,9 +69,31 @@ RSpec.describe "API entrypoint" do
         "name_full"            => I18n.t("product.name_full"),
         "copyright"            => I18n.t("product.copyright"),
         "support_website"      => I18n.t("product.support_website"),
-        "support_website_text" => I18n.t("product.support_website_text"),
+        "support_website_text" => I18n.t("product.support_website_text")
       )
     )
+
+    # This test will fail if you have the UI checked out and built with yarn
+    expect(response.parsed_body['product_info']['branding_info']).to eq({})
+  end
+
+  context 'UI is available' do
+    it 'product_info contains branding_info' do
+      api_basic_authorize
+
+      expect(ActionController::Base.helpers).to receive(:image_path).at_least(2).times.and_return("foo")
+
+      get api_entrypoint_url
+
+      expect(response.parsed_body).to include(
+        "product_info" => a_hash_including(
+          "branding_info" => a_hash_including(
+            "brand"      => "foo",
+            "logo"       => "foo"
+          )
+        )
+      )
+    end
   end
 
   it "will squeeze consecutive slashes in the path portion of the URI" do


### PR DESCRIPTION
If we want to customize the product name and branding, it's necessary to have a request that returns the product info without authentication. Also I would like to use this for the about modal, so adding the branding to the `/api` route as well.

@miq-bot add_reviewer @abellotti 

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1471301