### PR TITLE
[WIP] Test emses with actual leaf subclasses

### DIFF
--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'CloudSubnets API' do
-  let(:ems) { FactoryBot.create(:ems_network) }
+  let(:ems) { FactoryBot.create(:ems_amazon_network) }
 
   describe 'GET /api/cloud_subnets' do
     it 'lists all cloud subnets with an appropriate role' do

--- a/spec/requests/cloud_templates_spec.rb
+++ b/spec/requests/cloud_templates_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Cloud Templates API" do
   describe "POST /api/providers/:c_id/cloud_templates" do
     it "can queue the creation of an images" do
       api_basic_authorize(action_identifier(:cloud_templates, :create, :subcollection_actions))
-      ems = FactoryBot.create(:ems_cloud)
+      ems = FactoryBot.create(:ems_vmware_cloud)
 
       post(api_provider_cloud_templates_url(nil, ems), :params => { :name => "test-image", :vendor => "test-cloud", :location => "test-location" })
 
@@ -79,7 +79,7 @@ RSpec.describe "Cloud Templates API" do
 
     it "will not create an image unless authorized" do
       api_basic_authorize
-      ems = FactoryBot.create(:ems_cloud)
+      ems = FactoryBot.create(:ems_vmware_cloud)
 
       post(api_provider_cloud_templates_url(nil, ems), :params => { :name => "test-image" })
 
@@ -89,7 +89,7 @@ RSpec.describe "Cloud Templates API" do
 
   describe "POST /api/providers/:c_id/cloud_templates/:id" do
     it "can queue the updating of an image" do
-      ems = FactoryBot.create(:ems_cloud)
+      ems = FactoryBot.create(:ems_vmware_cloud)
       image = FactoryBot.create(:template_cloud, :ext_management_system => ems)
 
       api_basic_authorize(action_identifier(:cloud_templates, :edit, :subresource_actions, :post))
@@ -106,7 +106,7 @@ RSpec.describe "Cloud Templates API" do
     end
 
     it "can't queue the updating of an image unless authorized" do
-      ems = FactoryBot.create(:ems_cloud)
+      ems = FactoryBot.create(:ems_vmware_cloud)
       image = FactoryBot.create(:template_cloud, :ext_management_system => ems)
 
       api_basic_authorize

--- a/spec/requests/cloud_tenants_spec.rb
+++ b/spec/requests/cloud_tenants_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'CloudTenants API' do
 
   context 'As a subcollection' do
     it 'returns an empty array for collections that do not have cloud tenants' do
-      ems_infra = FactoryBot.create(:ems_infra)
+      ems_infra = FactoryBot.create(:ems_vmware)
       api_basic_authorize(subcollection_action_identifier(:providers, :cloud_tenants, :read, :get))
 
       get(api_provider_cloud_tenants_url(nil, ems_infra))

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -187,7 +187,7 @@ describe "Rest API Collections" do
     end
 
     it "query Providers" do
-      FactoryBot.create(:ext_management_system)
+      FactoryBot.create(:ems_vmware)
       test_collection_query(:providers, api_providers_url, ExtManagementSystem, :guid)
     end
 
@@ -497,7 +497,7 @@ describe "Rest API Collections" do
     end
 
     it "bulk query Providers" do
-      FactoryBot.create(:ext_management_system)
+      FactoryBot.create(:ems_vmware)
       test_collection_bulk_query(:providers, api_providers_url, ExtManagementSystem)
     end
 

--- a/spec/requests/configuration_script_sources_spec.rb
+++ b/spec/requests/configuration_script_sources_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Configuration Script Sources API' do
-  let(:provider) { FactoryBot.create(:ext_management_system) }
+  let(:provider) { FactoryBot.create(:ems_vmware) }
   let(:config_script_src) { FactoryBot.create(:ansible_configuration_script_source, :manager => provider) }
   let(:config_script_src_2) { FactoryBot.create(:ansible_configuration_script_source, :manager => provider) }
   let(:ansible_provider)      { FactoryBot.create(:provider_ansible_tower, :with_authentication) }

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -701,7 +701,7 @@ describe "Custom Actions API" do
 
   describe "Providers" do
     before do
