### PR TITLE
Fix missing job for ServiceTemplateTransformationPlanTask in ServiceRequestSpec

### DIFF
--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -635,6 +635,13 @@ describe "Service Requests API" do
     context "SubResource#cancel" do
       let(:resource_1_response) { {"success" => true, "message" => "RequestTask #{resource_1.id} canceled"} }
       let(:resource_2_response) { {"success" => true, "message" => "RequestTask #{resource_2.id} canceled"} }
+      let(:infra_conversion_job) { FactoryBot.create(:infra_conversion_job) }
+
+      before do
+        allow_any_instance_of(ServiceTemplateTransformationPlanTask).to receive(:infra_conversion_job).and_return(infra_conversion_job)
+        allow_any_instance_of(Job).to receive(:cancel)
+      end
+
       include_context "SubResource#cancel", [:service_request, :request_task], :service_template_transformation_plan_request, :service_template_transformation_plan_task
     end
   end


### PR DESCRIPTION
caused by https://github.com/ManageIQ/manageiq/pull/18415/files
causing CI failure: https://travis-ci.org/ManageIQ/manageiq-api/jobs/501544480


@jameswnl I am not familiar with this but it looks like that there is missing `Job` for ServiceTemplateTransformationPlanTask.

spec were failing [here](https://github.com/ManageIQ/manageiq/pull/18415/files#diff-eb7db57808b5f20ff8f0f07bfd565890R159) and when I added missing job,
the error was about that there is no method cancel on Job instance.
So I just mock the method `cancel`.

I am curious why we are calling method cancel on instance when the method is not defined but can you on this fix or is here better fix for this CI failure ?

thanks @jameswnl !


