### PR TITLE
Include the regions if they're supported with OPTIONS /api/providers

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -89,11 +89,16 @@ module Api
       end
 
       supported_providers = ExtManagementSystem.supported_types_for_create.map do |klass|
+        if klass.supports_regions?
+          regions = klass.parent::Regions.all.sort_by { |r| r[:description] }.map { |r| r.slice(:name, :description) }
+        end
+
         {
-          :title => klass.description,
-          :type  => klass.to_s,
-          :kind  => klass.to_s.demodulize.sub(/Manager$/, '').underscore
-        }
+          :title   => klass.description,
+          :type    => klass.to_s,
+          :kind    => klass.to_s.demodulize.sub(/Manager$/, '').underscore,
+          :regions => regions
+        }.compact
       end
 
       render_options(:providers, "provider_settings" => providers_options, "supported_providers" => supported_providers)


### PR DESCRIPTION
Requested by @Hyperkid123 in the issue below as a followup on https://github.com/ManageIQ/manageiq-api/pull/579, he needs the list of supported regions for providers that support it.

```json
$ curl -u admin:smartvm -XOPTIONS "http://localhost:3000/api/providers"
    // ...
    "supported_providers": [
      // ...
      {
        "title": "Amazon EC2",
        "type": "ManageIQ::Providers::Amazon::CloudManager",
        "kind": "cloud",
        "regions": [
          {
            "name": "ap-south-1",
            "description": "Asia Pacific (Mumbai)"
          },
      // ...
```

Fixes https://github.com/ManageIQ/manageiq-api/issues/580
@miq-bot add_label changelog/yes, hammer/no, enhancement
@miq-bot assign @abellotti 

I am a little worried about writing a spec for this, because I'm not 100% sure that we'd have a cloud provider neither that a cloud provider always has regions supported.