### PR TITLE
Expose Tenant Groups as a separate endpoint

### DIFF
--- a/app/controllers/api/tenant_groups_controller.rb
+++ b/app/controllers/api/tenant_groups_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  class TenantGroupsController < BaseController
+    def tenant_groups_search_conditions
+      ["group_type = ?", MiqGroup::TENANT_GROUP]
+    end
+
+    def find_tenant_groups(id)
+      MiqGroup.tenant_groups.find(id)
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -3661,6 +3661,17 @@
         :identifier: miq_template_protect
       - :name: resolve
         :identifier: miq_template_policy_sim
+  :tenant_groups:
+    :description: Tenant Groups
+    :identifier: rbac_group
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: MiqGroup
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: rbac_group_show_list
   :tenants:
     :description: Tenants
     :identifier: rbac_tenant

--- a/spec/requests/tenant_groups_spec.rb
+++ b/spec/requests/tenant_groups_spec.rb
@@ -1,0 +1,36 @@
+#
+# Rest API Request Tests - Tenant Groups specs
+#
+describe "Tenant Groups API" do
+  let(:tenant_group) { FactoryBot.create(:miq_group, :tenant_type, :description => 'lofasz') }
+  let(:group) { FactoryBot.create(:miq_group, :description => 'picsa') }
+
+  before do
+    @user.miq_groups << group
+    @user.miq_groups << tenant_group
+    api_basic_authorize collection_action_identifier('groups', 'read', :get)
+  end
+
+  describe 'GET /tenant_groups' do
+    it 'displays the tenant group only' do
+      get(api_tenant_groups_url)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["subcount"]).to eq(1)
+      expect(response.parsed_body["resources"].first["href"]).to end_with(tenant_group.id.to_s)
+    end
+  end
+
+  describe 'GET /tenant_groups/:id' do
+    it 'returns with the tenant group' do
+      get(api_tenant_group_url(nil, tenant_group.id))
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'with a non-tenant group' do
+      it 'returns with not found' do
+        get(api_tenant_group_url(nil, group.id))
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@brumik needs in his [set ownership PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/5863)a way to access `MiqGroup` resources that have `tenant` as `group_type`. With the `/api/groups/` endpoint this is not possible because of a [hard filtering condition](https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/groups_controller.rb#L9) in the controller.

```json
# curl -XGET http://admin:smartvm@localhost:3000/api/tenant_groups/1 | jq
{
  "href": "http://localhost:3000/api/tenant_groups/1",
  "id": "1",
  "description": "Tenant My Company access",
  "group_type": "tenant",
  "sequence": 1,
  "created_on": "2019-06-25T08:40:31Z",
  "updated_on": "2019-06-25T08:40:31Z",
  "settings": null,
  "tenant_id": "1"
}

# curl -XGET http://admin:smartvm@localhost:3000/api/tenant_groups | jq
{
  "name": "tenant_groups",
  "count": 20,
  "subcount": 1,
  "pages": 1,
  "resources": [
    {
      "href": "http://localhost:3000/api/tenant_groups/1"
    }
  ],
  "links": {
    "self": "http://localhost:3000/api/tenant_groups?offset=0",
    "first": "http://localhost:3000/api/tenant_groups?offset=0",
    "last": "http://localhost:3000/api/tenant_groups?offset=0"
  }
}
```

The RBAC is just the same as for the regular groups as this is a view-only feature.

@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @abellotti 
@miq-bot add_label ivanchuk/no, enhancement