### PR TITLE
Fixes conversion_hosts_spec.rb failures

### DIFF
--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -1,7 +1,7 @@
 describe "ConversionHosts API" do
   context "collections" do
     it 'lists all conversion hosts with an appropriate role' do
-      conversion_host = FactoryGirl.create(:conversion_host)
+      conversion_host = FactoryGirl.create(:conversion_host, :resource => FactoryGirl.create(:vm))
       api_basic_authorize(collection_action_identifier(:conversion_hosts, :read, :get))
       get(api_conversion_hosts_url)
 
@@ -19,7 +19,7 @@ describe "ConversionHosts API" do
 
   context "resources" do
     it 'will show a conversion host with an appropriate role' do
-      conversion_host = FactoryGirl.create(:conversion_host)
+      conversion_host = FactoryGirl.create(:conversion_host, :resource => FactoryGirl.create(:vm))
       api_basic_authorize(action_identifier(:conversion_hosts, :read, :resource_actions, :get))
 
       get(api_conversion_host_url(nil, conversion_host))
@@ -39,7 +39,7 @@ describe "ConversionHosts API" do
 
     it "forbids access to a conversion host resource without an appropriate role" do
       api_basic_authorize
-      conversion_host = FactoryGirl.create(:conversion_host)
+      conversion_host = FactoryGirl.create(:conversion_host, :resource => FactoryGirl.create(:vm))
       get(api_conversion_host_url(nil, conversion_host))
 
       expect(response).to have_http_status(:forbidden)
@@ -53,7 +53,7 @@ describe "ConversionHosts API" do
     let(:sample_conversion_host_from_vm) do
       {
         :name          => "test_conversion_host_from_vm",
-        :resource_type => vm.class.name,
+        :resource_type => "VmOrTemplate",
         :resource_id   => vm.id,
         :version       => "1.0"
       }
@@ -62,7 +62,7 @@ describe "ConversionHosts API" do
     let(:sample_conversion_host_from_host) do
       {
         :name          => "test_conversion_host_from_host",
-        :resource_type => host.class.name,
+        :resource_type => "Host",
         :resource_id   => host.id,
         :version       => "1.0"
       }
@@ -113,7 +113,7 @@ describe "ConversionHosts API" do
   end
 
   context "delete" do
-    let(:conversion_host)             { FactoryGirl.create(:conversion_host) }
+    let(:conversion_host)             { FactoryGirl.create(:conversion_host, :resource => FactoryGirl.create(:vm)) }
     let(:conversion_host_url)         { api_conversion_host_url(nil, conversion_host) }
     let(:invalid_conversion_host_url) { api_conversion_host_url(nil, 999_999) }
 
@@ -143,7 +143,7 @@ describe "ConversionHosts API" do
 
     it "can delete multiple conversion hosts" do
       api_basic_authorize(collection_action_identifier(:conversion_hosts, :delete))
-      chost1, chost2 = FactoryGirl.create_list(:conversion_host, 2)
+      chost1, chost2 = FactoryGirl.create_list(:conversion_host, 2, :resource => FactoryGirl.create(:vm))
 
       chost1_id, chost2_id = chost1.id, chost2.id
       chost1_url = api_conversion_host_url(nil, chost1_id)
@@ -168,7 +168,7 @@ describe "ConversionHosts API" do
 
     let(:invalid_tag_url) { api_tag_url(nil, 999_999) }
 
-    let(:conversion_host) { FactoryGirl.create(:conversion_host, :name => 'conversion_host_with_tags') }
+    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => FactoryGirl.create(:vm), :name => 'conversion_host_with_tags') }
 
     before do
       FactoryGirl.create(:classification_department_with_tags)


### PR DESCRIPTION
A recent change in https://github.com/ManageIQ/manageiq/pull/18277 caused specs to fail in the API since the new validations no longer allow the specs to create `:conversion_host` factories.

This change simply updates the specs to support these new restrictions, but it might not be the ideal API interface.


Links
-----

- Fixes issue brought up [here](https://github.com/ManageIQ/manageiq-api/pull/523#issuecomment-446665850)