### PR TITLE
Automate class CRUD

### DIFF
--- a/app/controllers/api/automate_classes_controller.rb
+++ b/app/controllers/api/automate_classes_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  class AutomateClassesController < BaseController
+    EDITABLE_ATTRS = %w[name display_name description].freeze
+
+    def edit_resource(type, id, data)
+      bad_attrs = data_includes_invalid_attrs(data)
+
+      if bad_attrs.present?
+        msg = "Attribute(s) '#{bad_attrs}' should not be specified for updating an automate class resource"
+        raise BadRequestError, msg
+      end
+
+      super
+    end
+
+    private
+
+    def data_includes_invalid_attrs(data)
+      return nil unless data
+
+      data.keys.reject { |key| EDITABLE_ATTRS.include?(key) }.compact.join(", ")
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -275,6 +275,36 @@
       :get:
       - :name: read
         :identifier: miq_ae_domain_view
+  :automate_classes:
+    :description: Automate Classes
+    :identifier: miq_ae_class
+    :options:
+    - :collection
+    :verbs: *gpd
+    :klass: MiqAeClass
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_ae_class
+      :post:
+      - :name: query
+        :identifier: miq_ae_class
+      - :name: edit
+        :identifier: miq_ae_class_edit
+      - :name: delete
+        :identifier: miq_ae_class_delete
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_ae_class
+      :post:
+      - :name: edit
+        :identifier: miq_ae_class_edit
+      - :name: delete
+        :identifier: miq_ae_class_delete
+      :delete:
+      - :name: delete
+        :identifier: miq_ae_class_delete
   :automate_domains:
     :description: Automate Domains
     :options:

