### PR TITLE
Expose the favicon URL in the branding info endpoints

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -95,7 +95,8 @@ module Api
       {
         :brand      => Settings.server.custom_brand ? image_path('/upload/custom_brand.png') : image_path('layout/brand.svg'),
         :logo       => Settings.server.custom_logo ? image_path('/upload/custom_logo.png') : image_path('layout/login-screen-logo.png'),
-        :login_logo => Settings.server.custom_login_logo ? image_path('/upload/custom_login_logo.png') : nil
+        :login_logo => Settings.server.custom_login_logo ? image_path('/upload/custom_login_logo.png') : nil,
+        :favicon    => Settings.server.custom_favicon ? image_path('/upload/custom_favicon.ico') : image_path('favicon.ico')
       }.compact
     end
 

--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -75,8 +75,9 @@ RSpec.describe "API entrypoint" do
 
     # This test will fail if you have the assets precompiled
     expect(response.parsed_body['product_info']['branding_info']).to eq(
-      "brand" => "/images/layout/brand.svg",
-      "logo"  => "/images/layout/login-screen-logo.png"
+      "brand"   => "/images/layout/brand.svg",
+      "logo"    => "/images/layout/login-screen-logo.png",
+      "favicon" => "/images/favicon.ico"
     )
   end
 


### PR DESCRIPTION
Testing call: `curl -XGET http://localhost:3000/api/product_info | jq `

When a custom favicon is not set:
```json
{
  "name": "ManageIQ",
  "name_full": "ManageIQ",
  "copyright": "Copyright (c) 2019 ManageIQ. Sponsored by Red Hat Inc.",
  "support_website": "http://www.manageiq.org",
  "support_website_text": "ManageIQ.org",
  "branding_info": {
    "brand": "/assets/layout/brand-7005158295b20605eae00a080448d69a9c7b541ee3f99469b86e1bae955b0e89.svg",
    "logo": "/assets/layout/login-screen-logo-cd43380036fc96964823fd8d6d7486fe9bcfcce1498daf0c41d8bc94385511da.png",
    "favicon": "/assets/favicon-6ca95f7b93eeb006088db7dd238353e62eb9ad976446654600ad6d42e2d62ae2.ico"
  }
}

```

When a custom favicon is set:
```json
{
  "name": "ManageIQ",
  "name_full": "ManageIQ",
  "copyright": "Copyright (c) 2019 ManageIQ. Sponsored by Red Hat Inc.",
  "support_website": "http://www.manageiq.org",
  "support_website_text": "ManageIQ.org",
  "branding_info": {
    "brand": "/assets/layout/brand-7005158295b20605eae00a080448d69a9c7b541ee3f99469b86e1bae955b0e89.svg",
    "logo": "/assets/layout/login-screen-logo-cd43380036fc96964823fd8d6d7486fe9bcfcce1498daf0c41d8bc94385511da.png",
    "favicon": "/upload/custom_favicon.ico"
  }
}
```

This is necessary for the SUI to know about the customized favicon.

https://bugzilla.redhat.com/show_bug.cgi?id=1578076

@miq-bot add_reviewer @himdel 