### PR TITLE
Fix specs for branding information

### DIFF
--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -73,8 +73,11 @@ RSpec.describe "API entrypoint" do
       )
     )
 
-    # This test will fail if you have the UI checked out and built with yarn
-    expect(response.parsed_body['product_info']['branding_info']).to eq({})
+    # This test will fail if you have the assets precompiled
+    expect(response.parsed_body['product_info']['branding_info']).to eq(
+      "brand" => "/images/layout/brand.svg",
+      "logo"  => "/images/layout/login-screen-logo.png"
+    )
   end
 
   context 'UI is available' do


### PR DESCRIPTION
Since https://github.com/ManageIQ/manageiq/pull/18228 got merged, the `asset_path` doesn't return `nil` but a string. 