### PR TITLE
Allow miq_regions to be edited, deleted

### DIFF
--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class RegionsController < BaseController
-    INVALID_REGIONS_ATTRS = %w[created_at updated_at].freeze
+    INVALID_REGIONS_ATTRS = ID_ATTRS + %w[created_at updated_at].freeze
 
     # Edit an existing region (MiqRegion). Certain fields are meant for
     # internal use only and may not be edited. Attempting to edit one of

--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class RegionsController < BaseController
-    INVALID_REGIONS_ATTRS = %w[id created_at updated_at].freeze
+    INVALID_REGIONS_ATTRS = %w[created_at updated_at].freeze
 
     # Edit an existing region (MiqRegion). Certain fields are meant for
     # internal use only and may not be edited. Attempting to edit one of
@@ -10,7 +10,7 @@ module Api
       bad_attrs = data_includes_invalid_attrs(data)
 
       if bad_attrs.present?
-        msg = "Attributes #{bad_attrs} should not be specified for updating a region resource"
+        msg = "Attribute(s) '#{bad_attrs}' should not be specified for updating a region resource"
         raise BadRequestError, msg
       end
 

--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -2,7 +2,7 @@ module Api
   class RegionsController < BaseController
     INVALID_REGIONS_ATTRS = %w(id created_on updated_on).freeze
 
-    def edit_region(type, id, data)
+    def edit_resource(type, id, data)
       bad_attrs = data_includes_invalid_attrs(data)
       if bad_attrs.present?
         raise BadRequestError, "Attributes #{bad_attrs} should not be specified for updating a region resource"

--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,4 +1,13 @@
 module Api
   class RegionsController < BaseController
+    INVALID_REGIONS_ATTRS = %w(id created_on updated_on).freeze
+
+    def edit_region(type, id, data)
+      bad_attrs = data_includes_invalid_attrs(data)
+      if bad_attrs.present?
+        raise BadRequestError, "Attributes #{bad_attrs} should not be specified for updating a region resource"
+      end
+      super
+    end
   end
 end

--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class RegionsController < BaseController
-    INVALID_REGIONS_ATTRS = %w[created_at updated_at].freeze
+    INVALID_REGIONS_ATTRS = %w[id created_at updated_at].freeze
 
     # Edit an existing region (MiqRegion). Certain fields are meant for
     # internal use only and may not be edited. Attempting to edit one of

--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,7 +1,11 @@
 module Api
   class RegionsController < BaseController
-    INVALID_REGIONS_ATTRS = %w(id created_at updated_at).freeze
+    INVALID_REGIONS_ATTRS = %w[created_at updated_at].freeze
 
+    # Edit an existing region (MiqRegion). Certain fields are meant for
+    # internal use only and may not be edited. Attempting to edit one of
+    # the forbidden fields will result in a bad request error.
+    #
     def edit_resource(type, id, data)
       bad_attrs = data_includes_invalid_attrs(data)
 
@@ -15,8 +19,13 @@ module Api
 
     private
 
+    # Check to see if any of the data attributes contain an invalid field.
+    # Returns a list of invalid fields as a comma separated string that you
+    # can use for error messages, or nil if the data argument is blank.
+    #
     def data_includes_invalid_attrs(data)
       return nil unless data
+
       data.keys.select { |key| INVALID_REGIONS_ATTRS.include?(key) }.compact.join(", ")
     end
   end

--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,13 +1,22 @@
 module Api
   class RegionsController < BaseController
-    INVALID_REGIONS_ATTRS = %w(id created_on updated_on).freeze
+    INVALID_REGIONS_ATTRS = %w(id created_at updated_at).freeze
 
     def edit_resource(type, id, data)
       bad_attrs = data_includes_invalid_attrs(data)
+
       if bad_attrs.present?
-        raise BadRequestError, "Attributes #{bad_attrs} should not be specified for updating a region resource"
+        msg = "Attributes #{bad_attrs} should not be specified for updating a region resource"
+        raise BadRequestError, msg
       end
+
       super
+    end
+
+    private
+
+    def data_includes_invalid_attrs(data)
+      data.keys.select { |k| INVALID_REGIONS_ATTRS.include?(k) }.compact.join(", ") if data
     end
   end
 end

--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -16,7 +16,8 @@ module Api
     private
 
     def data_includes_invalid_attrs(data)
-      data.keys.select { |k| INVALID_REGIONS_ATTRS.include?(k) }.compact.join(", ") if data
+      return nil unless data
+      data.keys.select { |key| INVALID_REGIONS_ATTRS.include?(key) }.compact.join(", ")
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2630,6 +2630,8 @@
       :post:
       - :name: query
         :identifier: region
+      - :name: edit
+        :identifier: region_edit
       - :name: delete
         :identifier: region_delete
     :resource_actions:

