### PR TITLE
GenericObject spec - fix failures after core PR

### DIFF
--- a/spec/requests/generic_objects_spec.rb
+++ b/spec/requests/generic_objects_spec.rb
@@ -108,8 +108,7 @@ RSpec.describe 'GenericObjects API' do
     it "includes the hrefs for custom buttons and button groups" do
       generic_no_group = FactoryBot.create(:custom_button, :name => "generic_no_group", :applies_to_class => "GenericObject")
       generic_group = FactoryBot.create(:custom_button, :name => "generic_group", :applies_to_class => "GenericObject")
-      generic_group_set = FactoryBot.create(:custom_button_set, :name => "generic_group_set")
-      generic_group_set.add_member(generic_group)
+      generic_group_set = FactoryBot.create(:custom_button_set, :name => "generic_group_set", :set_data => {:applies_to_class => "GenericObject", :button_order => [generic_group.id]})
       assigned_no_group = FactoryBot.create(
         :custom_button,
         :name             => "assigned_no_group",
@@ -122,8 +121,7 @@ RSpec.describe 'GenericObjects API' do
         :applies_to_class => "GenericObjectDefinition",
         :applies_to_id    => object_definition.id
       )
-      assigned_group_set = FactoryBot.create(:custom_button_set, :name => "assigned_group_set")
-      assigned_group_set.add_member(assigned_group)
+      assigned_group_set = FactoryBot.create(:custom_button_set, :name => "assigned_group_set", :set_data => {:applies_to_class => "GenericObject", :button_order => [assigned_group.id]})
       object_definition.update(:custom_button_sets => [assigned_group_set])
       api_basic_authorize action_identifier(:generic_objects, :read, :resource_actions, :get)
 


### PR DESCRIPTION
add_members doesn't set button_order,
but setting button_order now implicitly adds members

broken by https://github.com/ManageIQ/manageiq/pull/18368

this should fix this error on travis:

