### PR TITLE
Log exceptions to rails console

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -193,6 +193,8 @@ module Api
       # We don't want to return the stack trace, but only log it in case of an internal error
       api_log_error("\n\n#{error.backtrace.join("\n")}") if type == :internal_server_error && !error.backtrace.empty?
 
+      logger.fatal("Error caught: [#{error.class.name}] #{error.message}\n#{type == :internal_server_error ? error.backtrace.join("\n") : ""}")
+
       render :json => ErrorSerializer.new(type, error).serialize, :status => Rack::Utils.status_code(type)
       log_api_response
     end


### PR DESCRIPTION
Right now, if any UI request fails with an exception, it can be seen in rails console output and in development.log / production.log.
But, if the same problem happens with an API request, the only place where that exception is visible is api.log.

Logging API exceptions to rails output as well.
(Using the same logger invocation as ApplicationController.)
