### PR TITLE
Adding support for Collection action

### DIFF
--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -6,6 +6,11 @@ module Api
           return send("#{@req.method}_resource", type, id)
         end
 
+        unless id || @req.subcollection? || @req.json_body.key?("resources")
+          collection_target = "#{@req.action}_collection"
+          return send(collection_target, type, @req.json_body.except("action")) if respond_to?(collection_target)
+        end
+
         action = @req.action
         target = target_resource_method(type, action)
         raise BadRequestError,


### PR DESCRIPTION
Adding support for Collection actions in addition to the bulk resource action on collection endpoints.

There is a need to be able to trigger jobs as a single unit on a collection and not via the current bulk action which triggers async jobs individually. For example, receiving a bulk request to refresh providers resulting an a plural results with the individual task id's that can be monitored individually.

The current API bulk signature is designed and targeted for the latter use case.

For this enhancement, I was thinking of introducing an api.yml option to be introduced on the action definition in collection that would drive the API to behave differently for such actions, however, this does become cumbersome (and confusing) on the config side of things.

The approach taken here is more simplistic and more flexible.

Essentially ANY action targeted at a collection can behave as a collection action and not a bulk-resource action if the resources specification is blank and the controller for that collection type defines a collection action.

_Summary of Behavior_:

Current implementation of a resource action (single or bulk driven) is defined as follows:

Single resource action:
POST /api/<collection_type>/:id
```
{
   "action" : "<action_name>"
   <action_parameters> 
}
```

Bulk resource action:
POST /api/<collection_type>
```
{
  "action" : "<action_name>",
  "resources" : [
     { "id" : ..., <action_parameters>},
     { "id" : ..., <action_parameters>},
     ...
     
  ]
}
```

Both above signature leverage the collection's controller function with the parameters for the action coming in as data.

```
def <action_name>_resource(type, id, data)
```

With this enhancement, the following collection only action is also supported:

POST /api/<collection_type>

```
{
  "action" : "<action_name>",
  <action_parameters>
}
```

If a controller function is declared as follows:

```
def  <action_name>_collection(type, data)
```

So with this enhancement, support for resource, single and bulk as well as collection actions are supported with the following function signatures:

```
def <action_name>_resource(type, id, data)
def <action_name>_collection(type, data)
```
