### PR TITLE
Pass changed dialog field values to resource_action_workflow

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -207,8 +207,7 @@ module Api
 
       def submit_custom_action_dialog(resource, custom_button, data)
         wf = ResourceActionWorkflow.new({}, User.current_user, custom_button.resource_action, :target => resource)
-        data.each { |key, value| wf.set_value(key, value) } if data.present?
-        wf_result = wf.submit_request
+        wf_result = wf.submit_request(data)
         raise StandardError, Array(wf_result[:errors]).join(", ") if wf_result[:errors].present?
         wf_result
       end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594469

I think that the api needs to be passing the changed dialog field values into the resource action workflow when we make [the submit workflow call](https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/base_controller/generic.rb#L211). Otherwise the field values automate sees by the time we get to https://github.com/ManageIQ/manageiq/blob/master/app/models/resource_action_workflow.rb#L81 will be the default values only, not the updated fields you changed on the dialog. 

The setup this applies to is a custom button on a generic object.  

# Depends on:
~~https://github.com/ManageIQ/manageiq/pull/17855~~
~~https://github.com/ManageIQ/manageiq/pull/17973~~