### PR TITLE
Include product features list in the identity section of /api

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -91,7 +91,10 @@ module Api
 
     def miq_groups
       current_user.miq_groups.collect do |group|
-        group.attributes.merge(:sui_product_features => group.sui_product_features)
+        group.attributes.merge(
+          :sui_product_features => group.sui_product_features,
+          :product_features     => group.miq_product_features.map(&:identifier)
+        )
       end
     end
 


### PR DESCRIPTION
As we were discussing about it [on gitter](https://gitter.im/ManageIQ/api?at=5bbb5da85331811c2e6b5336) the UI should be informed through the API about what the user is allowed to do. SUI has a `sui_product_features` for this, so I analogously created `product_features` at the same location.

```js
// $ GET http://admin:smartvm@localhost:3000/api | jq -r .identity.miq_groups

[
  {
    "href": "http://localhost:3000/api/groups/2",
    "id": "2",
    "description": "EvmGroup-super_administrator",
    "group_type": "system",
    "sequence": 1,
    "created_on": "2017-10-06T16:35:38Z",
    "updated_on": "2017-10-06T16:35:38Z",
    "settings": null,
    "tenant_id": "1",
    "sui_product_features": [
      "sui_app_launcher",
      "sui_vm_details_view",
      // ...
    ],
    "product_features": [
      "everything"
    ]
  }
]
```

This should fix the problems @Hyperkid123 has with [custom button events](https://bugzilla.redhat.com/show_bug.cgi?id=1634053) in his new [RBAC UI PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/4562).