### PR TITLE
Change request_controller special privileges

### DIFF
--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -46,7 +46,7 @@ describe "Automation Requests API" do
     end
 
     it "lists all the automation requests if you are admin" do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
       other_user = FactoryGirl.create(:user)
       automation_request1 = FactoryGirl.create(:automation_request, :requester => other_user)
       automation_request2 = FactoryGirl.create(:automation_request, :requester => @user)
@@ -77,7 +77,7 @@ describe "Automation Requests API" do
     end
 
     it "an admin can see another user's request" do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
       other_user = FactoryGirl.create(:user)
       automation_request = FactoryGirl.create(:automation_request, :requester => other_user)
       api_basic_authorize action_identifier(:automation_requests, :read, :resource_actions, :get)

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -222,7 +222,7 @@ describe "Provision Requests API" do
     end
 
     it "lists all the provision requests if you are admin" do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
       other_user = FactoryGirl.create(:user)
       provision_request1 = FactoryGirl.create(:miq_provision_request, :requester => other_user)
       provision_request2 = FactoryGirl.create(:miq_provision_request, :requester => @user)
@@ -253,7 +253,7 @@ describe "Provision Requests API" do
     end
 
     it "an admin can see another user's request" do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
       other_user = FactoryGirl.create(:user)
       provision_request = FactoryGirl.create(:miq_provision_request, :requester => other_user)
       api_basic_authorize action_identifier(:provision_requests, :read, :resource_actions, :get)
@@ -383,7 +383,7 @@ describe "Provision Requests API" do
     let(:provreq2_url)  { api_provision_request_url(nil, provreq2) }
 
     before do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
     end
 
     it "supports approving a request" do

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Requests API" do
     end
 
     it "lists all the service requests if you are admin" do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
       other_user = FactoryGirl.create(:user)
       service_request_1 = FactoryGirl.create(:service_template_provision_request,
                                              :requester   => other_user,
@@ -98,7 +98,7 @@ RSpec.describe "Requests API" do
     end
 
     it "an admin can see another user's request" do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
       other_user = FactoryGirl.create(:user)
       service_request = FactoryGirl.create(:service_template_provision_request,
                                            :requester   => other_user,

--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -233,7 +233,7 @@ describe "Service Requests API" do
     end
 
     it "lists all the service requests if you are admin" do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
       other_user = FactoryGirl.create(:user)
       service_request_1 = FactoryGirl.create(:service_template_provision_request,
                                              :requester   => other_user,
@@ -260,7 +260,7 @@ describe "Service Requests API" do
     end
 
     it "an admin can see another user's request" do
-      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_superadmin))
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :features => %w(miq_request_approval))
       other_user = FactoryGirl.create(:user)
       service_request = FactoryGirl.create(:service_template_provision_request,
                                            :requester   => other_user,


### PR DESCRIPTION
**BLOCKED BY:**
- [x] https://github.com/ManageIQ/manageiq/pull/17849

To make green, also look into:
- [x] ManageIQ/manageiq-api#451 or ManageIQ/manageiq-api#452

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1608554

---

In #385 we introduced feature `miq_request_superadmin`
*no more hardcoded admin role name - **YAY***

The UI uses a different feature, `miq_request_approval`
*Inconsistencies - **BOO***

https://github.com/ManageIQ/manageiq/pull/17849 fixes main repo's identifier
*Consistencies - **YAY***

API Tests Fail -- **BOO**

This PR changes feature identifiers used - **YAY**

---
For those concerned: `miq_request_superadmin` is deprecated
