### PR TITLE
Support firmware update

### DIFF
--- a/app/controllers/api/physical_servers_controller.rb
+++ b/app/controllers/api/physical_servers_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class PhysicalServersController < BaseController
     include Subcollections::EventStreams
+    include Subcollections::FirmwareBinaries
 
     def blink_loc_led_resource(type, id, _data)
       change_resource_state(:blink_loc_led, type, id)

--- a/app/controllers/api/subcollections/firmware_binaries.rb
+++ b/app/controllers/api/subcollections/firmware_binaries.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module FirmwareBinaries
+      def firmware_binaries_query_resource(object)
+        object.compatible_firmware_binaries
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1225,6 +1225,16 @@
       :post:
       - :name: assign
       - :name: unassign
+  :firmware_binaries:
+    :description: Firmware Binaries
+    :options:
+    - :subcollection
+    :verbs: *g
+    :klass: FirmwareBinary
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: firmware
   :firmwares:
     :description: Firmwares
     :options:
@@ -1244,6 +1254,7 @@
       :get:
       - :name: read
         :identifier: firmware_show
+
   :flavors:
     :description: Flavors
     :identifier: flavor
@@ -1931,6 +1942,7 @@
     :klass: PhysicalServer
     :subcollections:
     - :event_streams
+    - :firmware_binaries
     :collection_actions:
       :get:
       - :name: read
@@ -2647,6 +2659,8 @@
           :identifier: vm_retire
         - :klass: PhysicalServerProvisionRequest
           :identifier: physical_server_provision
+        - :klass: PhysicalServerFirmwareUpdateRequest
+          :identifier: firmware
       - :name: edit
         :identifier: miq_request_edit
       - :name: approve


### PR DESCRIPTION
With this commit we expose neccessary operations for UI to be able to render a functional "Firmware Update" modal. User has to pick a firmware binary from the drop-down to apply it to selected server(s). 
The API call to support it looks like:

```
GET /api/physical_servers/{ID}/firmware_binaries
```

Eventually, when she submits the modal, a new Request of type PhysicalServerFirmwareUpdateRequest is created by means of POSTing to `/api/request`:

```
POST /api/requests
{
  "options" : {
    "request_type": "physical_server_firmware_update",
    "src_ids": [1,2,3],
    "firmware_binary_id": 1
  }
}
```