### PR TITLE
Add ability to enable and disable conversion hosts

### DIFF
--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -51,7 +51,6 @@ module Api
     # You may optionally provide an 'auth_user' parameter.
     #
     # POST /api/conversion_hosts/:id { "action": "disable" }
-    # POST /api/conversion_hosts/:id { "action": "disable" }
     # POST /api/conversion_hosts/:id { "action": "disable", "auth_user": "someone" }
     #
     # This differs from the DELETE action in that it returns a response body.
@@ -76,7 +75,6 @@ module Api
     #
     # You may optionally provide an 'auth_user' parameter.
     #
-    # DELETE /api/conversion_hosts/:id
     # DELETE /api/conversion_hosts/:id
     # DELETE /api/conversion_hosts/:id { "auth_user": "someone" }
     #

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -29,9 +29,19 @@ module Api
       # The 'auth_user' param must be deleted since the model will otherwise
       # pass the data hash directly as params to ConversionHost.new.
       auth_user = data.delete('auth_user')
-      data['resource'] = resource_search(data['resource_id'], resource_type, collection_class(collection_type))
+      resource = resource_search(data['resource_id'], resource_type, collection_class(collection_type))
 
-      ConversionHost.enable_queue(data, auth_user)
+      data['resource'] = resource
+
+      api_action(_type, _id) do
+        begin
+          message = "Enabling resource id:#{resource.id} type:#{resource.type}"
+          task_id = ConversionHost.enable_queue(data, auth_user)
+          action_result(true, message, :task_id => task_id)
+        rescue err
+          action_result(false, err.to_s)
+        end
+      end
     end
 
     # Disable the conversion host role by installing the conversion host module

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -28,8 +28,9 @@ module Api
     def create_resource(type, id, data)
       raise BadRequestError, "resource_id must be specified" unless data['resource_id']
       raise BadRequestError, "resource_type must be specified" unless data['resource_type']
+      raise BadRequestError, "invalid resource_type #{data['resource_type']}" unless VALID_TYPES[data['resource_type']]
 
-      resource_type = VALID_TYPES.fetch(data['resource_type']){ |resource_type| "invalid resource type: #{resource_type}" }
+      resource_type = VALID_TYPES[data['resource_type']]
       collection_type = resource_type.table_name
 
       # The 'auth_user' param must be deleted since the model will otherwise

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -1,5 +1,61 @@
 module Api
   class ConversionHostsController < BaseController
     include Subcollections::Tags
+
+    # Create a conversion host and enable it. This operation will run as an
+    # MiqTask.
+    #
+    # Both the 'resource_type' and 'resource_id' are mandatory arguments,
+    # and the 'resource_type' must be either 'Host' or 'VmOrTemplate'.
+    #
+    # You may optionally pass in 'param_v2v_vddk_package_url' or 'auth_user'
+    # arguments as well.
+    #
+    # POST /api/conversion_hosts {
+    #   "name": "some_name",
+    #   "resource_type": "Host",
+    #   "resource_id": "7"
+    #   "param_v2v_vddk_package_url": "some_url"
+    #   "auth_user": "some_user"
+    # }
+    #
+    def create_resource(_type, _id, data)
+      raise BadRequestError, "resource_id must be specified" unless data['resource_id']
+      raise BadRequestError, "resource_type must be specified" unless data['resource_type']
+
+      resource_type = data['resource_type']
+      collection_type = resource_type.include?('Host') ? 'hosts' : 'vms'
+
+      # The 'auth_user' param must be deleted since the model will otherwise
+      # pass the data hash directly as params to ConversionHost.new.
+      auth_user = data.delete('auth_user')
+      data['resource'] = resource_search(data['resource_id'], resource_type, collection_class(collection_type))
+
+      ConversionHost.enable_queue(data, auth_user)
+    end
+
+    # Disable the conversion host role by installing the conversion host module
+    # and running the conversion host playbook that disables it. This operation
+    # run as an MiqTask.
+    #
+    # You may optionally provide an 'auth_user' parameter.
+    #
+    # POST /api/conversion_hosts/:id { "action": "disable" }
+    # POST /api/conversion_hosts/:id { "action": "disable" }
+    # POST /api/conversion_hosts/:id { "action": "disable", "auth_user": "someone" }
+    #
+    def disable_resource(type, id, data)
+      conversion_host = resource_search(id, type, collection_class(type))
+
+      api_action(type, id) do
+        message = "Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}"
+        begin
+          task_id = conversion_host.disable_queue(data['auth_user']) # Ok if nil
+          action_result(true, message, :task_id => task_id)
+        rescue err
+          action_result(false, err.to_s)
+        end
+      end
+    end
   end
 end

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -24,7 +24,7 @@ module Api
       raise BadRequestError, "resource_type must be specified" unless data['resource_type']
 
       resource_type = data['resource_type']
