### PR TITLE
FIX CI: Parent_id should equals to nil - it is default value in request_specs

### DIFF
--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe "Requests API" do
 
       FactoryBot.create(:classification_department_with_tags)
 
-      t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
+      t = Classification.where(:description => 'Department', :parent_id => nil).includes(:tag).first
       request.add_tag(t.name, t.children.first.name)
 
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
@@ -289,7 +289,7 @@ RSpec.describe "Requests API" do
 
       FactoryBot.create(:classification_department_with_tags)
 
-      t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
+      t = Classification.where(:description => 'Department', :parent_id => nil).includes(:tag).first
       request.add_tag(t.name, t.children.first.name)
 
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)


### PR DESCRIPTION
caused by removing this https://github.com/ManageIQ/manageiq/pull/18301/files#diff-5bb77b717064efbd95e6ab04eb5a357fL5 (in https://github.com/ManageIQ/manageiq/pull/18301)

so I update condition to match nil.


cc @kbrock @d-m-u 
@miq-bot assign @jrafanie 

