### PR TITLE
Add tagging for cloud tenants

### DIFF
--- a/app/controllers/api/cloud_tenants_controller.rb
+++ b/app/controllers/api/cloud_tenants_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class CloudTenantsController < BaseController
     include Subcollections::SecurityGroups
+    include Subcollections::Tags
   end
 end


### PR DESCRIPTION
Copied update wording and code from previous update that added tagging support for other cloud resources (#361)

Adding tagging support for resources of the following collections:

  /api/cloud_tenants

Standard tagging subcollection signature as follows:

  /api/cloud_tenants/:id/tags

Fixes: #651