### PR TITLE
[WIP] Make custom_buttons a subcollection of custom_button_sets

### DIFF
--- a/app/controllers/api/custom_button_sets_controller.rb
+++ b/app/controllers/api/custom_button_sets_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class CustomButtonSetsController < BaseController
+    include Subcollections::CustomButtons
+
     def create_resource(type, id, data)
       super(type, id, data.deep_symbolize_keys)
     end

--- a/app/controllers/api/subcollections/custom_buttons.rb
+++ b/app/controllers/api/subcollections/custom_buttons.rb
@@ -1,0 +1,13 @@
+module Api
+  module Subcollections
+    module CustomButtons
+      def custom_buttons_query_resource(object)
+        object.custom_buttons
+      end
+
+      def custom_buttons_delete_resource(_object, type, id, data)
+        delete_resource(type, id, data)
+      end
+    end
+  end
+end

--- a/app/controllers/api/subcollections/custom_buttons.rb
+++ b/app/controllers/api/subcollections/custom_buttons.rb
@@ -4,10 +4,6 @@ module Api
       def custom_buttons_query_resource(object)
         object.custom_buttons
       end
-
-      def custom_buttons_delete_resource(_object, type, id, data)
-        delete_resource(type, id, data)
-      end
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1089,7 +1089,7 @@
     :subresource_actions:
       :get:
       - :name: read
-        :identifier: ab_group 
+        :identifier: ab_group
       :post:
       - :name: delete
         :identifier: ab_group_delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -1015,6 +1015,8 @@
     :identifier: ab_buttons_accord
     :options:
     - :collection
+    :subcollections:
+    - :custom_buttons
     :verbs: *gpppd
     :klass: CustomButtonSet
     :collection_actions:
@@ -1048,6 +1050,7 @@
     :identifier: ab_buttons_accord
     :options:
     - :collection
+    - :subcollection
     :verbs: *gpppd
     :klass: CustomButton
     :collection_actions:
@@ -1059,6 +1062,13 @@
         :identifier: ab_group_new
       - :name: edit
         :identifier: ab_group_edit
+      - :name: delete
+        :identifier: ab_group_delete
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: ab_group
+      :post:
       - :name: delete
         :identifier: ab_group_delete
     :resource_actions:
@@ -1074,6 +1084,13 @@
       - :name: edit
         :identifier: ab_group_edit
       :delete:
+      - :name: delete
+        :identifier: ab_group_delete
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: ab_group 
+      :post:
       - :name: delete
         :identifier: ab_group_delete
   :customization_scripts:

--- a/config/api.yml
+++ b/config/api.yml
@@ -1068,9 +1068,6 @@
       :get:
       - :name: read
         :identifier: ab_group
-      :post:
-      - :name: delete
-        :identifier: ab_group_delete
     :resource_actions:
       :get:
       - :name: read
@@ -1090,9 +1087,6 @@
       :get:
       - :name: read
         :identifier: ab_group
-      :post:
-      - :name: delete
-        :identifier: ab_group_delete
   :customization_scripts:
     :description: Customization Script
     :identifier: customization_script


### PR DESCRIPTION
This PR makes `custom_buttons` a subcollection of `custom_button_sets` and allows for the easy retrieval of, or deletion of, individual custom_buttons from the collection. So, now you can do this:

```
GET /api/custom_button_sets/:c_id/custom_buttons
GET /api/custom_button_sets/:c_id/custom_buttons/:s_id
POST /api/custom_button_sets/:c_id/custom_buttons/:s_id { "action": "delete" }
```

Tested via curl and seems to work but a WIP for now until I can get some specs added and/or Zita and the UI team decide this approach is acceptable.

Addresses https://github.com/ManageIQ/manageiq-api/issues/539