### PR TITLE
Explicitly pass transformation_mapping when generating mapping items

### DIFF
--- a/app/controllers/api/transformation_mappings_controller.rb
+++ b/app/controllers/api/transformation_mappings_controller.rb
@@ -2,9 +2,8 @@ module Api
   class TransformationMappingsController < BaseController
     def create_resource(_type, _id, data = {})
       raise "Must specify transformation_mapping_items" unless data["transformation_mapping_items"]
-      TransformationMapping.new(data.except("transformation_mapping_items")).tap do |mapping|
+      TransformationMapping.create(data.except("transformation_mapping_items")).tap do |mapping|
         mapping.transformation_mapping_items = create_mapping_items(data["transformation_mapping_items"], mapping)
-        mapping.save!
       end
     rescue StandardError => err
       raise BadRequestError, "Could not create Transformation Mapping - #{err}"


### PR DESCRIPTION
In order to properly perform validations on a `TransformationMappingItem`, we need the parent to already be defined in some cases. This modifies the `create_mapping` method so that it accepts and uses the parent transformation mapping when creating a new transformation mapping item.

Tied to https://github.com/ManageIQ/manageiq/pull/19204