### PR TITLE
Add pagination and ordering to hash column MiqReporResult#result_set

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -1,6 +1,28 @@
 module Api
   class BaseController
     module Parameters
+      module ResultsController
+        def sort_order
+          params['sort_order'] == 'desc' ? :descending : :ascending
+        end
+
+        def param_result_set?
+          params.key?(:hash_attribute) && params[:hash_attribute] == "result_set"
+        end
+
+        def report_options
+          params.merge(:sort_by => params['sort_by'], :sort_order => sort_order).merge(filter_options)
+        end
+
+        def filter_options
+          filtering_enabled? ? {:filter_string => params[:filter_string], :filter_column => params[:filter_column]} : {}
+        end
+
+        def filtering_enabled?
+          params.key?(:filter_column) && params.key?(:filter_string) && params[:filter_string]
+        end
+      end
+
       def hash_fetch(hash, element, default = {})
         hash[element] || default
       end

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -1,29 +1,11 @@
 module Api
   class ResultsController < BaseController
+    include Parameters::ResultsController
+
     before_action :set_additional_attributes, :only => [:index, :show]
 
     def results_search_conditions
       MiqReportResult.for_user(User.current_user).where_clause.ast
-    end
-
-    def sort_order
-      params['sort_order'] == 'desc' ? :descending : :ascending
-    end
-
-    def param_result_set?
-      params.key?(:hash_attribute) && params[:hash_attribute] == "result_set"
-    end
-
-    def report_options
-      params.merge(:sort_by => params['sort_by'], :sort_order => sort_order).merge(filter_options)
-    end
-
-    def filter_options
-      filtering_enabled? ? {:filter_string => params[:filter_string], :filter_column => params[:filter_column]} : {}
-    end
-
-    def filtering_enabled?
-      params.key?(:filter_column) && params.key?(:filter_string) && params[:filter_string]
     end
 
     def result_set

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -6,6 +6,74 @@ module Api
       MiqReportResult.for_user(User.current_user).where_clause.ast
     end
 
+    def apply_limit_and_offset(results, options)
+      results.slice(options['offset'].to_i, options['limit'].to_i) || []
+    end
+
+    def sort_order
+      params['sort_order'] == 'desc' ? :descending : :ascending
+    end
+
+    def sort_by(report_result)
+      sort_by(report_result).split(",").collect do |attr|
+        if report(report_result).col_order&.include?(attr)
+          attr
+        else
+          raise BadRequestError, "#{attr} is not a valid attribute for #{report_result.name}"
+        end
+      end.compact
+    end
+
+    def param_result_set?
+      params.key?(:hash_attribute) && params[:hash_attribute] == "result_set"
+    end
+
+    def format_result_set(miq_report, result_set)
+      tz = miq_report.get_time_zone(Time.zone)
+
+      col_format_hash = miq_report.col_order.zip(miq_report.col_formats).to_h
+
+      result_set.map! do |row|
+        row.map do |key, _|
+          [key, miq_report.format_column(key, row, tz, col_format_hash[key])]
+        end.to_h
+      end
+    end
+
+    def report(report_result)
+      @report ||= report_result.report || report_result.miq_report
+    end
+
+    def sort_by(report_result)
+      params['sort_by'] || report(report_result)&.sortby || report(report_result)&.col_order
+    end
+
+    def result_set
+      ensure_pagination
+
+      report_result = MiqReportResult.for_user(User.current_user).find(@req.collection_id)
+      result_set = report_result.result_set
+
+      if result_set.present? && report(report_result)
+        result_set = result_set.stable_sort_by(sort_by(report_result), sort_order)
+        result_set = apply_limit_and_offset(result_set, params)
+        result_set.map! { |x| x.slice(*report(report_result).col_order) }
+
+        result_set = format_result_set(report(report_result), result_set)
+      end
+
+      hash = {:result_set => result_set,
+              :count      => report_result.result_set.count,
+              :subcount   => result_set.count,
+              :pages      => (report_result.result_set.count / params['limit'].to_f).ceil}
+
+      report_result.attributes.merge(hash)
+    end
+
+    def show
+      param_result_set? ? render_resource(:results, result_set) : super
+    end
+
     def find_results(id)
       MiqReportResult.for_user(User.current_user).find(id)
     end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -97,18 +97,19 @@ RSpec.describe "reports API" do
     end
 
     context "pagination and sorting with report result's result_set" do
