### PR TITLE
Add a subcollection under VMs for displaying disks

### DIFF
--- a/app/controllers/api/subcollections/disks.rb
+++ b/app/controllers/api/subcollections/disks.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module Disks
+      def disks_query_resource(object)
+        object.disks
+      end
+    end
+  end
+end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class VmsController < BaseController
+    include Subcollections::Disks
     include Subcollections::Tags
     include Subcollections::Policies
     include Subcollections::PolicyProfiles

--- a/config/api.yml
+++ b/config/api.yml
@@ -1144,6 +1144,12 @@
         :identifier: storage_tag
       - :name: unassign
         :identifier: storage_tag
+  :disks:
+    :description: Disks
+    :options:
+    - :subcollection
+    :verbs: *g
+    :klass: Disk
   :enterprises:
     :description: Enterprises
     :options:
@@ -3741,6 +3747,7 @@
     :verbs: *gpd
     :klass: Vm
     :subcollections:
+    - :disks
     - :tags
     - :policies
     - :policy_profiles
@@ -3892,6 +3899,16 @@
       :delete:
       - :name: delete
         :identifier: vm_delete
+    :disks_subcollection_actions:
+      :get:
+      - :name: read
+        :identifier:
+        - vm_show
+    :disks_subresource_actions:
+      :get:
+      - :name: read
+        :identifier:
+        - vm_show
     :tags_subcollection_actions:
       :post:
       - :name: assign

--- a/spec/requests/disks_spec.rb
+++ b/spec/requests/disks_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "Disks API" do
+  let(:hw) { FactoryBot.create(:hardware) }
+  let(:vm) { FactoryBot.create(:vm_vmware, :hardware => hw) }
+  let!(:disk) { FactoryBot.create(:disk, :hardware => hw) }
+
+  describe "as a subcollection of VMs" do
+    describe "GET /api/vms/:c_id/disks" do
+      it "can list the snapshots of a VM" do
+        api_basic_authorize(subcollection_action_identifier(:vms, :disks, :read, :get))
+
+        _other_disk = FactoryBot.create(:disk)
+
+        get(api_vm_disks_url(nil, vm))
+
+        expected = {
+          "count"     => 2,
+          "name"      => "disks",
+          "subcount"  => 1,
+          "resources" => [
+            {"href" => api_vm_disk_url(nil, vm, disk)}
+          ]
+        }
+
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /api/vms/:c_id/disks/:s_id" do
+      it "can show a VM's disk" do
+        api_basic_authorize(subcollection_action_identifier(:vms, :disks, :read, :get))
+
+        get(api_vm_disk_url(nil, vm, disk))
+
+        expected = {
+          "href" => api_vm_disk_url(nil, vm, disk),
+          "id"   => disk.id.to_s,
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will not show a disk unless authorized" do
+        api_basic_authorize
+
+        get(api_vm_disk_url(nil, vm, disk))
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is required for the API-driven reconfigure VM screen where the user has to display the related disks. Any change is going through the `VmReconfigureRequest` model that is already supported by the API, therefore, there's no need for anything else than `GET`.

@miq-bot add_label hammer/no, changelog/yes
@miq-bot add_reviewer @abellotti 
@miq-bot add_reviewer @lpichler 