### PR TITLE
Seed tenant product features in Spec::Support::API::Helpers

### DIFF
--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -25,6 +25,8 @@ module Spec
               @role.miq_product_features << MiqProductFeature.find_or_create_by(:identifier => identifier) if identifier
             end
             @role.save
+
+            MiqProductFeature.seed_tenant_miq_product_features if identifiers & MiqProductFeature::TENANT_FEATURE_ROOT_IDENTIFIERS == identifiers
           end
 
           request_headers["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)


### PR DESCRIPTION
This fixes [test failures in API repo](url
https://travis-ci.org/ManageIQ/manageiq-api/jobs/452479021) because https://github.com/ManageIQ/manageiq/pull/18102 requires seeded product tenant features. 

**Note:**
in case that tenant product features are not seeded correctly - this fix is "safe point" https://github.com/ManageIQ/manageiq/pull/18179 (it skips tenant product feature authorisation)

@miq-bot add_label bug, spec

@miq-bot assign @gtanzillo 

