### PR TITLE
[WIP] Add beginning of endpoint to get parent vm choices

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -59,6 +59,14 @@ module Api
     end
     central_admin :suspend_resource, :suspend
 
+    def parent_choices_resource(ids)
+      parent_choices = {}
+      parent_choices[Digest::MD5.hexdigest(ids.inspect)] ||= begin
+        ems_ids = VmOrTemplate.where(:id => ids).distinct.pluck(:ems_id).compact
+        Rbac.filtered(VmOrTemplate.where(:ems_id => ems_ids).where.not(:id => ids).order(:name))
+      end
+    end
+
     def pause_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for pausing a #{type} resource" unless id
 

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -62,8 +62,8 @@ module Api
     def parent_choices_resource(ids)
       parent_choices = {}
       parent_choices[Digest::MD5.hexdigest(ids.inspect)] ||= begin
-        ems_ids = VmOrTemplate.where(:id => ids).distinct.pluck(:ems_id).compact
-        Rbac.filtered(VmOrTemplate.where(:ems_id => ems_ids).where.not(:id => ids).order(:name))
+        ems_ids = VmOrTemplate.where(:id => ids).select(:ems_id).distinct
+        Rbac.filtered(VmOrTemplate.where(:ems_id => ems_ids.where.not(:id => ids)))
       end
     end
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -3992,6 +3992,9 @@
         :identifier:
         - vm_show
         - sui_vm_details_view
+      - :name: parent_choices
+        :identifier:
+        - vm_parent_choices
       :post:
       - :name: edit
         :identifier: vm_edit


### PR DESCRIPTION
We let people set ancestry in the UI on VMs apparently and I was assigned https://github.com/ManageIQ/manageiq-api/issues/637.

It's bad the way it is, and this makes it worse. This is horrible and we shouldn't do this but I was asked to, so. 

One of the actions we allow on edit of vms today is to update the ancestry: see https://github.com/ManageIQ/manageiq-api/commit/314e9e721b134a9e3094aac1b994d06b29dfa5c2. I'm wondering if that needs to change to accommodate the logic the UI is currently running? 

It doesn't even matter if this even does the same thing as the UI in terms of logic. We're  changing API behavior with this, because at the moment we have no existing logic to limit from the API perspective what can be picked like the UI is doing. 

Also I don't think you should be able to do this from either, frankly. 

The core identifier addition:
https://github.com/ManageIQ/manageiq/pull/19286

@lpichler @gtanzillo 