### PR TITLE
Adjust ConversionHost support check so that it uses resource instead of singleton

### DIFF
--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -42,9 +42,7 @@ module Api
 
       resource = resource_search(data['resource_id'], resource_type.to_s, collection_class(collection_type))
 
-      unless resource.respond_to?(:supports_conversion_host?) && resource.supports_conversion_host?
-        raise BadRequestError, "unsupported resource_type #{resource_type}"
-      end
+      raise BadRequestError, "unsupported resource_type #{resource_type}" unless resource.supports_conversion_host?
 
       data['resource'] = resource
 

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -37,13 +37,13 @@ module Api
 
       raise BadRequestError, "invalid resource_type #{data['resource_type']}" unless resource_type
 
-      unless resource_type.respond_to?(:supports_conversion_host?) && resource_type.supports_conversion_host?
-        raise BadRequestError, "unsupported resource_type #{resource_type}"
-      end
-
       collection_type = resource_type.table_name
 
       resource = resource_search(data['resource_id'], resource_type.to_s, collection_class(collection_type))
+
+      unless resource.respond_to?(:supports_conversion_host?) && resource.supports_conversion_host?
+        raise BadRequestError, "unsupported resource_type #{resource_type}"
+      end
 
       data['resource'] = resource
 

--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -14,6 +14,7 @@ module Api
     #   * vmware_vddk_package_url
     #   * vmware_ssh_private_key
     #   * conversion_host_ssh_private_key
+    #   * openstack_tls_ca_certs
     #   * auth_user
     #
     # Example:

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -53,7 +53,7 @@ describe "ConversionHosts API" do
   context "create" do
     let(:zone) { FactoryBot.create(:zone) }
     let(:ems_openstack) { FactoryBot.create(:ems_openstack, :zone => zone) }
-    let(:ems_redhat) { FactoryBot.create(:ems_redhat, :zone => zone) }
+    let(:ems_redhat) { FactoryBot.create(:ems_redhat, :zone => zone, :api_version => '4.2.4') }
     let(:ems_azure) { FactoryBot.create(:ems_azure, :zone => zone) }
     let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems_openstack) }
     let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems_redhat) }


### PR DESCRIPTION
This PR updates the ConversionHostController#create method so that the supports check happens at the instance level instead of the singleton level. I also updated the comments slightly.

Effectively replaces https://github.com/ManageIQ/manageiq/pull/18799, since fiddling with the resource_type won't matter any more.

https://bugzilla.redhat.com/show_bug.cgi?id=1713394