### PR TITLE
Add a filter_parameters setting and use it when logging api requests

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -29,7 +29,10 @@ module Api
       end
 
       def log_api_request
-        @parameter_filter ||= ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
+        @parameter_filter ||= ActionDispatch::Http::ParameterFilter.new(
+          Rails.application.config.filter_parameters + Settings.api.filter_parameters
+        )
+
         return unless api_log_info?
         log_request("Request", @req.to_hash)
         unfiltered_params = request.query_parameters

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,7 @@
   :token_ttl: 10.minutes
   :authentication_timeout: 30.seconds
   :max_results_per_page: 1000
+  :filter_parameters:
+    - :conversion_host_ssh_private_key
+    - :openstack_tls_ca_certs
+    - :vmware_ssh_private_key


### PR DESCRIPTION
At the moment there's no way to specify custom parameters to filter out of the api.log. It's currently fixed at whatever's specified via `Rails.application.config.filter_parameters`. Anything else gets logged in plaintext to the api.log.

This PR adjusts the `Logger#log_api_request` method so that it will also use whatever's specified in the settings.yml file's `filter_parameters` entry. For now I've added 3 entries that we would like for V2V, but others can be added as needed later.

This partially addresses https://github.com/ManageIQ/manageiq-api/issues/595 in that it will filter the api.log data, but doesn't affect the core production (evm) log. IMO that should be a separate PR because it will need to be refactored so that it's easily pluggable by all providers.