### PR TITLE
Remove references to MiqPassword

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -111,7 +111,7 @@ module Api
       end
 
       def authenticate_with_system_token(x_miq_token)
-        @miq_token_hash = YAML.load(MiqPassword.decrypt(x_miq_token))
+        @miq_token_hash = YAML.load(ManageIQ::Password.decrypt(x_miq_token))
 
         validate_system_token_server(@miq_token_hash[:server_guid])
         validate_system_token_timestamp(@miq_token_hash[:timestamp])

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -385,7 +385,7 @@ describe "Authentication API" do
     AUTHENTICATION_ERROR = "Invalid System Authentication Token specified".freeze
 
     def systoken(server_guid, userid, timestamp)
-      MiqPassword.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
+      ManageIQ::Password.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
     end
 
     it "authentication using a bad token" do

--- a/spec/requests/logging_spec.rb
+++ b/spec/requests/logging_spec.rb
@@ -55,7 +55,7 @@ describe "Logging" do
         userid = @user.userid
         timestamp = Time.now.utc
 
-        miq_token = MiqPassword.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
+        miq_token = ManageIQ::Password.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
 
         get api_entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
 


### PR DESCRIPTION
@jrafanie @abellotti Please review.  This gets us one step closer to removing MiqPassword from manageiq-gems-pending.