+      let(:columns) { %w[name size] }
       let(:result_set) do
         [{"name" => "VM2", "size" => 115_533},
          {"name" => "VM1", "size" => 332_233},
          {"name" => "VG1", "size" => 112_233}]
       end
 
-      let(:col_formats) { Array.new(result_set.first.keys.count) }
+      let(:col_formats) { Array.new(columns.count) }
       let(:report_result) { FactoryBot.create(:miq_report_result, :miq_group => user.current_group) }
       let(:report) do
         FactoryBot.create(:miq_report, :miq_group          => user.current_group,
                                        :miq_report_results => [report_result],
-                                       :col_order          => result_set.first.keys,
+                                       :col_order          => columns,
                                        :col_formats        => col_formats)
       end
 


### PR DESCRIPTION
example:
**Sorting and Pagination:**

```
curl --user admin:smartvm -X GET -H "Accept: application/json" "http://localhost:3000/api/results/1242?hash_attribute=result_set&sort_by=disks.size&sort_order=desc&limit=3&offset=3"
```

```
/api/results/1242?hash_attribute=result_set&sort_by=disks.size&sort_order=desc&limit=4&offset=3
```
`hash_attribute=value - enables hash sorting and pagination for value column`
`sort_by - column from MiqReportResult#report#col_order`
`sort_order - asc or desc`
`limit - count of records for one page`
`offset -result will start with this record from whole result set`


returns:
```
{
   <resource>
    "count": 4,
    "pages": 1,
    "subcount": 4,
    "result_set": [
        {
            "disks.size": 1073741824,
            "mem_cpu": 1024,
            "name": "testloic",
            "retires_on": "2017-11-29T12:48:07Z",
            "storages.disk_size": null,
            "virtual_custom_attribute_Name": null
        },
        {
            "disks.size": 10737418240,
            "mem_cpu": 1024,
            "name": "demo-natevm",
            "retires_on": "2018-01-18T14:25:29Z",
            "storages.disk_size": 0,
            "virtual_custom_attribute_Name": null
        },
        {
            "disks.size": 10737418240,
            "mem_cpu": 1024,
            "name": "testloic",
            "retires_on": "2017-11-29T12:48:07Z",
            "storages.disk_size": null,
            "virtual_custom_attribute_Name": null
        },
        {
            "disks.size": 21474836480,
            "mem_cpu": 2048,
            "name": "cf-cirros001",
            "retires_on": "2018-02-15T19:36:26Z",
            "storages.disk_size": null,
            "virtual_custom_attribute_Name": null
        }
    ],
```


**Filtering:**
```
curl --user admin:smartvm -X GET -H "Accept: application/json" "http://localhost:3000/api/results/1242?hash_attribute=result_set&filter_column=disks.size&filter_string=55"
```
```
/api/results/1242?hash_attribute=result_set&filter_column=disks.size&filter_string=55
```

**filter_column** - chosen column for filtering
**filter_string** - this string value is used for filtering on  `:filter_column `, record of report result will be returned in API if  `:filter_string` is contained(case sensitive - is this ok ?) in value of   `:filter_column `.


Note: You can mix together Sorting and Pagination and Filtering





cc @martinpovolny 

- [x] https://github.com/ManageIQ/more_core_extensions/pull/67
- [x] https://github.com/ManageIQ/manageiq/pull/18532
- [x]  https://github.com/ManageIQ/manageiq/pull/18426
- [x] specs


# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1678150