### PR TITLE
[WIP] Make request_from_ui use params set in frontend dialog user controller

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -24,8 +24,9 @@ module Api
       end
 
       def request_from_ui?
+        $api_log.info("requester_type: #{params['requester_type']}")
         return false if request.headers["x-auth-token"].blank?
-        token_info.present?
+        token_info.present? && params['requester_type'] == "ui"
       end
 
       def order_request_options

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -503,6 +503,27 @@ describe "Service Templates API" do
         end
       end
 
+      context "when the request headers indicate that the request is coming from the API with an auth token" do
+        context "when the product setting for 'run_automate_methods_on_service_api_submit' is true" do
+          before do
+            stub_settings_merge(:product => {:run_automate_methods_on_service_api_submit => true})
+          end
+
+          it "orders the request with 'init_defaults' set to true" do
+            api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
+
+            post(api_service_templates_url, :params => { :requester_type => "api", :action => "order", :resources => [{:href => api_service_template_url(nil, service_template)}] })
+
+            expected = {
+              "results" => [a_hash_including("href"    => a_string_including(api_service_requests_url),
+                                             "options" => a_hash_including("request_options" => a_hash_including("init_defaults"=>true)))]
+            }
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body).to include(expected)
+          end
+        end
+      end
+
       it "can be ordered as a resource action" do
         api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1659602, an issue with default dialog values not populated when API auth type is auth token because the mechanism we had in place for determining the requester type (https://github.com/ManageIQ/manageiq-api/commit/f2f024a2ccabefcfbd833aa8df9b04757ab3d109) apparently wasn't bulletproof enough so if we force it by setting it in the params, maybe it'll be more right. 

## depends on
https://github.com/ManageIQ/manageiq-ui-classic/pull/5090/files