### PR TITLE
Fix failing specs due to model name in exception

### DIFF
--- a/spec/requests/alerts_spec.rb
+++ b/spec/requests/alerts_spec.rb
@@ -163,7 +163,7 @@ describe "Alerts API" do
       )
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include_error_with_message(
-        "Failed to add a new alert action resource - Assignee can't be blank"
+        "Failed to add a new alert action resource - MiqAlertStatusAction: Assignee can't be blank"
       )
     end
 

--- a/spec/requests/service_orders_spec.rb
+++ b/spec/requests/service_orders_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "service orders API" do
     expected = {
       'error' => a_hash_including(
         'kind'    => 'bad_request',
-        'message' => /Validation failed: State has already been taken/
+        'message' => /Validation failed: ServiceOrder: State has already been taken/
       )
     }
     expect(response).to have_http_status(:bad_request)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/17754 added a prefixed model
name in a number of exceptions which is causing a few specs to fail
which were matching on the raised exception.