### PR TITLE
Add custom_button_events subcollection for users, tenants and groups

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -2,6 +2,7 @@ module Api
   class GroupsController < BaseController
     INVALID_GROUP_ATTRS = %w(id href group_type).freeze
 
+    include Subcollections::CustomButtonEvents
     include Subcollections::Tags
 
     def groups_search_conditions

--- a/app/controllers/api/subcollections/custom_button_events.rb
+++ b/app/controllers/api/subcollections/custom_button_events.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module CustomButtonEvents
+      def custom_button_events_query_resource(object)
+        object.custom_button_events
+      end
+    end
+  end
+end

--- a/app/controllers/api/tenants_controller.rb
+++ b/app/controllers/api/tenants_controller.rb
@@ -2,6 +2,7 @@ module Api
   class TenantsController < BaseController
     INVALID_TENANT_ATTRS = %w(id href ancestry).freeze
 
+    include Subcollections::CustomButtonEvents
     include Subcollections::Tags
     include Subcollections::Quotas
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -4,6 +4,7 @@ module Api
     INVALID_SELF_USER_ATTRS = %w(id href current_group_id current_group).freeze
     EDITABLE_ATTRS = %w(password email settings).freeze
 
+    include Subcollections::CustomButtonEvents
     include Subcollections::Tags
 
     skip_before_action :validate_api_action, :only => :update

--- a/config/api.yml
+++ b/config/api.yml
@@ -958,6 +958,16 @@
       - :name: delete
       :delete:
       - :name: delete
+  :custom_button_events:
+    :description: Custom Button Events
+    :options:
+    - :subcollection
+    :verbs: *g
+    :klass: CustomButtonEvent
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: custom_button_events_show_list
   :custom_button_sets:
     :description: Custom Button Sets
     :identifier: ab_buttons_accord
@@ -1352,6 +1362,7 @@
     :klass: MiqGroup
     :identifying_attrs: description
     :subcollections:
+    - :custom_button_events
     - :tags
     :collection_actions:
       :get:
@@ -3337,6 +3348,7 @@
     :verbs: *gpppd
     :klass: Tenant
     :subcollections:
+    - :custom_button_events
     - :tags
     - :quotas
     :collection_actions:
@@ -3438,6 +3450,7 @@
     :klass: User
     :identifying_attrs: name,userid
     :subcollections:
+    - :custom_button_events
     - :tags
     :collection_actions:
       :get:

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -324,4 +324,28 @@ describe "Groups API" do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'GET /groups/:id/custom_button_events' do
+    let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
+    let!(:custom_button_event) { FactoryGirl.create(:custom_button_event, :target => group) }
+
+    it 'returns with the custom button events for the given user' do
+      api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
+
+      get(api_group_custom_button_events_url(nil, group))
+
+      expected = {
+        "name"      => "custom_button_events",
+        "count"     => 1,
+        "resources" => contain_exactly(
+          a_hash_including(
+            'href' => a_string_matching("custom_button_events/#{custom_button_event.id}")
+          )
+        )
+      }
+
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/tenants_spec.rb
+++ b/spec/requests/tenants_spec.rb
@@ -282,4 +282,29 @@ RSpec.describe "tenants API" do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  describe 'GET /tenants/:id/custom_button_events' do
+    let(:tenant) { FactoryGirl.create(:tenant, :parent => root_tenant) }
+    let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
+    let!(:custom_button_event) { FactoryGirl.create(:custom_button_event, :target => tenant) }
+
+    it 'returns with the custom button events for the given user' do
+      api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
+
+      get(api_tenant_custom_button_events_url(nil, tenant))
+
+      expected = {
+        "name"      => "custom_button_events",
+        "count"     => 1,
+        "resources" => contain_exactly(
+          a_hash_including(
+            'href' => a_string_matching("custom_button_events/#{custom_button_event.id}")
+          )
+        )
+      }
+
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -589,4 +589,28 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:bad_request)
     end
   end
+
+  describe 'GET /users/:id/custom_button_events' do
+    let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
+    let!(:custom_button_event) { FactoryGirl.create(:custom_button_event, :target => user1) }
+
+    it 'returns with the custom button events for the given user' do
+      api_basic_authorize(:user => super_admin.userid, :password => super_admin.password)
+
+      get(api_user_custom_button_events_url(nil, user1))
+
+      expected = {
+        "name"      => "custom_button_events",
+        "count"     => 1,
+        "resources" => contain_exactly(
+          a_hash_including(
+            'href' => a_string_matching("custom_button_events/#{custom_button_event.id}")
+          )
+        )
+      }
+
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
As we [discussed](https://github.com/ManageIQ/manageiq-ui-classic/pull/4514#issuecomment-417295590)  with @Hyperkid123 and @h-kataria, the new API-driven react/redux-based RBAC UI should include the custom button events via the API instead of using nested resources.

@miq-bot add_label enhancement, gaprindashvili/no
cc @Hyperkid123 you can start working with this in your PR

https://bugzilla.redhat.com/show_bug.cgi?id=1634053