### PR TITLE
Added PxeServer create, update and delete actions

### DIFF
--- a/app/controllers/api/pxe_menus_controller.rb
+++ b/app/controllers/api/pxe_menus_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class PxeMenusController < BaseController
+  end
+end

--- a/app/controllers/api/pxe_servers_controller.rb
+++ b/app/controllers/api/pxe_servers_controller.rb
@@ -1,21 +1,40 @@
 module Api
   class PxeServersController < BaseController
-    INVALID_PXE_SERVER_ATTRS = %w[id href].freeze # Cannot update or create these
-
     include Subcollections::PxeImages
     include Subcollections::PxeMenus
+    INVALID_ATTRIBUTES = {
+      "PxeServer" => %w[id href], # Cannot update or create these
+    }.freeze
+    PXE_ATTRIBUTES = {
+      "PxeServer"      => %w[name uri],
+      "PxeMenu"        => %w[file_name],
+      "Authentication" => %w[userid password]
+    }.freeze
 
     def create_resource(_type, _id, data = {})
-      validate_pxe_server_create_data(data)
+      authentication = data.delete('authentication')
       menus = data.delete('pxe_menus')
+      validate_data_for('PxeServer', data)
 
-      server = collection_class(:pxe_servers).create(data)
-      if server.invalid?
-        raise BadRequestError, "Failed to add a pxe server - #{server.errors.full_messages.join(', ')}"
+      PxeServer.transaction do
+        server = collection_class(:pxe_servers).new(data)
+        # generates uir_prefix which checks if server needs authentication or not
+        server.verify_uri_prefix_before_save
+
+        if server.requires_credentials? && server.missing_credentials?
+          validate_data_for('Authentication', authentication || {})
+          server.update_authentication({:default => authentication.compact}, {:save => true})
+        end
+
+        server.pxe_menus = create_pxe_menus(menus) if menus
+
+        if server.invalid?
+          raise BadRequestError, "Failed to add a pxe server - #{server.errors.full_messages.join(', ')}"
+        end
+
+        server.save
+        server
       end
-
-      server.pxe_menus = create_pxe_menus(menus) if menus
-      server
     end
 
     def delete_resource(_type, id = nil, data = nil)
@@ -27,34 +46,33 @@ module Api
     def edit_resource(type, id, data)
       server = resource_search(id, type, collection_class(:pxe_servers))
       menus = data.delete('pxe_menus')
-      if menus
-        server.pxe_menus.clear
-        data['pxe_menus'] = create_pxe_menus(menus)
+      authentication = data.delete('authentication')
+      PxeServer.transaction do
+        if menus
+          server.pxe_menus.clear
+          data['pxe_menus'] = create_pxe_menus(menus)
+        end
+        server.update!(data)
+        server.update_authentication({:default => authentication.transform_keys(&:to_sym)}, {:save => true}) if authentication && server.requires_credentials?
+        server
       end
-
-      server.update!(data)
-      server
     end
 
     private
 
     def create_pxe_menus(menus)
+      menus.each do |menu|
+        validate_data_for('PxeMenu', menu)
+      end
       menus.map do |menu|
         collection_class(:pxe_menus).create(menu)
       end
     end
 
-    def validate_pxe_server_data(data)
-      bad_attrs = data.keys.select { |k| INVALID_PXE_SERVER_ATTRS.include?(k) }.compact.join(", ")
-      raise BadRequestError, "Invalid attribute(s) #{bad_attrs} specified for a pxe server" if bad_attrs.present?
-    end
-
-    def validate_pxe_server_create_data(data)
-      validate_pxe_server_data(data)
-      req_attrs = %w[name uri]
+    def validate_data_for(klass, data)
       bad_attrs = []
-      req_attrs.each { |attr| bad_attrs << attr if data[attr].blank? }
-      raise BadRequestError, "Missing attribute(s) #{bad_attrs.join(', ')} for creating a pxe server" if bad_attrs.present?
+      PXE_ATTRIBUTES[klass].each { |attr| bad_attrs << attr if data[attr].blank? }
+      raise BadRequestError, "Missing attribute(s) #{bad_attrs.join(', ')} for creating a #{klass}" if bad_attrs.present?
     end
   end
 end

--- a/app/controllers/api/pxe_servers_controller.rb
+++ b/app/controllers/api/pxe_servers_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class PxeServersController < BaseController
-    INVALID_PXE_SERVER_ATTRS = %w(id href).freeze # Cannot update or create these
+    INVALID_PXE_SERVER_ATTRS = %w[id href].freeze # Cannot update or create these
 
     include Subcollections::PxeImages
     include Subcollections::PxeMenus
@@ -13,33 +13,33 @@ module Api
       if server.invalid?
         raise BadRequestError, "Failed to add a pxe server - #{server.errors.full_messages.join(', ')}"
       end
