### PR TITLE
Authorise action managing tenant quotas for according tenants in API

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -500,8 +500,15 @@ module Api
         collection_config.typed_subcollection_action(@req.collection, @req.subcollection, method)
       end
 
+      def custom_api_user_role_allows_method?(_action_identifier)
+        false
+      end
+
       def api_user_role_allows?(action_identifier)
         return true unless action_identifier
+
+        return custom_api_user_role_allows?(action_identifier) if custom_api_user_role_allows_method?(action_identifier)
+
         Array(action_identifier).any? { |identifier| User.current_user.role_allows?(:identifier => identifier) }
       end
 

--- a/app/controllers/api/subcollections/quotas.rb
+++ b/app/controllers/api/subcollections/quotas.rb
@@ -3,6 +3,15 @@ module Api
     module Quotas
       INVALID_QUOTA_ATTRS = %w(id href tenant_id unit).freeze
 
+      def custom_api_user_role_allows_method?(identifier)
+        MiqProductFeature.my_root_tenant_identifier?(identifier)
+      end
+
+      def custom_api_user_role_allows?(identifier)
+        tenant_identifier = MiqProductFeature.tenant_identifier(identifier, @req.collection_id)
+        User.current_user.role_allows?(:identifier => tenant_identifier)
+      end
+
       def quotas_create_resource(object, type, _id, data)
         bad_attrs = data.keys & INVALID_QUOTA_ATTRS
         errmsg = "Attributes %s should not be specified for creating a new tenant quota resource"

--- a/spec/requests/tenants_spec.rb
+++ b/spec/requests/tenants_spec.rb
@@ -1,6 +1,16 @@
 RSpec.describe "tenants API" do
   let!(:root_tenant) { Tenant.seed }
 
+  describe "custom_api_user_role_allows_method?" do
+    it "validates role in basic way for requests about some action of tenants" do
+      expect(Api::TenantsController.new.custom_api_user_role_allows_method?('rbac_tenant_add')).to be_falsey
+    end
+
+    it "validates role in custom way for requests about managing tenant quotas" do
+      expect(Api::TenantsController.new.custom_api_user_role_allows_method?('rbac_tenant_manage_quotas')).to be_truthy
+    end
+  end
+
   it "can list all the tenants" do
     api_basic_authorize action_identifier(:tenants, :read, :collection_actions, :get)
     tenant_1 = FactoryBot.create(:tenant, :parent => root_tenant)


### PR DESCRIPTION
this is PR is needed
- [x] https://github.com/ManageIQ/manageiq/pull/18322

This needs custom behaviour for role validation api requests -
this is done by adding method custom_api_user_role_allows_method?
in BaseController to decide if certain controller is allowing custom
api validation.

Authorisation action 'managing tenant quotas' according to tenants
needs custom validation this is defined in
`Api::Subcollections::Quotas `(`api/subcollections/quotas.rb`, included in `TenantController`)
this custom validation is used only if api wants to authorise
rbac_tenant_manage_quotas_tenant_`<TENANT_ID>` permission.

this is used for authorisation of permission 'manage tenant quota' with using dynamic tenant features.
see desricption here https://github.com/ManageIQ/manageiq/pull/18322


### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1468795