### PR TITLE
Include task_id in the response when invoking a custom button

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -196,7 +196,7 @@ module Api
                    wf_result = submit_custom_action_dialog(resource, custom_button, data)
                    action_result(true,
                                  "Invoked custom dialog action #{action} for #{type} id: #{resource.id}",
-                                 :result => wf_result[:request])
+                                 :result => wf_result[:request], :task_id => wf_result[:task_id])
                  rescue => err
                    action_result(false, err.to_s)
                  end


### PR DESCRIPTION
After merging [this](https://github.com/ManageIQ/manageiq/pull/17788) the API will know the ID of the task that has been created by the custom button action. This can be used further by @ZitaNemeckova for fixing her BZ.

@miq-bot add_reviewer @abellotti 
@miq-bot add_label bug, gaprindashvili/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1602023