### PR TITLE
Add a subcollection under VMs for displaying CD-ROMs

### DIFF
--- a/app/controllers/api/subcollections/cdroms.rb
+++ b/app/controllers/api/subcollections/cdroms.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module Cdroms
+      def cdroms_query_resource(object)
+        object.hardware.cdroms
+      end
+    end
+  end
+end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -10,6 +10,7 @@ module Api
     include Subcollections::Software
     include Subcollections::Snapshots
     include Subcollections::MetricRollups
+    include Subcollections::Cdroms
     extend Api::Mixins::CentralAdmin
 
     VALID_EDIT_ATTRS = %w(description child_resources parent_resource).freeze

--- a/config/api.yml
+++ b/config/api.yml
@@ -395,6 +395,12 @@
         :identifier: ops_settings
       - :name: delete
         :identifier: ops_settings
+  :cdroms:
+    :description: CD-ROMs
+    :options:
+    - :subcollection
+    :verbs: *g
+    :klass: Disk
   :chargebacks:
     :description: Chargebacks
     :identifier: chargeback
@@ -3751,6 +3757,7 @@
     :verbs: *gpd
     :klass: Vm
     :subcollections:
+    - :cdroms
     - :disks
     - :tags
     - :policies
@@ -3908,7 +3915,17 @@
       - :name: read
         :identifier:
         - vm_show
+    :cdroms_subcollection_actions:
+      :get:
+      - :name: read
+        :identifier:
+        - vm_show
     :disks_subresource_actions:
+      :get:
+      - :name: read
+        :identifier:
+        - vm_show
+    :cdroms_subresource_actions:
       :get:
       - :name: read
         :identifier:

--- a/spec/requests/cdroms_spec.rb
+++ b/spec/requests/cdroms_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "CD-ROMs API" do
+  let(:hw) { FactoryBot.create(:hardware) }
+  let(:vm) { FactoryBot.create(:vm_vmware, :hardware => hw) }
+  let!(:cdrom) { FactoryBot.create(:disk, :hardware => hw, :device_type => 'cdrom') }
+  describe "as a subcollection of VMs" do
+    describe "GET /api/vms/:c_id/cdroms" do
+      it "can list the CD-ROMs of a VM" do
+        api_basic_authorize(subcollection_action_identifier(:vms, :cdroms, :read, :get))
+
+        _other_disk = FactoryBot.create(:disk, :device_type => 'cdrom')
+
+        get(api_vm_cdroms_url(nil, vm))
+
+        expected = {
+          "count"     => 2,
+          "name"      => "cdroms",
+          "subcount"  => 1,
+          "resources" => [
+            {"href" => api_vm_cdrom_url(nil, vm, cdrom)}
+          ]
+        }
+
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /api/vms/:c_id/cdroms/:s_id" do
+      it "can show a VM's CD-ROM" do
+        api_basic_authorize(subcollection_action_identifier(:vms, :cdroms, :read, :get))
+
+        get(api_vm_cdrom_url(nil, vm, cdrom))
+
+        expected = {
+          "href" => api_vm_cdrom_url(nil, vm, cdrom),
+          "id"   => cdrom.id.to_s,
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will not show a CD-ROM unless authorized" do
+        api_basic_authorize
+
+        get(api_vm_cdrom_url(nil, vm, cdrom))
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is required for the API-driven reconfigure VM screen where the user has to display the related CD-ROMs. Any change is going through the VmReconfigureRequest model that is already supported by the API, therefore, there's no need for anything else than GET.

```
GET /api/vms/2/cdroms
{
  "name": "cdroms",
  "count": 1127,
  "subcount": 1,
  "pages": 2,
  "resources": [
    {
      "href": "http://localhost:3000/api/vms/2/cdroms/4"
    }
  ],
  "links": {
    "self": "http://localhost:3000/api/vms/2/cdroms?offset=0",
    "next": "http://localhost:3000/api/vms/2/cdroms?offset=1000",
    "first": "http://localhost:3000/api/vms/2/cdroms?offset=0",
    "last": "http://localhost:3000/api/vms/2/cdroms?offset=1000"
  }
}


GET /api/vms/2/cdroms/4
{
  "href": "http://localhost:3000/api/vms/2/cdroms/4",
  "id": "4",
  "device_name": "CD/DVD drive 1",
  "device_type": "cdrom-image",
  "location": "1:0",
  "filename": "[]",
  "hardware_id": "5",
  "mode": null,
  "controller_type": "ide",
  "size": null,
  "free_space": null,
  "size_on_disk": null,
  "present": true,
  "start_connected": false,
  "auto_detect": null,
  "created_on": "2017-10-06T16:41:11Z",
  "updated_on": "2017-10-06T16:41:11Z",
  "disk_type": null,
  "storage_id": null,
  "backing_id": null,
  "backing_type": null,
  "storage_profile_id": null,
  "bootable": null
}

```

@miq-bot add_label hammer/no, changelog/yes
@miq-bot add_reviewer @abellotti
@miq-bot add_reviewer @lpichler