### PR TITLE
Set the cred.manager to an EMS not a Provider

### DIFF
--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Authentications API' do
-  let(:provider) { FactoryGirl.create(:provider_ansible_tower) }
-  let(:auth) { FactoryGirl.create(:ansible_cloud_credential, :resource => provider) }
-  let(:auth_2) { FactoryGirl.create(:ansible_cloud_credential, :resource => provider) }
+  let(:manager) { FactoryGirl.create(:automation_manager_ansible_tower) }
+  let(:auth) { FactoryGirl.create(:ansible_cloud_credential, :resource => manager) }
+  let(:auth_2) { FactoryGirl.create(:ansible_cloud_credential, :resource => manager) }
 
   describe 'GET/api/authentications' do
     it 'lists all the authentication configuration script bases with an appropriate role' do
@@ -59,7 +59,6 @@ RSpec.describe 'Authentications API' do
   end
 
   describe 'POST /api/authentications' do
-    let(:manager) { provider.managers.first }
     let(:params) do
       {
         :id          => auth.id,


### PR DESCRIPTION
Introduced by ManageIQ/manageiq#17531 (but failure is actually due to a bad spec)

Credentials created by EmsRefresh set the credential.manager to the
AutomationManager not a Provider. This causes issues where
credential.manager is expected to be an ExtManagementSystem type.

Fixing test failures 99% stolen from: 

-  https://github.com/jameswnl/manageiq-api/tree/credential-spec
- https://github.com/ManageIQ/manageiq-api/pull/451