### PR TITLE
Use the replacement backend method for searching and valiating VMs

### DIFF
--- a/app/controllers/api/transformation_mappings_controller.rb
+++ b/app/controllers/api/transformation_mappings_controller.rb
@@ -12,7 +12,7 @@ module Api
 
     def validate_vms_resource(type, id, data = {})
       transformation_mapping = resource_search(id, type, collection_class(type))
-      (transformation_mapping.validate_vms(data["import"]) || {}).tap do |res|
+      (transformation_mapping.search_vms_and_validate(data["import"]) || {}).tap do |res|
         %w(valid_vms invalid_vms conflict_vms).each do |key|
           next unless res.key?(key)
           res[key].each do |entry|

--- a/spec/requests/transformation_mappings_spec.rb
+++ b/spec/requests/transformation_mappings_spec.rb
@@ -233,9 +233,9 @@ describe "Transformation Mappings" do
           post(api_transformation_mapping_url(nil, transformation_mapping), :params => request)
 
           expected = {
-            "valid_vms"    => [a_hash_including("name" => vm.name, "id" => vm.id.to_s, "href" => a_string_including(api_vm_url(nil, vm)))],
-            "invalid_vms"  => [a_hash_including("name" => "bad name")],
-            "conflict_vms" => []
+            "valid"      => [a_hash_including("name" => vm.name, "id" => vm.id.to_s, "status" => "ok", "reason" => "ok", "cluster" => source_ems.name)],
+            "invalid"    => [a_hash_including("name" => "bad name")],
+            "conflicted" => []
           }
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body).to include(expected)


### PR DESCRIPTION
This PR basically replaces `validate_vms` with `search_vms_and_validate`

To be merged after https://github.com/ManageIQ/manageiq/pull/17364 is merged