### PR TITLE
Expose the verify_credentials action for /api/providers

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -114,6 +114,15 @@ module Api
       end
     end
 
+    def verify_credentials_resource(_type, _id, data = {})
+      klass = fetch_provider_klass(collection_class(:providers), data)
+      zone_name = fetch_zone(data).name
+      task_id = klass.verify_credentials_task(current_user, zone_name, data)
+      action_result(true, 'Credentials sent for verification', :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     private
 
     def provider_options(type)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2297,6 +2297,8 @@
         :identifier: ems_infra_edit
       - :name: resume
         :identifier: ems_infra_edit
+      - :name: verify_credentials
+        :identifier: ems_infra_new
     :resource_actions:
       :get:
       - :name: read


### PR DESCRIPTION
Exposing the [`verify_credentials_task`](https://github.com/ManageIQ/manageiq/pull/19346) method as `verify_credentials` on `/api/providers` for the new provider forms. This action will return a task ID that can be polled for the credential verification of any provider. The request always requires a zone and the provider type, other provider-specific options are all optional.

**Request:**
```json
# POST http://admin:smartvm@localhost:3000/api/providers
{
  "action": "verify_credentials",
  "resource": {
    "zone": {
      "id": 1
    },
    "type": "ManageIQ::Providers::Redhat::InfraManager"
  }
}
```
**Response:**
```json
{
  "results": [
    {
      "success": true,
      "message": "Credentials sent for verification",
      "task_id": "366208",
      "task_href": "http://localhost:3000/api/tasks/366208"
    }
  ]
}
```

Related issue: https://github.com/ManageIQ/manageiq/issues/18818

@miq-bot add_reviewer @abellotti 
@miq-bot add_reviewer @lpichler 
@miq-bot add_label ivanchuk/no, enhancement

cc @agrare @Fryguy @Hyperkid123 