### PR TITLE
Hardening collections

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1217,9 +1217,11 @@
     :collection_actions:
       :get:
       - :name: read
+        :identifier: ems_infra
     :resource_actions:
       :get:
       - :name: read
+        :identifier: ems_infra
   :event_streams:
     :description: Event Streams
     :options:
@@ -1276,7 +1278,9 @@
     :subcollection_actions:
       :post:
       - :name: assign
+        :identifier: rbac_role_edit
       - :name: unassign
+        :identifier: rbac_role_edit
   :firmware_binaries:
     :description: Firmware Binaries
     :options:
@@ -2968,6 +2972,17 @@
     - :collection
     :verbs: *g
     :klass: MiqServer
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: ops_diagnostics
+      :post:
+      - :name: query
+        :identifier: ops_diagnostics
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: ops_diagnostics
   :service_catalogs:
     :description: Service Catalogs
     :identifier: st_catalog_accord

--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -10,6 +10,16 @@ describe 'API configuration (config/api.yml)' do
       expect(actual).to eq(expected)
     end
 
+    describe 'collection' do
+      it 'each primary collection has an identifier for GET read action except for a few' do
+        whitelisted = collection_settings.find_all do |_, v|
+          v.options.index(:collection) &&
+            v.collection_actions&.[](:get)&.find{ |h| h[:name] == 'read' }&.identifier.nil?
+        end.map(&:first).sort
+        expect(whitelisted).to eq(%i[automate_workspaces currencies features measures notifications pictures])
+      end
+    end
+
     describe 'identifiers' do
       let(:api_feature_identifiers) do
         feature_identifiers { |set, id| set.add(id) }

--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -14,7 +14,7 @@ describe 'API configuration (config/api.yml)' do
       it 'each primary collection has an identifier for GET read action except for a few' do
         whitelisted = collection_settings.find_all do |_, v|
           v.options.index(:collection) &&
-            v.collection_actions&.[](:get)&.find{ |h| h[:name] == 'read' }&.identifier.nil?
+            v.collection_actions&.[](:get)&.find { |h| h[:name] == 'read' }&.identifier.nil?
         end.map(&:first).sort
         expect(whitelisted).to eq(%i[automate_workspaces currencies features measures notifications pictures])
       end

--- a/spec/requests/enterprises_spec.rb
+++ b/spec/requests/enterprises_spec.rb
@@ -1,14 +1,25 @@
 describe "Enterprises API" do
   context "GET /api/enterprises" do
-    it "returns the enterprises" do
-      enterprise = MiqEnterprise.first
+    before do
+      @enterprise = MiqEnterprise.first
+    end
+
+    it "does not allow an unauthorized user to list the enterprises" do
       api_basic_authorize
+
+      get(api_enterprises_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns the enterprises" do
+      api_basic_authorize(:ems_infra)
 
       get(api_enterprises_url)
 
       expected = {
         "name"      => "enterprises",
-        "resources" => [{"href" => api_enterprise_url(nil, enterprise)}]
+        "resources" => [{"href" => api_enterprise_url(nil, @enterprise)}]
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -18,7 +29,7 @@ describe "Enterprises API" do
   context "GET /api/enterprises/:id" do
     it "returns the enterprise" do
       enterprise = FactoryBot.create(:miq_enterprise)
-      api_basic_authorize
+      api_basic_authorize(:ems_infra)
 
       get(api_enterprise_url(nil, enterprise))
 

--- a/spec/requests/roles_spec.rb
+++ b/spec/requests/roles_spec.rb
@@ -244,6 +244,26 @@ describe "Roles API" do
   end
 
   describe "Role Feature Assignments" do
+    it "does not allow assigning features for an unauthorized user" do
+      api_basic_authorize
+      role = FactoryBot.create(:miq_user_role, :features => "miq_request_approval")
+
+      new_feature = {:identifier => "miq_request_view"}
+      url = api_role_features_url(nil, role)
+      post(url, :params => gen_request(:assign, new_feature))
+
+      expect(response).to have_http_status(:forbidden)
+
+      # Refresh the role object
+      role = MiqUserRole.find(role.id)
+
+      # Confirm original feature
+      expect(role.allows?(:identifier => 'miq_request_approval')).to be_truthy
+
+      # Confirm new feature is not there
+      expect(role.allows?(new_feature)).to be_falsey
+    end
+
     it "supports assigning just a single product feature" do
       api_basic_authorize collection_action_identifier(:roles, :edit)
       role = FactoryBot.create(:miq_user_role, :features => "miq_request_approval")

--- a/spec/requests/roles_spec.rb
+++ b/spec/requests/roles_spec.rb
@@ -254,10 +254,8 @@ describe "Roles API" do
 
       expect(response).to have_http_status(:forbidden)
 
-      # Refresh the role object
-      role = MiqUserRole.find(role.id)
-
       # Confirm original feature
+      role.reload
       expect(role.allows?(:identifier => 'miq_request_approval')).to be_truthy
 
       # Confirm new feature is not there
@@ -275,10 +273,8 @@ describe "Roles API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", %w(id name read_only))
 
-      # Refresh the role object
-      role = MiqUserRole.find(role.id)
-
       # Confirm original feature
+      role.reload
       expect(role.allows?(:identifier => 'miq_request_approval')).to be_truthy
 
       # Confirm new feature

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -1,9 +1,19 @@
 RSpec.describe "Servers" do
   let(:server) { FactoryBot.create(:miq_server) }
 
+  describe "/api/servers" do
+    it "does not allow an unauthorized user to list the servers" do
+      api_basic_authorize
+
+      get(api_servers_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe "/api/servers/:id?expand=settings" do
     it "expands the settings subcollection" do
-      api_basic_authorize(:ops_settings)
+      api_basic_authorize(:ops_settings, :ops_diagnostics)
 
       get(api_server_url(nil, server), :params => {:expand => 'settings'})
 


### PR DESCRIPTION
Test that primary collections have rbac id for GET read action.
    
Add a spec checking that each primary collection has an rbac identifier
for GET read action. So that data cannot be read w/o authorization.
    
There are exceptions to the rule: there's data accessible to any
authenticated user. Those collections are whitelisted in the test.

Also adding missing feature identifiers.

