### PR TITLE
Don't use Tag when updating tag name

### DIFF
--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -17,15 +17,9 @@ module Api
       end
     end
 
-    def edit_resource(type, id, data)
-      klass = collection_class(type)
-      tag = resource_search(id, type, klass)
-      entry = Classification.find_by(:tag_id => tag.id)
+    def edit_resource(_type, id, data)
+      entry = Classification.find_by(:tag_id => id)
       raise BadRequestError, "Failed to find tag/#{id} resource" unless entry
-
-      if data["name"].present?
-        tag.update_attribute(:name, Classification.name2tag(data["name"], entry.parent_id, TAG_NAMESPACE))
-      end
       entry.update_attributes(data.except(*ID_ATTRS))
       entry.tag
     end


### PR DESCRIPTION
We used to need to manually change the `classification.tag.name`
Classification has been fixed so this is no longe necessary

Fixed in https://github.com/ManageIQ/manageiq/pull/18409

I am a little confused why we needed to look up the tag in the original code.
It does follow the typical pattern, but seems not necessary

