### PR TITLE
Performance updates for virtual_attribute_search

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -203,7 +203,8 @@ module Api
           # is relation in 'attribute' variable plural in the model class (from 'resource.class') ?
           if [:has_many, :has_and_belongs_to_many].include?(resource.class.reflection_with_virtual(attribute).try(:macro))
             resource_attr = resource.public_send(attribute)
-            return resource_attr unless resource_attr.try(:first).kind_of?(ApplicationRecord)
+            klass         = resource_attr.kind_of?(ActiveRecord::Relation) ? resource_attr.klass : resource_attr.try(:first).class
+            return resource_attr unless Rbac::Filterer.new.send(:apply_rbac_directly?, klass)
             Rbac.filtered(resource_attr)
           else
             Rbac.filtered_object(resource).try(:public_send, attribute)

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -82,7 +82,7 @@ describe "Services API" do
 
       # Once for the main query and counts, and 3 for the `all_service_children`
       expect(Rbac).to receive(:filtered).exactly(5).times.and_call_original
-      expect(Rbac).to receive(:filtered_object).exactly(9).times
+      expect(Rbac).to receive(:filtered_object).never
 
       get api_services_url, :params => search_filters
 
@@ -100,7 +100,7 @@ describe "Services API" do
 
         # Once for the main query and counts, and 1 for the `all_service_children`
         expect(Rbac).to receive(:filtered).exactly(3).times.and_call_original
-        expect(Rbac).to receive(:filtered_object).exactly(3).times
+        expect(Rbac).to receive(:filtered_object).never
 
         get api_services_url, :params => search_filters
 

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -30,6 +30,85 @@ describe "Services API" do
   let(:orchestration_template) { FactoryBot.create(:orchestration_template) }
   let(:ems) { FactoryBot.create(:ext_management_system) }
 
+  # Specs and queries here are based off of the following BZ:
+  #
+  #   https://bugzilla.redhat.com/show_bug.cgi?id=1656371
+  #
+  # Some data might not be fully fleshed out and could be improved to better
+  # capture all the improvements made and edge cases, but for now, shows a
+  # relative improvement with just these changes.
+  describe "Services search" do
+    let(:tenant) { FactoryBot.create(:tenant) }
+    let(:role)   { FactoryBot.create(:miq_user_role) }
+    let(:group)  { FactoryBot.create(:miq_group, :tenant => tenant, :miq_user_role => role) }
+
+    let!(:svc3) do
+      FactoryBot.create :service, :name        => "svc3",
+                                  :description => "svc3 description",
+                                  :parent      => svc2,
+                                  :miq_group   => group
+    end
+
+    let(:search_attrs) do
+      [
+        "picture", "picture.image_href", "chargeback_report",
+        "evm_owner.userid", "v_total_vms", "power_state",
+        "all_service_children", "tags"
+      ]
+    end
+
+    let(:search_filters) do
+      {
+        :expand       => "resources",
+        :attributes   => search_attrs.join(','),
+        :filter       => ['ancestry=null'],
+        :sort_by      => "created_at",
+        :sort_options => nil,
+        :sort_order   => "desc"
+      }
+    end
+
+    before do
+      # create services from above
+      svc
+      svc1
+
+      # Add svc2 to user group
+      svc2.update(:miq_group => group)
+    end
+
+    it "lists all of the Services" do
+      api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
+
+      # Once for the main query and counts, and 3 for the `all_service_children`
+      expect(Rbac).to receive(:filtered).exactly(5).times.and_call_original
+      expect(Rbac).to receive(:filtered_object).exactly(9).times
+
+      get api_services_url, :params => search_filters
+
+      expect(response.parsed_body["subcount"]).to eq 3
+    end
+
+    context "with restricted user" do
+      before do
+        @user.update(:miq_groups => [group])
+        @role = role
+      end
+
+      it "lists only visable services" do
+        api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
+
+        # Once for the main query and counts, and 1 for the `all_service_children`
+        expect(Rbac).to receive(:filtered).exactly(3).times.and_call_original
+        expect(Rbac).to receive(:filtered_object).exactly(3).times
+
+        get api_services_url, :params => search_filters
+
+        expect(response.parsed_body["subcount"]).to eq 1
+      end
+    end
+  end
+
   describe "Services create" do
     it "rejects requests without appropriate role" do
       api_basic_authorize


### PR DESCRIPTION
Fixes two simple performance issues:

- Avoids trying to Rbac records that don't need to be "Rbac'd" (first commit)
- Avoids repeating Rbac on records that have already been checked in the initial `collection_search` (second commit)


Benchmarks
----------

**Before**

```
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2197 |     322 |      194.4 | 1627 |
|  953 |     321 |      182.7 |  196 |
|  996 |     321 |      187.1 |  196 |
```

**After** (first commit)

```
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2274 |     282 |      166.2 | 1612 |
|  858 |     281 |      147.9 |  181 |
|  960 |     281 |      164.2 |  181 |
```

**After** (second commit)

```
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2004 |     263 |      156.8 | 1593 |
|  756 |     261 |      142.9 |  161 |
|  769 |     261 |      138.9 |  161 |
```


TODO
----

* [x] Make sure existing tests pass...
* [x] Add Tests


Links
-----

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656371
* Related to changes in https://github.com/ManageIQ/manageiq/pull/15145