### PR TITLE
Add best fit API for transformations moving vms to openstack

### DIFF
--- a/app/controllers/api/transformation_mappings_controller.rb
+++ b/app/controllers/api/transformation_mappings_controller.rb
@@ -22,6 +22,19 @@ module Api
       end
     end
 
+    def vm_flavor_fit_resource(_type, _id, data)
+      data["mappings"].collect do |mapping|
+        source      = Api::Utils.resource_search_by_href_slug(mapping["source_href_slug"])
+        destination = Api::Utils.resource_search_by_href_slug(mapping["destination_href_slug"])
+        fit         = TransformationMapping::CloudBestFit.new(source, destination)
+        {
+          :source_href_slug => mapping["source_href_slug"],
+          :best_fit         => Api::Utils.build_href_slug(Flavor, fit.best_fit_flavor.try(:id)),
+          :all_fit          => fit.available_fit_flavors.collect { |f| Api::Utils.build_href_slug(Flavor, f.id) }
+        }
+      end
+    end
+
     private
 
     def create_mapping_items(items)

--- a/config/api.yml
+++ b/config/api.yml
@@ -3366,6 +3366,8 @@
         :identifier: transformation_mapping_new
       - :name: delete
         :identifier: transformation_mapping_delete
+      - :name: vm_flavor_fit
+        :identifier: transformation_mapping_new
     :resource_actions:
       :get:
       - :name: read


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/17880
https://trello.com/c/b90ZCyNm/183-extend-cf-api-for-mapping-of-osp-flavors-and-security-groups