### PR TITLE
Add delete automate domain support

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -242,7 +242,7 @@
     :description: Automate Domains
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: MiqAeDomain
     :collection_actions:
       :get:
@@ -253,6 +253,8 @@
         :identifier: miq_ae_domain_view
       - :name: refresh_from_source
         :identifier: miq_ae_git_refresh
+      - :name: delete
+        :identifier: miq_ae_domain_delete
     :resource_actions:
       :get:
       - :name: read
@@ -260,6 +262,11 @@
       :post:
       - :name: refresh_from_source
         :identifier: miq_ae_git_refresh
+      - :name: delete
+        :identifier: miq_ae_domain_delete
+      :delete:
+      - :name: delete
+        :identifier: miq_ae_domain_delete
   :automate_workspaces:
     :description: Automate Workspaces
     :options:

--- a/spec/requests/automate_domains_spec.rb
+++ b/spec/requests/automate_domains_spec.rb
@@ -19,6 +19,51 @@ describe "Automate Domains API" do
     end
   end
 
+  describe 'delete action' do
+    let(:automate_domain) { FactoryBot.create(:miq_ae_domain) }
+    let(:automate_domain_locked) { FactoryBot.create(:miq_ae_domain_user_locked, :enabled => true) }
+    let(:automate_domain_system) { FactoryBot.create(:miq_ae_system_domain_enabled) }
+
+    it 'forbids access for users without proper permissions' do
+      api_basic_authorize
+
+      post(api_automate_domain_url(nil, automate_domain), :params => gen_request(:delete))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'does not delete locked domains' do
+      api_basic_authorize action_identifier(:automate_domains, :delete)
+
+      post(api_automate_domain_url(nil, automate_domain_locked), :params => gen_request(:delete))
+      expect_single_action_result(
+        :success => false,
+        :message => a_string_matching(/Not deleting.*locked/)
+      )
+    end
+
+    it 'does not delete system domains' do
+      api_basic_authorize action_identifier(:automate_domains, :delete)
+
+      post(api_automate_domain_url(nil, automate_domain_system), :params => gen_request(:delete))
+      expect_single_action_result(
+        :success => false,
+        :message => a_string_matching(/Not deleting.*locked/)
+      )
+    end
+
+    it 'deletes domains' do
+      api_basic_authorize action_identifier(:automate_domains, :delete)
+
+      post(api_automate_domain_url(nil, automate_domain), :params => gen_request(:delete))
+      expect_single_action_result(
+        :success => true,
+        :message => a_string_matching(/Delete queued for .*/),
+        :href    => api_automate_domain_url(nil, automate_domain)
+      )
+    end
+  end
+
   describe 'refresh_from_source action' do
     let(:git_domain) { FactoryBot.create(:miq_ae_git_domain) }
     it 'forbids access for users without proper permissions' do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1645041

This PR adds support to allow removal of automate domains via the API
This change only supports deletion of unlocked user domains. System and
GIT based domains will not be deleted.

**To test:**

- Create automated domains in the MiQ Database
- Attempt to delete one of the automated domains in the MiQ Database using the API with the _DELETE_ verb

_e.g.:_ 

`curl --insecure --user <user>:<password> -X DELETE <appliance URL>/api/automate_domains/<domain name>`

- Attempt to delete one of the automated domains in the MiQ Database using the API with the _POST_ verb

_e.g.:_

`curl --insecure --user " <user>:<password>" -H "Content-Type: application/json" --data '{"action":"delete"}' -X POST <URL>/api/automate_domains/<domain name>  `
