### PR TITLE
Don't request HTTP Basic authenticaion when using a token

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -16,10 +16,7 @@ module Api
             begin
               timeout = ::Settings.api.authentication_timeout.to_i_with_method
               user = User.authenticate(u, p, request, :require_user => true, :timeout => timeout)
-              auth_user_obj = userid_to_userobj(user.userid)
-              authorize_user_group(auth_user_obj)
-              validate_user_identity(auth_user_obj)
-              User.current_user = auth_user_obj
+              auth_user(user.userid)
             rescue MiqException::MiqEVMLoginError => e
               raise AuthenticationError, e.message
             end
@@ -39,10 +36,6 @@ module Api
           :locale                     => I18n.locale.to_s.sub('-', '_'),
           :asynchronous_notifications => ::Settings.server.asynchronous_notifications,
         }.merge(User.current_user.settings)
-      end
-
-      def userid_to_userobj(userid)
-        User.lookup_by_identity(userid)
       end
 
       def authorize_user_group(user_obj)
@@ -68,6 +61,13 @@ module Api
         Environment.user_token_service.token_mgr('api')
       end
 
+      def auth_user(userid)
+        auth_user_obj = User.lookup_by_identity(userid)
+        authorize_user_group(auth_user_obj)
+        validate_user_identity(auth_user_obj)
+        User.current_user = auth_user_obj
+      end
+
       def authenticate_with_user_token(auth_token)
         if !api_token_mgr.token_valid?(auth_token)
           raise AuthenticationError, "Invalid Authentication Token #{auth_token} specified"
@@ -75,15 +75,11 @@ module Api
           userid = api_token_mgr.token_get_info(auth_token, :userid)
           raise AuthenticationError, "Invalid Authentication Token #{auth_token} specified" unless userid
 
-          auth_user_obj = userid_to_userobj(userid)
-
           unless request.headers['X-Auth-Skip-Token-Renewal'] == 'true'
             api_token_mgr.reset_token(auth_token)
           end
 
-          authorize_user_group(auth_user_obj)
-          validate_user_identity(auth_user_obj)
-          User.current_user = auth_user_obj
+          auth_user(userid)
         end
       end
 
@@ -95,11 +91,7 @@ module Api
 
         User.authorize_user(@miq_token_hash[:userid])
 
-        auth_user_obj = userid_to_userobj(@miq_token_hash[:userid])
-
-        authorize_user_group(auth_user_obj)
-        validate_user_identity(auth_user_obj)
-        User.current_user = auth_user_obj
+        auth_user(@miq_token_hash[:userid])
       rescue => err
         api_log_error("Authentication Failed with System Token\nX-MIQ-Token: #{x_miq_token}\nError: #{err}")
         raise AuthenticationError, "Invalid System Authentication Token specified"

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -13,12 +13,9 @@ module Api
       def log_api_auth
         return unless api_log_info?
         if @miq_token_hash
-          auth_type = "system"
           log_request("System Auth", {:x_miq_token => request.headers[HttpHeaders::MIQ_TOKEN]}.merge(@miq_token_hash))
-        else
-          auth_type = request.headers[HttpHeaders::AUTH_TOKEN].blank? ? "basic" : "token"
         end
-        log_request("Authentication", :type        => auth_type,
+        log_request("Authentication", :type        => auth_mechanism.to_s,
                                       :token       => request.headers[HttpHeaders::AUTH_TOKEN],
                                       :x_miq_group => request.headers[HttpHeaders::MIQ_GROUP],
                                       :user        => User.current_user.userid)

--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -17,9 +17,7 @@ module Api
     private
 
     def authentication_requested?
-      [HttpHeaders::MIQ_TOKEN, HttpHeaders::AUTH_TOKEN, "HTTP_AUTHORIZATION"].any? do |header|
-        request.headers.include?(header)
-      end
+      !!auth_mechanism
     end
   end
 end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -222,6 +222,12 @@ describe "Authentication API" do
           expect(response).to have_http_status(:unauthorized)
         end
 
+        it "authentication using a bad token doesn't fallback to HTTP Basic" do
+          get api_entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => "badtoken"}
+
+          expect(response.headers.keys).not_to include('WWW-Authenticate')
+        end
+
         it "authentication using a valid token" do
           api_basic_authorize
 


### PR DESCRIPTION
Only request fallback to HTTP Basic if no other authentication method is used.

Specifically don't fall back to HTTP Basic when using the token, because otherwise there is no way for the UI to prevent the browser log in dialog when attempting to log out with a stale token (or even trying to use one during a normal request, after suspend for example).

Such attempts will now return a proper HTTP 401 JSON response, but will not trigger the popup.

--

Closes ManageIQ/manageiq-ui-classic#4717
Introduced in https://github.com/ManageIQ/manageiq-api/pull/359