-      collection_type = resource_type.include?('Host') ? 'hosts' : 'vms'
+      collection_type = resource_type.classify.constantize.table_name
 
       # The 'auth_user' param must be deleted since the model will otherwise
       # pass the data hash directly as params to ConversionHost.new.

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -52,45 +52,21 @@ module Api
     end
 
     # Disable the conversion host role by installing the conversion host module
-    # and running the conversion host playbook that disables it. This operation
-    # run as an MiqTask.
-    #
-    # You may optionally provide an 'auth_user' parameter.
-    #
-    # POST /api/conversion_hosts/:id { "action": "disable" }
-    # POST /api/conversion_hosts/:id { "action": "disable", "auth_user": "someone" }
-    #
-    # This differs from the DELETE action in that it returns a response body.
-    #
-    def disable_resource(type, id, data)
-      conversion_host = resource_search(id, type, collection_class(type))
-
-      api_action(type, id) do
-        message = "Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}"
-        begin
-          task_id = conversion_host.disable_queue(data['auth_user']) # Ok if nil
-          action_result(true, message, :task_id => task_id)
-        rescue => err
-          action_result(false, err.to_s)
-        end
-      end
-    end
-
-    # Disable the conversion host role by installing the conversion host module
-    # and running the conversion host playbook that disables it. This operation
-    # run as an MiqTask.
+    # and running the conversion host playbook that disables it, then delete
+    # the conversion host record. This operation run as an MiqTask.
     #
     # You may optionally provide an 'auth_user' parameter.
     #
     # DELETE /api/conversion_hosts/:id
     # DELETE /api/conversion_hosts/:id { "auth_user": "someone" }
     #
-    # This differs from the POST action in that it does not return a response body.
+    # Note that you can also delete via a POST action using "action: delete" as
+    # a parameter, which will include a response body.
     #
     def delete_resource(type, id, data = {})
       delete_action_handler do
         conversion_host = resource_search(id, type, collection_class(type))
-        message = "Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}"
+        message = "Disabling and deleting ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}"
         begin
           task_id = conversion_host.disable_queue(data['auth_user']) # Ok if nil
           action_result(true, message, :task_id => task_id)

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -19,7 +19,7 @@ module Api
     #
     # POST /api/conversion_hosts {
     #   "name": "some_name",
-    #   "resource_type": "Host",
+    #   "resource_type": "ManageIQ::Providers::Redhat::InfraManager::Host",
     #   "resource_id": "7"
     #   "param_v2v_vddk_package_url": "some_url"
     #   "auth_user": "some_user"

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -6,7 +6,7 @@ module Api
     VALID_TYPES = {
       'ManageIQ::Providers::Openstack::CloudManager::Vm' => ManageIQ::Providers::Openstack::CloudManager::Vm,
       'ManageIQ::Providers::Redhat::InfraManager::Host'  => ManageIQ::Providers::Redhat::InfraManager::Host
-    }
+    }.freeze
 
     # Create a conversion host and enable it. This operation will run as an
     # MiqTask.

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -33,9 +33,6 @@ module Api
       resource_type = VALID_TYPES[data['resource_type']]
       collection_type = resource_type.table_name
 
-      # The 'auth_user' param must be deleted since the model will otherwise
-      # pass the data hash directly as params to ConversionHost.new.
-      auth_user = data.delete('auth_user')
       resource = resource_search(data['resource_id'], resource_type.to_s, collection_class(collection_type))
 
       data['resource'] = resource
