### PR TITLE
Add conversion host resource access

### DIFF
--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -7,8 +7,7 @@ module Api
     #
     # POST /api/conversion_hosts/1 {'action': 'resource'}
     #
-    def resource_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for fetching a #{type}.resource" unless id
+    def resource_resource(type, id, _data = nil)
       conversion_host = resource_search(id, type, collection_class(type))
       conversion_host.resource
     rescue => err

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -1,5 +1,18 @@
 module Api
   class ConversionHostsController < BaseController
     include Subcollections::Tags
+
+    # Interface for the polymorphic resource, which could be either a Vm or
+    # a Host. Failure to provide a conversion host ID will raise an error.
+    #
+    # POST /api/conversion_hosts/1 {'action': 'resource'}
+    #
+    def resource_resource(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for fetching a #{type}.resource" unless id
+      conversion_host = resource_search(id, type, collection_class(type))
+      conversion_host.resource
+    rescue => err
+      raise BadRequestError, "Invalid resource #{type}/#{id}: #{err}"
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -967,6 +967,8 @@
         :identifier: conversion_host_edit
       - :name: delete
         :identifier: conversion_host_delete
+      - :name: resource
+        :identifier: conversion_host_resource
       :delete:
       - :name: delete
         :identifier: conversion_host_delete

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -162,6 +162,31 @@ describe "ConversionHosts API" do
     end
   end
 
+  context "polymorphic resource" do
+    let(:vm) { FactoryGirl.create(:vm, :name => "polymorphic_vm") }
+    let(:host) { FactoryGirl.create(:host, :name => "polymorphic_host") }
+    let(:conversion_host_resource_vm){ FactoryGirl.create(:conversion_host, :resource_type => "Vm", :resource_id => vm.id) }
+    let(:conversion_host_resource_host){ FactoryGirl.create(:conversion_host, :resource_type => "Host", :resource_id => host.id) }
+
+    it "retrieves the Vm polymorphic resource as expected" do
+      api_basic_authorize(resource_action_identifier(:conversion_hosts, :resource))
+      url = api_conversion_host_url(nil, conversion_host_resource_vm)
+      post(url, :params => {:action => 'resource'})
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('href' => api_vm_url(nil, vm))
+    end
+
+    it "retrieves the Host polymorphic resource as expected" do
+      api_basic_authorize(resource_action_identifier(:conversion_hosts, :resource))
+      url = api_conversion_host_url(nil, conversion_host_resource_host)
+      post(url, :params => {:action => 'resource'})
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('href' => api_host_url(nil, host))
+    end
+  end
+
   context "tags" do
     let(:tag1) { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
     let(:tag2) { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -165,8 +165,8 @@ describe "ConversionHosts API" do
   context "polymorphic resource" do
     let(:vm) { FactoryGirl.create(:vm, :name => "polymorphic_vm") }
     let(:host) { FactoryGirl.create(:host, :name => "polymorphic_host") }
-    let(:conversion_host_resource_vm){ FactoryGirl.create(:conversion_host, :resource_type => "Vm", :resource_id => vm.id) }
-    let(:conversion_host_resource_host){ FactoryGirl.create(:conversion_host, :resource_type => "Host", :resource_id => host.id) }
+    let(:conversion_host_resource_vm) { FactoryGirl.create(:conversion_host, :resource_type => "Vm", :resource_id => vm.id) }
+    let(:conversion_host_resource_host) { FactoryGirl.create(:conversion_host, :resource_type => "Host", :resource_id => host.id) }
 
     it "retrieves the Vm polymorphic resource as expected" do
       api_basic_authorize(resource_action_identifier(:conversion_hosts, :resource))


### PR DESCRIPTION
This adds the `resource` POST action to the conversion hosts REST API. The `resource` is a polymorphic resource that is either a Vm or Host.

Originally I was going to add subcollections for Vm's and Host's as per the BZ, but as was pointed out to me, that wouldn't really make sense since it's only a single resource.

Completes https://bugzilla.redhat.com/show_bug.cgi?id=1643938