### PR TITLE
Remove autoload_path

### DIFF
--- a/lib/manageiq/api/engine.rb
+++ b/lib/manageiq/api/engine.rb
@@ -2,7 +2,7 @@ require 'rails/engine'
 module ManageIQ
   module Api
     class Engine < ::Rails::Engine
-      isolate_namespace ManageIQ::Api
+      isolate_namespace Api
 
       # NOTE:  If you are going to make changes to autoload_paths, please make
       # sure they are all strings.  Rails will push these paths into the
@@ -12,7 +12,6 @@ module ManageIQ
       #
       #   https://bugs.ruby-lang.org/issues/14372
       #
-      config.autoload_paths << root.join('app', 'controllers', 'api').to_s
       config.autoload_paths << root.join('lib', 'services').to_s
       config.autoload_paths << root.join('lib').to_s
 


### PR DESCRIPTION
This autoload_path is not necessary as all Api controllers are
namespaced.  This actually causes errors when there are similarly named
top-level classes elsewhere, as Rails wil try to autload from this path
and not find that top-level class.

Fixes #708

@abellotti @jrafanie Please review.