### PR TITLE
[Gaprindashvili] Fix invalid count on report index

### DIFF
--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -7,7 +7,7 @@ module Api
     before_action :set_additional_attributes, :only => [:index, :show]
 
     def reports_search_conditions
-      MiqReport.for_user(User.current_user).where_clause.ast unless User.current_user.admin?
+      MiqReport.for_user(User.current_user).where_clause.ast unless User.current_user.admin_user?
     end
 
     def find_reports(id)


### PR DESCRIPTION
Since `User#admin?` and `User#admin_user?` are not equivalent, there is a possibility when not using the `admin` user to cause an invalid query of:

```SQL
SELECT  "miq_reports".* FROM "miq_reports" WHERE () LIMIT 1000 OFFSET 0
```

Where the `WHERE ()` is caused by trying to do a:

```ruby
MiqReport.where(MiqReport.all.where_clause.ast)
```

This happens because the check in place to avoid this in `Api::ReportsController#reports_search_conditions`, `User#admin?`, which only can be a user with `userid == "admin"`, is less specific then the check in `MiqReport.for_user`, which calls `User#admin_user?` and allows any user with either of the following roles:

- `"EvmRole-super_administrator"`
- `"EvmRole-administrator"`

When a user is just a `"EvmRole-administrator"`, this will cause an error, and this error is corrected by using the same check.


Links
-----
* Related fix for `master`/`hammer`:  https://github.com/ManageIQ/manageiq-api/pull/520
* Offending PR:  https://github.com/ManageIQ/manageiq/pull/15472

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656242