### PR TITLE
Support physical server provisioning

### DIFF
--- a/app/controllers/api/customization_templates_controller.rb
+++ b/app/controllers/api/customization_templates_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class CustomizationTemplatesController < BaseController
+  end
+end

--- a/app/controllers/api/pxe_images_controller.rb
+++ b/app/controllers/api/pxe_images_controller.rb
@@ -1,0 +1,5 @@
+module Api
+  class PxeImagesController < BaseController
+    include Subcollections::CustomizationTemplates
+  end
+end

--- a/app/controllers/api/pxe_servers_controller.rb
+++ b/app/controllers/api/pxe_servers_controller.rb
@@ -1,0 +1,5 @@
+module Api
+  class PxeServersController < BaseController
+    include Subcollections::PxeImages
+  end
+end

--- a/app/controllers/api/subcollections/customization_templates.rb
+++ b/app/controllers/api/subcollections/customization_templates.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module CustomizationTemplates
+      def customization_templates_query_resource(object)
+        object.customization_templates
+      end
+    end
+  end
+end

--- a/app/controllers/api/subcollections/pxe_images.rb
+++ b/app/controllers/api/subcollections/pxe_images.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module PxeImages
+      def pxe_images_query_resource(object)
+        object.images
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1082,6 +1082,29 @@
       :get:
       - :name: read
         :identifier: customization_script_show
+  :customization_templates:
+    :description: Customization Template
+    :identifier: customization_template_accord
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: CustomizationTemplate
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: customization_template_view
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: customization_template_view
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: customization_template_view
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: customization_template_view
   :data_stores:
     :description: Datastores
     :identifier: storage
@@ -2329,6 +2352,48 @@
         :identifier: miq_request_control
       - :name: edit
         :identifier: miq_request_edit
+  :pxe_images:
+    :description: PXE Images
+    :identifier: pxe_server_accord
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: PxeImage
+    :subcollections:
+    - :customization_templates
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+  :pxe_servers:
+    :description: PXE Servers
+    :identifier: pxe_server_accord
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: PxeServer
+    :subcollections:
+    - :pxe_images
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
   :quotas:
     :description: TenantQuotas
     :options:
@@ -2514,6 +2579,8 @@
           :identifier: service_retire
         - :klass: VmRetireRequest
           :identifier: vm_retire
+        - :klass: PhysicalServerProvisionRequest
+          :identifier: physical_server_provision
       - :name: edit
         :identifier: miq_request_edit
       - :name: approve

