### PR TITLE
Expose NetworkPorts

### DIFF
--- a/app/controllers/api/network_ports_controller.rb
+++ b/app/controllers/api/network_ports_controller.rb
@@ -1,0 +1,6 @@
+module Api
+  class NetworkPortsController < BaseController
+    include Subcollections::CloudSubnets
+    include Subcollections::SecurityGroups
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -513,6 +513,25 @@
         :identifier: cloud_subnet_tag
       - :name: unassign
         :identifier: cloud_subnet_tag
+  :network_ports:
+    :description: Network Ports
+    :identifier: network_port
+    :options:
+    - :collection
+    - :custom_actions
+    :verbs: *g
+    :klass: NetworkPort
+    :subcollections:
+    - :cloud_subnets
+    - :security_groups
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: network_port_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: network_port_show
   :cloud_templates:
     :description: Cloud Templates
     :identifier: image

--- a/spec/requests/network_ports_spec.rb
+++ b/spec/requests/network_ports_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe 'NetworkPorts API' do
+  let(:ems) { FactoryGirl.create(:ems_network) }
+
+  describe 'GET /api/network_ports' do
+    it 'lists all network ports with an appropriate role' do
+      network_port = FactoryGirl.create(:network_port)
+      api_basic_authorize collection_action_identifier(:network_ports, :read, :get)
+      get(api_network_ports_url)
+
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'network_ports',
+        'resources' => [
+          hash_including('href' => api_network_port_url(nil, network_port))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids access to network ports without an appropriate role' do
+      api_basic_authorize
+
+      get(api_network_ports_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/network_ports/:id' do
+    it 'will show a network port with an appropriate role' do
+      network_port = FactoryGirl.create(:network_port)
+      api_basic_authorize action_identifier(:network_ports, :read, :resource_actions, :get)
+
+      get(api_network_port_url(nil, network_port))
+
+      expect(response.parsed_body).to include('href' => api_network_port_url(nil, network_port))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access to a network port without an appropriate role' do
+      network_port = FactoryGirl.create(:network_port)
+      api_basic_authorize
+
+      get(api_network_port_url(nil, network_port))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
With this commit we allow user to list and fetch NetworkPorts. Example requests:

```
GET /api/network_ports
GET /api/network_ports/7
```

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574979

@miq-bot add_label enhancement
@miq-bot assign @abellotti