```
Failures:
  1) GenericObjects API GET /api/generic_objects/:id includes the hrefs for custom buttons and button groups
     Failure/Error: expect(response.parsed_body).to include(expected)
       expected {"href" => "http://www.example.com/api/generic_objects/87000000000011", "id" => "87000000000011", "name"=...ric_group", "method" => "post", "href" => "http://www.example.com/api/generic_objects/87000000000011"}]} to include {"custom_actions" => (a hash including {"buttons" => (a collection containing exactly (a hash including {"href" => "http://www.example.com/api/custom_buttons/87000000000021"}) and (a hash including {"href" => "http://www.example.com/api/custom_buttons/87000000000019"})), "button_groups" => (a collection containing exactly (a hash including {"href" => "http://www.example.com/api/custom_button_sets/87000000000005", "buttons...exactly (a hash including {"href" => "http://www.example.com/api/custom_buttons/87000000000020"}))}) and (a hash including {"href" => "http://www.example.com/api/custom_button_sets/87000000000006", "buttons...exactly (a hash including {"href" => "http://www.example.com/api/custom_buttons/87000000000022"}))}))})}
       Diff:
       @@ -1,2 +1,10 @@
       -"custom_actions" => (a hash including {"buttons" => (a collection containing exactly (a hash including {"href" => "http://www.example.com/api/custom_buttons/87000000000021"}) and (a hash including {"href" => "http://www.example.com/api/custom_buttons/87000000000019"})), "button_groups" => (a collection containing exactly (a hash including {"href" => "http://www.example.com/api/custom_button_sets/87000000000005", "buttons...exactly (a hash including {"href" => "http://www.example.com/api/custom_buttons/87000000000020"}))}) and (a hash including {"href" => "http://www.example.com/api/custom_button_sets/87000000000006", "buttons...exactly (a hash including {"href" => "http://www.example.com/api/custom_buttons/87000000000022"}))}))}),
       +"actions" => [{"name"=>"method_a", "method"=>"post", "href"=>"http://www.example.com/api/generic_objects/87000000000011"}, {"name"=>"method_b", "method"=>"post", "href"=>"http://www.example.com/api/generic_objects/87000000000011"}, {"name"=>"generic_no_group", "method"=>"post", "href"=>"http://www.example.com/api/generic_objects/87000000000011"}, {"name"=>"assigned_no_group", "method"=>"post", "href"=>"http://www.example.com/api/generic_objects/87000000000011"}, {"name"=>"assigned_group", "method"=>"post", "href"=>"http://www.example.com/api/generic_objects/87000000000011"}, {"name"=>"generic_group", "method"=>"post", "href"=>"http://www.example.com/api/generic_objects/87000000000011"}],
       +"created_at" => "2019-03-08T01:44:43Z",
       +"custom_actions" => {"buttons"=>[{"id"=>"87000000000019", "guid"=>"60782fe7-34c2-4afe-b843-214767cc0def", "description"=>"custom_button_0000000000018", "applies_to_class"=>"GenericObject", "visibility_expression"=>nil, "options"=>{}, "userid"=>nil, "wait_for_complete"=>nil, "created_on"=>"2019-03-08T01:44:43Z", "updated_on"=>"2019-03-08T01:44:43Z", "name"=>"generic_no_group", "visibility"=>nil, "applies_to_id"=>nil, "enablement_expression"=>nil, "disabled_text"=>nil, "enabled"=>true, "href"=>"http://www.example.com/api/custom_buttons/87000000000019"}, {"id"=>"87000000000021", "guid"=>"a995cd72-d13e-4a85-980e-c74389c13be3", "description"=>"custom_button_0000000000020", "applies_to_class"=>"GenericObjectDefinition", "visibility_expression"=>nil, "options"=>{}, "userid"=>nil, "wait_for_complete"=>nil, "created_on"=>"2019-03-08T01:44:43Z", "updated_on"=>"2019-03-08T01:44:43Z", "name"=>"assigned_no_group", "visibility"=>nil, "applies_to_id"=>"87000000000026", "enablement_expression"=>nil, "disabled_text"=>nil, "enabled"=>true, "href"=>"http://www.example.com/api/custom_buttons/87000000000021"}, {"id"=>"87000000000022", "guid"=>"6587977a-0793-4974-9c21-cf32703f851e", "description"=>"custom_button_0000000000021", "applies_to_class"=>"GenericObjectDefinition", "visibility_expression"=>nil, "options"=>{}, "userid"=>nil, "wait_for_complete"=>nil, "created_on"=>"2019-03-08T01:44:43Z", "updated_on"=>"2019-03-08T01:44:43Z", "name"=>"assigned_group", "visibility"=>nil, "applies_to_id"=>"87000000000026", "enablement_expression"=>nil, "disabled_text"=>nil, "enabled"=>true, "href"=>"http://www.example.com/api/custom_buttons/87000000000022"}], "button_groups"=>[{"id"=>"87000000000005", "name"=>"generic_group_set", "description"=>"custom_button_set_0000000000005", "created_on"=>"2019-03-08T01:44:43Z", "updated_on"=>"2019-03-08T01:44:43Z", "guid"=>"05235aaa-020a-4f9b-b68e-542cfd5890eb", "read_only"=>nil, "set_data"=>nil, "mode"=>nil, "owner_type"=>nil, "owner_id"=>nil, "userid"=>nil, "group_id"=>nil, "buttons"=>[{"id"=>"87000000000020", "guid"=>"c0a9b5c1-cd75-4cdb-8c76-2fdcfc2e820b", "description"=>"custom_button_0000000000019", "applies_to_class"=>"GenericObject", "visibility_expression"=>nil, "options"=>{}, "userid"=>nil, "wait_for_complete"=>nil, "created_on"=>"2019-03-08T01:44:43Z", "updated_on"=>"2019-03-08T01:44:43Z", "name"=>"generic_group", "visibility"=>nil, "applies_to_id"=>nil, "enablement_expression"=>nil, "disabled_text"=>nil, "enabled"=>true, "href"=>"http://www.example.com/api/custom_buttons/87000000000020"}], "href"=>"http://www.example.com/api/custom_button_sets/87000000000005"}]},
       +"generic_object_definition_id" => "87000000000026",
       +"href" => "http://www.example.com/api/generic_objects/87000000000011",
       +"id" => "87000000000011",
       +"name" => "object 1",
       +"uid" => nil,
       +"updated_at" => "2019-03-08T01:44:43Z",
     # ./spec/requests/generic_objects_spec.rb:155:in `block (3 levels) in <top (required)>'
```