### PR TITLE
Add tagging for cloud tenants

### DIFF
--- a/app/controllers/api/cloud_tenants_controller.rb
+++ b/app/controllers/api/cloud_tenants_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class CloudTenantsController < BaseController
     include Subcollections::SecurityGroups
+    include Subcollections::Tags
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -622,6 +622,7 @@
     :klass: CloudTenant
     :subcollections:
     - :security_groups
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -641,6 +642,12 @@
       :get:
       - :name: read
         :identifier: cloud_tenant_show
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: cloud_tenant_tag
+      - :name: unassign
+        :identifier: cloud_tenant_tag
   :cloud_volume_types:
     :description: Cloud Volume Types
     :identifier: cloud_volume_type


### PR DESCRIPTION
Replacement of https://github.com/ManageIQ/manageiq-api/pull/652

  * Added subcollection and RBAC feature identifiers to the definition file (`api.yml`).
  * Added specs: the same set that we have for other 'tag' subcollections.
