### PR TITLE
Remove references to Tag where possible

### DIFF
--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "categories API" do
     classification = FactoryBot.create(:classification_tag)
     category = FactoryBot.create(:category, :children => [classification])
     tag = classification.tag
-    Tag.create(:name => "some_other_tag")
+    FactoryBot.create(:classification, :name => "some_other_tag")
     api_basic_authorize
 
     get(api_category_tags_url(nil, category))

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -650,8 +650,8 @@ describe "Querying" do
     end
 
     it "can do fuzzy matching on strings with forward slashes" do
-      tag_1 = FactoryBot.create(:tag, :name => "/managed/foo")
-      _tag_2 = FactoryBot.create(:tag, :name => "/managed/bar")
+      tag_1 = FactoryBot.create(:classification, :name => "foo").tag
+      _tag_2 = FactoryBot.create(:classification, :name => "bar")
       api_basic_authorize collection_action_identifier(:tags, :read, :get)
 
       get(api_tags_url, :params => { :filter => ["name='*/foo'"] })


### PR DESCRIPTION
Test only changes.

Tag is based upon classifications, so just use classifications where possible.
Mostly replaced the `Tag.find()` with `Classification.find_by(:tag_id)`

@miq-bot add_label test