### PR TITLE
Ensure ServiceTemplate ordering passes through the submit_workflow flag

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -30,8 +30,9 @@ module Api
 
       def order_request_options
         init_defaults = !request_from_ui? && Settings.product.run_automate_methods_on_service_api_submit
+        submit_workflow = request_from_ui? || Settings.product.allow_api_service_ordering
 
-        {:submit_workflow => request_from_ui?, :init_defaults => init_defaults}
+        {:submit_workflow => submit_workflow, :init_defaults => init_defaults}
       end
 
       def token_info

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -484,6 +484,25 @@ describe "Service Templates API" do
     end
 
     context "with an orderable template" do
+      context "when the request headers do not indicate that the request is coming from the UI" do
+        before do
+          request_headers.delete("x-auth-token")
+        end
+
+        it "orders the request with 'submit_workflow' set to true" do
+          api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
+
+          post(api_service_templates_url, :params => { :action => "order", :resources => [{:href => api_service_template_url(nil, service_template)}] })
+
+          expected = {
+            "results" => [a_hash_including("href"    => a_string_including(api_service_requests_url),
+                                           "options" => a_hash_including("request_options" => a_hash_including("submit_workflow"=>true)))]
+          }
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
+        end
+      end
+
       it "can be ordered as a resource action" do
         api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
 


### PR DESCRIPTION
When I made #476, #485 got merged before it, and I overlooked an issue where the `submit_workflow` flag was not being set correctly, causing issues when submitting requests directly through the API instead of the UI. When the backend attempts to validate the dialog, the correct values that were passed through the request are not loaded without the `submit_workflow` flag set.

@miq-bot add_label bug, hammer/yes, gaprindashvili/yes
@miq-bot add_reviewer @d-m-u 
@miq-bot assign @bdunne 