### PR TITLE
Expose error messages from ServiceTemplate.orderable?

### DIFF
--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -16,8 +16,9 @@ module Api
 
       private
 
-      def validate_order(service_template)
+      def validate_order(_service_template)
         raise BadRequestError, "Service ordering via API is not allowed" unless api_request_allowed?
+
         true
       end
       alias orderable? validate_order

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -16,7 +16,7 @@ module Api
       private
 
       def validate_order(service_template)
-        service_template.unsupported_reason_add(:order, 'Service ordering via API is not allowed') unless  api_request_allowed?
+        service_template.unsupported_reason_add(:order, 'Service ordering via API is not allowed') unless api_request_allowed?
         service_template.supports_order?
       end
       alias orderable? validate_order

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -3,7 +3,7 @@ module Api
     module ServiceTemplates
       def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
-        errors = validate_order(service_template)
+        errors = validate_order(service_template, true)
         if errors.present?
           raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered - #{errors.join(", ")}"
         end
@@ -18,16 +18,15 @@ module Api
 
       private
 
-      def validate_order(service_template)
+      def validate_order(service_template, with_errors = false)
         errors = []
         errors << 'Service ordering via API is not allowed' unless api_request_allowed?
-        errors += service_template.validate_order
+        errors += service_template.validate_order(true)
         errors
-      end
 
-      def orderable?(service_template)
-        validate_order(service_template).blank?
+        with_errors ? errors : errors.blank?
       end
+      alias orderable? validate_order
 
       def api_request_allowed?
         return true if request_from_ui?

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -3,10 +3,7 @@ module Api
     module ServiceTemplates
       def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
-        errors = validate_order(service_template, true)
-        if errors.present?
-          raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered - #{errors.join(", ")}"
-        end
+        raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered - #{service_template.unsupported_reason(:order)}" unless service_template.supports_order?
 
         request_result = service_template.order(User.current_user, (data || {}), order_request_options, scheduled_time)
         errors = request_result[:errors]
@@ -18,11 +15,8 @@ module Api
 
       private
 
-      def validate_order(service_template, with_errors = false)
-        errors = []
-        errors << 'Service ordering via API is not allowed' unless api_request_allowed?
-        errors += service_template.validate_order(true)
-        with_errors ? errors : errors.blank?
+      def validate_order(service_template)
+        service_template.supports_order?
       end
       alias orderable? validate_order
 

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -20,7 +20,8 @@ module Api
       def orderable?(service_template)
         errors = []
         errors << 'Service ordering via API is not allowed' unless api_request_allowed?
-        errors << service_template.orderable?
+        errors += service_template.orderable?
+        errors
       end
 
       def api_request_allowed?

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -3,7 +3,10 @@ module Api
     module ServiceTemplates
       def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
-        raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered" unless orderable?(service_template)
+        errors = orderable?(service_template)
+        if errors.present?
+          raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered - #{errors.join(", ")}"
+        end
         request_result = service_template.order(User.current_user, (data || {}), order_request_options, scheduled_time)
         errors = request_result[:errors]
         if errors.present?
@@ -15,7 +18,9 @@ module Api
       private
 
       def orderable?(service_template)
-        api_request_allowed? && service_template.orderable?
+        errors = []
+        errors << 'Service ordering via API is not allowed' unless api_request_allowed?
+        errors << service_template.orderable?
       end
 
       def api_request_allowed?

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -3,7 +3,7 @@ module Api
     module ServiceTemplates
       def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
-        validate_order(service_template)
+        raise BadRequestError, "Service ordering via API is not allowed" unless api_request_allowed?
         raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered - #{service_template.unsupported_reason(:order)}" unless service_template.supports_order?
 
         request_result = service_template.order(User.current_user, (data || {}), order_request_options, scheduled_time)
@@ -15,13 +15,6 @@ module Api
       end
 
       private
-
-      def validate_order(_service_template)
-        raise BadRequestError, "Service ordering via API is not allowed" unless api_request_allowed?
-
-        true
-      end
-      alias orderable? validate_order
 
       def api_request_allowed?
         return true if request_from_ui?

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -22,8 +22,6 @@ module Api
         errors = []
         errors << 'Service ordering via API is not allowed' unless api_request_allowed?
         errors += service_template.validate_order(true)
-        errors
-
         with_errors ? errors : errors.blank?
       end
       alias orderable? validate_order

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -16,6 +16,7 @@ module Api
       private
 
       def validate_order(service_template)
+        service_template.unsupported_reason_add(:order, 'Service ordering via API is not allowed') unless  api_request_allowed?
         service_template.supports_order?
       end
       alias orderable? validate_order

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -3,6 +3,7 @@ module Api
     module ServiceTemplates
       def order_service_template(id, data, scheduled_time = nil)
         service_template = resource_search(id, :service_templates, ServiceTemplate)
