### PR TITLE
Remove `modifier` to fix failing test

### DIFF
--- a/spec/requests/conditions_spec.rb
+++ b/spec/requests/conditions_spec.rb
@@ -24,8 +24,7 @@ describe "Conditions API" do
         :name        => "name",
         :description => "description",
         :expression  => {"=" => {"field" => "ContainerImage-architecture", "value" => "dsa"}},
-        :towhat      => "ExtManagementSystem",
-        :modifier    => "allow"
+        :towhat      => "ExtManagementSystem"
       }
     end
     let(:condition) { FactoryGirl.create(:condition) }


### PR DESCRIPTION
Modifier was removed in https://github.com/ManageIQ/manageiq-schema/pull/95