### PR TITLE
Filter - add a new ===, !==, =~, !~ operators to match exact strings or regexes, without mangling

### DIFF
--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -11,6 +11,10 @@ module Api
       # string-only matching, use quotes
       "===" => {:default => "="},
       "!==" => {:default => "!="},
+
+      # regex-only matching without mangling, use slashes and optionally /i
+      "=~" => {:default => "REGULAR EXPRESSION MATCHES"},
+      "!~" => {:default => "REGULAR EXPRESSION DOES NOT MATCH"},
     }.freeze
 
     attr_reader :filters, :model

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -1,20 +1,20 @@
 module Api
   class Filter
     OPERATORS = {
-      "!=" => {:default => "!=", :regex => "REGULAR EXPRESSION DOES NOT MATCH", :null => "IS NOT NULL"},
-      "<=" => {:default => "<="},
-      ">=" => {:default => ">="},
-      "<"  => {:default => "<", :datetime => "BEFORE"},
-      ">"  => {:default => ">", :datetime => "AFTER"},
-      "="  => {:default => "=", :datetime => "IS", :regex => "REGULAR EXPRESSION MATCHES", :null => "IS NULL"},
+      "!="  => {:default => "!=", :regex => "REGULAR EXPRESSION DOES NOT MATCH", :null => "IS NOT NULL"},
+      "<="  => {:default => "<="},
+      ">="  => {:default => ">="},
+      "<"   => {:default => "<", :datetime => "BEFORE"},
+      ">"   => {:default => ">", :datetime => "AFTER"},
+      "="   => {:default => "=", :datetime => "IS", :regex => "REGULAR EXPRESSION MATCHES", :null => "IS NULL"},
 
       # string-only matching, use quotes
       "===" => {:default => "="},
       "!==" => {:default => "!="},
 
       # regex-only matching without mangling, use slashes and optionally /i
-      "=~" => {:default => "REGULAR EXPRESSION MATCHES"},
-      "!~" => {:default => "REGULAR EXPRESSION DOES NOT MATCH"},
+      "=~"  => {:default => "REGULAR EXPRESSION MATCHES"},
+      "!~"  => {:default => "REGULAR EXPRESSION DOES NOT MATCH"},
     }.freeze
 
     attr_reader :filters, :model

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -9,7 +9,7 @@ module Api
       "="   => {:default => "=", :datetime => "IS", :regex => "REGULAR EXPRESSION MATCHES", :null => "IS NULL"},
 
       # string-only matching, use quotes
-      "===" => {:default => "="},
+      "=="  => {:default => "="},
       "!==" => {:default => "!="},
 
       # regex-only matching without mangling, use slashes and optionally /i

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -346,5 +346,23 @@ RSpec.describe Api::Filter do
       expected = {"!=" => {"field" => "MiqReport-name", "value" => "  foo.*bar%f "}}
       expect(actual.exp).to eq(expected)
     end
+
+    it "can handle regexes" do
+      filters = ["name =~ /foo/i"]
+
+      actual = described_class.parse(filters, MiqReport)
+
+      expected = {"REGULAR EXPRESSION MATCHES" => {"field" => "MiqReport-name", "value" => "/foo/i"}}
+      expect(actual.exp).to eq(expected)
+    end
+
+    it "can handle negative regexes" do
+      filters = ["name !~ /foo/i"]
+
+      actual = described_class.parse(filters, MiqReport)
+
+      expected = {"REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "MiqReport-name", "value" => "/foo/i"}}
+      expect(actual.exp).to eq(expected)
+    end
   end
 end

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -330,7 +330,7 @@ RSpec.describe Api::Filter do
     end
 
     it "can handle exact strings" do
-      filters = ["name==='  foo.*bar%f '"]
+      filters = ["name=='  foo.*bar%f '"]
 
       actual = described_class.parse(filters, MiqReport)
 

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -328,5 +328,23 @@ RSpec.describe Api::Filter do
       expected = {"=" => {"field" => "MiqReport-name", "value" => "Vms with free space > 50 percent"}}
       expect(actual.exp).to eq(expected)
     end
+
+    it "can handle exact strings" do
+      filters = ["name==='  foo.*bar%f '"]
+
+      actual = described_class.parse(filters, MiqReport)
+
+      expected = {"=" => {"field" => "MiqReport-name", "value" => "  foo.*bar%f "}}
+      expect(actual.exp).to eq(expected)
+    end
+
+    it "can handle exact string nonequality" do
+      filters = ["name !== '  foo.*bar%f ' "]
+
+      actual = described_class.parse(filters, MiqReport)
+
+      expected = {"!=" => {"field" => "MiqReport-name", "value" => "  foo.*bar%f "}}
+      expect(actual.exp).to eq(expected)
+    end
   end
 end


### PR DESCRIPTION
Right now, if you have a VM (or anything) with a `%` or `*` in name,
it's impossible to find via the API by that name, without using wildcards.

This adds 4 new operators:

`===` and `!==`, which do the same thing as `=` and `!=` without trying to interpret the value as a regular expression,
`=~` and `!~`, which just parse the value as a regex for MiqExpression, with no extra mangling, allowing for case insensitive matches like `name =~ /foo/i`

The filtering code still mangles whitespace, but wrapping the value in single quotes (strings) or slashes (regex) prevents that.


---

This change also affects the `<=`, `>=`, `<` and `>` operators, which will no longer attempt to parse the value as a regex either.

(Related to https://bugzilla.redhat.com/show_bug.cgi?id=1680954, but not quite there yet.)