### PR TITLE
Adding ability to override encrypted attribute behavior in responses

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -184,6 +184,10 @@ module Api
       @collection_config ||= CollectionConfig.new
     end
 
+    def api_resource_action_options
+      []
+    end
+
     def api_error(type, error)
       api_log_error("#{error.class.name}: #{error.message}")
       # We don't want to return the stack trace, but only log it in case of an internal error

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -23,7 +23,7 @@ module Api
 
         is_ar = obj.kind_of?(ActiveRecord::Base)
         attrs.each do |k|
-          next if Api.encrypted_attribute?(k)
+          next if Api.encrypted_attribute?(k) && api_resource_action_options.exclude?("include_encrypted_attributes")
           next if is_ar ? !obj.respond_to?(k) : !obj.key?(k)
           result[k] = normalize_attr(k, is_ar ? obj.try(k) : obj[k])
         end
@@ -45,7 +45,7 @@ module Api
         elsif Api.url_attribute?(attr)
           normalize_url(value)
         elsif Api.encrypted_attribute?(attr)
-          normalize_encrypted
+          normalize_encrypted(value)
         elsif Api.resource_attribute?(attr)
           normalize_resource(value)
         else
@@ -110,7 +110,7 @@ module Api
       #
       # Let's filter out encrypted attributes, i.e. passwords
       #
-      def normalize_encrypted
+      def normalize_encrypted(_value)
         nil
       end
 

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -122,13 +122,9 @@ module Api
       raise BadRequestError, "Invalid dialog_class #{data['dialog_class']} for creating a service dialog from template" unless DIALOG_CLASSES.include?(data['dialog_class'])
     end
 
-    def normalize_encrypted(value)
-      value
-    end
-
     def api_resource_action_options
       if @req.action == "refresh_dialog_fields" && @req.collection_id && @req.subcollection.blank?
-        super + %w[include_encrypted_attributes]
+        %w[include_encrypted_attributes]
       else
         super
       end

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -121,5 +121,17 @@ module Api
       raise BadRequestError, "Invalid template_class #{data['template_class']} for creating a service dialog from template" unless TEMPLATE_CLASSES.include?(data['template_class'])
       raise BadRequestError, "Invalid dialog_class #{data['dialog_class']} for creating a service dialog from template" unless DIALOG_CLASSES.include?(data['dialog_class'])
     end
+
+    def normalize_encrypted(value)
+      value
+    end
+
+    def api_resource_action_options
+      if @req.action == "refresh_dialog_fields" && @req.collection_id && @req.subcollection.blank?
+        super + %w[include_encrypted_attributes]
+      else
+        super
+      end
+    end
   end
 end


### PR DESCRIPTION
Adding support for resource action options that are controller driven and not api.yml driven.

We needed the ability to override the default behavior of hiding encrypted attributes in responses for the refresh_dialog_field action when exercised on a resource.  This was causing the UI to hang when fields being refreshed via automate were encrypted (i.e. passwords) and never returned to the caller.

This needed to be implemented without breaking any of the behavior for all other actions and queries.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1705021

/cc @tinaafitz 