### PR TITLE
Added tagging support for cloud_volumes

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class CloudVolumesController < BaseController
+    include Subcollections::Tags
     def delete_resource(type, id, _data = {})
       delete_action_handler do
         cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))


### PR DESCRIPTION
Copied edits and update wording from previous change that added tagging support (https://github.com/ManageIQ/manageiq-api/pull/361)

Adding tagging support for resources of the following collections:

/api/cloud_volumes

Standard tagging subcollection signature as follows:

/api/cloud_volumes/:id/tags

Fixes: #638