### PR TITLE
TransformationMapping: API for adding mapping item

### DIFF
--- a/app/controllers/api/transformation_mappings_controller.rb
+++ b/app/controllers/api/transformation_mappings_controller.rb
@@ -49,6 +49,15 @@ module Api
       end
     end
 
+    def add_mapping_item_resource(type, id, data)
+      resource_search(id, type, collection_class(type)).tap do |mapping|
+        mapping.transformation_mapping_items.append(create_mapping_items([data]))
+        mapping.save!
+      end
+    rescue StandardError => err
+      raise BadRequestError, "Failed to update Transformation Mapping - #{err}"
+    end
+
     private
 
     def create_mapping_items(items)

--- a/config/api.yml
+++ b/config/api.yml
@@ -3628,6 +3628,8 @@
         :identifier: transformation_mapping_new
       - :name: delete
         :identifier: transformation_mapping_delete
+      - :name: add_mapping_item
+        :identifier: transformation_mapping_new
       :delete:
       - :name: delete
         :identifier: transformation_mapping_delete

--- a/spec/requests/transformation_mappings_spec.rb
+++ b/spec/requests/transformation_mappings_spec.rb
@@ -382,6 +382,20 @@ describe "Transformation Mappings" do
             expect(response.parsed_body).to include(expected)
           end
         end
+
+        context "add_mapping_item" do
+          it "can add transformation mapping item" do
+            api_basic_authorize(action_identifier(:transformation_mappings, :add_mapping_item, :resource_actions, :post))
+            transformation_mapping = FactoryBot.create(:transformation_mapping)
+            request = {
+              'action'   => 'add_mapping_item',
+              'resource' => {'source' => api_cluster_url(nil, source_cluster), 'destination' => api_cluster_url(nil, destination_cluster)}
+            }
+            post(api_transformation_mapping_url(nil, transformation_mapping), :params => request)
+            expect(response).to have_http_status(:ok)
+            expect(transformation_mapping.transformation_mapping_items.length).to eq(1)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This change implements new action (`add_mapping_item`) for transformation mapping: it adds new transformation mapping item to previously created transformation mapping.

Requested in https://trello.com/c/P5W747wT/217-spike-add-patch-method-to-api-transformationmappings-id (originally requested as a `PATCH` method, but using `POST` and new action is more straightforward).

Usage:
1. Create transformation mapping with empty list of transformation mapping items
```
$ cat create-mapping.json
{
    "name": "infra-mapping",
    "description": "infra-mapping",
    "state": "draft",
    "transformation_mapping_items": []
}
$ curl -X POST -d @create-mapping.json http://appliance-url/api/transformation_mappings
...
```

2. Add new transformation mapping item using the newly created action
```
$ cat add-mapping-item.json
{
    "action": "add_mapping_item",
    "resource": {
        "source": "/api/clusters/1",
        "destination": "/api/clusters/2"
    }
}
$ curl -X POST -d @add-mapping-item.json http://appliance-url/api/transformation_mappings/1
```

@himdel @michaelkro