### PR TITLE
Display plugins in the product_info under the root route

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -65,7 +65,8 @@ module Api
         :server_href     => "#{@req.api_prefix}/servers/#{MiqServer.my_server.id}",
         :zone_href       => "#{@req.api_prefix}/zones/#{MiqServer.my_server.zone.id}",
         :region_href     => "#{@req.api_prefix}/regions/#{MiqRegion.my_region.id}",
-        :enterprise_href => "#{@req.api_prefix}/enterprises/#{MiqEnterprise.my_enterprise.id}"
+        :enterprise_href => "#{@req.api_prefix}/enterprises/#{MiqEnterprise.my_enterprise.id}",
+        :plugins         => plugin_info
       }
     end
 
@@ -77,6 +78,15 @@ module Api
         :support_website      => I18n.t("product.support_website"),
         :support_website_text => I18n.t("product.support_website_text"),
       }
+    end
+
+    def plugin_info
+      Vmdb::Plugins.versions.each_with_object({}) do |(engine, version), hash|
+        hash[engine.to_s] = {
+          :display_name => engine.respond_to?(:plugin_name) ? engine.plugin_name : engine.to_s.gsub(/ManageIQ::|::Engine/, ''),
+          :version      => version
+        }
+      end
     end
 
     def miq_groups


### PR DESCRIPTION
Would be nice to have this to fix https://github.com/ManageIQ/manageiq-ui-classic/issues/4581.
@miq-bot add_label gaprindashvili/no

*GET /api*
```json
{
   ...
    "server_info": {
    "version": "master",
     "build": "unknown_8234e5eb01",
     "appliance": null,
     "time": "2018-09-20T13:06:37Z",
     "server_href": "http://localhost:3000/api/servers/1",
     "zone_href": "http://localhost:3000/api/zones/1",
     "region_href": "http://localhost:3000/api/regions/1",
     "enterprise_href": "http://localhost:3000/api/enterprises/1",
     "plugins" : {
       "ENGINE": {
         "display_name": "PLUGIN NAME",
         "version": "PLUGIN_VERSION",
       },
       ...
     },
     ...
}
```