### PR TITLE
Added logic to support both string and symbol access to keys in dialog hash under options

### DIFF
--- a/lib/services/api/request_parser.rb
+++ b/lib/services/api/request_parser.rb
@@ -10,7 +10,11 @@ module Api
 
     def self.parse_options(data)
       raise BadRequestError, "Request is missing options" if data["options"].blank?
-      data["options"].deep_symbolize_keys
+      # Need to preserve string keys in dialog sub-hash while still supporting access by symbols
+      dialog = data["options"].delete("dialog")
+      data["options"].deep_symbolize_keys.tap do |hash|
+        hash[:dialog] = dialog.with_indifferent_access if dialog.present?
+      end
     end
 
     def self.parse_auto_approve(data)

--- a/spec/lib/services/api/request_parser_spec.rb
+++ b/spec/lib/services/api/request_parser_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Api::RequestParser do
       expected = {:foo => "bar", :foobar => {:bazz => "foo"}}
       expect(actual).to eq(expected)
     end
+
+    it "deep symbolizes keys except the dialog" do
+      actual = described_class.parse_options("options" => {"foo" => "bar", "dialog" => { "item" => "value"}})
+      expected = {:foo => "bar", :dialog => { "item" => "value" }}
+      expect(actual).to eq(expected)
+      expect(actual[:dialog][:item]).to eq("value")
+      expect(actual[:dialog]["item"]).to eq("value")
+    end
   end
 
   describe ".parse_auto_approve" do


### PR DESCRIPTION
This addresses an issue that was introduced in https://github.com/ManageIQ/manageiq-api/pull/312. That change resulted in symbolizing the keys in the `dialog` hash under `options` when a service is ordered with an API request.

This change enables accessing keys in the dialog hash both as strings and symbols

/cc @tinaafitz, @lfu, @jrafanie 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1694716