### PR TITLE
Deny standalone service template ordering when product setting is enabled

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -3,11 +3,8 @@ module Api
     module ServiceTemplates
       def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
-        unless api_request_allowed? && service_template.orderable?
-          raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered"
-        end
-        init_defaults = !request_from_ui? && Settings.product.run_automate_methods_on_service_api_submit
-        request_result = service_template.order(User.current_user, (data || {}), {:submit_workflow => request_from_ui?, :init_defaults => init_defaults}, scheduled_time)
+        raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered" unless orderable?
+        request_result = service_template.order(User.current_user, (data || {}), order_request_options, scheduled_time)
         errors = request_result[:errors]
         if errors.present?
           raise BadRequestError, "Failed to order #{service_template_ident(service_template)} - #{errors.join(", ")}"
@@ -17,9 +14,24 @@ module Api
 
       private
 
+      def orderable?
+        api_request_allowed? && service_template.orderable?
+      end
+
+      def api_request_allowed?
+        return true if request_from_ui?
+        Settings.product.allow_api_service_ordering
+      end
+
       def request_from_ui?
         return false if request.headers["x-auth-token"].blank?
         token_info.present?
+      end
+
+      def order_request_options
+        init_defaults = !request_from_ui? && Settings.product.run_automate_methods_on_service_api_submit
+
+        {:submit_workflow => request_from_ui?, :init_defaults => init_defaults}
       end
 
       def token_info
@@ -29,15 +41,6 @@ module Api
 
       def service_template_ident(st)
         "Service Template id:#{st.id} name:'#{st.name}'"
-      end
-
-      def api_request_allowed?
-        return true if request_from_ui?
-        Settings.product.allow_api_service_ordering
-      end
-
-      def request_from_ui?
-        !request.authorization.try(:downcase).try(:starts_with?, "basic")
       end
     end
   end

--- a/spec/requests/service_catalogs_spec.rb
+++ b/spec/requests/service_catalogs_spec.rb
@@ -376,7 +376,10 @@ describe "Service Catalogs API" do
     end
 
     before do
-      stub_settings_merge(:product => double(:allow_api_service_ordering => true))
+      stub_settings_merge(:product => {:allow_api_service_ordering => true})
+      userid = User.first.userid
+      test_token = Api::UserTokenService.new.generate_token(userid, "api")
+      request_headers["x-auth-token"] = test_token
     end
 
     def init_st(service_template, resource_action)

--- a/spec/requests/service_catalogs_spec.rb
+++ b/spec/requests/service_catalogs_spec.rb
@@ -375,6 +375,10 @@ describe "Service Catalogs API" do
       request_headers["x-auth-token"] = test_token
     end
 
+    before do
+      stub_settings_merge(:product => double(:allow_api_service_ordering => true))
+    end
+
     def init_st(service_template, resource_action)
       service_template.resource_actions = [resource_action]
       dialog1.dialog_tabs << tab1

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -466,6 +466,12 @@ describe "Service Templates API" do
 
   describe "Service Templates order" do
     let(:service_template) { FactoryGirl.create(:service_template, :with_provision_resource_action_and_dialog, :orderable) }
+    let(:product_settings) { double(:allow_api_service_ordering => allow_api_service_ordering) }
+    let(:allow_api_service_ordering) { true }
+
+    before do
+      stub_settings_merge(:product => product_settings)
+    end
 
     it "is forbidden without appropriate role" do
       api_basic_authorize


### PR DESCRIPTION
The issue this PR fixes is that currently, you can simply POST to the service_template order endpoint with whatever data you want (ideally, there is sort of a flow, i.e. you request the dialog, you may request any dialog field refreshes, and *then* you can POST to the service_template order endpoint with the data you've gathered from the previous requests). With any random data, it won't really work, but for example if a dropdown only contains the options "A" or "B", but the API request is submitted with "C", it is accepted.

This change, along with a product setting called `allow_api_service_ordering`, that the users must set to `false` first (as it is defaulted to `true` via [this PR](https://github.com/ManageIQ/manageiq/pull/18029)), should ensure that only the API calls that come from the UIs will be accepted. Otherwise everything will behave as it does now. This is mostly just a quick fix solution until we can potentially implement RBAC for API users, or add code to the model to validate the values against expected values, but those options are both a lot more involved.

/cc @tinaafitz 

https://bugzilla.redhat.com/show_bug.cgi?id=1632416