+
       server.pxe_menus = create_pxe_menus(menus) if menus
       server
     end
 
     def delete_resource(_type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for deleting a pxe server" unless id
+
       super
     end
 
-
     def edit_resource(type, id, data)
       server = resource_search(id, type, collection_class(:pxe_servers))
-      
-
       menus = data.delete('pxe_menus')
       if menus
         server.pxe_menus.clear
-        data.merge!('pxe_menus' => create_pxe_menus(menus))
+        data['pxe_menus'] = create_pxe_menus(menus)
       end
-      server.update_attributes!(data)
+
+      server.update!(data)
       server
     end
 
     private
 
     def create_pxe_menus(menus)
-      menus.map do | menu |
+      menus.map do |menu|
         collection_class(:pxe_menus).create(menu)
       end
     end
@@ -51,7 +51,7 @@ module Api
 
     def validate_pxe_server_create_data(data)
       validate_pxe_server_data(data)
-      req_attrs = %w(name uri)
+      req_attrs = %w[name uri]
       bad_attrs = []
       req_attrs.each { |attr| bad_attrs << attr if data[attr].blank? }
       raise BadRequestError, "Missing attribute(s) #{bad_attrs.join(', ')} for creating a pxe server" if bad_attrs.present?

--- a/app/controllers/api/pxe_servers_controller.rb
+++ b/app/controllers/api/pxe_servers_controller.rb
@@ -1,5 +1,60 @@
 module Api
   class PxeServersController < BaseController
+    INVALID_PXE_SERVER_ATTRS = %w(id href).freeze # Cannot update or create these
+
     include Subcollections::PxeImages
+    include Subcollections::PxeMenus
+
+    def create_resource(_type, _id, data = {})
+      validate_pxe_server_create_data(data)
+      menus = data.delete('pxe_menus')
+
+      server = collection_class(:pxe_servers).create(data)
+      if server.invalid?
+        raise BadRequestError, "Failed to add a pxe server - #{server.errors.full_messages.join(', ')}"
+      end
+      server.pxe_menus = create_pxe_menus(menus) if menus
+      server
+    end
+
+    def delete_resource(_type, id = nil, data = nil)
+      raise BadRequestError, "Must specify an id for deleting a pxe server" unless id
+      super
+    end
+
+
+    def edit_resource(type, id, data)
+      server = resource_search(id, type, collection_class(:pxe_servers))
+      
+
+      menus = data.delete('pxe_menus')
+      if menus
+        server.pxe_menus.clear
+        data.merge!('pxe_menus' => create_pxe_menus(menus))
+      end
+      server.update_attributes!(data)
+      server
+    end
+
+    private
+
+    def create_pxe_menus(menus)
+      menus.map do | menu |
+        collection_class(:pxe_menus).create(menu)
+      end
+    end
+
+    def validate_pxe_server_data(data)
+      bad_attrs = data.keys.select { |k| INVALID_PXE_SERVER_ATTRS.include?(k) }.compact.join(", ")
+      raise BadRequestError, "Invalid attribute(s) #{bad_attrs} specified for a pxe server" if bad_attrs.present?
+    end
+
+    def validate_pxe_server_create_data(data)
+      validate_pxe_server_data(data)
+      req_attrs = %w(name uri)
+      bad_attrs = []
+      req_attrs.each { |attr| bad_attrs << attr if data[attr].blank? }
+      raise BadRequestError, "Missing attribute(s) #{bad_attrs.join(', ')} for creating a pxe server" if bad_attrs.present?
+    end
   end
 end

--- a/app/controllers/api/subcollections/pxe_menus.rb
+++ b/app/controllers/api/subcollections/pxe_menus.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module PxeMenus
+      def pxe_menus_query_resource(object)
+        object.pxe_menus
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2356,6 +2356,31 @@
         :identifier: miq_request_control
       - :name: edit
         :identifier: miq_request_edit
+  :pxe_menus:
+    :description: PXE Menus
+    :identifier: pxe_server_accord
+    :options:
+      - :collection
+    :verbs: *gpppd
+    :klass: PxeMenu
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+      :post:
+      - :name: create
+        :identifier: pxe_server_create
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+      :post:
+      - :name: create
+        :identifier: pxe_server_create
   :pxe_images:
     :description: PXE Images
     :identifier: pxe_server_accord
@@ -2386,11 +2411,21 @@
     :identifier: pxe_server_accord
     :options:
     - :collection
-    :verbs: *g
+    :verbs: *gpppd
     :klass: PxeServer
     :subcollections:
     - :pxe_images
+    - :pxe_menus
     :collection_actions:
+      :post:
+      - :name: create
+        :identifier: pxe_server_create
+      :patch:
+      - :name: edit
+        :identifier: pxe_server_edit
+      :delete:
+      - :name: delete
+        :identifier: pxe_server_delete
       :get:
       - :name: read
         :identifier: pxe_server_view

--- a/config/api.yml
+++ b/config/api.yml
@@ -2356,31 +2356,6 @@
         :identifier: miq_request_control
       - :name: edit
         :identifier: miq_request_edit
-  :pxe_menus:
-    :description: PXE Menus
-    :identifier: pxe_server_accord
-    :options:
-      - :collection
-    :verbs: *gpppd
-    :klass: PxeMenu
-    :collection_actions:
-      :get:
-      - :name: read
-        :identifier: pxe_server_view
-      :post:
-      - :name: create
-        :identifier: pxe_server_create
-    :subresource_actions:
-      :get:
-      - :name: read
-        :identifier: pxe_server_view
-    :subcollection_actions:
-      :get:
-      - :name: read
-        :identifier: pxe_server_view
-      :post:
-      - :name: create
-        :identifier: pxe_server_create
   :pxe_images:
     :description: PXE Images
     :identifier: pxe_server_accord
@@ -2406,6 +2381,31 @@
       :get:
       - :name: read
         :identifier: pxe_server_view
+  :pxe_menus:
+    :description: PXE Menus
+    :identifier: pxe_server_accord
+    :options:
+    - :collection
+    :verbs: *gpppd
+    :klass: PxeMenu
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+      :post:
+      - :name: create
+        :identifier: pxe_server_create
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
+      :post:
+      - :name: create
+        :identifier: pxe_server_create
   :pxe_servers:
     :description: PXE Servers
     :identifier: pxe_server_accord

--- a/config/api.yml
+++ b/config/api.yml
@@ -2420,6 +2420,8 @@
       :post:
       - :name: create
         :identifier: pxe_server_create
+      - :name: edit
+        :identifier: pxe_server_edit
       :patch:
       - :name: edit
         :identifier: pxe_server_edit
@@ -2433,6 +2435,17 @@
       :get:
       - :name: read
         :identifier: pxe_server_view
+      :patch:
+      - :name: edit
+        :identifier: pxe_server_edit
+      :post:
+      - :name: create
+        :identifier: pxe_server_create
+      - :name: edit
+        :identifier: pxe_server_edit
+      :delete:
+      - :name: delete
+        :identifier: pxe_server_delete
   :quotas:
     :description: TenantQuotas
     :options:

--- a/spec/requests/pxe_servers_spec.rb
+++ b/spec/requests/pxe_servers_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'PxeServers API' do
         "href"          => api_pxe_server_pxe_menu_url(nil, pxe_server, pxe_menu_1),
         "id"            => pxe_menu_1.id.to_s,
         "pxe_server_id" => pxe_server.id.to_s,
-        "file_name"          => pxe_menu_1.file_name
+        "file_name"     => pxe_menu_1.file_name
       )
       expect(response).to have_http_status(:ok)
     end
