### PR TITLE
[WIP] Deprecate category

### DIFF
--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -5,12 +5,12 @@ module Api
     before_action :set_additional_attributes, :only => [:index, :show, :update]
 
     def edit_resource(type, id, data = {})
-      raise ForbiddenError if Category.find(id).read_only?
+      raise ForbiddenError if Classification.is_category.find(id).read_only?
       super
     end
 
     def delete_resource(type, id, data = {})
-      raise ForbiddenError if Category.find(id).read_only?
+      raise ForbiddenError if Classification.is_category.find(id).read_only?
       super
     end
 

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -47,7 +47,7 @@ module Api
       unless category_id
         raise BadRequestError, "Category id, href or name needs to be specified for creating a new tag resource"
       end
-      Category.find_by(:id => category_id)
+      Classification.is_category.find_by(:id => category_id)
     end
 
     def destroy_tag_and_classification(tag_id)

--- a/config/api.yml
+++ b/config/api.yml
@@ -346,7 +346,7 @@
     :options:
     - :collection
     :verbs: *gpd
-    :klass: Category
+    :klass: Classification
     :subcollections:
     - :tags
     :collection_actions:

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "categories API" do
   it "can list all the categories" do
     categories = FactoryBot.create_list(:category, 2)
+    FactoryBot.create(:classification_tag, :parent => categories.first)
     api_basic_authorize collection_action_identifier(:categories, :read, :get)
 
     get api_categories_url
@@ -78,7 +79,7 @@ RSpec.describe "categories API" do
 
       expect do
         post api_categories_url, :params => { :name => "test", :description => "Test" }
-      end.to change(Category, :count).by(1)
+      end.to change(Classification, :count).by(1)
 
       expect(response).to have_http_status(:ok)
     end
@@ -107,7 +108,7 @@ RSpec.describe "categories API" do
       api_basic_authorize collection_action_identifier(:categories, :create)
 
       post api_categories_url, :params => { :name => "test", :description => "Test" }
-      category = Category.find(response.parsed_body["results"].first["id"])
+      category = Classification.is_category.find(response.parsed_body["results"].first["id"])
 
       expect(category.tag.name).to eq("/managed/test")
     end
@@ -130,7 +131,7 @@ RSpec.describe "categories API" do
 
       expect do
         post api_category_url(nil, category), :params => gen_request(:delete)
-      end.to change(Category, :count).by(-1)
+      end.to change(Classification, :count).by(-1)
 
       expect(response).to have_http_status(:ok)
     end
@@ -141,7 +142,7 @@ RSpec.describe "categories API" do
 
       expect do
         delete api_category_url(nil, category)
