### PR TITLE
Switch find_by_* to lookup_by_*

### DIFF
--- a/app/controllers/api/alert_definition_profiles_controller.rb
+++ b/app/controllers/api/alert_definition_profiles_controller.rb
@@ -67,7 +67,7 @@ module Api
     def fetch_tag_classification_resource(data)
       tag_spec = tag_specified(data["id"], data)
       raise BadRequestError, "Must specify tag id, href, or name of classification" if tag_spec.empty?
-      classification = Classification.find_by_name(tag_spec[:category])
+      classification = Classification.lookup_by_name(tag_spec[:category])
       classification.find_entry_by_name(tag_spec[:name])
     end
     # rubocop:enable Rails/DynamicFindBy

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -37,7 +37,7 @@ module Api
 
     def fetch_category(data)
       category_id = parse_id(data, :categories)
-      category_id ||= collection_class(:categories).find_by_name(data["name"]).try(:id) if data["name"]
+      category_id ||= collection_class(:categories).lookup_by_name(data["name"]).try(:id) if data["name"]
       unless category_id
         raise BadRequestError, "Category id, href or name needs to be specified for creating a new tag resource"
       end


### PR DESCRIPTION
The find_by_* methods defined in manageiq repo has conflicts with
rails dynamic finding and now they have been changed to lookup_by_*
Switching the callers in this repo to the lookup_by_ methods.

Depend on ManageIQ/manageiq#19313

@miq-bot add_label ivanchuk/no, refactoring