### PR TITLE
Pass `User#userid` instead of `User#id` to queue chargeback report

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -137,7 +137,7 @@ module Api
 
     def queue_chargeback_report_resource(_type, id, _data)
       service = resource_search(id, :services, Service)
-      task = service.queue_chargeback_report_generation(:userid => current_user.id)
+      task = service.queue_chargeback_report_generation(:userid => current_user.userid)
       action_result(true, "Queued chargeback report generation for #{service_ident(service)}", :task_id => task.id)
     rescue StandardError => err
       action_result(false, "Could not queue chargeback report generation - #{err}")

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1472,5 +1472,16 @@ describe "Services API" do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'can queue chargeback report for the current user' do
+      api_basic_authorize action_identifier(:services, :queue_chargeback_report)
+
+      post(api_service_url(nil, svc1), :params => {:action => 'queue_chargeback_report'})
+
+      expect(response).to have_http_status(:ok)
+
+      q = MiqQueue.where(:class_name  => "Service", :method_name => "generate_chargeback_report").take
+      expect(q.args).to eq([{:userid=>"api_user_id"}])
+    end
   end
 end


### PR DESCRIPTION
The method expects the user's login and not the integer id

https://bugzilla.redhat.com/show_bug.cgi?id=1530952