@@ -43,7 +40,7 @@ module Api
       api_action(type, id) do
         begin
           message = "Enabling resource id:#{resource.id} type:#{resource.type}"
-          task_id = ConversionHost.enable_queue(data, auth_user)
+          task_id = ConversionHost.enable_queue(data.except('auth_user'), data['auth_user'])
           action_result(true, message, :task_id => task_id)
         rescue => err
           action_result(false, err.to_s)

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -19,7 +19,7 @@ module Api
     #   "auth_user": "some_user"
     # }
     #
-    def create_resource(_type, _id, data)
+    def create_resource(type, id, data)
       raise BadRequestError, "resource_id must be specified" unless data['resource_id']
       raise BadRequestError, "resource_type must be specified" unless data['resource_type']
 
@@ -33,7 +33,7 @@ module Api
 
       data['resource'] = resource
 
-      api_action(_type, _id) do
+      api_action(type, id) do
         begin
           message = "Enabling resource id:#{resource.id} type:#{resource.type}"
           task_id = ConversionHost.enable_queue(data, auth_user)

--- a/config/api.yml
+++ b/config/api.yml
@@ -967,6 +967,8 @@
         :identifier: conversion_host_edit
       - :name: delete
         :identifier: conversion_host_delete
+      - :name: disable
+        :identifier: conversion_host_disable
       :delete:
       - :name: delete
         :identifier: conversion_host_delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -967,8 +967,6 @@
         :identifier: conversion_host_edit
       - :name: delete
         :identifier: conversion_host_delete
-      - :name: disable
-        :identifier: conversion_host_disable
       :delete:
       - :name: delete
         :identifier: conversion_host_delete

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -87,9 +87,11 @@ describe "ConversionHosts API" do
 
       expect(response).to have_http_status(:ok)
 
-      results = response.parsed_body["results"]
-      expect(results).to be_kind_of(Array)
-      expect(results.first).to be_kind_of(Integer)
+      results = response.parsed_body["results"].first
+
+      expect(results['success']).to be_truthy
+      expect(results['href']).to eql('http://www.example.com/api/conversion_hosts/')
+      expect(results['message']).to eql("Enabling resource id:#{vm.id} type:Vm")
     end
 
     it "supports multiple conversion host creation" do
@@ -99,9 +101,13 @@ describe "ConversionHosts API" do
       post(api_conversion_hosts_url, :params => gen_request(:create, conversion_hosts))
 
       expect(response).to have_http_status(:ok)
+
       results = response.parsed_body["results"]
-      expect(results).to be_kind_of(Array)
-      expect(results.first).to be_kind_of(Integer)
+
+      expect(results).to match_array([
+        a_hash_including("message" => "Enabling resource id:#{vm.id} type:Vm"),
+        a_hash_including("message" => "Enabling resource id:#{host.id} type:Host"),
+      ])
     end
   end
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -207,18 +207,26 @@ describe "ConversionHosts API" do
       expect_multiple_action_result(2)
 
       results = response.parsed_body['results']
+      task_one_id = results.first['task_id']
+      task_two_id = results.last['task_id']
 
-      expect(results.first['success']).to be_truthy
-      expect(results.first['message']).to eql("Disabling ConversionHost id:#{chost1.id} name:#{chost1.name}")
-      expect(results.first['task_id']).to match(/\d+/)
-      expect(results.first['task_href']).to eql("http://www.example.com/api/tasks/#{results.first['task_id']}")
-      expect(MiqTask.exists?(results.first['task_id'].to_i)).to be_truthy
+      expect(MiqTask.exists?(task_one_id.to_i)).to be_truthy
+      expect(MiqTask.exists?(task_two_id.to_i)).to be_truthy
 
