### PR TITLE
Add endpoints for widget content generation

### DIFF
--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  class WidgetsController < BaseController
+    def generate_content_resource(type, id, _data = nil)
+      api_action(type, id) do |klass|
+        widget = resource_search(id, type, klass)
+        api_log_info("Generating content for #{widget_ident(widget)}")
+        generate_widget_content(widget)
+      end
+    end
+
+    private
+
+    def generate_widget_content(widget)
+      desc = "#{widget_ident(widget)} content generation"
+      task_id = queue_object_action(widget, desc, :method_name => "generate_content", :role => "reporting")
+      action_result(true, desc, :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def widget_ident(widget)
+      "Widget id:#{widget.id} name:'#{widget.name}'"
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -4103,6 +4103,30 @@
         :identifier:
         - vm_snapshot_delete
         - sui_vm_snapshot_delete
+  :widgets:
+    :description: Miq Widgets
+    :identifier: miq_report_widget_admin
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: MiqWidget
+    :subcollections:
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_widget_show_list
+      :post:
+      - :name: query
+        :identifier: miq_widget_show_list
+      - :name: generate_content
+        :identifier: widget_generate_content
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_widget_show
+      :post:
+      - :name: generate_content
+        :identifier: widget_generate_content
   :zones:
     :description: Zones
     :identifier: zone

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -1,0 +1,100 @@
+describe "Widgets API" do
+  context "GET /api/widgets" do
+    it "returns all Widgets" do
+      miq_widget = FactoryBot.create(:miq_widget)
+      api_basic_authorize('miq_widget_show_list')
+
+      get(api_widgets_url)
+
+      expected = {
+        "name"      => "widgets",
+        "resources" => [{"href" => api_widget_url(nil, miq_widget)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "GET /api/miq_widgets/:id" do
+    it "returns a single Widget" do
+      miq_widget = FactoryBot.create(:miq_widget)
+      api_basic_authorize('miq_widget_show')
+
+      get(api_widget_url(nil, miq_widget))
+
+      expected = {
+        "description" => miq_widget.name,
+        "href"        => api_widget_url(nil, miq_widget)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe "Widgets generate_content action" do
+    context "with an invalid id" do
+      it "it responds with 404 Not Found" do
+        api_basic_authorize(action_identifier(:widgets, :generate_content, :resource_actions, :post))
+
+        post(api_widget_url(nil, 999_999), :params => gen_request(:generate_content))
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "without an appropriate role" do
+      it "it responds with 403 Forbidden" do
+        miq_widget = FactoryBot.create(:miq_widget)
+        api_basic_authorize
+
+        post(api_widget_url(nil, miq_widget), :params => gen_request(:generate_content))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with an appropriate role" do
+      it "rejects generate_content for an unspecified Widget" do
+        api_basic_authorize(action_identifier(:widgets, :generate_content, :resource_actions, :post))
+
+        post(api_widgets_url, :params => gen_request(:generate_content, [{"href" => api_widgets_url}, {"href" => api_widgets_url}]))
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "generate_content of a single Widget" do
+        miq_widget = FactoryBot.create(:miq_widget)
+        api_basic_authorize('widget_generate_content')
+
+        post(api_widget_url(nil, miq_widget), :params => gen_request(:generate_content))
+
+        expect_single_action_result(:success => true, :message => /#{miq_widget.id}.* content generation/i, :href => api_widget_url(nil, miq_widget))
+      end
+
+      it "generate_content of multiple Widgets" do
+        first_miq_widget = FactoryBot.create(:miq_widget)
+        second_miq_widget = FactoryBot.create(:miq_widget)
+        api_basic_authorize('widget_generate_content')
+
+        post(api_widgets_url, :params => gen_request(:generate_content, [{"href" => api_widget_url(nil, first_miq_widget)}, {"href" => api_widget_url(nil, second_miq_widget)}]))
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including(
+              "message" => a_string_matching(/#{first_miq_widget.id}.* content generation/i),
+              "success" => true,
+              "href"    => api_widget_url(nil, first_miq_widget)
+            ),
+            a_hash_including(
+              "message" => a_string_matching(/#{second_miq_widget.id}.* content generation/i),
+              "success" => true,
+              "href"    => api_widget_url(nil, second_miq_widget)
+            )
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add ability to trigger generation of widget content from the API. 

~~@miq-bot add_label enhancement, hammer/yes, ivanchuk/yes~~ 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1623607

@gmcculloug please review, it's your ~~party~~ funeral 
@abellotti please also review, it's less of but still kinda your party
