### PR TITLE
[V2V] Added validations for the input params for conversion hosts.

### DIFF
--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -30,6 +30,10 @@ module Api
     def create_resource(type, id, data)
       raise BadRequestError, "resource_id must be specified" unless data['resource_id']
       raise BadRequestError, "resource_type must be specified" unless data['resource_type']
+      raise BadRequestError, "auth_user must be specified" unless data['auth_user']
+      raise BadRequestError, "conversion_host_ssh_private_key must be specified" unless data['conversion_host_ssh_private_key']
+      raise BadRequestError, "vmware_vddk_package_url or vmware_ssh_private_key must be specified" unless data['vmware_vddk_package_url'] || data['vmware_ssh_private_key']
+      raise BadRequestError, "vmware_vddk_package_url and vmware_ssh_private_key cannot both be specified" if data['vmware_vddk_package_url'] && data['vmware_ssh_private_key']
 
       # The scary constantize call below is mitigated by the fact that it won't get
       # past the following checks we make before passing along the params.


### PR DESCRIPTION
added validations for auth user, conv. host ssh key, vmware, vddk url, and vmware ssh private key. 

Previously it validated resource only.  Now it validates all input params for a conversion host.

https://bugzilla.redhat.com/show_bug.cgi?id=1757352