### PR TITLE
Destroy pxe_menu images upon removal

### DIFF
--- a/app/controllers/api/pxe_servers_controller.rb
+++ b/app/controllers/api/pxe_servers_controller.rb
@@ -49,7 +49,7 @@ module Api
       authentication = data.delete('authentication')
       PxeServer.transaction do
         if menus
-          server.pxe_menus.clear
+          server.pxe_menus.destroy_all
           data['pxe_menus'] = create_pxe_menus(menus)
         end
         server.update!(data)


### PR DESCRIPTION
We were invoking `.delete_all` method (aliased as `.clear`) which avoids `:dependent => destroy` callbacks hence related PXE images remained in database.

Fixes https://github.com/ManageIQ/manageiq/issues/18940

@miq-bot add_label bug,ivanchuk/yes
@miq-bot assign @bdunne 
