### PR TITLE
Add create Git backed automation domain

### DIFF
--- a/app/controllers/api/automate_domains_controller.rb
+++ b/app/controllers/api/automate_domains_controller.rb
@@ -3,7 +3,7 @@ module Api
 
     REQUIRED_FIELDS = %w(git_url ref_type ref_name)
 
-    def create_resource(type, _id, data)
+    def create_from_git_resource(type, _id, data)
       assert_all_required_fields_exists(data, type, REQUIRED_FIELDS)
       raise BadRequestError, 'ref_type must be "branch" or "tag"' unless valid_ref_type?(data)
       
@@ -17,7 +17,7 @@ module Api
                                                                            data["ref_name"],
                                                                            data["ref_type"],
                                                                            User.current_user.current_tenant.id,
-                                                                           optional_data(data))
+                                                                           prepare_optional_auth(data))
 
         action_result(true, 'Creating Automate Domain from git repository', :task_id => task_id)
       rescue => err
@@ -104,15 +104,15 @@ module Api
       false
     end
 
-    def optional_data(data)
-        optional_data = {}
-        optional_data["userid"] = data["userid"] if data.has_key?("userid")
-        optional_data["password"] = data["password"] if data.has_key?("password")
+    def prepare_optional_auth(data)
+        optional_auth = {}
+        optional_auth["userid"] = data["userid"] if data.has_key?("userid")
+        optional_auth["password"] = data["password"] if data.has_key?("password")
 
         # If data["verify_ssl"] is missing or set to false use VERIFY_NONE. If true use VERIFY_PEER
-        optional_data["verify_ssl"] = data["verify_ssl"] ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+        optional_auth["verify_ssl"] = data["verify_ssl"] ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
 
-        optional_data
+        optional_auth
     end
   end
 end

--- a/app/controllers/api/automate_domains_controller.rb
+++ b/app/controllers/api/automate_domains_controller.rb
@@ -1,12 +1,11 @@
 module Api
   class AutomateDomainsController < BaseController
-
-    REQUIRED_FIELDS = %w(git_url ref_type ref_name)
+    REQUIRED_FIELDS = %w[git_url ref_type ref_name].freeze
 
     def create_from_git_resource(type, _id, data)
       assert_all_required_fields_exists(data, type, REQUIRED_FIELDS)
       raise BadRequestError, 'ref_type must be "branch" or "tag"' unless valid_ref_type?(data)
-      
+
       api_log_info("Create will be queued for automate domain from #{data["git_url"]} / #{data["ref_name"]}")
 
       begin
@@ -99,20 +98,20 @@ module Api
     end
 
     def valid_ref_type?(data)
-      return false unless data.has_key?("ref_type")
+      return false unless data.key?("ref_type")
       return true if data["ref_type"] == "tag" || data["ref_type"] == "branch"
       false
     end
 
     def prepare_optional_auth(data)
-        optional_auth = {}
-        optional_auth["userid"] = data["userid"] if data.has_key?("userid")
-        optional_auth["password"] = data["password"] if data.has_key?("password")
+      optional_auth = {}
+      optional_auth["userid"] = data["userid"] if data.key?("userid")
+      optional_auth["password"] = data["password"] if data.key?("password")
 
-        # If data["verify_ssl"] is missing or set to false use VERIFY_NONE. If true use VERIFY_PEER
-        optional_auth["verify_ssl"] = data["verify_ssl"] ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+      # If data["verify_ssl"] is missing or set to false use VERIFY_NONE. If true use VERIFY_PEER
+      optional_auth["verify_ssl"] = data["verify_ssl"] ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
 
-        optional_auth
+      optional_auth
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -251,7 +251,7 @@
       :post:
       - :name: query
         :identifier: miq_ae_domain_view
-      - :name: create
+      - :name: create_from_git
         :identifier: miq_ae_domain_new
       - :name: refresh_from_source
         :identifier: miq_ae_git_refresh
@@ -262,7 +262,7 @@
       - :name: read
         :identifier: miq_ae_domain_view
       :post:
-      - :name: create
+      - :name: create_from_git
         :identifier: miq_ae_domain_new
       - :name: refresh_from_source
         :identifier: miq_ae_git_refresh

--- a/config/api.yml
+++ b/config/api.yml
@@ -242,7 +242,7 @@
     :description: Automate Domains
     :options:
     - :collection
-    :verbs: *gpd
+    :verbs: *gpppd
     :klass: MiqAeDomain
     :collection_actions:
       :get:
@@ -251,6 +251,8 @@
       :post:
       - :name: query
         :identifier: miq_ae_domain_view
+      - :name: create
+        :identifier: miq_ae_domain_new
       - :name: refresh_from_source
         :identifier: miq_ae_git_refresh
       - :name: delete
@@ -260,6 +262,8 @@
       - :name: read
         :identifier: miq_ae_domain_view
       :post:
+      - :name: create
+        :identifier: miq_ae_domain_new
       - :name: refresh_from_source
         :identifier: miq_ae_git_refresh
       - :name: delete

