### PR TITLE
Remove useless param methods in ResultsController

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -11,15 +11,7 @@ module Api
         end
 
         def report_options
-          params.merge(:sort_by => params['sort_by'], :sort_order => sort_order).merge(filter_options)
-        end
-
-        def filter_options
-          filtering_enabled? ? {:filter_string => params[:filter_string], :filter_column => params[:filter_column]} : {}
-        end
-
-        def filtering_enabled?
-          params.key?(:filter_column) && params.key?(:filter_string) && params[:filter_string]
+          params.merge(:sort_order => sort_order)
         end
       end
 


### PR DESCRIPTION
it looks like leftover after https://github.com/ManageIQ/manageiq-api/pull/547


this already happens in https://github.com/ManageIQ/manageiq/blob/ed89b4df6cdc829e1413044bca48bbfe51f7ae91/app/models/miq_report_result/result_set_operations.rb#L16 
and we pull also parameters from `params` also here.

@miq-bot add_label technical_debt

@miq-bot assign @abellotti 