-      expect(results.last['success']).to be_truthy
-      expect(results.last['message']).to eql("Disabling ConversionHost id:#{chost2.id} name:#{chost2.name}")
-      expect(results.last['task_id']).to match(/\d+/)
-      expect(results.last['task_href']).to eql("http://www.example.com/api/tasks/#{results.last['task_id']}")
-      expect(MiqTask.exists?(results.last['task_id'].to_i)).to be_truthy
+      expect(results).to contain_exactly(
+        a_hash_including(
+          'success'   => true,
+          'message'   => "Disabling ConversionHost id:#{chost1.id} name:#{chost1.name}",
+          'task_id'   => task_one_id,
+          'task_href' => "http://www.example.com/api/tasks/#{task_one_id}"
+        ),
+        a_hash_including(
+          'success'   => true,
+          'message'   => "Disabling ConversionHost id:#{chost2.id} name:#{chost2.name}",
+          'task_id'   => task_two_id,
+          'task_href' => "http://www.example.com/api/tasks/#{task_two_id}"
+        )
+      )
     end
   end
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -128,43 +128,6 @@ describe "ConversionHosts API" do
     end
   end
 
-  context "disable" do
-    let(:zone) { FactoryBot.create(:zone) }
-    let(:ems) { FactoryBot.create(:ems_openstack, :zone => zone) }
-    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
-    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
-    let(:conversion_host_url) { api_conversion_host_url(nil, conversion_host) }
-
-    before do
-      allow(conversion_host).to receive(:install_conversion_host_module).and_return(true)
-      allow(conversion_host).to receive(:resource_search).and_return(vm)
-      allow(conversion_host).to receive(:ansible_playbook).and_return({})
-    end
-
-    it "can disable a resource via POST" do
-      api_basic_authorize(action_identifier(:conversion_hosts, :disable, :resource_actions))
-      allow(conversion_host).to receive(:check_conversion_host_role).and_return('disabled')
-
-      post(conversion_host_url, :params => {"action" => "disable"})
-
-      expect(response).to have_http_status(:ok)
-
-      results = response.parsed_body
-      task_id = results['task_id']
-
-      expect(task_id).to match(/\d+/)
-      expect(MiqTask.exists?(task_id.to_i)).to be_truthy
-
-      expect(results).to include(
-        'success'   => true,
-        'href'      => "http://www.example.com/api/conversion_hosts/#{conversion_host.id}",
-        'message'   => "Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}",
-        'task_id'   => task_id,
-        'task_href' => "http://www.example.com/api/tasks/#{task_id}"
-      )
-    end
-  end
-
   context "delete" do
     let(:zone)                        { FactoryBot.create(:zone) }
     let(:ems)                         { FactoryBot.create(:ems_openstack, :zone => zone) }
@@ -193,7 +156,7 @@ describe "ConversionHosts API" do
 
       expect(results).to include(
         'success'   => true,
-        'message'   => "Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}",
+        'message'   => "Disabling and deleting ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}",
         'task_id'   => task_id,
         'task_href' => "http://www.example.com/api/tasks/#{task_id}"
       )
