### PR TITLE
Provide the path to the custom branding assets instead of booleans

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -93,9 +93,9 @@ module Api
 
     def branding_info
       {
-        :brand      => Settings.server.custom_brand || image_path('layout/brand.svg'),
-        :logo       => Settings.server.custom_logo || image_path('layout/login-screen-logo.png'),
-        :login_logo => Settings.server.custom_login_logo.presence
+        :brand      => Settings.server.custom_brand ? image_path('/upload/custom_brand.png') : image_path('layout/brand.svg'),
+        :logo       => Settings.server.custom_logo ? image_path('/upload/custom_logo.png') : image_path('layout/login-screen-logo.png'),
+        :login_logo => Settings.server.custom_login_logo ? image_path('/upload/custom_login_logo.png') : nil
       }.compact
     end
 


### PR DESCRIPTION
These config values are booleans and not the actual path to the given assets, so the SUI cannot even display these icons even if we set them. By sending the actual asset path, this will work as expected.

https://bugzilla.redhat.com/show_bug.cgi?id=1471301

@miq-bot add_label bug
@miq-bot add_reviewer @himdel 