### PR TITLE
Introduce the auth_key_pairs endpoint with set_ownership feature

### DIFF
--- a/app/controllers/api/auth_key_pairs_controller.rb
+++ b/app/controllers/api/auth_key_pairs_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class AuthKeyPairsController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -182,6 +182,43 @@
     :options:
     - :primary
     :verbs: *gd
+  :auth_key_pairs:
+    :description: Auth Key Pairs
+    :verbs: *gpppd
+    :identifier: auth_key_pair_cloud
+    :options:
+    - :collection
+    :klass: ManageIQ::Providers::CloudManager::AuthKeyPair
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: auth_key_pair_cloud_view
+      :post:
+      - :name: create
+        :identifier: auth_key_pair_cloud_new
+      - :name: edit
+        :identifier: auth_key_pair_cloud_admin
+      - :name: delete
+        :identifier: auth_key_pair_cloud_delete
+      - :name: set_ownership
+        :identifier: auth_key_pair_ownership
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: auth_key_pair_cloud_show
+      :post:
+      - :name: edit
+        :identifier: auth_key_pair_cloud_admin
+      - :name: delete
+        :identifier: auth_key_pair_cloud_delete
+      - :name: set_ownership
+        :identifier: auth_key_pair_ownership
+      :put:
+      - :name: edit
+        :identifier: auth_key_pair_cloud_admin
+      :delete:
+      - :name: delete
+        :identifier: auth_key_pair_cloud_delete
   :authentications:
     :description: Authentications
     :options:

--- a/spec/requests/auth_key_pairs_spec.rb
+++ b/spec/requests/auth_key_pairs_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe "Auth Key Pairs API" do
+  let(:akp) { FactoryBot.create(:auth_key_pair_cloud) }
+
+  describe 'GET /api/auth_key_pairs' do
+    before { akp }
+
+    context 'without an appropriate role' do
+      it 'does not list auth key pairs' do
+        api_basic_authorize
+        get(api_auth_key_pairs_url)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'with an appropriate role' do
+      before { api_basic_authorize collection_action_identifier(:auth_key_pairs, :read, :get) }
+
+      it 'lists all auth key pairs' do
+        get(api_auth_key_pairs_url)
+
+        expected = {
+          'count'     => 1,
+          'subcount'  => 1,
+          'name'      => 'auth_key_pairs',
+          'resources' => [
+            hash_including('href' => api_auth_key_pair_url(nil, akp))
+          ]
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+    end
+  end
+
+  describe 'GET /api/auth_key_pairs/:id' do
+    context 'without an appropriate role' do
+      it 'does not let you query a custom button' do
+        api_basic_authorize
+        get(api_auth_key_pair_url(nil, akp))
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'with an appropriate role' do
+      before { api_basic_authorize action_identifier(:auth_key_pairs, :read, :resource_actions, :get) }
+
+      it 'can query an auth key pair by its id' do
+        get(api_auth_key_pair_url(nil, akp))
+
+        expected = {
+          'id'   => akp.id.to_s,
+          'type' => "ManageIQ::Providers::CloudManager::AuthKeyPair"
+        }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+    end
+  end
+
+  describe 'POST /api/auth_key_pairs' do
+    it 'can create auth_key_pairs' do
+      api_basic_authorize collection_action_identifier(:auth_key_pairs, :create)
+
+      post(api_auth_key_pairs_url, :params => {'name' => 'foo'})
+
+      expect(response).to have_http_status(:ok)
+
+      auth_key_pair = ManageIQ::Providers::CloudManager::AuthKeyPair.find(response.parsed_body['results'].first["id"])
+      expect(auth_key_pair.name).to eq('foo')
+    end
+  end
+
+  describe 'PUT /api/auth_key_pairs/:id' do
+    it 'can edit an auth key pair by id' do
+      api_basic_authorize action_identifier(:auth_key_pairs, :edit)
+
+      expect(akp.name).not_to eq('foo')
+      put(api_auth_key_pair_url(nil, akp), :params => {'name' => 'foo'})
+      expect(response).to have_http_status(:ok)
+      expect(akp.reload.name).to eq('foo')
+    end
+  end
+
+  describe 'DELETE /api/auth_key_pairs/:id' do
+    it 'can delete an auth key pair by id' do
+      api_basic_authorize action_identifier(:auth_key_pairs, :delete, :resource_actions, :delete)
+
+      delete(api_auth_key_pair_url(nil, akp))
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end


### PR DESCRIPTION
Needed for setting ownership for auth key pairs in the UI using the new react component.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6007

@miq-bot add_label ivanchuk/no, enhancement, hammer/no
@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @abellotti 