### PR TITLE
Remove SQL select from exception error messages.

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -43,9 +43,9 @@ module Api
         response.headers["Content-Type"] = "application/json"
         case auth_mechanism
         when :system, :token
-          render :status => 401, :json => ErrorSerializer.new(:unauthorized, e).serialize.to_json
+          render :status => 401, :json => ErrorSerializer.new(:unauthorized, e).serialize(true).to_json
         when :basic, nil
-          request_http_basic_authentication("Application", ErrorSerializer.new(:unauthorized, e).serialize.to_json)
+          request_http_basic_authentication("Application", ErrorSerializer.new(:unauthorized, e).serialize(true).to_json)
         end
         log_api_response
       end

--- a/lib/services/api/error_serializer.rb
+++ b/lib/services/api/error_serializer.rb
@@ -2,12 +2,14 @@ module Api
   class ErrorSerializer
     attr_reader :kind, :error
 
+    SQL_STATEMENTS = " SELECT | UPDATE | INSERT | DELETE ".freeze
+
     def initialize(kind, error)
       @kind = kind
       @error = error
     end
 
-    def serialize(remove_sql_select = false)
+    def serialize(no_sql_query = false)
       result = {
         :error => {
           :kind    => kind,
@@ -15,9 +17,16 @@ module Api
           :klass   => error.class.name
         }
       }
-      result[:error][:message] = error.message.split(/ SELECT /i)[0] if remove_sql_select
+      result[:error][:message] = remove_sql_query(error.message) if no_sql_query
       result[:error][:backtrace] = error.backtrace.join("\n") if Rails.env.test?
       result