--- a/config/api.yml
+++ b/config/api.yml
@@ -2621,7 +2621,7 @@
     - :settings
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: MiqRegion
     :collection_actions:
       :get:
@@ -2637,6 +2637,9 @@
       :post:
       - :name: edit
         :identifier: region_edit
+      - :name: delete
+        :identifier: region_delete
+      :delete:
       - :name: delete
         :identifier: region_delete
   :reports:

--- a/config/api.yml
+++ b/config/api.yml
@@ -2630,6 +2630,8 @@
       :post:
       - :name: query
         :identifier: region
+      - :name: delete
+        :identifier: region_delete
     :resource_actions:
       :get:
       - :name: read

--- a/config/api.yml
+++ b/config/api.yml
@@ -2634,6 +2634,11 @@
       :get:
       - :name: read
         :identifier: region
+      :post:
+      - :name: edit
+        :identifier: region_edit
+      - :name: delete
+        :identifier: region_delete
   :reports:
     :description: Reports
     :identifier: miq_report

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -109,9 +109,7 @@ RSpec.describe "Regions API", :regions do
 
       post api_regions_url, :params => gen_request(:edit, options)
 
-      expected_message = "Attribute(s) 'created_at' should not be specified for updating a region resource"
-      expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body['error']['message']).to eql(expected_message)
+      expect_bad_request("Attribute(s) 'created_at' should not be specified for updating a region resource")
     end
   end
 

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Regions API", :regions do
 
       post api_region_url(nil, region), :params => gen_request(:edit, :created_at => Time.now)
 
-      expect(response).to have_http_status(:internal_server_error)
+      expect(response).to have_http_status(:bad_request)
     end
   end
 

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe "Regions API", :regions do
 
       expect(response).to have_http_status(:ok)
 
