### PR TITLE
Custom Buttons with dialogs should be running invoke

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -193,6 +193,7 @@ module Api
 
       def invoke_custom_action_with_dialog(type, resource, action, data, custom_button)
         result = begin
+                   custom_button.publish_event(nil, resource)
                    wf_result = submit_custom_action_dialog(resource, custom_button, data)
                    action_result(true,
                                  "Invoked custom dialog action #{action} for #{type} id: #{resource.id}",

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -581,9 +581,12 @@ describe "Custom Actions API" do
     it "accept custom actions" do
       api_basic_authorize
 
+      expect(CustomButtonEvent.count).to eq(0)
+
       post api_generic_object_url(nil, @resource), :params => gen_request(@button.name, "key1" => "value1")
 
       expect_single_action_result(:success => true, :message => /.*/, :href => api_generic_object_url(nil, @resource))
+      expect(CustomButtonEvent.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1511126.

Since the [custom button ```publish event``` method](https://github.com/ManageIQ/manageiq/blob/master/app/models/custom_button.rb#L103) is [where we create custom button events](https://github.com/ManageIQ/manageiq/blob/master/app/models/custom_button.rb#L108), and we expect (per convo with GM) that _all_ cb runs will create events, I think _all_ cb runs, regardless of sans/avec dialogue, should be running the publish event method.

As GM points out, this is a blocker bug, so perhaps refactoring this to better reflect the fact that the paths for custom buttons branch should be done after this gets merged. Er. Please, people?


## depends on 
~~https://github.com/ManageIQ/manageiq/pull/18178~~