@@ -229,13 +192,13 @@ describe "ConversionHosts API" do
       expect(results).to contain_exactly(
         a_hash_including(
           'success'   => true,
-          'message'   => "Disabling ConversionHost id:#{chost1.id} name:#{chost1.name}",
+          'message'   => "Disabling and deleting ConversionHost id:#{chost1.id} name:#{chost1.name}",
           'task_id'   => task_one_id,
           'task_href' => "http://www.example.com/api/tasks/#{task_one_id}"
         ),
         a_hash_including(
           'success'   => true,
-          'message'   => "Disabling ConversionHost id:#{chost2.id} name:#{chost2.name}",
+          'message'   => "Disabling and deleting ConversionHost id:#{chost2.id} name:#{chost2.name}",
           'task_id'   => task_two_id,
           'task_href' => "http://www.example.com/api/tasks/#{task_two_id}"
         )

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -51,7 +51,7 @@ describe "ConversionHosts API" do
   end
 
   context "create" do
-    let(:zone) { FactoryBot.create(:zone, :name => "api_zone") }
+    let(:zone) { FactoryBot.create(:zone) }
     let(:ems) { FactoryBot.create(:ems_openstack, :zone => zone) }
     let(:vm) { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }
     let(:host) { FactoryBot.create(:host, :ems_id => ems.id, :type => "Host") }
@@ -110,7 +110,7 @@ describe "ConversionHosts API" do
   end
 
   context "disable" do
-    let(:zone) { FactoryBot.create(:zone, :name => "api_zone") }
+    let(:zone) { FactoryBot.create(:zone) }
     let(:ems) { FactoryBot.create(:ems_openstack, :zone => zone) }
     let(:vm) { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
@@ -141,7 +141,7 @@ describe "ConversionHosts API" do
   end
 
   context "delete" do
-    let(:zone)                        { FactoryBot.create(:zone, :name => "api_zone") }
+    let(:zone)                        { FactoryBot.create(:zone) }
     let(:ems)                         { FactoryBot.create(:ems_openstack, :zone => zone) }
     let(:vm)                          { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }
     let(:vm2)                         { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -53,8 +53,8 @@ describe "ConversionHosts API" do
   context "create" do
     let(:zone) { FactoryBot.create(:zone) }
     let(:ems) { FactoryBot.create(:ems_openstack, :zone => zone) }
-    let(:vm) { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }
-    let(:host) { FactoryBot.create(:host_redhat, :ems_id => ems.id) }
+    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
 
     let(:sample_conversion_host_from_vm) do
       {
@@ -112,7 +112,7 @@ describe "ConversionHosts API" do
   context "disable" do
     let(:zone) { FactoryBot.create(:zone) }
     let(:ems) { FactoryBot.create(:ems_openstack, :zone => zone) }
-    let(:vm) { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }
+    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
     let(:conversion_host_url) { api_conversion_host_url(nil, conversion_host) }
 
@@ -143,8 +143,8 @@ describe "ConversionHosts API" do
   context "delete" do
     let(:zone)                        { FactoryBot.create(:zone) }
     let(:ems)                         { FactoryBot.create(:ems_openstack, :zone => zone) }
-    let(:vm)                          { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }
-    let(:vm2)                         { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }
+    let(:vm)                          { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
+    let(:vm2)                         { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
     let(:conversion_host)             { FactoryBot.create(:conversion_host, :resource => vm) }
     let(:conversion_host_url)         { api_conversion_host_url(nil, conversion_host) }
     let(:invalid_conversion_host_url) { api_conversion_host_url(nil, 999_999) }

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -121,10 +121,10 @@ describe "ConversionHosts API" do
 
       results = response.parsed_body["results"]
 
-      expect(results).to match_array([
+      expect(results).to contain_exactly(
         a_hash_including("message" => "Enabling resource id:#{vm.id} type:#{vm.class}", "task_id" => a_kind_of(String)),
         a_hash_including("message" => "Enabling resource id:#{host.id} type:#{host.class}", "task_id" => a_kind_of(String)),
-      ])
+      )
     end
   end
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -92,6 +92,7 @@ describe "ConversionHosts API" do
       expect(results['success']).to be_truthy
       expect(results['href']).to eql('http://www.example.com/api/conversion_hosts/')
       expect(results['message']).to eql("Enabling resource id:#{vm.id} type:Vm")
+      expect(results['task_id']).to match(/\d+/)
     end
 
     it "supports multiple conversion host creation" do
@@ -105,8 +106,8 @@ describe "ConversionHosts API" do
       results = response.parsed_body["results"]
 
       expect(results).to match_array([
-        a_hash_including("message" => "Enabling resource id:#{vm.id} type:Vm"),
-        a_hash_including("message" => "Enabling resource id:#{host.id} type:Host"),
+        a_hash_including("message" => "Enabling resource id:#{vm.id} type:Vm", "task_id" => a_kind_of(String)),
+        a_hash_including("message" => "Enabling resource id:#{host.id} type:Host", "task_id" => a_kind_of(String)),
       ])
     end
   end

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -54,7 +54,7 @@ describe "ConversionHosts API" do
     let(:zone) { FactoryBot.create(:zone) }
     let(:ems) { FactoryBot.create(:ems_openstack, :zone => zone) }
     let(:vm) { FactoryBot.create(:vm_openstack, :ems_id => ems.id) }
-    let(:host) { FactoryBot.create(:host, :ems_id => ems.id, :type => "Host") }
+    let(:host) { FactoryBot.create(:host_redhat, :ems_id => ems.id) }
 
     let(:sample_conversion_host_from_vm) do
       {

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -131,6 +131,13 @@ describe "ConversionHosts API" do
       post(conversion_host_url, :params => {"action" => "disable"})
 
       expect(response).to have_http_status(:ok)
+
+      results = response.parsed_body
+
+      expect(results['success']).to be_truthy
+      expect(results['href']).to eql("http://www.example.com/api/conversion_hosts/#{conversion_host.id}")
+      expect(results['message']).to eql("Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}")
+      expect(results['task_id']).to match(/\d+/)
     end
   end
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -89,6 +89,18 @@ describe "ConversionHosts API" do
       expect(results['error']['message']).to eql('invalid resource_type bogus')
     end
 
+    it "raises an error if an unsupported resource type is provided" do
+      api_basic_authorize(collection_action_identifier(:conversion_hosts, :create))
+      sample_conversion_host_from_vm['resource_type'] = 'Logger'
+      post(api_conversion_hosts_url, :params => sample_conversion_host_from_vm)
+
+      expect(response).to have_http_status(400)
+
+      results = response.parsed_body
+      expect(results['error']['kind']).to eql('bad_request')
+      expect(results['error']['message']).to eql('unsupported resource_type Logger')
+    end
+
     it "supports single conversion host creation" do
       api_basic_authorize(collection_action_identifier(:conversion_hosts, :create))
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -1,5 +1,5 @@
 describe "ConversionHosts API" do
-  before(:each) do
+  before do
     NotificationType.seed
   end
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -54,7 +54,7 @@ describe "ConversionHosts API" do
     let(:zone) { FactoryBot.create(:zone, :name => "api_zone") }
     let(:ems) { FactoryBot.create(:ems_vmware, :zone => zone) }
     let(:vm) { FactoryBot.create(:vm, :ems_id => ems.id) }
-    let(:host) { FactoryBot.create(:host, :ems_id => ems.id) }
+    let(:host) { FactoryBot.create(:host, :ems_id => ems.id, :type => "Host") }
 
     let(:sample_conversion_host_from_vm) do
       {

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -1,5 +1,5 @@
 describe "ConversionHosts API" do
-  before(:all) do
+  before(:each) do
     NotificationType.seed
   end
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -77,6 +77,18 @@ describe "ConversionHosts API" do
 
     let(:expected_attributes) { %w(id name resource_type resource_id version) }
 
+    it "raises an error if an invalid resource type is provided" do
+      api_basic_authorize(collection_action_identifier(:conversion_hosts, :create))
+      sample_conversion_host_from_vm['resource_type'] = 'bogus'
+      post(api_conversion_hosts_url, :params => sample_conversion_host_from_vm)
+
+      expect(response).to have_http_status(400)
+
+      results = response.parsed_body
+      expect(results['error']['kind']).to eql('bad_request')
+      expect(results['error']['message']).to eql('invalid resource_type bogus')
+    end
+
     it "supports single conversion host creation" do
       api_basic_authorize(collection_action_identifier(:conversion_hosts, :create))
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -84,12 +84,18 @@ describe "ConversionHosts API" do
       expect(response).to have_http_status(:ok)
 
       results = response.parsed_body["results"].first
+      task_id = results['task_id']
 
-      expect(results['success']).to be_truthy
-      expect(results['href']).to eql('http://www.example.com/api/conversion_hosts/')
-      expect(results['message']).to eql("Enabling resource id:#{vm.id} type:#{vm.class}")
-      expect(results['task_id']).to match(/\d+/)
-      expect(MiqTask.exists?(results['task_id'].to_i)).to be_truthy
+      expect(task_id).to match(/\d+/)
+      expect(MiqTask.exists?(task_id.to_i)).to be_truthy
+
+      expect(results).to include(
+        'success'   => true,
+        'href'      => 'http://www.example.com/api/conversion_hosts/',
+        'message'   => "Enabling resource id:#{vm.id} type:#{vm.class}",
+        'task_id'   => task_id,
+        'task_href' => "http://www.example.com/api/tasks/#{task_id}"
+      )
     end
 
     it "supports multiple conversion host creation" do
@@ -131,12 +137,18 @@ describe "ConversionHosts API" do
       expect(response).to have_http_status(:ok)
 
       results = response.parsed_body
+      task_id = results['task_id']
 
-      expect(results['success']).to be_truthy
-      expect(results['href']).to eql("http://www.example.com/api/conversion_hosts/#{conversion_host.id}")
-      expect(results['message']).to eql("Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}")
-      expect(results['task_id']).to match(/\d+/)
-      expect(MiqTask.exists?(results['task_id'].to_i)).to be_truthy
+      expect(task_id).to match(/\d+/)
+      expect(MiqTask.exists?(task_id.to_i)).to be_truthy
+
+      expect(results).to include(
+        'success'   => true,
+        'href'      => "http://www.example.com/api/conversion_hosts/#{conversion_host.id}",
+        'message'   => "Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}",
+        'task_id'   => task_id,
+        'task_href' => "http://www.example.com/api/tasks/#{task_id}"
+      )
     end
   end
 
@@ -161,13 +173,17 @@ describe "ConversionHosts API" do
       post(conversion_host_url, :params => gen_request(:delete))
 
       results = response.parsed_body
+      task_id = results['task_id']
 
-      expect(results['success']).to be_truthy
-      expect(results['message']).to eql("Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}")
-      expect(results['task_id']).to match(/\d+/)
-      expect(results['task_href']).to eql("http://www.example.com/api/tasks/#{results['task_id']}")
-      expect(MiqTask.exists?(results['task_id'].to_i)).to be_truthy
+      expect(task_id).to match(/\d+/)
+      expect(MiqTask.exists?(task_id.to_i)).to be_truthy
 
+      expect(results).to include(
+        'success'   => true,
+        'message'   => "Disabling ConversionHost id:#{conversion_host.id} name:#{conversion_host.name}",
+        'task_id'   => task_id,
+        'task_href' => "http://www.example.com/api/tasks/#{task_id}"
+      )
     end
 
     it "will not delete a conversion host unless authorized" do

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -76,10 +76,6 @@ describe "ConversionHosts API" do
 
     let(:expected_attributes) { %w(id name resource_type resource_id version) }
 
-    before do
-      allow_any_instance_of(ConversionHost).to receive(:enable_conversion_host_role).and_return(true)
-    end
-
     it "supports single conversion host creation" do
       api_basic_authorize(collection_action_identifier(:conversion_hosts, :create))
 

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -52,14 +52,15 @@ describe "ConversionHosts API" do
 
   context "create" do
     let(:zone) { FactoryBot.create(:zone) }
-    let(:ems) { FactoryBot.create(:ems_openstack, :zone => zone) }
-    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
-    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+    let(:ems_openstack) { FactoryBot.create(:ems_openstack, :zone => zone) }
+    let(:ems_redhat) { FactoryBot.create(:ems_redhat, :zone => zone) }
+    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems_openstack) }
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems_redhat) }
 
     let(:sample_conversion_host_from_vm) do
       {
         :name          => "test_conversion_host_from_vm",
-        :resource_type => "VmOrTemplate",
+        :resource_type => vm.type,
         :resource_id   => vm.id,
         :version       => "1.0"
       }
@@ -68,7 +69,7 @@ describe "ConversionHosts API" do
     let(:sample_conversion_host_from_host) do
       {
         :name          => "test_conversion_host_from_host",
-        :resource_type => "Host",
+        :resource_type => host.type,
         :resource_id   => host.id,
         :version       => "1.0"
       }


### PR DESCRIPTION
Part of the V2V effort, this effectively wraps the `enable_conversion_host_role` and `disable_conversion_host_role` methods from the `ConversionHost` model.

~~WIP for now as I need to add specs, and make sure that the `eligible?` check isn't too strict.~~

Update: specs added, and now the create and delete actions call the `enable_queue` and `disable_queue` methods, respectively, behind the scenes (which also create/delete the record). This decision was made after some discussion with James W where we decided that the "queue" methods should only be called. The non-queue methods would probably only ever be used by devs for local testing, which we can accomplish on the console by using the model directly, if necessary.

We also decided that the `delete` method should be redefined to avoid a potential database inconsistency where the record could get deleted, but the conversion host was still enabled.

A `POST` action was still left in for disablement because it returns a body, whereas the `DELETE` action doesn't, so this offers some flexibility for end users.
