### PR TITLE
Updated service template's ui token info check to use token metadata for requester_type

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -10,9 +10,9 @@ module Api
       res = {
         :auth_token => auth_token,
         :token_ttl  => token_info[:token_ttl],
-        :expires_on => token_info[:expires_on],
+        :expires_on => token_info[:expires_on]
       }
-      res.merge!(:requester_type => token_info[:requester_type]) if token_info[:requester_type]
+      res[:requester_type] = token_info[:requester_type] if token_info[:requester_type]
       render_resource :auth, res
     end
 

--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -12,6 +12,7 @@ module Api
         :token_ttl  => token_info[:token_ttl],
         :expires_on => token_info[:expires_on],
       }
+      res.merge!(:requester_type => token_info[:requester_type]) if token_info[:requester_type]
       render_resource :auth, res
     end
 

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -24,8 +24,11 @@ module Api
       end
 
       def request_from_ui?
-        return false if request.headers["x-auth-token"].blank?
-        token_info.present?
+        api_token = request.headers["x-auth-token"]
+        return false if api_token.blank?
+        token_info = Environment.user_token_service.token_mgr("api").token_get_info(api_token)
+        $api_log.info("XXXXXXXXXXX service_templates.rb:  The Token Used #{token_info}")
+        token_info["requester_type"] == "ui"
       end
 
       def order_request_options
@@ -33,11 +36,6 @@ module Api
         submit_workflow = request_from_ui? || Settings.product.allow_api_service_ordering
 
         {:submit_workflow => submit_workflow, :init_defaults => init_defaults}
-      end
-
-      def token_info
-        requester_type = params['requester_type'] || 'api'
-        Environment.user_token_service.token_mgr(requester_type).token_get_info(request.headers["x-auth-token"])
       end
 
       def service_template_ident(st)

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -28,7 +28,7 @@ module Api
         return false if api_token.blank?
         token_info = Environment.user_token_service.token_mgr("api").token_get_info(api_token)
         $api_log.info("XXXXXXXXXXX service_templates.rb:  The Token Used #{token_info}")
-        token_info["requester_type"] == "ui"
+        token_info[:requester_type] == "ui"
       end
 
       def order_request_options

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -26,8 +26,8 @@ module Api
       def request_from_ui?
         api_token = request.headers["x-auth-token"]
         return false if api_token.blank?
+
         token_info = Environment.user_token_service.token_mgr("api").token_get_info(api_token)
-        $api_log.info("XXXXXXXXXXX service_templates.rb:  The Token Used #{token_info}")
         token_info[:requester_type] == "ui"
       end
 

--- a/lib/services/api/user_token_service.rb
+++ b/lib/services/api/user_token_service.rb
@@ -35,7 +35,9 @@ module Api
 
       $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type} token_ttl: #{token_ttl}")
 
-      token_mgr(requester_type).gen_token(:userid => userid, :token_ttl_override => token_ttl)
+      token_metadata = { userid => userid, :token_ttl_override => token_ttl }
+      token_metadata.merge!(:requester_type => requester_type) if requester_type != "api"
+      token_mgr(requester_type).gen_token(token_metadata)
     end
 
     def validate_requester_type(requester_type)

--- a/lib/services/api/user_token_service.rb
+++ b/lib/services/api/user_token_service.rb
@@ -36,7 +36,7 @@ module Api
       $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type} token_ttl: #{token_ttl}")
 
       token_metadata = { :userid => userid, :token_ttl_override => token_ttl }
-      token_metadata.merge!(:requester_type => requester_type) if requester_type != "api"
+      token_metadata[:requester_type] = requester_type if requester_type != "api"
       token_mgr(requester_type).gen_token(token_metadata)
     end
 

--- a/lib/services/api/user_token_service.rb
+++ b/lib/services/api/user_token_service.rb
@@ -35,7 +35,7 @@ module Api
 
       $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type} token_ttl: #{token_ttl}")
 
-      token_metadata = { userid => userid, :token_ttl_override => token_ttl }
+      token_metadata = { :userid => userid, :token_ttl_override => token_ttl }
       token_metadata.merge!(:requester_type => requester_type) if requester_type != "api"
       token_mgr(requester_type).gen_token(token_metadata)
     end

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -503,6 +503,27 @@ describe "Service Templates API" do
         end
       end
 
+      context "with requests that are not coming from UI" do
+        context "when the product setting for 'run_automate_methods_on_service_api_submit' is true" do
+          before do
+            stub_settings_merge(:product => {:run_automate_methods_on_service_api_submit => true})
+          end
+
+          it "orders the request with 'init_defaults' set to true" do
+            api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
+
+            post(api_service_templates_url, :params => { :action => "order", :resources => [{:href => api_service_template_url(nil, service_template)}] })
+
+            expected = {
+              "results" => [a_hash_including("href"    => a_string_including(api_service_requests_url),
+                                             "options" => a_hash_including("request_options" => a_hash_including("init_defaults"=>true)))]
+            }
+            expect(response).to(have_http_status(:ok))
+            expect(response.parsed_body).to(include(expected))
+          end
+        end
+      end
+
       it "can be ordered as a resource action" do
         api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
 


### PR DESCRIPTION
Updated service template's ui token info check to make user of a token manager enhancement
where we store the requester_type with the api token.

- Updated the user token service to include the requester_type in the
  token metadata for non-api types.
- updated the API get auth to return the requester_type if defined.