### PR TITLE
Refactor region and zone specs a bit

### DIFF
--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Regions API", :regions do
       region = FactoryBot.create(:miq_region)
 
       expect { post api_region_url(nil, region), :params => gen_request(:delete) }.to change(MiqRegion, :count).by(-1)
-      expect(response).to have_http_status(:ok)
+      expect_single_action_result(:success => true, :message => /#{region.id}/)
     end
 
     it "can delete a region with DELETE" do
@@ -150,7 +150,7 @@ RSpec.describe "Regions API", :regions do
       ]
 
       expect { post api_regions_url, :params => gen_request(:delete, options) }.to change(MiqRegion, :count).by(-2)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(regions.size)
     end
 
     it "forbids deletion of a region without an appropriate role" do

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -9,23 +9,15 @@
 #
 
 RSpec.describe "Regions API", :regions do
+  let(:region) { FactoryBot.create(:miq_region, :region => '2') }
+
   context "authorization", :authorization do
     it "forbids access to regions without an appropriate role" do
-      api_basic_authorize
-
-      get(api_regions_url)
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request { get(api_regions_url) }
     end
 
     it "forbids access to a region resource without an appropriate role" do
-      api_basic_authorize
-
-      region = FactoryBot.create(:miq_region, :region => "2")
-
-      get(api_region_url(nil, region))
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request { get(api_region_url(nil, region)) }
     end
   end
 
@@ -57,7 +49,7 @@ RSpec.describe "Regions API", :regions do
       expect(region.description).to eq("New Region description")
     end
 
-    it "will fail if you try to edit forbidden fields" do
+    it "will fail if you try to edit invalid fields" do
       api_basic_authorize action_identifier(:regions, :edit)
 
       region = FactoryBot.create(:miq_region, :description => "Current Region description")
@@ -96,7 +88,7 @@ RSpec.describe "Regions API", :regions do
       expect(region2.reload.description).to eq("Updated Test Region 2")
     end
 
-    it "will fail to update multiple regions if any forbidden fields are edited" do
+    it "will fail to update multiple regions if any invalid fields are edited" do
       api_basic_authorize action_identifier(:regions, :edit)
 
       region1 = FactoryBot.create(:miq_region, :description => "Test Region 1")
@@ -113,13 +105,10 @@ RSpec.describe "Regions API", :regions do
     end
 
     it "forbids edit of a region without an appropriate role" do
-      api_basic_authorize
-
-      region = FactoryBot.create(:miq_region, :description => "Current Region description")
-
-      post api_region_url(nil, region), :params => gen_request(:edit, :description => "New Region description")
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request do
+        region = FactoryBot.create(:miq_region, :description => "Current Region description")
+        post(api_region_url(nil, region), :params => gen_request(:edit, :description => "New Region description"))
+      end
     end
   end
 
@@ -154,12 +143,10 @@ RSpec.describe "Regions API", :regions do
     end
 
     it "forbids deletion of a region without an appropriate role" do
-      api_basic_authorize
-      region = FactoryBot.create(:miq_region, :description => "Current Region description")
-
-      delete api_region_url(nil, region)
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request do
+        region = FactoryBot.create(:miq_region, :description => "Current Region description")
+        delete(api_region_url(nil, region))
+      end
     end
   end
 
@@ -205,11 +192,7 @@ RSpec.describe "Regions API", :regions do
       end
 
       it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
-        api_basic_authorize
-
-        get(api_region_settings_url(nil, region))
-
-        expect(response).to have_http_status(:forbidden)
+        expect_forbidden_request { get(api_region_settings_url(nil, region)) }
       end
 
       it "does not allow an unauthenticated user to view the settings" do

--- a/spec/requests/zones_spec.rb
+++ b/spec/requests/zones_spec.rb
@@ -3,19 +3,11 @@ RSpec.describe "Zones" do
 
   context "authorization", :authorization do
     it "forbids access to zones without an appropriate role" do
-      api_basic_authorize
-
-      get(api_zones_url)
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request { get(api_zones_url) }
     end
 
     it "forbids access to a zone resource without an appropriate role" do
-      api_basic_authorize
-
-      get(api_zone_url(nil, zone))
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request { get(api_zone_url(nil, zone)) }
     end
   end
 
@@ -33,7 +25,7 @@ RSpec.describe "Zones" do
   end
 
   context "edit", :edit do
-    it "will fail if you try to edit forbidden fields" do
+    it "will fail if you try to edit invalid fields" do
       api_basic_authorize action_identifier(:zones, :edit)
 
       zone = FactoryBot.create(:zone, :description => "Current Zone description")
@@ -72,7 +64,7 @@ RSpec.describe "Zones" do
       expect(zone2.reload.description).to eq("Updated Test Zone 2")
     end
 
-    it "will fail to update multiple zones if any forbidden fields are edited" do
+    it "will fail to update multiple zones if any invalid fields are edited" do
       api_basic_authorize action_identifier(:zones, :edit)
 
       zone1 = FactoryBot.create(:zone, :description => "Test Zone 1")
@@ -89,13 +81,10 @@ RSpec.describe "Zones" do
     end
 
     it "forbids edit of a zone without an appropriate role" do
-      api_basic_authorize
-
-      zone = FactoryBot.create(:zone, :description => "Current Zone description")
-
-      post api_zone_url(nil, zone), :params => gen_request(:edit, :description => "New Zone description")
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request do
+        zone = FactoryBot.create(:zone, :description => "Current Zone description")
+        post(api_zone_url(nil, zone), :params => gen_request(:edit, :description => "New Zone description"))
+      end
     end
   end
 
@@ -130,12 +119,10 @@ RSpec.describe "Zones" do
     end
 
     it "forbids deletion of a zone without an appropriate role" do
-      api_basic_authorize
-      zone = FactoryBot.create(:zone, :description => "Current Region description")
-
-      delete api_zone_url(nil, zone)
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request do
+        zone = FactoryBot.create(:zone, :description => "Current Region description")
+        delete api_zone_url(nil, zone)
+      end
     end
   end
 
@@ -171,11 +158,7 @@ RSpec.describe "Zones" do
     end
 
     it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
-      api_basic_authorize
-
-      get(api_zone_settings_url(nil, zone))
-
-      expect(response).to have_http_status(:forbidden)
+      expect_forbidden_request { get(api_zone_settings_url(nil, zone)) }
     end
 
     it "does not allow an unauthenticated user to view the settings" do


### PR DESCRIPTION
Since I just submitted PR's for updated region and zone specs, I went back and refactored them a bit. Mainly this consisted of using `expect_forbidden_request` for simple specs that use a basic authorize, as well as `expect_single_action_result` in a few places, which is a little more thorough.

There were a couple other very minor tweaks, like using a single factory where we can, and changing "forbidden" to "invalid" in some spec descriptions to avoid confusion with forbidden requests.