### PR TITLE
Expose conversion hosts as part of REST API

### DIFF
--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ConversionHostsController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -938,6 +938,21 @@
       :get:
       - :name: read
         :identifier: container_show
+  :conversion_hosts:
+    :description: Conversion Hosts
+    :identifier: conversion_host
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: ConversionHost
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: conversion_host_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: conversion_host_show
   :currencies:
     :description: Currencies
     :identifier: currency
@@ -2835,7 +2850,7 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: 
+        :identifier:
         - svc_catalog_provision
         - sui_orders_view
       :post:

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -1,0 +1,48 @@
+describe "ConversionHosts API" do
+  context "collections" do
+    it 'lists all conversion hosts with an appropriate role' do
+      conversion_host = FactoryGirl.create(:conversion_host)
+      api_basic_authorize(collection_action_identifier(:conversion_hosts, :read, :get))
+      get(api_conversion_hosts_url)
+
+      expected = {
+        'count'     => 1,
+        'name'      => 'conversion_hosts',
+        'resources' => [
+          hash_including('href' => api_conversion_host_url(nil, conversion_host))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "resources" do
+    it 'will show a conversion host with an appropriate role' do
+      conversion_host = FactoryGirl.create(:conversion_host)
+      api_basic_authorize(action_identifier(:conversion_hosts, :read, :resource_actions, :get))
+
+      get(api_conversion_host_url(nil, conversion_host))
+
+      expect(response.parsed_body).to include('href' => api_conversion_host_url(nil, conversion_host))
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "access" do
+    it "forbids access to conversion hosts without an appropriate role" do
+      api_basic_authorize
+      get(api_conversion_hosts_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "forbids access to a conversion host resource without an appropriate role" do
+      api_basic_authorize
+      conversion_host = FactoryGirl.create(:conversion_host)
+      get(api_conversion_host_url(nil, conversion_host))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
This PR will enable us to access conversion hosts as part of the REST API, e.g.:

```
http://some_miq_host/api/conversion_hosts
http://some_miq_host/api/conversion_hosts/0
```

It's just the basics for now.

Required as part of the V2V effort.