-      @resource = FactoryBot.create(:ext_management_system)
+      @resource = FactoryBot.create(:ems_vmware)
       @button1 = define_custom_button1(@resource)
     end
 

--- a/spec/requests/custom_attributes_spec.rb
+++ b/spec/requests/custom_attributes_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Custom Attributes API" do
 
   describe "POST /api/<collection>/:cid/custom_attributes/:sid" do
     it "does not duplicate a custom attribute" do
-      ems = FactoryBot.create(:ext_management_system)
+      ems = FactoryBot.create(:ems_vmware)
       custom_attribute = FactoryBot.create(:custom_attribute, :name => "foo", :value => "bar", :section => "metadata", :resource => ems)
       api_basic_authorize(subcollection_action_identifier(:providers, :custom_attributes, :add, :post))
 
@@ -51,7 +51,7 @@ RSpec.describe "Custom Attributes API" do
   end
 
   it 'returns the correct href' do
-    provider = FactoryBot.create(:ext_management_system)
+    provider = FactoryBot.create(:ems_vmware)
     custom_attribute = FactoryBot.create(:custom_attribute, :resource => provider, :name => 'foo', :value => 'bar')
     api_basic_authorize subcollection_action_identifier(:providers, :custom_attributes, :edit, :post)
 

--- a/spec/requests/flavors_spec.rb
+++ b/spec/requests/flavors_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Flavors API" do
     describe "GET /api/providers/:c_id/flavors" do
       it "can list the flavors of a provider" do
         api_basic_authorize(action_identifier(:flavors, :read, :subcollection_actions, :get))
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor = FactoryBot.create(:flavor, :ext_management_system => ems)
 
         get(api_provider_flavors_url(nil, ems))
@@ -21,7 +21,7 @@ RSpec.describe "Flavors API" do
 
       it "will not list flavors unless authorized" do
         api_basic_authorize
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         FactoryBot.create(:flavor, :ext_management_system => ems)
 
         get(api_provider_flavors_url(nil, ems))
@@ -30,7 +30,7 @@ RSpec.describe "Flavors API" do
       end
 
       it 'returns an empty array for collections that do not have flavors' do
-        ems_infra = FactoryBot.create(:ems_infra)
+        ems_infra = FactoryBot.create(:ems_vmware)
         api_basic_authorize(subcollection_action_identifier(:providers, :flavors, :read, :get))
 
         get(api_provider_flavors_url(nil, ems_infra))
@@ -43,7 +43,7 @@ RSpec.describe "Flavors API" do
     describe "GET /api/providers/:c_id/flavors/:id" do
       it "can show a provider's flavor" do
         api_basic_authorize(action_identifier(:flavors, :read, :subresource_actions, :get))
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor = FactoryBot.create(:flavor, :ext_management_system => ems)
 
         get(api_provider_flavor_url(nil, ems, flavor))
@@ -58,7 +58,7 @@ RSpec.describe "Flavors API" do
 
       it "will not show a flavor unless authorized" do
         api_basic_authorize
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor = FactoryBot.create(:flavor, :ext_management_system => ems)
 
         get(api_provider_flavor_url(nil, ems, flavor))
@@ -70,7 +70,7 @@ RSpec.describe "Flavors API" do
     describe "POST /api/providers/:c_id/flavors" do
       it "can queue the creation of a flavors" do
         api_basic_authorize(action_identifier(:flavors, :create, :subcollection_actions))
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
 
         post(api_provider_flavors_url(nil, ems), :params => { :name => "test-flavor" })
 
@@ -90,7 +90,7 @@ RSpec.describe "Flavors API" do
 
       it "will not create a flavor unless authorized" do
         api_basic_authorize
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
 
         post(api_provider_flavors_url(nil, ems), :params => { :name => "test-flavor" })
 
