### PR TITLE
Expose DDF schema for a provider when asking using OPTIONS + type

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1588,6 +1588,31 @@ describe "Providers API" do
       )
       expect(response.parsed_body["data"]["provider_settings"]["kubernetes"]["proxy_settings"]["settings"]["http_proxy"]["label"]).to eq('HTTP Proxy')
     end
+
+    context 'single provider queried' do
+      it 'raises an error if the provider is invalid' do
+        options("#{api_providers_url}?type=foo")
+        expect_bad_request("Invalid provider - foo")
+      end
+
+      context 'valid provider' do
+        before do
+          class DummyProvider; end
+          allow(DummyProvider).to receive(:<).with(ExtManagementSystem).and_return(true)
+        end
+
+        it 'raises an error if the provider has no DDF' do
+          options("#{api_providers_url}?type=DummyProvider")
+          expect_bad_request("No DDF specified for - DummyProvider")
+        end
+
+        it 'calls the .params_for_create on the provider' do
+          expect(DummyProvider).to receive(:params_for_create).and_return('foo' => 'bar')
+          options("#{api_providers_url}?type=DummyProvider")
+          expect(response.parsed_body['data']['provider_form_schema']).to eq('foo' => 'bar')
+        end
+      end
+    end
   end
 
   context 'GET /api/providers/:id/vms' do


### PR DESCRIPTION
Extracted the `providers_options` into a separate method and only returning when the `type` isn't set for the `/api/providers`. If the `type` param is set in a request, the API will try to append the data-driven-form schema if specified under the `data.provider_form_schema` key. This schema can be used by the UI to render the right form that contains all the required info for adding a provider of the given type. 

```json
// OPTIONS api/providers?type=ManageIQ::Providers::Amazon::CloudManager
{
  ...
  "data": {
    ...
    "provider_form_schema": {
      "title": "Configure AWS",
      "fields": [
        {
          "component": "text-field",
          "name": "role",
          "type": "hidden",
          "initialValue": "ec2"
        },
        {
          "component": "text-field",
          "name": "region",
          "label": "Region"
        },
        {
          "component": "text-field",
          "name": "ec2_username",
          "label": "Access Key"
        },
        {
          "component": "text-field",
          "name": "ec2_password",
          "label": "Secret Key",
          "type": "password"
        }
      ]
    }
  }
}
```

If the `type` argument cannot be safely constantized into a subclass of `ExtManagementSystem` or the provider has no DDF specified it will raise an `BadRequestError`. The request without the `type` parameter behaves like the OPTIONS request before this change.

Example of the DDF schema in the amazon provider: https://github.com/ManageIQ/manageiq-providers-amazon/pull/551
Parent issue: https://github.com/ManageIQ/manageiq/issues/18818

@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @abellotti 
@miq-bot add_label enhancement, ivanchuk/no, hammer/no

cc @Hyperkid123, @martinpovolny, @agrare