### PR TITLE
Add flag to initialize field default values

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -4,7 +4,8 @@ module Api
       def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
         raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered" unless service_template.orderable?
-        request_result = service_template.order(User.current_user, (data || {}), {:submit_workflow => true}, scheduled_time)
+        init_defaults = !request_from_ui? && Settings.product.run_automate_methods_on_service_api_submit
+        request_result = service_template.order(User.current_user, (data || {}), {:submit_workflow => request_from_ui?, :init_defaults => init_defaults}, scheduled_time)
         errors = request_result[:errors]
         if errors.present?
           raise BadRequestError, "Failed to order #{service_template_ident(service_template)} - #{errors.join(", ")}"
@@ -13,6 +14,16 @@ module Api
       end
 
       private
+
+      def request_from_ui?
+        return false if request.headers["x-auth-token"].blank?
+        token_info.present?
+      end
+
+      def token_info
+        requester_type = params['requester_type'] || 'api'
+        Environment.user_token_service.token_mgr(requester_type).token_get_info(request.headers["x-auth-token"])
+      end
 
       def service_template_ident(st)
         "Service Template id:#{st.id} name:'#{st.name}'"

--- a/spec/requests/service_catalogs_spec.rb
+++ b/spec/requests/service_catalogs_spec.rb
@@ -358,15 +358,22 @@ describe "Service Catalogs API" do
        "status"         => "Ok"}
     end
 
-    let(:dialog1) { FactoryGirl.create(:dialog, :label => "Dialog1") }
-    let(:tab1)    { FactoryGirl.create(:dialog_tab, :label => "Tab1") }
-    let(:group1)  { FactoryGirl.create(:dialog_group, :label => "Group1") }
-    let(:text1)   { FactoryGirl.create(:dialog_field_text_box, :label => "TextBox1", :name => "text1") }
-    let(:ra1)     { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
-    let(:st1)     { FactoryGirl.create(:service_template, :name => "service template 1", :display => true) }
-    let(:ra2)     { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
-    let(:st2)     { FactoryGirl.create(:service_template, :name => "service template 2", :display => true) }
-    let(:sc)      { FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description") }
+    let(:dialog1)                                            { FactoryGirl.create(:dialog, :label => "Dialog1") }
+    let(:tab1)                                               { FactoryGirl.create(:dialog_tab, :label => "Tab1") }
+    let(:group1)                                             { FactoryGirl.create(:dialog_group, :label => "Group1") }
+    let(:text1)                                              { FactoryGirl.create(:dialog_field_text_box, :label => "TextBox1", :name => "text1") }
+    let(:ra1)                                                { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
+    let(:st1)                                                { FactoryGirl.create(:service_template, :name => "service template 1", :display => true) }
+    let(:ra2)                                                { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
+    let(:st2)                                                { FactoryGirl.create(:service_template, :name => "service template 2", :display => true) }
+    let(:sc)                                                 { FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description") }
+
+    before do
+      stub_settings_merge(:product => {:run_automate_methods_on_service_api_submit => true})
+      userid = User.first.userid
+      test_token = Api::UserTokenService.new.generate_token(userid, "api")
+      request_headers["x-auth-token"] = test_token
+    end
 
     def init_st(service_template, resource_action)
       service_template.resource_actions = [resource_action]

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -492,7 +492,7 @@ describe "Service Templates API" do
 
         expected = {
           "results" => [a_hash_including("href"    => a_string_including(api_service_requests_url),
-                                         "options" => a_hash_including("request_options" => a_hash_including("submit_workflow"=>true)))]
+                                         "options" => a_hash_including("request_options" => a_hash_including("submit_workflow"=>false)))]
         }
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)
@@ -574,6 +574,27 @@ describe "Service Templates API" do
 
         actions = response.parsed_body["actions"].collect { |action| action["name"] }
         expect(actions).to_not include("order")
+      end
+    end
+
+    context "with the product setting not allowing automate to run on submit" do
+      let(:template_no_display) { FactoryGirl.create(:service_template, :display => false) }
+      context "if the token info is blank" do
+        before do
+          request_headers["x-auth_token"] = ""
+        end
+        it "rejects the request" do
+          api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
+          post(api_service_template_url(nil, template_no_display), :params => { :action => "order" })
+          expected = {
+            "error" => a_hash_including(
+              "kind"    => "bad_request",
+              "message" => /cannot be ordered/
+            )
+          }
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body).to include(expected)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1635673

At this point if a service dialog gets ordered via the API, it will not honor defaults on static fields. To remedy this, this adds a flag to the call to also let us call ```load_values_into_fields(values, false)```, thus honoring the default values. This builds on the recent changes to https://github.com/ManageIQ/manageiq/pull/17844


## Related: 
https://github.com/ManageIQ/manageiq/pull/18061