@@ -102,7 +102,7 @@ RSpec.describe "Flavors API" do
       it "can queue a flavor for deletion" do
         api_basic_authorize(action_identifier(:flavors, :delete, :subresource_actions))
 
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor = FactoryBot.create(:flavor, :ext_management_system => ems)
 
         post(api_provider_flavor_url(nil, ems, flavor), :params => { :action => "delete" })
@@ -119,7 +119,7 @@ RSpec.describe "Flavors API" do
 
       it "will not delete a flavor unless authorized" do
         api_basic_authorize
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor = FactoryBot.create(:flavor, :ext_management_system => ems)
 
         post(api_provider_flavor_url(nil, ems, flavor), :params => { :action => "delete" })
@@ -130,7 +130,7 @@ RSpec.describe "Flavors API" do
 
     describe "POST /api/providers/:c_id/flavors/ with delete action" do
       it "can delete multiple flavors" do
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor1, flavor2 = FactoryBot.create_list(:flavor, 2)
 
         api_basic_authorize(action_identifier(:flavors, :delete, :subresource_actions))
@@ -142,7 +142,7 @@ RSpec.describe "Flavors API" do
       end
 
       it "forbids multiple flavor deletion without an appropriate role" do
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor1, flavor2 = FactoryBot.create_list(:flavor, 2)
 
         api_basic_authorize
@@ -156,7 +156,7 @@ RSpec.describe "Flavors API" do
 
     describe "DELETE /api/providers/:c_id/flavors/:s_id" do
       it "can delete a flavor" do
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor = FactoryBot.create(:flavor, :ext_management_system => ems)
 
         api_basic_authorize(action_identifier(:flavors, :delete, :subresource_actions, :delete))
@@ -167,7 +167,7 @@ RSpec.describe "Flavors API" do
       end
 
       it "will not delete a flavor unless authorized" do
-        ems = FactoryBot.create(:ems_cloud)
+        ems = FactoryBot.create(:ems_vmware_cloud)
         flavor = FactoryBot.create(:flavor, :ext_management_system => ems)
 
         api_basic_authorize

--- a/spec/requests/network_routers_spec.rb
+++ b/spec/requests/network_routers_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'NetworkRouters API' do
 
   describe "POST /api/network_routers with delete action" do
     it "can delete a router" do
-      ems = FactoryBot.create(:ems_network)
+      ems = FactoryBot.create(:ems_amazon_network)
       network_router = FactoryBot.create(:network_router_openstack, :ext_management_system => ems)
       api_basic_authorize(action_identifier(:network_routers, :delete, :resource_actions))
 
@@ -104,7 +104,7 @@ RSpec.describe 'NetworkRouters API' do
     end
 
     it "can delete multiple network_routers" do
-      ems = FactoryBot.create(:ems_network)
+      ems = FactoryBot.create(:ems_amazon_network)
       network_router1, network_router2 = FactoryBot.create_list(:network_router_openstack, 2, :ext_management_system => ems)
       api_basic_authorize(action_identifier(:network_routers, :delete, :resource_actions))
 

--- a/spec/requests/orchestration_templates_spec.rb
+++ b/spec/requests/orchestration_templates_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Orchestration Template API' do
-  let(:ems) { FactoryBot.create(:ext_management_system) }
+  let(:ems) { FactoryBot.create(:ems_vmware) }
 
   context 'orchestration_template index' do
     it 'can list the orchestration_template' do

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -238,7 +238,7 @@ describe "Providers API" do
   end
 
   context "Provider custom_attributes" do
-    let(:provider) { FactoryBot.create(:ext_management_system, sample_rhevm.except("credentials")) }
+    let(:provider) { FactoryBot.create(:ems_redhat, sample_rhevm.except("credentials")) }
     let(:provider_url) { api_provider_url(nil, provider) }
     let(:ca1) { FactoryBot.create(:custom_attribute, :name => "name1", :value => "value1") }
     let(:ca2) { FactoryBot.create(:custom_attribute, :name => "name2", :value => "value2") }
