### PR TITLE
Load product features from all ManageIQ plugins

### DIFF
--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -38,7 +38,19 @@ describe 'API configuration (config/api.yml)' do
         expect(sui_product_features.subset?(api_feature_identifiers))
       end
 
-      def each_product_feature(feature = YAML.load_file("#{MiqProductFeature::FIXTURE_PATH}.yml"), &block)
+      def all_product_features
+        features = YAML.load_file("#{MiqProductFeature::FIXTURE_PATH}.yml")
+        plugin_files = Vmdb::Plugins.flat_map do |plugin|
+          Dir.glob("#{plugin.root.join(MiqProductFeature::RELATIVE_FIXTURE_PATH)}{.yml,.yaml,/*.yml,/*.yaml}")
+        end
+        plugin_files.each do |plugin|
+          features[:children] += YAML.load_file(plugin)
+        end
+
+        features
+      end
+
+      def each_product_feature(feature = all_product_features, &block)
         yield(feature)
         Array(feature[:children]).each do |child|
           each_product_feature(child, &block)


### PR DESCRIPTION
There's a test in manageiq-api, that looks whether or not are all product features mentioned in `api.yml` present. After we made the product features pluggable and with https://github.com/ManageIQ/manageiq/pull/18884 in place, the current test would fail with:
```
Failures:
  1) API configuration (config/api.yml) collections identifiers contains only valid miq_feature identifiers
     Failure/Error: expect(dangling).to be_empty
       expected `#<Set: {"conversion_host"}>.empty?` to return true, got false
     # ./spec/lib/api/api_config_spec.rb:34:in `block (4 levels) in <top (required)>'
```
because it did not load product features from plugins.

This change should fix the problem.

@Fryguy 