+    end
+
+    private
+
+    def remove_sql_query(message)
+      return message unless message =~ /PG.*ERROR/i
+      message.split(/#{SQL_STATEMENTS}/i)[0]
     end
   end
 end

--- a/lib/services/api/error_serializer.rb
+++ b/lib/services/api/error_serializer.rb
@@ -7,7 +7,7 @@ module Api
       @error = error
     end
 
-    def serialize
+    def serialize(remove_sql_select = false)
       result = {
         :error => {
           :kind    => kind,
@@ -15,6 +15,7 @@ module Api
           :klass   => error.class.name
         }
       }
+      result[:error][:message] = error.message.split(/ SELECT /i)[0] if remove_sql_select
       result[:error][:backtrace] = error.backtrace.join("\n") if Rails.env.test?
       result
     end

--- a/spec/lib/services/api/error_serializer_spec.rb
+++ b/spec/lib/services/api/error_serializer_spec.rb
@@ -1,20 +1,58 @@
 RSpec.describe Api::ErrorSerializer do
-  let(:message_without_sql_select) { "Error" }
-  let(:message_with_sql_select) { "#{message_without_sql_select} SELECT  \"users\".* FROM \"users\"" }
-  let(:error) { double("error", :message => message_with_sql_select, :backtrace => []) }
+  let(:non_sql_message) { "Not a PostgreSQL error" }
+  let(:non_sql_error) { double("non sql error", :message => non_sql_message, :backtrace => []) }
+
+  let(:pg_message_header) { "PG::Error" }
+
+  let(:pg_select_error) { "#{pg_message_header} SeLeCt  \"users\".* FROM \"users\"" }
+  let(:select_error) { double("select error", :message => pg_select_error, :backtrace => []) }
+
+  let(:pg_update_error) { "#{pg_message_header} UpDate  \"users\".* FROM \"users\"" }
+  let(:update_error) { double("update error", :message => pg_update_error, :backtrace => []) }
+
+  let(:pg_insert_error) { "#{pg_message_header} Insert  \"users\".* FROM \"users\"" }
+  let(:insert_error) { double("insert error", :message => pg_insert_error, :backtrace => []) }
+
+  let(:delete_error) { double("delete error", :message => pg_delete_error, :backtrace => []) }
+  let(:pg_delete_error) { "#{pg_message_header} dEleTe  \"users\".* FROM \"users\"" }
+
   let(:kind) { "kind" }
 
   describe ".serialize" do
-    it "returns a message with the SQL SELECT by default" do
-      actual = described_class.new(kind, error).serialize
+    it "returns the original message when not a PG error" do
+      actual = described_class.new(kind, non_sql_error).serialize
 
-      expect(actual[:error][:message]).to eq(message_with_sql_select)
+      expect(actual[:error][:message]).to eq(non_sql_message)
     end
 
-    it "returns a message without the SQL SELECT when requested" do
-      actual = described_class.new(kind, error).serialize(true)
+    it "returns a message with the SQL statement by default" do
+      actual = described_class.new(kind, select_error).serialize
 
-      expect(actual[:error][:message]).to eq(message_without_sql_select)
+      expect(actual[:error][:message]).to eq(pg_select_error)
+    end
+
+    it "returns a message without the SQL SELECT statement when requested" do
+      actual = described_class.new(kind, select_error).serialize(true)
+
+      expect(actual[:error][:message]).to eq(pg_message_header)
+    end
+
+    it "returns a message without the SQL UPDATE statement when requested" do
+      actual = described_class.new(kind, update_error).serialize(true)
+
+      expect(actual[:error][:message]).to eq(pg_message_header)
+    end
+
+    it "returns a message without the SQL INSERT statement when requested" do
+      actual = described_class.new(kind, insert_error).serialize(true)
+
+      expect(actual[:error][:message]).to eq(pg_message_header)
+    end
+
+    it "returns a message without the SQL DELETE statement when requested" do
+      actual = described_class.new(kind, delete_error).serialize(true)
+
+      expect(actual[:error][:message]).to eq(pg_message_header)
     end
   end
 end

--- a/spec/lib/services/api/error_serializer_spec.rb
+++ b/spec/lib/services/api/error_serializer_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Api::ErrorSerializer do
+  let(:message_without_sql_select) { "Error" }
+  let(:message_with_sql_select) { "#{message_without_sql_select} SELECT  \"users\".* FROM \"users\"" }
+  let(:error) { double("error", :message => message_with_sql_select, :backtrace => []) }
+  let(:kind) { "kind" }
+
+  describe ".serialize" do
+    it "returns a message with the SQL SELECT by default" do
+      actual = described_class.new(kind, error).serialize
+
+      expect(actual[:error][:message]).to eq(message_with_sql_select)
+    end
+
+    it "returns a message without the SQL SELECT when requested" do
+      actual = described_class.new(kind, error).serialize(true)
+
+      expect(actual[:error][:message]).to eq(message_without_sql_select)
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1661445

This PR will ensure SQL database SELECT statements are not returned in the result of
failed API authentication calls.

**To test:**

Exercise the API with a curl command similar to the following:

```bash
curl -X GET 'https://<IP>/api/auth?requester_type=ui' -H 'Authorization: Basic testing' -H 'Cache-Control: no-cache' -H 'Postman-Token: c791ee47-dd7d-42c9-b9f2-a2c681d5dfe5' -k
```

Ensure that the SQL SELECT is not included in the returned error message.

**Examples of an _invalid_ and a _valid_ return:**

- This is an example of an _invalid_ return that includes the SQL SELECT.

```bash
Actual results:
{"error":{"kind":"unauthorized","message":"PG::CharacterNotInRepertoire: ERROR:  invalid byte sequence for encoding \"UTF8\": 0xb5\n: SELECT  \"users\".* FROM \"users\" WHERE (\"users\".\"id\" BETWEEN $1 AND $2) AND \"users\".\"userid\" = $3 LIMIT $4","klass":"MiqException::MiqEVMLoginError"}}
```

- This is an example of a _valid_ return, with the SQL SELECT removed.


```bash
Actual results:
{"error":{"kind":"unauthorized","message":"PG::CharacterNotInRepertoire: ERROR:  invalid byte sequence for encoding \"UTF8\": 0xb5\n: "klass":"MiqException::MiqEVMLoginError"}}
```
