### PR TITLE
Logging cleanup

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -68,7 +68,6 @@ module Api
         method = api_get_method_name(caller.first, __method__)
         log_prefix = "MIQ(#{self.class.name}.#{method})"
 
-        $api_log.error("#{log_prefix} #{ApiConfig.base.name} Error")
         msg.split("\n").each { |l| $api_log.error("#{log_prefix} #{l}") }
       end
 

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -74,7 +74,7 @@ module Api
         if api_log_debug?
           method = api_get_method_name(caller.first, __method__)
 
-          $api_log.info("MIQ(#{self.class.name}.#{method}) #{msg}")
+          $api_log.debug("MIQ(#{self.class.name}.#{method}) #{msg}")
         end
       end
 

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -66,25 +66,22 @@ module Api
 
       def api_log_error(msg)
         method = api_get_method_name(caller.first, __method__)
-        log_prefix = "MIQ(#{self.class.name}.#{method})"
 
-        msg.split("\n").each { |l| $api_log.error("#{log_prefix} #{l}") }
+        $api_log.error("MIQ(#{self.class.name}.#{method}) #{msg}")
       end
 
       def api_log_debug(msg)
         if api_log_debug?
           method = api_get_method_name(caller.first, __method__)
-          log_prefix = "MIQ(#{self.class.name}.#{method})"
 
-          msg.split("\n").each { |l| $api_log.info("#{log_prefix} #{l}") }
+          $api_log.info("MIQ(#{self.class.name}.#{method}) #{msg}")
         end
       end
 
       def api_log_info(msg)
         method = api_get_method_name(caller.first, __method__)
-        log_prefix = "MIQ(#{self.class.name}.#{method})"
 
-        msg.split("\n").each { |l| $api_log.info("#{log_prefix} #{l}") }
+        $api_log.info("MIQ(#{self.class.name}.#{method}) #{msg}")
       end
 
       private


### PR DESCRIPTION
- Remove unnecessary error message
- Ensure multi-line messages are logged as a single message for parser compatibility
- Debug messages should logged in debug level

Currently:
```
[----] E, [2018-09-25T16:36:13.142625 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) API Error
[----] E, [2018-09-25T16:36:13.142802 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) TypeError: no implicit conversion of nil into String
[----] E, [2018-09-25T16:36:13.143408 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) API Error
[----] E, [2018-09-25T16:36:13.143621 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) 
[----] E, [2018-09-25T16:36:13.143774 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) 
[----] E, [2018-09-25T16:36:13.143910 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) /usr/share/gems/gems/json-2.1.0/lib/json/common.rb:156:in `initialize'
[----] E, [2018-09-25T16:36:13.144014 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) /usr/share/gems/gems/json-2.1.0/lib/json/common.rb:156:in `new'
[----] E, [2018-09-25T16:36:13.144114 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) /usr/share/gems/gems/json-2.1.0/lib/json/common.rb:156:in `parse'
[----] E, [2018-09-25T16:36:13.144213 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) /opt/rh/cfme-gemset/bundler/gems/cfme-api-b8d14803f964/app/controllers/api/mixins/central_admin.rb:24:in `block (2 levels) in central_admin'
[----] E, [2018-09-25T16:36:13.144311 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) /opt/rh/cfme-gemset/bundler/gems/cfme-api-b8d14803f964/app/controllers/api/base_controller/manager.rb:105:in `update_one_collection'
[----] E, [2018-09-25T16:36:13.144410 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) /opt/rh/cfme-gemset/bundler/gems/cfme-api-b8d14803f964/app/controllers/api/base_controller/manager.rb:92:in `get_and_update_one_collection'
...
```

Should be:
```
[----] E, [2018-09-25T16:36:13.142802 #2132:1495fb0] ERROR -- : MIQ(Api::VmsController.api_error) TypeError: no implicit conversion of nil into String
/usr/share/gems/gems/json-2.1.0/lib/json/common.rb:156:in `initialize'
/usr/share/gems/gems/json-2.1.0/lib/json/common.rb:156:in `new'
/usr/share/gems/gems/json-2.1.0/lib/json/common.rb:156:in `parse'
/opt/rh/cfme-gemset/bundler/gems/cfme-api-b8d14803f964/app/controllers/api/mixins/central_admin.rb:24:in `block (2 levels) in central_admin'
/opt/rh/cfme-gemset/bundler/gems/cfme-api-b8d14803f964/app/controllers/api/base_controller/manager.rb:105:in `update_one_collection'
/opt/rh/cfme-gemset/bundler/gems/cfme-api-b8d14803f964/app/controllers/api/base_controller/manager.rb:92:in `get_and_update_one_collection'
...
```