### PR TITLE
[GAPRINDASHVILI] Set zone name to "default" when creating with factory so that it matches settings.yml

### DIFF
--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -42,10 +42,10 @@ describe "Regions API" do
   end
 
   describe "/api/regions/:id/settings" do
-    let(:region_number) { ApplicationRecord.my_region_number + 1 }
+    let(:region_number) { ApplicationRecord.my_region_number }
     let(:id) { ApplicationRecord.id_in_region(1, region_number) }
     let(:region) { FactoryGirl.create(:miq_region, :id => id, :region => region_number) }
-    let(:zone) { FactoryGirl.create(:zone, :id => id) }
+    let(:zone) { FactoryGirl.create(:zone, :id => id, :name => "default") }
     let!(:server) { EvmSpecHelper.remote_miq_server(:id => id, :zone => zone) }
     let(:original_timeout) { region.settings_for_resource[:api][:authentication_timeout] }
     let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Servers" do
   describe "/api/servers/:id/settings" do
-    let(:server) { FactoryGirl.create(:miq_server) }
+    let(:server) { FactoryGirl.create(:miq_server, :zone => FactoryGirl.create(:zone, :name => "default")) }
     let(:original_timeout) { server.settings_for_resource[:api][:authentication_timeout] }
     let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
 

--- a/spec/requests/zones_spec.rb
+++ b/spec/requests/zones_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Zones" do
   describe "/api/zones/:id/settings" do
-    let(:zone) { FactoryGirl.create(:zone) }
+    let(:zone) { FactoryGirl.create(:zone, :name => "default") }
     let(:original_timeout) { zone.settings_for_resource[:api][:authentication_timeout] }
     let(:super_admin) { FactoryGirl.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
 


### PR DESCRIPTION
This fixes tests failures like

```
Zones /api/zones/:id/settings with an existing settings change does not allow an authenticated non-super-admin user to delete settings
     Failure/Error: raise "configuration invalid" unless VMDB::Config::Validator.new(new_settings).valid?
     RuntimeError:
       configuration invalid
     # ./spec/manageiq/lib/vmdb/settings.rb:50:in `save!'
     # ./spec/manageiq/app/models/mixins/configuration_management_mixin.rb:13:in `add_settings_for_resource'
     # ./spec/requests/zones_spec.rb:60:in `block (4 levels) in <top (required)>'
```
Because zone name does not match default value in settings.yml

Note - on master https://github.com/ManageIQ/manageiq/pull/17140 removed `:zone: default` from settings.yml so the failure does not exist there.

I was considering backporting that PR but figured a surgical fix to the failing test was lower risk.