-      expect_results_to_match_hash("results",
+      expect_results_to_match_hash(
+        "results",
         [
           {"id" => region1.id.to_s, "description" => "Updated Test Region 1"},
           {"id" => region2.id.to_s, "description" => "Updated Test Region 2"}

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -95,6 +95,22 @@ RSpec.describe "Regions API", :regions do
       expect(region_1.reload.name).to eq("Updated Test Region 1")
       expect(region_2.reload.name).to eq("Updated Test Region 2")
     end
+
+    it "will fail to update multiple regions if forbidden fields are used" do
+      api_basic_authorize action_identifier(:regions, :edit)
+
+      region_1 = FactoryBot.create(:miq_region, :description => "Test Region 1")
+      region_2 = FactoryBot.create(:miq_region, :description => "Test Region 2")
+
+      options = [
+        {"href" => api_region_url(nil, region_1), "description" => "Updated Test Region 1"},
+        {"href" => api_region_url(nil, region_2), "description" => "Updated Test Region 2"}
+      ]
+
+      post api_regions_url, :params => gen_request(:edit, options)
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   context "delete", :delete do

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -85,6 +85,19 @@ RSpec.describe "Regions API", :regions do
       expect { delete api_region_url(nil, region) }.to change(MiqRegion, :count).by(-1)
       expect(response).to have_http_status(:no_content)
     end
+
+    it "can delete multiple regions with POST" do
+      api_basic_authorize action_identifier(:regions, :delete)
+      regions = FactoryBot.create_list(:miq_region, 2)
+
+      options = [
+        {"href" => api_region_url(nil, regions.first)},
+        {"href" => api_region_url(nil, regions.last)}
+      ]
+
+      expect { post api_regions_url, :params => gen_request(:delete, options) }.to change(MiqRegion, :count).by(-2)
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   context "Settings", :settings do

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Regions API", :regions do
 
       region = FactoryBot.create(:miq_region, :description => "Current Region description")
 
-      post api_region_url(nil, region), :params => gen_request(:edit, :created_at => Time.now)
+      post api_region_url(nil, region), :params => gen_request(:edit, :created_at => Time.now.utc)
 
       expect(response).to have_http_status(:bad_request)
     end

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -111,6 +111,16 @@ RSpec.describe "Regions API", :regions do
 
       expect_bad_request("Attribute(s) 'created_at' should not be specified for updating a region resource")
     end
+
+    it "forbids edit of a region without an appropriate role" do
+      api_basic_authorize
+
+      region = FactoryBot.create(:miq_region, :description => "Current Region description")
+
+      post api_region_url(nil, region), :params => gen_request(:edit, :description => "New Region description")
+
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 
   context "delete", :delete do
@@ -141,6 +151,15 @@ RSpec.describe "Regions API", :regions do
 
       expect { post api_regions_url, :params => gen_request(:delete, options) }.to change(MiqRegion, :count).by(-2)
       expect(response).to have_http_status(:ok)
+    end
+
+    it "forbids deletion of a region without an appropriate role" do
+      api_basic_authorize
+      region = FactoryBot.create(:miq_region, :description => "Current Region description")
+
+      delete api_region_url(nil, region)
+
+      expect(response).to have_http_status(:forbidden)
     end
   end
 

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -69,6 +69,24 @@ RSpec.describe "Regions API", :regions do
     end
   end
 
+  context "delete", :delete do
+    it "can delete a region with POST" do
+      api_basic_authorize action_identifier(:regions, :delete)
+      region = FactoryBot.create(:miq_region)
+
+      expect { post api_region_url(nil, region), :params => gen_request(:delete) }.to change(MiqRegion, :count).by(-1)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can delete a region with DELETE" do
+      api_basic_authorize action_identifier(:regions, :delete)
+      region = FactoryBot.create(:miq_region)
+
+      expect { delete api_region_url(nil, region) }.to change(MiqRegion, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
   context "Settings", :settings do
     let(:region_number) { ApplicationRecord.my_region_number + 1 }
     let(:id) { ApplicationRecord.id_in_region(1, region_number) }

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe "Regions API", :regions do
         ]
       )
 
-      expect(region1.reload.name).to eq("Updated Test Region 1")
-      expect(region2.reload.name).to eq("Updated Test Region 2")
+      expect(region1.reload.description).to eq("Updated Test Region 1")
+      expect(region2.reload.description).to eq("Updated Test Region 2")
     end
 
     it "will fail to update multiple regions if any forbidden fields are edited" do

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -41,6 +41,18 @@ describe "Regions API" do
     )
   end
 
+  it "can update a region with POST" do
+    api_basic_authorize action_identifier(:regions, :edit)
+
+    region = FactoryBot.create(:miq_region, :description => "Current Region description")
+
+    post api_region_url(nil, region), :params => gen_request(:edit, :description => "New Region description")
+
+    expect(response).to have_http_status(:ok)
+    region.reload
+    expect(region.description).to eq("New Region description")
+  end
+
   describe "Settings" do
     let(:region_number) { ApplicationRecord.my_region_number + 1 }
     let(:id) { ApplicationRecord.id_in_region(1, region_number) }

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -63,10 +63,10 @@ RSpec.describe "Regions API", :regions do
       region = FactoryBot.create(:miq_region, :description => "Current Region description")
 
       post api_region_url(nil, region), :params => gen_request(:edit, :created_at => Time.now.utc)
-      expect(response).to have_http_status(:bad_request)
+      expect_bad_request("Attribute(s) 'created_at' should not be specified for updating a region resource")
 
       post api_region_url(nil, region), :params => gen_request(:edit, :updated_at => Time.now.utc)
-      expect(response).to have_http_status(:bad_request)
+      expect_bad_request("Attribute(s) 'updated_at' should not be specified for updating a region resource")
     end
 
     it "can update multiple regions with POST" do

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe "Regions API", :regions do
 
       get(api_region_url(nil, region))
 
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include(
+      expect_single_resource_query(
         "href" => api_region_url(nil, region),
         "id"   => region.id.to_s
       )

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -64,8 +64,36 @@ RSpec.describe "Regions API", :regions do
       region = FactoryBot.create(:miq_region, :description => "Current Region description")
 
       post api_region_url(nil, region), :params => gen_request(:edit, :created_at => Time.now.utc)
-
       expect(response).to have_http_status(:bad_request)
+
+      post api_region_url(nil, region), :params => gen_request(:edit, :id => 999)
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "can update multiple regions with POST" do
+      api_basic_authorize action_identifier(:regions, :edit)
+
+      region_1 = FactoryBot.create(:miq_region, :description => "Test Region 1")
+      region_2 = FactoryBot.create(:miq_region, :description => "Test Region 2")
+
+      options = [
+        {"href" => api_region_url(nil, region_1), "description" => "Updated Test Region 1"},
+        {"href" => api_region_url(nil, region_2), "description" => "Updated Test Region 2"}
+      ]
+
+      post api_regions_url, :params => gen_request(:edit, options)
+
+      expect(response).to have_http_status(:ok)
+
+      expect_results_to_match_hash("results",
+        [
+          {"id" => region_1.id.to_s, "description" => "Updated Test Region 1"},
+          {"id" => region_2.id.to_s, "description" => "Updated Test Region 2"}
+        ]
+      )
+
+      expect(region_1.reload.name).to eq("Updated Test Region 1")
+      expect(region_2.reload.name).to eq("Updated Test Region 2")
     end
   end
 


### PR DESCRIPTION
This adds edit and delete actions to the rest api for MiqRegion's. A delete can be performed using either a POST or DELETE.

A few fields have been explicitly blacklisted. Will update, if desired.

I added some rspec tags for convenience.

Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1753806