@@ -142,10 +142,7 @@ RSpec.describe 'PxeServers API' do
 
     it 'create new pxe server' do
       api_basic_authorize collection_action_identifier(:pxe_servers, :create, :post)
-      post(url, :params => {
-        :name => 'foo',
-        :uri  => 'bar/quax'
-      })
+      post(url, :params => {:name => 'foo', :uri => 'bar/quax'})
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['results'].first['name']).to eq('foo')
       expect(response.parsed_body['results'].first['uri']).to eq('bar/quax')
@@ -153,11 +150,7 @@ RSpec.describe 'PxeServers API' do
 
     it 'create new pxe server with pxe menu' do
       api_basic_authorize collection_action_identifier(:pxe_servers, :create, :post)
-      post(url, :params => {
-        :name       => 'foo',
-        :uri        => 'bar/quax',
-        :pxe_menus  => [{:file_name => 'menu_1'}]
-      })
+      post(url, :params => {:name => 'foo', :uri => 'bar/quax', :pxe_menus => [{:file_name => 'menu_1'}]})
       expect(response).to have_http_status(:ok)
       expect(PxeServer.find(response.parsed_body['results'].first['id']).pxe_menus.first[:file_name]).to eq('menu_1')
     end
@@ -168,11 +161,7 @@ RSpec.describe 'PxeServers API' do
 
     it 'update pxe server' do
       api_basic_authorize collection_action_identifier(:pxe_servers, :edit, :patch)
-      patch(url, :params => {
-        :name       => 'updated name',
-        :uri        => 'updated/url',
-        :pxe_menus  => [{ file_name: 'updated menu' }]
-      })
+      patch(url, :params => {:name => 'updated name', :uri => 'updated/url', :pxe_menus => [{:file_name => 'updated menu'}]})
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['name']).to eq('updated name')
       expect(response.parsed_body['uri']).to eq('updated/url')