--- a/spec/requests/customization_templates_spec.rb
+++ b/spec/requests/customization_templates_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe 'CustomizationTemplates API' do
+  let!(:template) { FactoryBot.create(:customization_template) }
+
+  describe 'GET /api/customization_templates' do
+    let(:url) { api_customization_templates_url }
+
+    it 'lists all customization templates images with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:customization_templates, :read, :get)
+      get(url)
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'customization_templates',
+        'resources' => [
+          hash_including('href' => api_customization_template_url(nil, template))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/customization_templates/:id' do
+    let(:url) { api_customization_template_url(nil, template) }
+
+    it 'will show a customization template with an appropriate role' do
+      api_basic_authorize action_identifier(:customization_templates, :read, :resource_actions, :get)
+      get(url)
+      expect(response.parsed_body).to include('href' => api_customization_template_url(nil, template))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/pxe_images_spec.rb
+++ b/spec/requests/pxe_images_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe 'PxeImages API' do
+  let!(:pxe_image)  { FactoryBot.create(:pxe_image, :pxe_image_type => image_type) }
+  let!(:image_type) { FactoryBot.create(:pxe_image_type) }
+  let!(:template_1) { FactoryBot.create(:customization_template, :pxe_image_type => image_type) }
+  let!(:template_2) { FactoryBot.create(:customization_template, :pxe_image_type => image_type) }
+
+  describe 'GET /api/pxe_images' do
+    let(:url) { api_pxe_images_url }
+
+    it 'lists all pxe images with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:pxe_images, :read, :get)
+      get(url)
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'pxe_images',
+        'resources' => [
+          hash_including('href' => api_pxe_image_url(nil, pxe_image))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/pxe_images/:id' do
+    let(:url) { api_pxe_image_url(nil, pxe_image) }
+
+    it 'will show a pxe image with an appropriate role' do
+      api_basic_authorize action_identifier(:pxe_images, :read, :resource_actions, :get)
+      get(url)
+      expect(response.parsed_body).to include('href' => api_pxe_image_url(nil, pxe_image))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/pxe_images/:id/customization_templates' do
+    let(:url) { "/api/pxe_images/#{pxe_image.id}/customization_templates" }
+
+    it 'lists all customization templates for a pxe image' do
+      api_basic_authorize subcollection_action_identifier(:pxe_images, :customization_templates, :read, :get)
+      get(url)
+      expect_result_resources_to_include_hrefs(
+        "resources",
+        [
+          api_pxe_image_customization_template_url(nil, pxe_image, template_1),
+          api_pxe_image_customization_template_url(nil, pxe_image, template_2),
+        ]
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/pxe_images/:id/customization_templates/:id' do
+    let(:url) { "/api/pxe_images/#{pxe_image.id}/customization_templates/#{template_1.id}" }
+
+    it "will show a single customization template of a pxe image" do
+      api_basic_authorize subcollection_action_identifier(:pxe_images, :customization_templates, :read, :get)
+      get(url)
+      expect_result_to_match_hash(
+        response.parsed_body,
+        "href"              => api_pxe_image_customization_template_url(nil, pxe_image, template_1),
+        "id"                => template_1.id.to_s,
+        "pxe_image_type_id" => image_type.id.to_s,
+        "name"              => template_1.name
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/pxe_servers_spec.rb
+++ b/spec/requests/pxe_servers_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe 'PxeServers API' do
+  let!(:pxe_server) { FactoryBot.create(:pxe_server) }
+  let!(:pxe_image_1) { FactoryBot.create(:pxe_image, :pxe_server => pxe_server) }
+  let!(:pxe_image_2) { FactoryBot.create(:pxe_image, :pxe_server => pxe_server) }
+
+  describe 'GET /api/pxe_servers' do
+    let(:url) { api_pxe_servers_url }
+
+    it 'lists all pxe servers with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:pxe_servers, :read, :get)
+      get(url)
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'pxe_servers',
+        'resources' => [
+          hash_including('href' => api_pxe_server_url(nil, pxe_server))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/pxe_servers/:id' do
+    let(:url) { api_pxe_server_url(nil, pxe_server) }
+
+    it 'will show a pxe server with an appropriate role' do
+      api_basic_authorize action_identifier(:pxe_servers, :read, :resource_actions, :get)
+      get(url)
+      expect(response.parsed_body).to include('href' => api_pxe_server_url(nil, pxe_server))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/pxe_servers/:id/pxe_images' do
+    let(:url) { "/api/pxe_servers/#{pxe_server.id}/pxe_images" }
+
+    it 'lists all pxe images of a pxe server' do
+      api_basic_authorize subcollection_action_identifier(:pxe_servers, :pxe_images, :read, :get)
+      get(url)
+      expect_result_resources_to_include_hrefs(
+        "resources",
+        [
+          api_pxe_server_pxe_image_url(nil, pxe_server, pxe_image_1),
+          api_pxe_server_pxe_image_url(nil, pxe_server, pxe_image_2),
+        ]
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/pxe_servers/:id/pxe_images/:id' do
+    let(:url) { "/api/pxe_servers/#{pxe_server.id}/pxe_images/#{pxe_image_1.id}" }
+
+    it "will show a single pxe image of a pxe server" do
+      api_basic_authorize subcollection_action_identifier(:pxe_servers, :pxe_images, :read, :get)
+      get(url)
+      expect_result_to_match_hash(
+        response.parsed_body,
+        "href"          => api_pxe_server_pxe_image_url(nil, pxe_server, pxe_image_1),
+        "id"            => pxe_image_1.id.to_s,
+        "pxe_server_id" => pxe_server.id.to_s,
+        "name"          => pxe_image_1.name
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
With this commit we implement two things:

1. Expose necessary API calls so React can **populate dropdowns** for provisioning dialog (when showing popup to user, see [React implementation PR here](https://github.com/ManageIQ/manageiq-providers-redfish/pull/58))
2. allow React to **create Request** of type PhysicalServerProvisionRequest    via API (when user clicks "Provision" on the popup)

![Capture](https://user-images.githubusercontent.com/8102426/56348709-55f4bf00-61c7-11e9-8053-2e1b16ac3939.PNG)

To fulfil (1) we basically need following API calls:

```
/api/pxe_servers                            # offer user to pick PXE server
/api/pxe_servers/:id/pxe_images             # offer user to pick image on selected server
/api/pxe_images/:id/customization_templates # offer user to pick template on selected image
```

And to fulfil (2) we basically need following API call to be accepted:

```
POST /api/requests
{
    "options" : {
      "request_type" : "provision_physical_server", # maps to PhysicalServerProvisionRequest
      "src_ids": [1],
      "pxe_image_id": 1,
      "configuration_profile_id": 1
  }
}
```

@miq-bot add_label enhancement
@miq-bot assign @abellotti