### PR TITLE
Support filtering for multiple IP

### DIFF
--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -81,10 +81,9 @@ module Api
       str_method = is_regex ? methods[:regex] : methods[:default]
 
       filter_value, method = case filter_value
-                             when /^'.*'$/
-                               [filter_value.gsub(/^'|'$/, ''), str_method]
-                             when /^".*"$/
-                               [filter_value.gsub(/^"|"$/, ''), str_method]
+                             when /^['"](.*)['"]$/
+                               unquoted_filter_value = $1
+                               [unquoted_filter_value, str_method]
                              when /^(NULL|nil)$/i
                                [nil, methods[:null] || methods[:default]]
                              else

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -82,7 +82,7 @@ module Api
       str_method = is_regex ? methods[:regex] : methods[:default]
 
       filter_value, method = case filter_value
-                             when /^['"](.*)['"]$/
+                             when /^'(.*)'$/, /^"(.*)"$/
                                unquoted_filter_value = $1
                                if column_type(model, filter_attr) == :string_set && methods[:string_set]
                                  [unquoted_filter_value, methods[:string_set]]

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -84,11 +84,7 @@ module Api
       filter_value, method = case filter_value
                              when /^['"](.*)['"]$/
                                unquoted_filter_value = $1
-                               if column_type(model, filter_attr) == :string_set
-                                 unless methods[:string_set]
-                                   raise BadRequestError, "Unsupported operator for string_set: #{operator}"
-                                 end
-
+                               if column_type(model, filter_attr) == :string_set && methods[:string_set]
                                  [unquoted_filter_value, methods[:string_set]]
                                else
                                  [unquoted_filter_value, str_method]

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -173,6 +173,15 @@ RSpec.describe Api::Filter do
       expect(actual.exp).to eq(expected)
     end
 
+    it "supports filtering by string set attributes, e.g.: ipaddresses" do
+      filters = ["ipaddresses='192.0.2.0'"]
+
+      actual = described_class.parse(filters, Vm)
+
+      expected = {"includes all" => {"field" => "Vm-ipaddresses", "value" => "192.0.2.0"}}
+      expect(actual.exp).to eq(expected)
+    end
+
     it "supports flexible filtering by virtual string attributes" do
       filters = ["host_name='a%'"]
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1684681

This PR adds filtering support for virtual attribute array element matching, which is required
for the associated RFE to work.

The associated RFE requests API filtering for VMs that are assigned multiple IP addresses.
The ipaddresses virtual element is an array or ipaddresses so the "includes all" miq expression
operator is what should have been used to filter VM ipaddresses.

This PR changes the operator for ipaddresses filtering from "equals" to  "includes all".

To test:
-------

Configure MiQ with a provider that has VMs with multiple IP Addresses.

Save the below ruby code example to a file, e.g. get_vms_w_filter_ipaddr.rb Note: change the ipaddress 192.0.2.0 in the example ruby code to be a valid IP address for one of your VMs
that has multiple IP addresses.

```ruby
#!/usr/bin/env ruby

require "net/http"
require "uri"
require "json"

uri = URI.parse("https://#{ENV['MIQ']}/api/vms/?expand=resources&attributes=ipaddresses,name&filter[]=ipaddresses='192.0.2.0'")

http = Net::HTTP.new(uri.host, uri.port)
http.use_ssl = true
http.verify_mode = OpenSSL::SSL::VERIFY_NONE

request = Net::HTTP::Get.new(uri.request_uri)
request.basic_auth("admin", "smartvm")

response = http.request(request)

puts "Reply:\n " + JSON.pretty_generate(JSON.parse(response.body.strip))
```

Then run the test:

```bash
export MIQ="<the ipaddress of your MiQ appliance>"
./get_vms_w_filter_ipaddr.rb
```
