### PR TITLE
Rename the "Cloud Intel" menu item to "Overview"

### DIFF
--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -421,7 +421,7 @@ RSpec.describe "reports API" do
       report_1 = FactoryBot.create(:miq_report_with_results)
       report_2 = FactoryBot.create(:miq_report_with_results)
 
-      # Includes roles "API" and "Cloud Intel"
+      # Includes roles "API" and "Overview"
       MiqProductFeature.seed
       api_basic_authorize :dashboard, :miq_report, :chargeback, :timeline, :rss, :api_exclusive
       get api_reports_url


### PR DESCRIPTION
Just a small change in a commend to make it consistent with the rest of the code.

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/5808
https://bugzilla.redhat.com/show_bug.cgi?id=1678196

@miq-bot add_reviewer @lpichler 
@miq-bot add_label enhancement, hammer/no