### PR TITLE
Expose CloudSubnet creation

### DIFF
--- a/app/controllers/api/subcollections/cloud_subnets.rb
+++ b/app/controllers/api/subcollections/cloud_subnets.rb
@@ -4,6 +4,19 @@ module Api
       def cloud_subnets_query_resource(object)
         object.respond_to?(:cloud_subnets) ? Array(object.cloud_subnets) : []
       end
+
+      def cloud_subnets_create_resource(parent, _type, _id, data = {})
+        data.deep_symbolize_keys!
+        raise 'Must specify a name for the subnet' unless data[:name]
+
+        begin
+          message = "Creating subnet #{data[:name]}"
+          task_id = queue_object_action(parent, message, :method_name => "create_cloud_subnet", :args => [data])
+          action_result(true, message, :task_id => task_id)
+        rescue StandardError => e
+          action_result(false, e.to_s)
+        end
+      end
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -500,6 +500,9 @@
       :get:
       - :name: read
         :identifier: cloud_subnet_show_list
+      :post:
+      - :name: create
+        :identifier: cloud_subnet_new
     :subresource_actions:
       :get:
       - :name: read


### PR DESCRIPTION
With this commit we allow user to create CloudSubnet via API. Example request:

```
POST /api/providers/4/cloud_subnets HTTP/1.1
{
	"action": "create",
	"resource": {
		"router_ref": "aae5c1ff-9860-4a56-bb01-e936a7086f5a",
		"name": "My New Cloud Subnet",
		"address": "130.130.130.0",
		"netmask": "255.255.255.0",
		"gateway": "130.130.130.1"
	}
}
```

(it's up to raw_create_cloud_subnet on each provider to decide what arguments are consumed, example above is for Nuage provider, see here https://github.com/ManageIQ/manageiq-providers-nuage/blob/master/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb#L54-L61)

Needed for: https://github.com/ManageIQ/manageiq-providers-nuage/pull/118
RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574972

@miq-bot add_label enhancement
@miq-bot assign @abellotti 

/cc @Ladas @agrare 

Assigning @abellotti since you merged last few PRs so I assume you're the guy - are you? 😃 