--- a/spec/requests/pxe_servers_spec.rb
+++ b/spec/requests/pxe_servers_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe 'PxeServers API' do
   let!(:pxe_server) { FactoryBot.create(:pxe_server) }
   let!(:pxe_image_1) { FactoryBot.create(:pxe_image, :pxe_server => pxe_server) }
   let!(:pxe_image_2) { FactoryBot.create(:pxe_image, :pxe_server => pxe_server) }
+  let!(:pxe_menu_1) { FactoryBot.create(:pxe_menu, :pxe_server => pxe_server) }
 
   describe 'GET /api/pxe_servers' do
     let(:url) { api_pxe_servers_url }
@@ -88,6 +89,105 @@ RSpec.describe 'PxeServers API' do
       api_basic_authorize
       get(url)
       expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/pxe_servers/:id/pxe_menus' do
+    let(:url) { "/api/pxe_servers/#{pxe_server.id}/pxe_menus" }
+
+    it 'lists all pxe menus of a pxe server' do
+      api_basic_authorize subcollection_action_identifier(:pxe_servers, :pxe_menus, :read, :get)
+      get(url)
+      expect_result_resources_to_include_hrefs(
+        "resources",
+        [
+          api_pxe_server_pxe_menu_url(nil, pxe_server, pxe_menu_1)
+        ]
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/pxe_servers/:id/pxe_menus/:id' do
+    let(:url) { "/api/pxe_servers/#{pxe_server.id}/pxe_menus/#{pxe_menu_1.id}" }
+
+    it "will show a single pxe menu of a pxe server" do
+      api_basic_authorize subcollection_action_identifier(:pxe_servers, :pxe_images, :read, :get)
+      get(url)
+      expect_result_to_match_hash(
+        response.parsed_body,
+        "href"          => api_pxe_server_pxe_menu_url(nil, pxe_server, pxe_menu_1),
+        "id"            => pxe_menu_1.id.to_s,
+        "pxe_server_id" => pxe_server.id.to_s,
+        "file_name"          => pxe_menu_1.file_name
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'POST /api/pxe_servers/' do
+    let(:url) { "/api/pxe_servers/" }
+
+    it 'create new pxe server' do
+      api_basic_authorize collection_action_identifier(:pxe_servers, :create, :post)
+      post(url, :params => {
+        :name => 'foo',
+        :uri  => 'bar/quax'
+      })
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['results'].first['name']).to eq('foo')
+      expect(response.parsed_body['results'].first['uri']).to eq('bar/quax')
+    end
+
+    it 'create new pxe server with pxe menu' do
+      api_basic_authorize collection_action_identifier(:pxe_servers, :create, :post)
+      post(url, :params => {
+        :name       => 'foo',
+        :uri        => 'bar/quax',
+        :pxe_menus  => [{:file_name => 'menu_1'}]
+      })
+      expect(response).to have_http_status(:ok)
+      expect(PxeServer.find(response.parsed_body['results'].first['id']).pxe_menus.first[:file_name]).to eq('menu_1')
+    end
+  end
+
+  describe 'patch /api/pxe_servers/:id' do
+    let(:url) { "/api/pxe_servers/#{pxe_server.id}" }
+
+    it 'update pxe server' do
+      api_basic_authorize collection_action_identifier(:pxe_servers, :edit, :patch)
+      patch(url, :params => {
+        :name       => 'updated name',
+        :uri        => 'updated/url',
+        :pxe_menus  => [{ file_name: 'updated menu' }]
+      })
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['name']).to eq('updated name')
+      expect(response.parsed_body['uri']).to eq('updated/url')
+      expect(PxeServer.find(response.parsed_body['id']).pxe_menus.first[:file_name]).to eq('updated menu')
+    end
+  end
+
+  describe 'delete /api/pxe_servers/:id' do
+    let(:url) { "/api/pxe_servers/#{pxe_server.id}" }
+
+    it 'delete pxe server' do
+      api_basic_authorize collection_action_identifier(:pxe_servers, :delete, :delete)
+      delete(url)
+      expect(response).to have_http_status(:no_content)
+      expect(PxeServer.exists?(pxe_server.id)).to be_falsey
     end
   end
 end


### PR DESCRIPTION
We've got a BZ for add/edit PxeServer in ui-classic which will require us to rewrite the UI. Part of that is removing current code from ui-classic and let the API handle these actions instead.

https://bugzilla.redhat.com/show_bug.cgi?id=1537267

```javascript
POST
/api/pxe_servers {
  uri: string,
  name: string,
  pxe_directory?: string,
  windows_images_directory?: string,
  customization_directory?: string
  pxe_menus?: [{
    file_name: string
  }],
  authentication?: { //only if uri has not nfs prefix
    userid: string,
    passworkd: string
  }
}
```

### TODO
- ~file depot credentials validation id model: https://github.com/ManageIQ/manageiq/pull/18795~