### PR TITLE
Add scheduling option to automation requests as provision requests have

### DIFF
--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -18,7 +18,7 @@ describe "Automation Requests API" do
         "uri_parts"  => {"
           namespace" => "System", "class" => "Request", "instance" => "InspectME", "message" => "create"
          },
-        "parameters" => {"var1" => "xyzzy", "var2" => 1024, "var3" => true},
+        "parameters" => {"var1" => "xyzzy", "var2" => 1024, "var3" => true, "schedule_time" => Time.now.utc + 10.days },
         "requester"  => {"user_name" => approver.userid, "auto_approve" => true}
       }
     end


### PR DESCRIPTION
We need the functionality of scheduling automation requests like we do provisioning requests. Lucky for us, the request creates a task, which, as long as it has the right option, the scheduler will handle correctly (see https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_request_task.rb#L174 when the task gets queued.). So I don't know that there are any changes needed here at all. 

Start to https://bugzilla.redhat.com/show_bug.cgi?id=1486765

## depends on
https://github.com/ManageIQ/manageiq/pull/18741

For reference:
https://manageiq.org/docs/reference/latest/api/appendices/provision_attributes.html#schedule-attributes

(it's a testhancement. it enhances things but the functionality already exists so it is an enhancement but only needs tests? maybe? only the enhancements aren't here, they're on the linked pr. which it does depend on. just not really. labels are difficult.)