### PR TITLE
Fixes the pxe_servers collection actions

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2505,20 +2505,16 @@
     - :pxe_images
     - :pxe_menus
     :collection_actions:
+      :get:
+      - :name: read
+        :identifier: pxe_server_view
       :post:
       - :name: create
         :identifier: pxe_server_create
       - :name: edit
         :identifier: pxe_server_edit
-      :patch:
-      - :name: edit
-        :identifier: pxe_server_edit
-      :delete:
       - :name: delete
         :identifier: pxe_server_delete
-      :get:
-      - :name: read
-        :identifier: pxe_server_view
     :resource_actions:
       :get:
       - :name: read


### PR DESCRIPTION
Fixes the pxe_servers collection actions, PATCH and DELETE verbs should not
be exposed at the collection level, these are only resource verbs.

Added a test for the bulk delete action since this is now properly
exposed at the collection level.

bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1754972