### PR TITLE
Added create orchestration template service dialog action.

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2884,6 +2884,8 @@
         :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
+      - :name: orchestration_template_service_dialog
+        :identifier: dialog_new_editor
     :resource_actions:
       :get:
       - :name: read
@@ -2899,6 +2901,8 @@
         :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
+      - :name: orchestration_template_service_dialog
+        :identifier: dialog_new_editor
       :delete:
       - :name: delete
         :identifier: dialog_delete


### PR DESCRIPTION
Action for creating service dialog from orchestration template. Part of an effort of refactoring orchestration dialog forms. Based on current implementation in ui classic which this should eventually replace.
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/catalog_controller.rb#L1108

```
POST /api/service_dialogs
{
  action: 'orchestration_template_service_dialog',
  resource: {
    label: 'dialog label'
     ot_id: '569' // orchestration template ID
  }
}
```