### PR TITLE
Set the cred.manager to an EMS not a Provider

### DIFF
--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Authentications API' do
-  let(:provider) { FactoryGirl.create(:provider_ansible_tower) }
+  let(:provider) { FactoryGirl.create(:automation_manager_ansible_tower) }
   let(:auth) { FactoryGirl.create(:ansible_cloud_credential, :resource => provider) }
   let(:auth_2) { FactoryGirl.create(:ansible_cloud_credential, :resource => provider) }
 


### PR DESCRIPTION
Credentials created by EmsRefresh set the credential.manager to the
AutomationManager not a Provider.  This causes issues where
credential.manager is expected to be an ExtManagementSystem type.