### PR TITLE
Fix call to generate_content

### DIFF
--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -12,8 +12,8 @@ module Api
 
     def generate_widget_content(widget)
       desc = "#{widget_ident(widget)} content generation"
-      task_id = queue_object_action(widget, desc, :method_name => "generate_content", :args => ["User", User.current_user.current_group.description, [User.current_user.userid]])
-      action_result(true, desc, :task_id => task_id)
+      widget.queue_generate_content
+      action_result(true, desc)
     rescue => err
       action_result(false, err.to_s)
     end


### PR DESCRIPTION
Fixing a bug introduced originally introduced in https://github.com/ManageIQ/manageiq-api/pull/660. ```queue_object_action``` can't be used here because not all generate_content calls create tasks, and so relying on a task_id is bad. Per conversation with Libor we should just call ```queue_gen_content``` directly. 

@miq-bot add_label bug
@miq-bot assign @lpichler 
@miq-bot add label hammer/yes, ivanchuk/yes

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1761836