### PR TITLE
Add tagging for cloud volumes

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class CloudVolumesController < BaseController
+    include Subcollections::Tags
     def delete_resource(type, id, _data = {})
       delete_action_handler do
         cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class CloudVolumesController < BaseController
     include Subcollections::Tags
+
     def delete_resource(type, id, _data = {})
       delete_action_handler do
         cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))

--- a/config/api.yml
+++ b/config/api.yml
@@ -670,6 +670,8 @@
     - :collection
     - :custom_actions
     :verbs: *gpd
+    :subcollections:
+    - :tags
     :klass: CloudVolume
     :collection_actions:
       :get:
@@ -690,6 +692,12 @@
       :delete:
       - :name: delete
         :identifier: cloud_volume_delete
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: cloud_volume_tag
+      - :name: unassign
+        :identifier: cloud_volume_tag
   :clusters:
     :description: Clusters
     :identifier: ems_cluster


### PR DESCRIPTION
 Add tagging for cloud volumes
    
   * Added subcollection and RBAC feature identifiers to the definition
      file (api.yml).
    
   * Added specs: the same set that we have for other 'tag'
      subcollections.

Replacement for https://github.com/ManageIQ/manageiq-api/pull/640