### PR TITLE
Change the feature identifier for listing auth key pairs

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -192,7 +192,7 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: auth_key_pair_cloud_view
+        :identifier: auth_key_pair_cloud_show_list
       :post:
       - :name: create
         :identifier: auth_key_pair_cloud_new


### PR DESCRIPTION
The `_view` is not the right suffix for listing all the items, it should be `_show_list` so fixing.

@miq-bot assign @lpichler 
@miq-bot add_label bug, ivanchuk/no