@@ -723,7 +723,7 @@ describe "Providers API" do
     it "supports single resource edit" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryBot.create(:ext_management_system, sample_rhevm.except("credentials"))
+      provider = FactoryBot.create(:ems_redhat, sample_rhevm.except("credentials"))
 
       post(api_provider_url(nil, provider), :params => gen_request(:edit, "name" => "updated provider", "port" => "8080"))
 
@@ -735,7 +735,7 @@ describe "Providers API" do
     it "supports editing per provider options" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryBot.create(:ext_management_system, sample_rhevm.except("credentials"))
+      provider = FactoryBot.create(:ems_redhat, sample_rhevm.except("credentials"))
 
       options = {"hello" => "world"}
       options_symbolized = options.deep_symbolize_keys
@@ -748,7 +748,7 @@ describe "Providers API" do
     it "only returns real attributes" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryBot.create(:ext_management_system, sample_rhevm.except("credentials"))
+      provider = FactoryBot.create(:ems_redhat, sample_rhevm.except("credentials"))
 
       post(api_provider_url(nil, provider), :params => gen_request(:edit, "name" => "updated provider", "port" => "8080"))
 
@@ -760,7 +760,7 @@ describe "Providers API" do
     it "supports updates of credentials" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryBot.create(:ext_management_system, sample_vmware.except("credentials"))