+        validate_order(service_template)
         raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered - #{service_template.unsupported_reason(:order)}" unless service_template.supports_order?
 
         request_result = service_template.order(User.current_user, (data || {}), order_request_options, scheduled_time)
@@ -16,8 +17,8 @@ module Api
       private
 
       def validate_order(service_template)
-        service_template.unsupported_reason_add(:order, 'Service ordering via API is not allowed') unless api_request_allowed?
-        service_template.supports_order?
+        raise BadRequestError, "Service ordering via API is not allowed" unless api_request_allowed?
+        true
       end
       alias orderable? validate_order
 

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -559,7 +559,7 @@ describe "Service Templates API" do
       end
 
       it "can order multiple service templates" do
-        service_template2 = FactoryBot.create(:service_template, :with_provision_resource_action_and_dialog, :orderable)
+        service_template2 = FactoryBot.create(:service_template, :with_provision_resource_action_and_dialog, :service_template_catalog => service_template_catalog, :display => true)
         api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
 
         post(api_service_templates_url, :params => { :action => "order", :resources =>

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -607,7 +607,7 @@ describe "Service Templates API" do
         expected = {
           "error" => a_hash_including(
             "kind"    => "bad_request",
-            "message" => /cannot be ordered - Service template does not belong to a service catalog, Service template is not configured to be displayed/
+            "message" => /cannot be ordered - Service template is not configured to be displayed/
           )
         }
         expect(response).to have_http_status(:bad_request)

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -608,7 +608,7 @@ describe "Service Templates API" do
         expected = {
           "error" => a_hash_including(
             "kind"    => "bad_request",
-            "message" => /cannot be ordered/
+            "message" => /cannot be ordered - Service template does not belong to a service catalog, Service template is not configured to be displayed/
           )
         }
         expect(response).to have_http_status(:bad_request)

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -465,11 +465,13 @@ describe "Service Templates API" do
   end
 
   describe "Service Templates order" do
-    let(:service_template) { FactoryBot.create(:service_template, :with_provision_resource_action_and_dialog, :orderable) }
+    let(:service_template_catalog) { FactoryBot.create(:service_template_catalog) }
+    let(:service_template) { FactoryBot.create(:service_template, :with_provision_resource_action_and_dialog, :service_template_catalog => service_template_catalog, :display => true) }
     let(:allow_api_service_ordering) { true }
 
     before do
       stub_settings_merge(:product => {:allow_api_service_ordering => allow_api_service_ordering})
+      allow(Api::ServiceTemplatesController).to receive(:resource_search).and_return(service_template)
       userid = User.first.userid
       test_token = Api::UserTokenService.new.generate_token(userid, "api")
       request_headers["x-auth-token"] = test_token

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -627,7 +627,6 @@ describe "Service Templates API" do
     end
 
     context "with the product setting not allowing automate to run on submit" do
-      let(:template_no_display) { FactoryBot.create(:service_template, :display => false) }
       let(:allow_api_service_ordering) { false }
 
       context "if the token info is blank" do
@@ -637,11 +636,11 @@ describe "Service Templates API" do
 
         it "rejects the request" do
           api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
-          post(api_service_template_url(nil, template_no_display), :params => { :action => "order" })
+          post(api_service_template_url(nil, service_template), :params => { :action => "order" })
           expected = {
             "error" => a_hash_including(
               "kind"    => "bad_request",
-              "message" => /cannot be ordered/
+              "message" => "Service ordering via API is not allowed"
             )
           }
           expect(response).to have_http_status(:bad_request)

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -471,7 +471,6 @@ describe "Service Templates API" do
 
     before do
       stub_settings_merge(:product => {:allow_api_service_ordering => allow_api_service_ordering})
-      allow(Api::ServiceTemplatesController).to receive(:resource_search).and_return(service_template)
       userid = User.first.userid
       test_token = Api::UserTokenService.new.generate_token(userid, "api")
       request_headers["x-auth-token"] = test_token

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -627,6 +627,7 @@ describe "Service Templates API" do
     end
 
     context "with the product setting not allowing automate to run on submit" do
+      let(:template_no_display) { FactoryBot.create(:service_template, :display => false) }
       let(:allow_api_service_ordering) { false }
 
       context "if the token info is blank" do
@@ -636,7 +637,7 @@ describe "Service Templates API" do
 
         it "rejects the request" do
           api_basic_authorize action_identifier(:service_templates, :order, :resource_actions, :post)
-          post(api_service_template_url(nil, service_template), :params => { :action => "order" })
+          post(api_service_template_url(nil, template_no_display), :params => { :action => "order" })
           expected = {
             "error" => a_hash_including(
               "kind"    => "bad_request",


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/ManageIQ/manageiq/pull/19186 to accept an array of error messages from `ServiceTemplate.orderable?`, and to display these messages in the response.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1744197
Depends on: https://github.com/ManageIQ/manageiq/pull/19186, #662