### PR TITLE
Expose SecurityGroups that are connected to a CloudSubnet

### DIFF
--- a/app/controllers/api/cloud_subnets_controller.rb
+++ b/app/controllers/api/cloud_subnets_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class CloudSubnetsController < BaseController
     include Subcollections::Tags
+    include Subcollections::SecurityGroups
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -480,6 +480,7 @@
     :klass: CloudSubnet
     :subcollections:
     - :tags
+    - :security_groups
     :collection_actions:
       :get:
       - :name: read
@@ -495,6 +496,8 @@
       :get:
       - :name: read
         :identifier: cloud_subnet_show_list
+      - :name: read
+        :identifier: security_group_show_list
       :post:
       - :name: create
         :identifier: cloud_subnet_new

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -77,4 +77,17 @@ RSpec.describe 'CloudSubnets API' do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  describe 'security groups subcollection' do
+    it "can list a subnet's security groups" do
+      subnet = FactoryGirl.create(:cloud_subnet)
+      subnet.security_groups = [FactoryGirl.create(:security_group)]
+      api_basic_authorize(action_identifier(:cloud_subnets, :read, :subcollection_actions, :get))
+
+      get(api_cloud_subnet_security_groups_url(nil, subnet))
+
+      expect(response.parsed_body).to include('subcount' => 1)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
With this commit we let user access CloudSubnet's SecurityGroups. Example URL:

```
GET /api/cloud_subnets/2/security_groups
```

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574979

@miq-bot add_label enhancement
@miq-bot assign @abellotti