### PR TITLE
Create dialog from template - generic endpoint

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2960,7 +2960,7 @@
         :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
-      - :name: orchestration_template_service_dialog
+      - :name: template_service_dialog
         :identifier: dialog_new_editor
     :resource_actions:
       :get:
@@ -2977,7 +2977,7 @@
         :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
-      - :name: orchestration_template_service_dialog
+      - :name: template_service_dialog
         :identifier: dialog_new_editor
       :delete:
       - :name: delete


### PR DESCRIPTION
see https://github.com/ManageIQ/manageiq/issues/18931

Description 

- adds generic endpoint for creating service_dialog from templates

```javascript
POST /api/service_dialogs
{
  action: 'template_service_dialog',
  resource: {
    label: 'dialog label',
    template_id: '569',
    template_class: oneOf(['OrchestrationTemplate', 'ConfigurationScript']),
    dialog_class: oneOf(['Dialog::OrchestrationTemplateServiceDialog' , 'Dialog::AnsibleTowerJobTemplateDialogService'])
  }
}
```

### MERGE TOGETHER WITH UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/5842
~~**WAITING FOR**: https://github.com/ManageIQ/manageiq/pull/18932 https://github.com/ManageIQ/manageiq-ui-classic/pull/5765~~
TODO:
- [X] tests