### PR TITLE
Fix API retirement identifiers and role checking

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -62,18 +62,14 @@ module Api
       end
 
       def request_retire_resource(type, id, _data = nil)
-        if api_user_role_allows?('miq_request_approval')
-          klass = collection_class(type)
-          if id
-            msg = "#{User.current_user.userid} retiring #{type} id #{id} immediately as a request."
-            resource = resource_search(id, type, klass)
-            api_log_info(msg)
-            klass.make_retire_request(resource.id, User.current_user)
-          else
-            raise BadRequestError, "Must specify an id for retiring a #{type} resource"
-          end
+        klass = collection_class(type)
+        if id
+          msg = "#{User.current_user.userid} retiring #{type} id #{id} immediately as a request."
+          resource = resource_search(id, type, klass)
+          api_log_info(msg)
+          klass.make_retire_request(resource.id, User.current_user)
         else
-          raise ForbiddenError, "User lacking correct permissions to approve a #{type} retire as a request."
+          raise BadRequestError, "Must specify an id for retiring a #{type} resource"
         end
       end
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -3234,12 +3234,12 @@
         - sui_services_edit
       - :name: retire
         :identifier:
-        - service_retire
+        - service_retire_now
         - sui_services_retire
       - :name: request_retire
         :identifier:
-        - service_retire
-        - sui_services_retire_date
+        - service_retire_now
+        - sui_services_retire
       - :name: set_ownership
         :identifier:
         - service_ownership

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -484,8 +484,10 @@ describe "Services API" do
 
           expect(response).to have_http_status(:forbidden)
         end
+      end
 
-        it "rejects multiple requests without approval" do
+      context "good permissions" do
+        it "supports single service retirement now" do
           api_basic_authorize(action_identifier(:services, :request_retire))
 
           post(api_service_url(nil, svc), :params => gen_request(:request_retire))
@@ -493,23 +495,7 @@ describe "Services API" do
           expected = {
             "href"    => a_string_matching(api_requests_url),
             "message" => a_string_matching(/Service Retire - Request Created/),
-            "options" => a_hash_including("src_ids" => a_collection_containing_exactly(svc.id))
-          }
-          expect(response).to have_http_status(:forbidden)
-          expect(response.parsed_body).to_not include(expected)
-        end
-      end
-
-      context "good permissions" do
-        it "supports single service retirement now" do
-          api_basic_authorize(action_identifier(:services, :request_retire), :miq_request_approval)
-
-          post(api_service_url(nil, svc), :params => gen_request(:request_retire))
-
-          expected = {
-            "href"    => a_string_matching(api_requests_url),
-            "message" => a_string_matching(/Service Retire - Request Created/),
-            "options" => a_hash_including("src_ids" => a_collection_containing_exactly(svc.id))
+            "options" => a_hash_including("src_ids" => a_collection_including(svc.id))
           }
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body).to include(expected)

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1097,20 +1097,6 @@ describe "Vms API" do
     context "request_retire" do
       context "valid" do
         it "to a single Vm" do
-          api_basic_authorize(action_identifier(:vms, :request_retire), :miq_request_approval)
-
-          post(vm_url, :params => gen_request(:request_retire))
-
-          expected = {
-            "href"    => a_string_matching(api_requests_url),
-            "message" => a_string_matching(/VM Retire - Request Created/),
-            "options" => a_hash_including("src_ids" => a_collection_containing_exactly(vm.id))
-          }
-          expect(response).to have_http_status(:ok)
-          expect(response.parsed_body).to include(expected)
-        end
-
-        it "to a single Vm without approval" do
           api_basic_authorize(action_identifier(:vms, :request_retire))
 
           post(vm_url, :params => gen_request(:request_retire))
@@ -1118,14 +1104,14 @@ describe "Vms API" do
           expected = {
             "href"    => a_string_matching(api_requests_url),
             "message" => a_string_matching(/VM Retire - Request Created/),
-            "options" => a_hash_including("src_ids" => a_collection_containing_exactly(vm.id))
+            "options" => a_hash_including("src_ids" => a_collection_including(vm.id))
           }
-          expect(response).to have_http_status(:forbidden)
-          expect(response.parsed_body).to_not include(expected)
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to include(expected)
         end
 
         it "to multiple Vms" do
-          api_basic_authorize(collection_action_identifier(:vms, :request_retire), :miq_request_approval)
+          api_basic_authorize(collection_action_identifier(:vms, :request_retire))
 
           post(api_vms_url, :params => gen_request(:request_retire, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
@@ -1150,19 +1136,11 @@ describe "Vms API" do
 
       context "invalid" do
         it "to an invalid vm" do
-          api_basic_authorize(action_identifier(:vms, :request_retire), :miq_request_approval)
-
-          post(invalid_vm_url, :params => gen_request(:request_retire))
-
-          expect(response).to have_http_status(:not_found)
-        end
-
-        it "to an invalid vm without approval" do
           api_basic_authorize(action_identifier(:vms, :request_retire))
 
           post(invalid_vm_url, :params => gen_request(:request_retire))
 
-          expect(response).to have_http_status(:forbidden)
+          expect(response).to have_http_status(:not_found)
         end
 
         it "to an invalid vm with only basic auth" do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1699943

GM and Tina and I discussed the fact that this call probably shouldn't have an approval check on it because the intent was to match the request system for provisioning.  This also fixes a bug where the identifiers in the api.yml file were wrong for retirement -- they should both be using retire_now, and the identifier to set a retirement date (instead it should just be service retirement in general) shouldn't show up in the post section for service retirement. 

edit: thanks AB and GM for the help