### PR TITLE
Expose SecurityGroups that are connected to a NetworkRouter

### DIFF
--- a/app/controllers/api/network_routers_controller.rb
+++ b/app/controllers/api/network_routers_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class NetworkRoutersController < BaseController
     include Subcollections::Tags
+    include Subcollections::SecurityGroups
 
     def delete_resource(type, id, _data = {})
       delete_action_handler do

--- a/config/api.yml
+++ b/config/api.yml
@@ -1659,11 +1659,13 @@
     :identifier: network_router
     :options:
     - :collection
+    - :subcollection
     - :custom_actions
     :verbs: *gpd
     :klass: NetworkRouter
     :subcollections:
     - :tags
+    - :security_groups
     :collection_actions:
       :get:
       - :name: read
@@ -1689,6 +1691,10 @@
         :identifier: network_router_tag
       - :name: unassign
         :identifier: network_router_tag
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: security_group_show_list
   :networks:
     :description: Networks
     :options:

--- a/spec/requests/network_routers_spec.rb
+++ b/spec/requests/network_routers_spec.rb
@@ -138,4 +138,17 @@ RSpec.describe 'NetworkRouters API' do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  describe 'security groups subcollection' do
+    it "can list a router's security groups" do
+      router = FactoryGirl.create(:network_router)
+      router.security_groups = [FactoryGirl.create(:security_group)]
+      api_basic_authorize(action_identifier(:network_routers, :read, :subcollection_actions, :get))
+
+      get(api_network_router_security_groups_url(nil, router))
+
+      expect(response.parsed_body).to include('subcount' => 1)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
With this commit we let user access NetworkRouter's SecurityGroups. Example URL:

```
GET /api/network_routers/2/security_groups
```

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574979

@miq-bot add_label enhancement
@miq-bot assign @abellotti