--- a/spec/requests/automate_domains_spec.rb
+++ b/spec/requests/automate_domains_spec.rb
@@ -70,7 +70,7 @@ describe "Automate Domains API" do
     let(:event) { FactoryBot.create(:miq_event_definition) }
     let(:miq_automate_domains_contents) do
       {"automate_domains" => [{'event_id' => event.id,
-                              "actions"  => [{"action_id" => action.id, "opts" => { :qualifier => "failure" }}] }]}
+                               "actions"  => [{"action_id" => action.id, "opts" => { :qualifier => "failure" }}] }]}
     end
 
     let(:sample_params) do
@@ -96,7 +96,7 @@ describe "Automate Domains API" do
       it 'should not create a new automate domain from git when missing params' do
         api_basic_authorize collection_action_identifier(:automate_domains, :create_from_git)
 
-        post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create_from_git, { "git_url" => "url" }))
+        post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create_from_git, "git_url" => "url"))
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body["error"]["message"]).to include(miq_automate_domains_contents.keys.join(", "))
       end
@@ -118,7 +118,7 @@ describe "Automate Domains API" do
         expect_single_action_result(
           :success => true,
           :message => "Creating Automate Domain from git repository",
-          :zhref    => api_automate_domain_url(nil, git_domain)
+          :zhref   => api_automate_domain_url(nil, git_domain)
         )
       end
     end

--- a/spec/requests/automate_domains_spec.rb
+++ b/spec/requests/automate_domains_spec.rb
@@ -64,7 +64,7 @@ describe "Automate Domains API" do
     end
   end
 
-  describe 'create action' do
+  describe 'create_from_git action' do
     let(:git_domain) { FactoryBot.create(:miq_ae_git_domain) }
     let(:action) { FactoryBot.create(:miq_action) }
     let(:event) { FactoryBot.create(:miq_event_definition) }
@@ -81,10 +81,10 @@ describe "Automate Domains API" do
       }
     end
 
-    it 'forbids create for users without proper permissions' do
+    it 'forbids create_from_git for users without proper permissions' do
       api_basic_authorize
 
-      post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create))
+      post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create_from_git))
       expect(response).to have_http_status(:forbidden)
     end
 
@@ -93,28 +93,28 @@ describe "Automate Domains API" do
         allow(GitBasedDomainImportService).to receive(:available?).and_return(true)
       end
 
-      it 'should not create a new automate domain when missing params' do
-        api_basic_authorize collection_action_identifier(:automate_domains, :create)
+      it 'should not create a new automate domain from git when missing params' do
+        api_basic_authorize collection_action_identifier(:automate_domains, :create_from_git)
 
-        post(api_automate_domain_url(nil, git_domain), :params => { "git_url" => "url" })
+        post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create_from_git, { "git_url" => "url" }))
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body["error"]["message"]).to include(miq_automate_domains_contents.keys.join(", "))
       end
 
-      it 'should not create new automate domain with incorrect ref_type param' do
-        api_basic_authorize collection_action_identifier(:automate_domains, :create)
+      it 'should not create new automate domain from git with incorrect ref_type param' do
+        api_basic_authorize collection_action_identifier(:automate_domains, :create_from_git)
 
-        post(api_automate_domain_url(nil, git_domain), :params => sample_params)
+        post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create_from_git, sample_params))
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body["error"]["message"]).to include("ref_type must be")
       end
 
-      it 'create domain from git_repository' do
-        api_basic_authorize collection_action_identifier(:automate_domains, :create)
+      it 'create domain from a git repository' do
+        api_basic_authorize collection_action_identifier(:automate_domains, :create_from_git)
         expect_any_instance_of(GitBasedDomainImportService).to receive(:queue_refresh_and_import)
         sample_params["ref_type"] = "tag"
 
-        post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create, sample_params))
+        post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create_from_git, sample_params))
         expect_single_action_result(
           :success => true,
           :message => "Creating Automate Domain from git repository",

--- a/spec/requests/automate_domains_spec.rb
+++ b/spec/requests/automate_domains_spec.rb
@@ -117,7 +117,7 @@ describe "Automate Domains API" do
         post(api_automate_domain_url(nil, git_domain), :params => gen_request(:create_from_git, sample_params))
         expect_single_action_result(
           :success => true,
-          :message => "Creating Automate Domain from git repository",
+          :message => "Creating Automate Domain from #{sample_params["git_url"]}/#{sample_params["ref_name"]}",
           :zhref   => api_automate_domain_url(nil, git_domain)
         )
       end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600961

This PR, along with PR [manageiq-ui-classic/5416](https://github.com/ManageIQ/manageiq-ui-classic/pull/5416) will provide  the support to allow the API to be used to create a Git backed automation domain.

### Steps for Testing/QA [Optional]

Create a GIT based automate domain repository.

Use the API to issue a POST command to `/api/automate_domains with data similar to:
{
  "git_url": "https://gitlab.exampledomain.com/gitlab_repo/AwesomeDomain",
  "ref_type": "branch",
  "ref_name": "master",
}

e.g.:

> cat action_create_from_git
> {
>   "git_url": "https://gitlab.exampledomain.com/gitlab_repo/AwesomeDomain",
>   "ref_type": "branch",
>   "ref_name": "master",
> }
> curl -k --user admin:SECRET_PASSWORD -i -X POST -H "Accept: application/json" -d  @action_create_from_git  https://my-miq-host/api/automate_domains
