### PR TITLE
Allow bulk assignment and unassignment of tags for users

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -3402,6 +3402,10 @@
         :identifier: rbac_user_edit
       - :name: delete
         :identifier: rbac_user_delete
+      - :name: assign_tags
+        :identifier: rbac_user_tags_edit
+      - :name: unassign_tags
+        :identifier: rbac_user_tags_edit
     :resource_actions:
       :get:
       - :name: read


### PR DESCRIPTION
Resolves #459

http://manageiq.org/docs/reference/latest/api/reference/tagging#bulk-assigning-tags

cc @Hyperkid123 