### PR TITLE
Fix specs for display/visible rename from core repo yesterday

### DIFF
--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -267,16 +267,16 @@ describe "Services API" do
                                                    {"action" => "remove", "path" => "description"},
                                                    {"action" => "add",    "path" => "display", "value" => true}])
 
-      expect_single_resource_query("id" => svc.id.to_s, "name" => "updated svc1", "display" => true)
+      expect_single_resource_query("id" => svc.id.to_s, "name" => "updated svc1", "visible" => true)
       expect(svc.reload.name).to eq("updated svc1")
       expect(svc.description).to be_nil
-      expect(svc.display).to be_truthy
+      expect(svc.visible).to be_truthy
     end
 
     it "supports edits of single resource via a standard PATCH" do
       api_basic_authorize collection_action_identifier(:services, :edit)
 
-      updated_service_attributes = { "name" => "updated svc1", "description" => nil, "display" => true }
+      updated_service_attributes = { "name" => "updated svc1", "description" => nil, "visible" => true }
 
       patch(api_service_url(nil, svc), :params => updated_service_attributes)
 


### PR DESCRIPTION
Service display got renamed to visible yesterday, see linked PR, and the specs need update. 

See https://github.com/ManageIQ/manageiq/pull/19211