### PR TITLE
Allow reconfigure vm on OSP provider over Centralized Administration

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2571,6 +2571,8 @@
           :identifier: configured_system_provision
         - :klass: VmReconfigureRequest
           :identifier: vm_reconfigure
+        - :klass: VmCloudReconfigureRequest
+          :identifier: vm_cloud_reconfigure
         - :klass: VmMigrateRequest
           :identifier: vm_migrate
         - :klass: ServiceTemplateProvisionRequest


### PR DESCRIPTION
ISSUE:
 Attempt to reconfigure vm on global region raises ```Unsupported request class VmCloudReconfigureRequest``` error

AFTER:
<img width="1229" alt="after" src="https://user-images.githubusercontent.com/6556758/59508163-b184b580-8eb5-11e9-8451-ea8def3730a2.png">


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1710808

@miq-bot add-label bug, changelog/yes