-      end.to change(Category, :count).by(-1)
+      end.to change(Classification, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
@@ -153,7 +154,7 @@ RSpec.describe "categories API" do
 
         expect do
           post api_category_url(nil, category), :params => gen_request(:delete)
-        end.not_to change(Category, :count)
+        end.not_to change(Classification, :count)
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -176,7 +177,7 @@ RSpec.describe "categories API" do
 
         expect do
           post api_categories_url, :params => { :name => "test", :description => "Test" }
-        end.not_to change(Category, :count)
+        end.not_to change(Classification, :count)
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -198,7 +199,7 @@ RSpec.describe "categories API" do
 
         expect do
           post api_category_url(nil, category), :params => gen_request(:delete)
-        end.not_to change(Category, :count)
+        end.not_to change(Classification, :count)
 
         expect(response).to have_http_status(:forbidden)
       end
@@ -209,7 +210,7 @@ RSpec.describe "categories API" do
 
         expect do
           delete api_category_url(nil, category)
-        end.not_to change(Category, :count)
+        end.not_to change(Classification, :count)
 
         expect(response).to have_http_status(:forbidden)
       end

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -73,7 +73,8 @@ describe "Rest API Collections" do
     end
 
     it "query Categories" do
-      FactoryBot.create(:category)
+      category = FactoryBot.create(:category)
+      FactoryBot.create(:classification_tag, :parent => category)
       test_collection_query(:categories, api_categories_url, Classification.is_category)
     end
 
@@ -411,7 +412,8 @@ describe "Rest API Collections" do
     end
 
     it "bulk query Categories" do
-      FactoryBot.create(:category)
+      category = FactoryBot.create(:category)
+      FactoryBot.create(:classification_tag, :parent => category) # should not come back
       test_collection_bulk_query(:categories, api_categories_url, Classification.is_category)
     end
 

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -74,7 +74,7 @@ describe "Rest API Collections" do
 
     it "query Categories" do
       FactoryBot.create(:category)
-      test_collection_query(:categories, api_categories_url, Category)
+      test_collection_query(:categories, api_categories_url, Classification.is_category)
     end
 
     it "query Chargebacks" do
@@ -412,7 +412,7 @@ describe "Rest API Collections" do
 
     it "bulk query Categories" do
       FactoryBot.create(:category)
-      test_collection_bulk_query(:categories, api_categories_url, Category)
+      test_collection_bulk_query(:categories, api_categories_url, Classification.is_category)
     end
 
     it "bulk query Chargebacks" do

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -23,14 +23,14 @@ describe "Tags API" do
     context "with an appropriate role" do
       it "can create a tag with category by href" do
         api_basic_authorize collection_action_identifier(:tags, :create)
-        category = FactoryBot.create(:category)
+        category = FactoryBot.create(:classification)
         options = {:name => "test_tag", :description => "Test Tag", :category => {:href => api_category_url(nil, category)}}
 
         expect { post api_tags_url, :params => options }.to change(Tag, :count).by(1)
 
         result = response.parsed_body["results"].first
         tag = Tag.find(result["id"])
-        tag_category = Category.find(tag.category.id)
+        tag_category = tag.category
         expect(tag_category).to eq(category)
         expect(result["href"]).to include(api_tag_url(nil, tag))
         expect(response).to have_http_status(:ok)
@@ -38,14 +38,14 @@ describe "Tags API" do
 
       it "can create a tag with a category by id" do
         api_basic_authorize collection_action_identifier(:tags, :create)
-        category = FactoryBot.create(:category)
+        category = FactoryBot.create(:classification)
 
         expect do
           post api_tags_url, :params => { :name => "test_tag", :description => "Test Tag", :category => {:id => category.id} }
         end.to change(Tag, :count).by(1)
 
         tag = Tag.find(response.parsed_body["results"].first["id"])
-        tag_category = Category.find(tag.category.id)
+        tag_category = tag.category
         expect(tag_category).to eq(category)
 
         expect(response).to have_http_status(:ok)
@@ -53,14 +53,14 @@ describe "Tags API" do
 
       it "can create a tag with a category by name" do
         api_basic_authorize collection_action_identifier(:tags, :create)
-        category = FactoryBot.create(:category)
+        category = FactoryBot.create(:classification)
 
         expect do
           post api_tags_url, :params => { :name => "test_tag", :description => "Test Tag", :category => {:name => category.name} }
         end.to change(Tag, :count).by(1)
 
         tag = Tag.find(response.parsed_body["results"].first["id"])
-        tag_category = Category.find(tag.category.id)
+        tag_category = tag.category
         expect(tag_category).to eq(category)
 
         expect(response).to have_http_status(:ok)
@@ -68,13 +68,13 @@ describe "Tags API" do
 
       it "can create a tag as a subresource of a category" do
         api_basic_authorize collection_action_identifier(:tags, :create)
-        category = FactoryBot.create(:category)
+        category = FactoryBot.create(:classification)
 
         expect do
           post(api_category_tags_url(nil, category), :params => { :name => "test_tag", :description => "Test Tag" })
         end.to change(Tag, :count).by(1)
         tag = Tag.find(response.parsed_body["results"].first["id"])
-        tag_category = Category.find(tag.category.id)
+        tag_category = tag.category
         expect(tag_category).to eq(category)
 
         expect(response).to have_http_status(:ok)
@@ -91,7 +91,7 @@ describe "Tags API" do
       it "can update a tag's name" do
         api_basic_authorize action_identifier(:tags, :edit)
         classification = FactoryBot.create(:classification_tag)
-        category = FactoryBot.create(:category, :children => [classification])
+        category = FactoryBot.create(:classification, :children => [classification])
         tag = classification.tag
 
         expect do
@@ -104,7 +104,7 @@ describe "Tags API" do
       it "can update a tag's description" do
         api_basic_authorize action_identifier(:tags, :edit)
         classification = FactoryBot.create(:classification_tag)
-        FactoryBot.create(:category, :children => [classification])
+        FactoryBot.create(:classification, :children => [classification])
         tag = classification.tag
 
         expect do
@@ -160,7 +160,7 @@ describe "Tags API" do
         api_basic_authorize action_identifier(:tags, :delete)
         classification1 = FactoryBot.create(:classification_tag)
         classification2 = FactoryBot.create(:classification_tag)
-        category = FactoryBot.create(:category, :children => [classification1, classification2])
+        category = FactoryBot.create(:classification, :children => [classification1, classification2])
         tag1 = classification1.tag
         tag2 = classification2.tag
 
@@ -183,7 +183,7 @@ describe "Tags API" do
         api_basic_authorize action_identifier(:tags, :delete)
         classification1 = FactoryBot.create(:classification_tag)
         classification2 = FactoryBot.create(:classification_tag)
-        category = FactoryBot.create(:category, :children => [classification1, classification2])
+        category = FactoryBot.create(:classification, :children => [classification1, classification2])
         tag1 = classification1.tag
         tag2 = classification2.tag
         body = gen_request(:delete, [{:name => tag1.name}, {:name => tag2.name}])


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/17210

Removing `Category` from app/models.rb

It is just a child of `Classification` with a `default scope { where(:parent_id => 0) }`
So there is not much lost.

Also, in anticipation of removing `Tag` class (merging with `Classification`), I changed tests to reference `Classification` instead of `Tag` where possible.