### PR TITLE
Avoid hardcoding paths to assets since it changes

### DIFF
--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -73,12 +73,7 @@ RSpec.describe "API entrypoint" do
       )
     )
 
-    # This test will fail if you have the assets precompiled
-    expect(response.parsed_body['product_info']['branding_info']).to eq(
-      "brand"   => "/images/layout/brand.svg",
-      "logo"    => "/images/layout/login-screen-logo.png",
-      "favicon" => "/images/favicon.ico"
-    )
+    expect(response.parsed_body['product_info']['branding_info'].keys).to match_array(%w[brand favicon logo])
   end
 
   context 'UI is available' do


### PR DESCRIPTION
It's not important here what the path is to the assets.  They can change
if you're precompiling them or not.

Extracted from #606