### PR TITLE
Remove conditional and assume plugin_name exists

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -103,7 +103,7 @@ module Api
     def plugin_info
       Vmdb::Plugins.versions.each_with_object({}) do |(engine, version), hash|
         hash[engine.to_s] = {
-          :display_name => engine.respond_to?(:plugin_name) ? engine.plugin_name : engine.to_s.gsub(/ManageIQ::|::Engine/, ''),
+          :display_name => engine.plugin_name,
           :version      => version
         }
       end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/18755 which ensures that all plugins will have a plugin_name, simplifying the question here.