### PR TITLE
Include a list of supported providers in `OPTIONS /api/providers`

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -87,7 +87,16 @@ module Api
       providers_options = ManageIQ::Providers::BaseManager.leaf_subclasses.inject({}) do |po, ems|
         po.merge(ems.ems_type => ems.options_description)
       end
-      render_options(:providers, "provider_settings" => providers_options)
+
+      supported_providers = ExtManagementSystem.supported_types_for_create.map do |klass|
+        {
+          :title => klass.description,
+          :type  => klass.to_s,
+          :kind  => klass.to_s.demodulize.sub(/Manager$/, '').underscore
+        }
+      end
+
+      render_options(:providers, "provider_settings" => providers_options, "supported_providers" => supported_providers)
     end
 
     def pause_resource(type, id, _data)

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1584,6 +1584,9 @@ describe "Providers API" do
       expect(response.parsed_body["data"]["provider_settings"].keys.count).to eq(
         ManageIQ::Providers::BaseManager.leaf_subclasses.count
       )
+      expect(response.parsed_body["data"]["supported_providers"].count).to eq(
+        ExtManagementSystem.supported_types_for_create.count
+      )
       expect(response.parsed_body["data"]["provider_settings"]["kubernetes"]["proxy_settings"]["settings"]["http_proxy"]["label"]).to eq(N_('HTTP Proxy'))
     end
   end


### PR DESCRIPTION
@Hyperkid123 is working on the new API-driven forms for adding a provider and for that he needs a way to ask for the list of supported providers with their names and classes. Since https://github.com/ManageIQ/manageiq/issues/18568 we can ask for the list of the provider classes that are available for adding via the UI.

```json
$ curl -u admin:smartvm -XOPTIONS "http://localhost:3000/api/providers" | jq

{
 ...
  "data": {
    "provider_settings": {
       ...
    },
    "supported_providers": [
      {
        "title": "Ansible Tower Automation",
        "type": "ManageIQ::Providers::AnsibleTower::AutomationManager",
        "kind": "automation"
      },
      {
        "title": "Kubernetes",
        "type": "ManageIQ::Providers::Kubernetes::ContainerManager",
        "kind": "container"
      },
      {
        "title": "OpenShift",
        "type": "ManageIQ::Providers::Openshift::ContainerManager",
        "kind": "container"
      },
      {
        "title": "Lenovo XClarity",
        "type": "ManageIQ::Providers::Lenovo::PhysicalInfraManager",
        "kind": "physical_infra"
      },
      {
        "title": "Redfish",
        "type": "ManageIQ::Providers::Redfish::PhysicalInfraManager",
        "kind": "physical_infra"
      },
      {
        "title": "OpenStack Platform Director",
        "type": "ManageIQ::Providers::Openstack::InfraManager",
        "kind": "infra"
      },
      {
        "title": "Red Hat Virtualization",
        "type": "ManageIQ::Providers::Redhat::InfraManager",
        "kind": "infra"
      },
      {
        "title": "Microsoft System Center VMM",
        "type": "ManageIQ::Providers::Microsoft::InfraManager",
        "kind": "infra"
      },
      {
        "title": "VMware vCenter",
        "type": "ManageIQ::Providers::Vmware::InfraManager",
        "kind": "infra"
      },
      {
        "title": "Foreman Configuration",
        "type": "ManageIQ::Providers::Foreman::ConfigurationManager",
        "kind": "configuration"
      },
      {
        "title": "Amazon EC2",
        "type": "ManageIQ::Providers::Amazon::CloudManager",
        "kind": "cloud"
      },
      {
        "title": "Azure",
        "type": "ManageIQ::Providers::Azure::CloudManager",
        "kind": "cloud"
      },
      {
        "title": "Google Compute Engine",
        "type": "ManageIQ::Providers::Google::CloudManager",
        "kind": "cloud"
      },
      {
        "title": "OpenStack",
        "type": "ManageIQ::Providers::Openstack::CloudManager",
        "kind": "cloud"
      },
      {
        "title": "VMware vCloud",
        "type": "ManageIQ::Providers::Vmware::CloudManager",
        "kind": "cloud"
      }
    ]
  }
}
```

Originally I wanted to group these fields by the `kind` of the provider, but IMO this can be done on the client much easier. Maybe the `kind` and `type` keys should be changed to something else, I wasn't sure about the `class` as it might be a reserved word in other worlds.

@miq-bot add_reviewer @abellotti 
@miq-bot add_reviewer @djberg96 
cc @Hyperkid123, @agrare, @martinpovolny 