### PR TITLE
Add subcollection options support for CORS prefilghted requests

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -103,7 +103,11 @@ module Api
     end
 
     def options
-      render_options(@req.collection)
+      if params.key?(:subcollection)
+        render :json => ""
+      else
+        render_options(@req.collection)
+      end
     end
 
     def settings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,9 @@ Rails.application.routes.draw do
         end
 
         Array(collection.subcollections).each do |subcollection_name|
+          # OPTIONS action for each subcollection
+          match "/:c_id/#{subcollection_name}", :controller => collection_name, :action => :options, :via => :options, :as => nil, :subcollection => true
+
           if subcollection_name == :settings
             match(
               "/:c_id/settings",

--- a/spec/requests/tenant_quotas_spec.rb
+++ b/spec/requests/tenant_quotas_spec.rb
@@ -131,6 +131,12 @@ describe "tenant quotas API" do
       expect(response).to have_http_status(:no_content)
     end
 
+    it "supports OPTIONS requests on a subcollection without authorization" do
+      options "/api/tenants/#{tenant.id}/quotas"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to be_empty
+    end
+
     it "can delete multiple quotas from a tenant with POST" do
       api_basic_authorize action_identifier(:quotas, :delete, :subcollection_actions, :post)
 

--- a/spec/requests/tenant_quotas_spec.rb
+++ b/spec/requests/tenant_quotas_spec.rb
@@ -132,7 +132,7 @@ describe "tenant quotas API" do
     end
 
     it "supports OPTIONS requests on a subcollection without authorization" do
-      options api_tenant_quotas_url(:c_id => tenant.id)
+      options api_tenant_quotas_url(nil, tenant)
       expect(response).to have_http_status(:ok)
       expect(response.body).to be_empty
     end

--- a/spec/requests/tenant_quotas_spec.rb
+++ b/spec/requests/tenant_quotas_spec.rb
@@ -132,7 +132,7 @@ describe "tenant quotas API" do
     end
 
     it "supports OPTIONS requests on a subcollection without authorization" do
-      options "/api/tenants/#{tenant.id}/quotas"
+      options api_tenant_quotas_url(:c_id => tenant.id)
       expect(response).to have_http_status(:ok)
       expect(response.body).to be_empty
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1599259

This PR adds support for the options verb on subcollections. This is needed to support
the prefilghted requests done by CORS.

To test this ensure the options verb responds successfully for subcollections
**e.g.:**

`curl -X OPTIONS -k --user admin:<password> https://<API Server>/api/tenants/<id>/quotas`