### PR TITLE
FirmwareRegistry create/list/delete and sync_fw_binaries

### DIFF
--- a/app/controllers/api/firmware_registries_controller.rb
+++ b/app/controllers/api/firmware_registries_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  class FirmwareRegistriesController < BaseController
+    def create_resource(type, _id, data)
+      assert_id_not_specified(data, type)
+      collection_class(type).create_firmware_registry(data.symbolize_keys)
+    end
+
+    def sync_fw_binaries_resource(type, id, _data)
+      resource_search(id, type, collection_class(type)).sync_fw_binaries_queue
+      action_result(true, "FirmwareBinary [id: #{id}] synced")
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def delete_resource(type, id, _data = {})
+      delete_action_handler do
+        resource_search(id, type, collection_class(:firmware_registries)).destroy
+        action_result(true, "FirmwareBinary [id: #{id}] deleted")
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1235,6 +1235,33 @@
       :get:
       - :name: read
         :identifier: firmware
+  :firmware_registries:
+    :description: Firmware Registries
+    :options:
+    - :collection
+    :verbs: *gpd
+    :klass: FirmwareRegistry
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: firmware
+      :post:
+      - :name: create
+        :identifier: firmware
+      - :name: delete
+        :identifier: firmware
+      - :name: sync_fw_binaries
+        :identifier: firmware
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: firmware
+      :delete:
+      - :name: delete
+        :identifier: firmware
+      :post:
+      - :name: sync_fw_binaries
+        :identifier: firmware
   :firmwares:
     :description: Firmwares
     :options:

--- a/spec/requests/firmware_registries_spec.rb
+++ b/spec/requests/firmware_registries_spec.rb
@@ -1,0 +1,158 @@
+RSpec.describe "firmware_registries API" do
+  let!(:registry) { FactoryBot.create(:firmware_registry) }
+  let(:registry2) { FactoryBot.create(:firmware_registry) }
+
+  describe 'GET /api/firmware_registries' do
+    let(:url) { api_firmware_registries_url }
+
+    it 'returns the firmware_registries with an appropriate role' do
+      api_basic_authorize action_identifier(:firmware_registries, :read, :collection_actions, :get)
+      get(url)
+      expect_result_resources_to_include_hrefs(
+        'resources',
+        [
+          api_firmware_registry_url(nil, registry)
+        ]
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'does not return the firmware_registries without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'POST /api/firmware_registries' do
+    let(:url) { api_firmware_registries_url }
+
+    context 'action: create' do
+      let(:params) do
+        {
+          :type     => 'FirmwareRegistry::RestApiDepot',
+          :name     => 'test-registry',
+          :url      => 'http://my-registry.com:1234/images',
+          :userid   => 'username',
+          :password => 'password'
+        }
+      end
+
+      it 'creates firmware registry with an appropriate role' do
+        api_basic_authorize action_identifier(:firmware_registries, :create, :collection_actions, :post)
+        post(url, :params => gen_request(:create, params))
+        expect(response).to have_http_status(:ok)
+        expect_single_action_result('name' => 'test-registry')
+      end
+
+      it 'does not create firmware_registries without an appropriate role' do
+        api_basic_authorize
+        post(url, :params => gen_request(:create, params))
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'action: delete' do
+      it 'deletes single firmware registry with an appropriate role' do
+        api_basic_authorize action_identifier(:firmware_registries, :delete, :collection_actions, :post)
+        post(url, :params => gen_request(:delete, [{:id => registry.id}]))
+        expect(FirmwareRegistry.count).to be_zero
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'deletes multiple firmware registries with an appropriate role' do
+        api_basic_authorize action_identifier(:firmware_registries, :delete, :collection_actions, :post)
+        post(url, :params => gen_request(:delete, [{:id => registry.id}, {:id => registry2.id}]))
+        expect(FirmwareRegistry.count).to be_zero
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not create firmware_registries without an appropriate role' do
+        api_basic_authorize
+        post(url, :params => gen_request(:delete, []))
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'action: sync_fw_binaries' do
+      it 'syncs firmware registry with an appropriate role' do
+        api_basic_authorize action_identifier(:firmware_registries, :sync_fw_binaries, :collection_actions, :post)
+        post(url, :params => gen_request(:sync_fw_binaries, [{:id => registry.id}]))
+        expect(MiqQueue.count).to eq(1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'syncs multiple firmware registries with an appropriate role' do
+        api_basic_authorize action_identifier(:firmware_registries, :sync_fw_binaries, :collection_actions, :post)
+        post(url, :params => gen_request(:sync_fw_binaries, [{:id => registry.id}, {:id => registry2.id}]))
+        expect(MiqQueue.count).to eq(2)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not create firmware_registries without an appropriate role' do
+        api_basic_authorize
+        post(url, :params => gen_request(:sync_fw_binaries, []))
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'GET /api/firmware_registries/:id' do
+    let(:url) { api_firmware_registry_url(nil, registry) }
+
+    it 'returns the firmware_registry with an appropriate role' do
+      api_basic_authorize action_identifier(:firmware_registries, :read, :resource_actions, :get)
+      get(url)
+      expect_single_resource_query('href' => api_firmware_registry_url(nil, registry))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'does not return the firmware_registries without an appropriate role' do
+      api_basic_authorize
+      get(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'DELETE /api/firmware_registries/:id' do
+    let(:url) { api_firmware_registry_url(nil, registry) }
+
+    it 'destroys firmware_registry with an appropriate role' do
+      api_basic_authorize action_identifier(:firmware_registries, :read, :resource_actions, :get)
+      expect(FirmwareRegistry.count).to eq(1)
+      delete(url)
+      expect(response).to have_http_status(:no_content)
+      expect(FirmwareRegistry.count).to eq(0)
+    end
+
+    it 'does not destroy firmware_registry without an appropriate role' do
+      api_basic_authorize
+      delete(url)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'POST /api/firmware_registries/:id' do
+    let(:url) { api_firmware_registry_url(nil, registry) }
+
+    context 'action: sync_fw_binaries' do
+      let(:params) { gen_request(:sync_fw_binaries) }
+
+      it 'triggers sync_fw_binaries with an appropriate role' do
+        api_basic_authorize action_identifier(:firmware_registries, :sync_fw_binaries, :resource_actions, :post)
+        expect(MiqQueue.count).to eq(0)
+        post(url, :params => params)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['message']).to eq("FirmwareBinary [id: #{registry.id}] synced")
+        expect(MiqQueue.count).to eq(1)
+        expect(MiqQueue.first).to have_attributes(:instance_id => registry.id)
+      end
+
+      it 'does not trigger without an appropriate role' do
+        api_basic_authorize
+        post(url, :params => params)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this commit we introduce following new API calls:

```
GET /api/firmware_registries
GET /api/firmware_registries/:id
DELETE /api/firmware_registries/:id
POST /api/firmware_registries/:id (action=sync_fw_binaries)
```

The POST call queues FirmwareRegistry refresh task and returns immediately.

Depends on: https://github.com/ManageIQ/manageiq/pull/19069
Needed by: https://github.com/ManageIQ/manageiq-ui-classic/pull/5929

@miq-bot add_label enhancement,ivanchuk/yes