--- a/spec/requests/automate_classes_spec.rb
+++ b/spec/requests/automate_classes_spec.rb
@@ -1,0 +1,152 @@
+#
+# REST API Request Tests - Automate classes
+#
+# Regions primary collections:
+#   /api/automate_classes
+#
+# Tests for:
+# GET /api/automate_classes/:id
+#
+
+RSpec.describe "Regions API", :automate_classes do
+  let(:domain) do
+    FactoryBot.create(:miq_ae_system_domain, :name => 'ns1', :priority => 10)
+  end
+
+  let(:automate_class) do
+    FactoryBot.create(:miq_ae_class, :namespace_id => domain.id, :name => 'foo')
+  end
+
+  let(:automate_class2) do
+    FactoryBot.create(:miq_ae_class, :namespace_id => domain.id, :name => 'bar')
+  end
+
+  let(:automate_classes) do
+    [automate_class, automate_class2]
+  end
+
+  context "authorization", :authorization do
+    it "forbids access to automate_classes without an appropriate role" do
+      expect_forbidden_request { get(api_automate_classes_url) }
+    end
+
+    it "forbids access to a automate_class resource without an appropriate role" do
+      expect_forbidden_request { get(api_automate_class_url(nil, automate_class)) }
+    end
+  end
+
+  context "get", :get do
+    it "allows GETs of a automate_class" do
+      api_basic_authorize action_identifier(:automate_classes, :read, :resource_actions, :get)
+
+      get(api_automate_class_url(nil, automate_class))
+
+      expect_single_resource_query(
+        "href" => api_automate_class_url(nil, automate_class),
+        "id"   => automate_class.id.to_s
+      )
+    end
+  end
+
+  context "edit", :edit do
+    it "can update a automate_class with POST" do
+      api_basic_authorize action_identifier(:automate_classes, :edit)
+
+      post api_automate_class_url(nil, automate_class), :params => gen_request(:edit, :description => 'New Class description')
+
+      expect(response).to have_http_status(:ok)
+      automate_class.reload
+      expect(automate_class.description).to eq('New Class description')
+    end
+
+    it "will fail if you try to edit invalid fields" do
+      api_basic_authorize action_identifier(:automate_classes, :edit)
+
+      post api_automate_class_url(nil, automate_class), :params => gen_request(:edit, :created_at => Time.now.utc)
+      expect_bad_request("Attribute(s) 'created_at' should not be specified for updating an automate class resource")
+
+      post api_automate_class_url(nil, automate_class), :params => gen_request(:edit, :updated_at => Time.now.utc)
+      expect_bad_request("Attribute(s) 'updated_at' should not be specified for updating an automate class resource")
+    end
+
+    it "can update multiple automate_classes with POST" do
+      api_basic_authorize action_identifier(:automate_classes, :edit)
+
+      options = [
+        {"href" => api_automate_class_url(nil, automate_class), "description" => "Updated Test Class 1"},
+        {"href" => api_automate_class_url(nil, automate_class2), "description" => "Updated Test Class 2"}
+      ]
+
+      post api_automate_classes_url, :params => gen_request(:edit, options)
+
+      expect(response).to have_http_status(:ok)
+
+      expect_results_to_match_hash(
+        "results",
+        [
+          {"id" => automate_class.id.to_s, "description" => "Updated Test Class 1"},
+          {"id" => automate_class2.id.to_s, "description" => "Updated Test Class 2"}
+        ]
+      )
+
+      expect(automate_class.reload.description).to eq("Updated Test Class 1")
+      expect(automate_class2.reload.description).to eq("Updated Test Class 2")
+    end
+
+    it "will fail to update multiple automate_classes if any invalid fields are edited" do
+      api_basic_authorize action_identifier(:automate_classes, :edit)
+
+      options = [
+        {"href" => api_automate_class_url(nil, automate_class), "description" => "New description"},
+        {"href" => api_automate_class_url(nil, automate_class2), "created_at" => Time.now.utc}
+      ]
+
+      post api_automate_classes_url, :params => gen_request(:edit, options)
+
+      expect_bad_request("Attribute(s) 'created_at' should not be specified for updating an automate class resource")
+    end
+
+    it "forbids edit of a automate_class without an appropriate role" do
+      expect_forbidden_request do
+        post(api_automate_class_url(nil, automate_class), :params => gen_request(:edit, :description => "New Region description"))
+      end
+    end
+  end
+
+  context "delete", :delete do
+    it "can delete a automate_class with POST" do
+      api_basic_authorize action_identifier(:automate_classes, :delete)
+      automate_class
+
+      expect { post api_automate_class_url(nil, automate_class), :params => gen_request(:delete) }.to change(MiqAeClass, :count).by(-1)
+      expect_single_action_result(:success => true, :message => /#{automate_class.id}/)
+    end
+
+    it "can delete a automate_class with DELETE" do
+      api_basic_authorize action_identifier(:automate_classes, :delete)
+      automate_class
+
+      expect { delete api_automate_class_url(nil, automate_class) }.to change(MiqAeClass, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "can delete multiple automate_classes with POST" do
+      api_basic_authorize action_identifier(:automate_classes, :delete)
+      automate_classes
+
+      options = [
+        {"href" => api_automate_class_url(nil, automate_classes.first)},
+        {"href" => api_automate_class_url(nil, automate_classes.last)}
+      ]
+
+      expect { post api_automate_classes_url, :params => gen_request(:delete, options) }.to change(MiqAeClass, :count).by(-2)
+      expect_multiple_action_result(automate_classes.size)
+    end
+
+    it "forbids deletion of a automate_class without an appropriate role" do
+      expect_forbidden_request do
+        delete(api_automate_class_url(nil, automate_class))
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #https://github.com/ManageIQ/manageiq-api/issues/700

```
$ apic get automate_classes/721 --attributes=name,display_name,description,fqname
{
  "href": "http://localhost:3000/api/automate_classes/721",
  "name": "DynamicDialogs",
  "display_name": null,
  "description": null,
  "id": "721",
  "fqname": "/OP_Satellite/Integration/Satellite/DynamicDialogs"
}
```