### PR TITLE
Allow authentication against the _vmdb_session cookie for UI only

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -18,6 +18,7 @@ module Api
     include_concern 'Generic'
     include_concern 'Authentication'
     include ActionController::HttpAuthentication::Basic::ControllerMethods
+    include ActionController::RequestForgeryProtection
 
     before_action :log_request_initiated
     before_action :require_api_user_or_token, :except => [:options, :product_info]


### PR DESCRIPTION
We're consuming the API from our UI with token authentication, which is not the best because we have to poll the API to renew the token. This made the complexity of the login code unnecessarily high and also the token renewal floods the log with useless information every X seconds.

The API and the UI workers are both using the same memcached server to store short-living information, such as sessions or tokens. As the two workers are basically the same application, they implicitly have the same session cookie and so through memcached, sharing the access to the same session. However, the API was not using this session, for now.

I'm proposing a new authentication mechanism for the UI only (replaces https://github.com/ManageIQ/manageiq-api/pull/542) that will test if the CSRF header is set on the API request. This header will be used from the UI only and will also prevent from opening a HTTP basic auth dialog even if the session times out. This will make https://github.com/ManageIQ/manageiq-api/pull/542 completely obsolete.

I've discussed this with @Fryguy already and honestly, due to the simplicity of this feature I am afraid that this is too good to be true. Anyway, we will use this PR with @himdel to work further on the UI part and make changes if something goes wrong. The behavior of the API should not be affected by this change, however, we will be able to drop a few hunderd lines of JS from the UI.

When using external authentication, the apache would force basic auth on every unauthorized API request, but there's a fix for that here: https://github.com/ManageIQ/manageiq-appliance/pull/224