+      provider = FactoryBot.create(:ems_vmware, sample_vmware.except("credentials"))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       post(api_provider_url(nil, provider), :params => gen_request(:edit,
@@ -779,7 +779,7 @@ describe "Providers API" do
         it "does not schedule a new credentials check if endpoint does not change" do
           api_basic_authorize collection_action_identifier(:providers, :edit)
 
-          provider = FactoryBot.create(:ext_management_system, sample_containers_multi_end_point_with_hawkular)
+          provider = FactoryBot.create(:ems_openshift, sample_containers_multi_end_point_with_hawkular)
           MiqQueue.where(:method_name => "authentication_check_types",
                          :class_name  => "ExtManagementSystem",
                          :instance_id => provider.id).delete_all
@@ -798,7 +798,7 @@ describe "Providers API" do
         it "schedules a new credentials check if endpoint change" do
           api_basic_authorize collection_action_identifier(:providers, :edit)
 
-          provider = FactoryBot.create(:ext_management_system, sample_containers_multi_end_point_with_hawkular)
+          provider = FactoryBot.create(:ems_kubernetes)
           MiqQueue.where(:method_name => "authentication_check_types",
                          :class_name  => "ExtManagementSystem",
                          :instance_id => provider.id).delete_all
@@ -823,7 +823,7 @@ describe "Providers API" do
     it "supports additions of credentials" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryBot.create(:ext_management_system, sample_rhevm.except("credentials"))
+      provider = FactoryBot.create(:ems_redhat, sample_rhevm.except("credentials"))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       post(api_provider_url(nil, provider), :params => gen_request(:edit,
@@ -883,7 +883,7 @@ describe "Providers API" do
     it "supports single provider delete" do
       api_basic_authorize collection_action_identifier(:providers, :delete)
 
-      provider = FactoryBot.create(:ext_management_system, :name => "provider", :hostname => "provider.com")
+      provider = FactoryBot.create(:ems_redhat, :name => "provider", :hostname => "provider.com")
 
       delete(api_provider_url(nil, provider))
 
@@ -893,7 +893,7 @@ describe "Providers API" do
     it "supports single provider delete action" do
       api_basic_authorize collection_action_identifier(:providers, :delete)
 
-      provider = FactoryBot.create(:ext_management_system, :name => "provider", :hostname => "provider.com")
+      provider = FactoryBot.create(:ems_redhat, :name => "provider", :hostname => "provider.com")
 
       post(api_provider_url(nil, provider), :params => gen_request(:delete))
 
@@ -907,8 +907,8 @@ describe "Providers API" do
     it "supports multiple provider deletes" do
       api_basic_authorize collection_action_identifier(:providers, :delete)
 
-      p1 = FactoryBot.create(:ext_management_system, :name => "provider name 1")
-      p2 = FactoryBot.create(:ext_management_system, :name => "provider name 2")
+      p1 = FactoryBot.create(:ems_redhat)
+      p2 = FactoryBot.create(:ems_redhat)
 
       post(api_providers_url, :params => gen_request(:delete,
                                                      [{"href" => api_provider_url(nil, p1)},
@@ -940,7 +940,7 @@ describe "Providers API" do
     it "supports single provider refresh" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
-      provider = FactoryBot.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type, :credentials))
+      provider = FactoryBot.create(:ems_vmware, sample_vmware.symbolize_keys.except(:type, :credentials))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       post(api_provider_url(nil, provider), :params => gen_request(:refresh))
@@ -951,7 +951,7 @@ describe "Providers API" do
     it "supports cloud provider refresh" do
       api_basic_authorize 'ems_cloud_refresh'
 
-      provider = FactoryBot.create(:ext_management_system, sample_amazon.symbolize_keys.except(:type, :credentials))
+      provider = FactoryBot.create(:ems_amazon, sample_amazon.symbolize_keys.except(:type, :credentials))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       post(api_provider_url(nil, provider), :params => gen_request(:refresh))
@@ -962,10 +962,10 @@ describe "Providers API" do
     it "supports multiple provider refreshes" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
-      p1 = FactoryBot.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type, :credentials))
+      p1 = FactoryBot.create(:ems_vmware, sample_vmware.symbolize_keys.except(:type, :credentials))
       p1.update_authentication(:default => default_credentials.symbolize_keys)
 
-      p2 = FactoryBot.create(:ext_management_system, sample_rhevm.symbolize_keys.except(:type, :credentials))
+      p2 = FactoryBot.create(:ems_redhat, sample_rhevm.symbolize_keys.except(:type, :credentials))
       p2.update_authentication(:default => default_credentials.symbolize_keys)
 
       post(api_providers_url, :params => gen_request(:refresh, [{"href" => api_provider_url(nil, p1)},
@@ -977,7 +977,7 @@ describe "Providers API" do
     it "provider refresh are created with a task" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
-      provider = FactoryBot.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type, :credentials))
+      provider = FactoryBot.create(:ems_vmware, sample_vmware.symbolize_keys.except(:type, :credentials))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
       provider.authentication_type(:default).update(:status => "Valid")
 
@@ -1029,7 +1029,7 @@ describe "Providers API" do
   end
 
   describe "Providers pause" do
-    let(:provider) { FactoryBot.create(:ext_management_system) }
+    let(:provider) { FactoryBot.create(:ems_vmware) }
 
     it "rejects pause requests without an appropriate role" do
       api_basic_authorize
@@ -1049,7 +1049,7 @@ describe "Providers API" do
     end
 
     it "can pause multiple providers" do
-      provider2 = FactoryBot.create(:ext_management_system)
+      provider2 = FactoryBot.create(:ems_vmware)
       api_basic_authorize collection_action_identifier(:providers, :pause)
 
       post(api_providers_url, :params =>
@@ -1077,7 +1077,7 @@ describe "Providers API" do
   end
 
   describe "Providers resume" do
-    let(:provider) { FactoryBot.create(:ext_management_system) }
+    let(:provider) { FactoryBot.create(:ems_vmware) }
 
     it "rejects resume requests without an appropriate role" do
       api_basic_authorize
@@ -1097,7 +1097,7 @@ describe "Providers API" do
     end
 
     it "can resume multiple providers" do
-      provider2 = FactoryBot.create(:ext_management_system)
+      provider2 = FactoryBot.create(:ems_vmware)
       api_basic_authorize collection_action_identifier(:providers, :resume)
 
       post(api_providers_url, :params =>
@@ -1125,7 +1125,7 @@ describe "Providers API" do
   end
 
   describe 'Providers import VM' do
-    let(:provider)      { FactoryBot.create(:ems_redhat, sample_rhevm.except("credentials")) }
+    let(:provider)      { FactoryBot.create(:ems_vmware, sample_rhevm.except("credentials")) }
     let(:provider_url)  { api_provider_url(nil, provider) }
 
     let(:vm)            { FactoryBot.create(:vm_vmware) }
@@ -1181,7 +1181,7 @@ describe "Providers API" do
   end
 
   describe 'change provider password' do
-    let(:ems_physical_infra) { FactoryBot.create(:ems_physical_infra) }
+    let(:ems_physical_infra) { FactoryBot.create(:ems_redfish_physical_infra) }
     let(:invalid_change_password_payload) do
       { "action"           => "change_password",
         "current_password" => "current_password",
@@ -1593,7 +1593,7 @@ describe "Providers API" do
 
   context 'GET /api/providers/:id/vms' do
     it 'returns the vms for a provider with an appropriate role' do
-      ems = FactoryBot.create(:ext_management_system)
+      ems = FactoryBot.create(:ems_amazon)
       vm = FactoryBot.create(:vm_amazon, :ext_management_system => ems)
       api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
 
@@ -1611,21 +1611,21 @@ describe "Providers API" do
     end
 
     it 'allows for expansion of vms on a provider' do
-      ems = FactoryBot.create(:ext_management_system)
+      ems = FactoryBot.create(:ems_amazon)
       vm = FactoryBot.create(:vm_amazon, :ext_management_system => ems)
       api_basic_authorize collection_action_identifier(:providers, :read, :get)
       get(api_providers_url, :params => { :expand => 'resources,vms' })
 
       expected = {
         'name'      => 'providers',
-        'resources' => [
+        'resources' => a_collection_including(
           a_hash_including(
             'href' => api_provider_url(nil, ems),
             'vms'  => [
               a_hash_including('href' => api_provider_vm_url(nil, ems, vm))
             ]
           )
-        ]
+        )
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -1634,7 +1634,7 @@ describe "Providers API" do
 
   context 'Folders subcollection' do
     let(:folder) { FactoryBot.create(:ems_folder) }
-    let(:ems) { FactoryBot.create(:ext_management_system) }
+    let(:ems) { FactoryBot.create(:ems_vmware) }
 
     before do
       ems.add_folder(folder)
@@ -1685,7 +1685,7 @@ describe "Providers API" do
   context 'Networks subcollection' do
     let(:hardware) { FactoryBot.create(:hardware) }
     let(:network) { FactoryBot.create(:network, :hardware => hardware) }
-    let(:ems) { FactoryBot.create(:ext_management_system) }
+    let(:ems) { FactoryBot.create(:ems_amazon) }
 
     context 'GET /api/providers/:id/networks' do
       it 'returns the networks with an appropriate role' do
@@ -1735,7 +1735,7 @@ describe "Providers API" do
     let(:lan) { FactoryBot.create(:lan) }
     let(:switch) { FactoryBot.create(:switch, :lans => [lan]) }
     let(:host) { FactoryBot.create(:host, :switches => [switch]) }
-    let(:ems) { FactoryBot.create(:ext_management_system) }
+    let(:ems) { FactoryBot.create(:ems_vmware) }
 
     before do
       ems.hosts << host

--- a/spec/requests/queries_spec.rb
+++ b/spec/requests/queries_spec.rb
@@ -136,7 +136,7 @@ describe "Queries API" do
 
       credentials = {:userid => "admin", :password => "super_password"}
 
-      provider = FactoryBot.create(:ext_management_system, :name => "sample", :hostname => "sample.com")
+      provider = FactoryBot.create(:ems_vmware, :name => "sample", :hostname => "sample.com")
       provider.update_authentication(:default => credentials)
 
       get(api_provider_url(nil, provider), :params => { :attributes => "authentications" })

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -526,7 +526,7 @@ describe "Querying" do
     end
 
     it "supports filtering by virtual boolean attributes" do
-      ems = FactoryBot.create(:ext_management_system)
+      ems = FactoryBot.create(:ems_vmware)
       storage = FactoryBot.create(:storage)
       host = FactoryBot.create(:host, :storages => [storage])
       _vm = FactoryBot.create(:vm, :host => host, :ext_management_system => ems)

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -28,7 +28,7 @@ describe "Services API" do
   let(:svc2) { FactoryBot.create(:service, :name => "svc2", :description => "svc2 description") }
   let(:svc_orchestration) { FactoryBot.create(:service_orchestration) }
   let(:orchestration_template) { FactoryBot.create(:orchestration_template) }
-  let(:ems) { FactoryBot.create(:ext_management_system) }
+  let(:ems) { FactoryBot.create(:ems_vmware) }
 
   # Specs and queries here are based off of the following BZ:
   #

--- a/spec/requests/snapshots_spec.rb
+++ b/spec/requests/snapshots_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Snapshots API" do
     describe "POST /api/vms/:c_id/snapshots" do
       it "can queue the creation of a snapshot" do
         api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :create))
-        ems = FactoryBot.create(:ext_management_system)
+        ems = FactoryBot.create(:ems_vmware)
         host = FactoryBot.create(:host, :ext_management_system => ems)
         vm = FactoryBot.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
 
@@ -105,7 +105,7 @@ RSpec.describe "Snapshots API" do
 
       it "renders a failed action response if a name is not provided" do
         api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :create))
-        ems = FactoryBot.create(:ext_management_system)
+        ems = FactoryBot.create(:ems_vmware)
         host = FactoryBot.create(:host, :ext_management_system => ems)
         vm = FactoryBot.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
 
@@ -136,7 +136,7 @@ RSpec.describe "Snapshots API" do
     describe "POST /api/vms/:c_id/snapshots/:s_id with revert action" do
       it "can queue a VM for reverting to a snapshot" do
         api_basic_authorize(action_identifier(:vms, :revert, :snapshots_subresource_actions))
-        ems = FactoryBot.create(:ext_management_system)
+        ems = FactoryBot.create(:ems_vmware)
         host = FactoryBot.create(:host, :ext_management_system => ems)
         vm = FactoryBot.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
         snapshot = FactoryBot.create(:snapshot, :name => "Alice's snapshot", :vm_or_template => vm)
@@ -182,7 +182,7 @@ RSpec.describe "Snapshots API" do
     describe "POST /api/vms/:c_id/snapshots/:s_id with delete action" do
       it "can queue a snapshot for deletion" do
         api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :delete))
-        ems = FactoryBot.create(:ext_management_system)
+        ems = FactoryBot.create(:ems_vmware)
         host = FactoryBot.create(:host, :ext_management_system => ems)
         vm = FactoryBot.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
         snapshot = FactoryBot.create(:snapshot, :name => "Alice's snapshot", :vm_or_template => vm)
@@ -245,7 +245,7 @@ RSpec.describe "Snapshots API" do
     describe "POST /api/vms/:c_id/snapshots with delete action" do
       it "can queue multiple snapshots for deletion" do
         api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subcollection_actions, :post))
-        ems = FactoryBot.create(:ext_management_system)
+        ems = FactoryBot.create(:ems_vmware)
         host = FactoryBot.create(:host, :ext_management_system => ems)
         vm = FactoryBot.create(:vm_vmware, :name => "Alice and Bob's VM", :host => host, :ext_management_system => ems)
         snapshot1 = FactoryBot.create(:snapshot, :name => "Alice's snapshot", :vm_or_template => vm)


### PR DESCRIPTION
This fixes a bunch of specs that aren't creating leaf subclasses for emses. 

The original ticket is to remove GCE provider downstream but in order to do this, we have to validate that the provider being added is of a type that's supported. Which means that everywhere we have specs with providers without types, those tests will now 🐡 
 
for https://github.com/ManageIQ/manageiq/pull/18842