### PR TITLE
Create TransformationMapping before Item (FIX CI FAILURE)

### DIFF
--- a/app/controllers/api/transformation_mappings_controller.rb
+++ b/app/controllers/api/transformation_mappings_controller.rb
@@ -3,7 +3,7 @@ module Api
     def create_resource(_type, _id, data = {})
       raise "Must specify transformation_mapping_items" unless data["transformation_mapping_items"]
       TransformationMapping.new(data.except("transformation_mapping_items")).tap do |mapping|
-        mapping.transformation_mapping_items = create_mapping_items(data["transformation_mapping_items"])
+        mapping.transformation_mapping_items = create_mapping_items(data["transformation_mapping_items"], mapping)
         mapping.save!
       end
     rescue StandardError => err
@@ -13,11 +13,9 @@ module Api
     def edit_resource(type, id, data)
       raise "Must specify transformation_mapping_items" unless data["transformation_mapping_items"]
       transformation_mapping = resource_search(id, type, collection_class(type))
-
       updated_data = data.except("transformation_mapping_items")
       transformation_mapping.update_attributes!(updated_data) if updated_data.present?
-
-      transformation_mapping.transformation_mapping_items = create_mapping_items(data["transformation_mapping_items"])
+      transformation_mapping.transformation_mapping_items = create_mapping_items(data["transformation_mapping_items"], transformation_mapping)
       transformation_mapping.save!
       transformation_mapping
     rescue StandardError => err
@@ -51,7 +49,7 @@ module Api
 
     def add_mapping_item_resource(type, id, data)
       resource_search(id, type, collection_class(type)).tap do |mapping|
-        mapping.transformation_mapping_items.append(create_mapping_items([data]))
+        mapping.transformation_mapping_items.append(create_mapping_items([data], mapping))
         mapping.save!
       end
     rescue StandardError => err
@@ -60,10 +58,14 @@ module Api
 
     private
 
-    def create_mapping_items(items)
+    def create_mapping_items(items, mapping)
       items.collect do |item|
         raise "Must specify source and destination hrefs" unless item["source"] && item["destination"]
-        TransformationMappingItem.new(:source => fetch_mapping_resource(item["source"]), :destination => fetch_mapping_resource(item["destination"]))
+        TransformationMappingItem.new(
+          :transformation_mapping => mapping,
+          :source                 => fetch_mapping_resource(item["source"]),
+          :destination            => fetch_mapping_resource(item["destination"])
+        )
       end
     end
 


### PR DESCRIPTION
FIXing CI failure https://travis-ci.org/ManageIQ/manageiq-api/jobs/578155651

After this https://github.com/ManageIQ/manageiq/pull/19204 it looks like that when we are creating 

`TransformationMapping` with `TransformationMappingItems`( with [DataStorage](https://github.com/ManageIQ/manageiq/blob/50c0ca0bb7a18aa6fea88ff44c579c716ce3fe56/app/models/transformation_mapping_item.rb) which requires created `TransformationMapping `)

we need to create first
`TransformationMapping `

and then create `TransformationMappingItems ` and then assign `TransformationMapping `


It looks like that there is also issue  in create operation https://github.com/ManageIQ/manageiq-api/blob/ba3258bef9b483b3c0cf5d9c950f62d235bbba91/app/controllers/api/transformation_mappings_controller.rb 



please review @agrare @thearifsmail @djberg96 


@miq-bot assign @abellotti 

