### PR TITLE
[WIP] API for expression editor 

### DIFF
--- a/app/controllers/api/expressions_controller.rb
+++ b/app/controllers/api/expressions_controller.rb
@@ -45,7 +45,7 @@ module Api
       parent = {}
       parent[:assoc_path] = root_model
       parent[:root] = root_model
-      MiqExpression.expression_reflections_for(model, parent).map { |x| [x[:human_name]] } || []
+      MiqExpression.expression_reflections_for(model, parent).map { |x| x[:human_name] } || []
     end
 
     def autocomplete_action_entity(options)
@@ -62,7 +62,7 @@ module Api
         written_input.last == MiqExpression.value2human(model).strip ? relations_in_human_form_for(model, root_model) : []
       when 2
         relation = model_info_from(written_input, model, 1)
-        association_model = relation[:association_klass]
+        association_model = relation&.dig(:association_klass)
 
         if association_model && !MiqExpression.parse_field_or_tag("#{model}.#{relation[:association]}")&.plural?
           relations_in_human_form_for(association_model, root_model)

--- a/app/controllers/api/expressions_controller.rb
+++ b/app/controllers/api/expressions_controller.rb
@@ -1,0 +1,222 @@
+module Api
+  class ExpressionsController < BaseController
+    AUTOCOMPLETE_ACTIONS = %w[registry_value registry_data registry_key registry_operator tag_value tag_field exp_type entity field category operator tag_operator expression_operator value check_operator].freeze
+    REQUIRED_PARAMETERS_KEYS = %i[model autocomplete_actions].freeze
+
+    def index
+      REQUIRED_PARAMETERS_KEYS.each do |key|
+        raise "Required parameter #{key} is missing" unless params[key]
+      end
+
+      autocomplete_actions = Array(params[:autocomplete_actions])
+      if (autocomplete_actions & AUTOCOMPLETE_ACTIONS).empty?
+        raise "Any of autocomplete actions: #{autocomplete_actions.join(", ")} is not allowed."
+      end
+
+      response = {}
+      options = {:secondary_filter => params[:secondary_filter], :model => params[:model], :only_tag => params[:only_tag], :written_input => params[:written_input]}
+      autocomplete_actions.each_with_object(response) do |action_name, _|
+        autocomplete_action_method = "autocomplete_action_#{action_name}"
+        response[action_name] = send(autocomplete_action_method, options) if respond_to?(autocomplete_action_method)
+      end
+
+      render :json => response
+    end
+
+    def autocomplete_action_exp_type(options)
+      if options[:secondary_filter]
+        ExpAtomHelper.expression_types_for_secondary_filter(options[:columns_order], options[:columns])
+      else
+        ExpAtomHelper.expression_types_for_primary_filter(options[:model], options[:only_tag])
+      end.map(&:first)
+    end
+
+    def find_reflection_by(human_name, model)
+      parent = {}
+      parent[:assoc_path] = model
+      parent[:root] = model
+
+      MiqExpression.expression_reflections_for(model, parent).detect do |reflection_options|
+        human_name.strip == reflection_options[:human_name]
+      end
+    end
+
+    def relations_in_human_form_for(model, root_model)
+      parent = {}
+      parent[:assoc_path] = root_model
+      parent[:root] = root_model
+      MiqExpression.expression_reflections_for(model, parent).map { |x| [x[:human_name]] } || []
+    end
+
+    def autocomplete_action_entity(options)
+      written_input = options[:written_input] || []
+      model = options[:model]
+      root_model = model
+
+      raise "Unable to find #{model}" unless model.safe_constantize
+
+      case written_input.count
+      when 0
+        [MiqExpression.value2human(model).strip]
+      when 1
+        written_input.last == MiqExpression.value2human(model).strip ? relations_in_human_form_for(model, root_model) : []
+      when 2
+        relation = model_info_from(written_input, model, 1)
+        association_model = relation[:association_klass]
+
+        if association_model && !MiqExpression.parse_field_or_tag("#{model}.#{relation[:association]}")&.plural?
+          relations_in_human_form_for(association_model, root_model)
+        else
+          []
+        end
+      else
+        []
+      end
+    end
+
+    def model_info_from(written_input, model, offset = 2)
+      if written_input.count > offset
+        written_input[1..-offset].map do |human_entity|
+          relation = find_reflection_by(human_entity, model)
+          model = relation&.dig(:association_klass)
+          relation
+        end.last
+      else
+        {:association_klass => model}
+      end
+    end
+
+    def autocomplete_action_field(options)
+      written_input = options[:written_input] || []
+
+      model = options[:model]
+
+      raise "Unable to find #{model}" unless model.safe_constantize
+
+      model = model_info_from(written_input, model, 1)[:association_klass]
+
+      columns = model.safe_constantize.attribute_names.map do |x|
+        MiqExpression.value2human("#{model}-#{x}").split(":").last.strip
+      end
+      model ? columns : []
+    end
+
+    def autocomplete_action_value(options)
+      model = options[:model]
+
+      raise "Unable to find #{model}" unless model.safe_constantize
+
+      _operator = options[:written_input].pop
+      written_input = options[:written_input]
+
+      return [] if written_input.count < 2
+
+      model = model_info_from(written_input, options[:model])[:association_klass]
+
+      column_from_input = written_input.last
+      column = column_by_human_name(column_from_input, model)
+
+      MiqExpression::Field.parse("#{model}-#{column}").column_values
+    end
+
+    def autocomplete_action_operator(options)
+      model = options[:model]
+
+      raise "Unable to find #{model}" unless model.safe_constantize
+
+      written_input = options[:written_input]
+
+      return [] if written_input.count < 2
+
+      model = model_info_from(written_input, options[:model])[:association_klass]
+
+      column_from_input = written_input.last
+      column = column_by_human_name(column_from_input, model)
+
+      MiqExpression.get_col_operators("#{model}-#{column}")
+    end
+
+    def column_by_human_name(human_value, model)
+      model.safe_constantize.attribute_names.detect do |x|
+        human_value.strip == MiqExpression.value2human("#{model}-#{x}").split(":").last.strip
+      end
+    end
+
+    def autocomplete_action_tag_field(options)
+      model = options[:model]
+
+      setting = {:typ => 'tag', :include_table => true, :include_model => false, :include_my_tags => false}
+
+      MiqExpression::TAG_CLASSES.invert.each_with_object([]) do |(tag_association, tag_klass), return_array|
+        next if tag_klass.constantize.base_class == model.constantize.base_class
+
+        return_array.push(MiqExpression.value2human("#{model}.#{tag_association}", setting).strip)
+      end
+    end
+
+    def autocomplete_action_category(options)
+      model = options[:model]
+
+      if MiqExpression::TAG_CLASSES.include?(model)
+        ret = []
+        @classifications ||= MiqExpression.categories
+        @classifications.each do |_, classification|
+          ret << classification.description
+        end
+
+        ret.sort! { |a, b| a.to_s <=> b.to_s }
+      else
+        []
+      end
+    end
+
+    def autocomplete_action_tag_value(options)
+      model = options[:model]
+      humanize_tag_field = options[:written_input]&.last&.strip
+
+      if MiqExpression::TAG_CLASSES.include?(model) && humanize_tag_field
+        @classifications ||= MiqExpression.categories
+        target_classification = @classifications.detect do |_, classification|
+          classification.description == humanize_tag_field
+        end
+        target_classification ? target_classification.second.entries.map(&:description) : []
+      else
+        []
+      end
+    end
+
+    def autocomplete_action_tag_operator(_options)
+      ["CONTAINS"]
+    end
+
+    def autocomplete_action_expression_operator(_options)
+      %w(AND OR)
+    end
+
+    def autocomplete_action_check_operator(_options)
+      ["CHECK ALL", "CHECK ANY", "CHECK COUNT"]
+    end
+
+    def autocomplete_action_registry_key(_options)
+      RegistryItem.all.map { |x| x.name.split(" : ").first + " :" }.uniq
+    end
+
+    def autocomplete_action_registry_operator(options)
+      options[:written_input].count == 1 ? %w[KEY\ EXISTS] : MiqExpression::REGKEY_OPERATORS - %w[KEY\ EXISTS] + MiqExpression::STRING_OPERATORS
+    end
+
+    def autocomplete_action_registry_value(options)
+      written_registry_key = options[:written_input].last.gsub('\\\\', '\\').strip
+
+      RegistryItem.where("name LIKE ? ESCAPE ''", written_registry_key + "%").map { |x| x.name.split(" : ").second }.uniq
+    end
+
+    def autocomplete_action_registry_data(options)
+      written_registry_key, written_registry_value = options[:written_input]
+      written_registry_key.gsub!('\\\\', '\\').strip
+      written_registry_value.strip!
+
+      RegistryItem.where(:name => "#{written_registry_key} #{written_registry_value}").pluck(:data).uniq
+    end
+  end
+end

--- a/app/controllers/api/expressions_controller.rb
+++ b/app/controllers/api/expressions_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ExpressionsController < BaseController
-    AUTOCOMPLETE_ACTIONS = %w[registry_value registry_data registry_key registry_operator tag_value tag_field exp_type entity field category operator tag_operator expression_operator value check_operator].freeze
+    AUTOCOMPLETE_ACTIONS = %w[registry_value registry_data registry_key registry_operator tag_value tag_field exp_type entity field category operator tag_operator expression_operator value check_operator count_operator].freeze
     REQUIRED_PARAMETERS_KEYS = %i[model autocomplete_actions].freeze
 
     def index
@@ -195,6 +195,10 @@ module Api
 
     def autocomplete_action_check_operator(_options)
       ["CHECK ALL", "CHECK ANY", "CHECK COUNT"]
+    end
+
+    def autocomplete_action_count_operator(_options)
+      MiqExpression::NUM_OPERATORS
     end
 
     def autocomplete_action_registry_key(_options)

--- a/config/api.yml
+++ b/config/api.yml
@@ -1267,6 +1267,18 @@
       :get:
       - :name: read
         :identifier: event
+  :expressions:
+    :description: Expressions
+    :identifier: event
+    :options:
+      - :collection
+      - :subcollection
+    :verbs: *gp
+    :klass: MiqExpression
+    :resource_actions:
+      :get:
+        - :name: read
+          :identifier: miq_expression
   :features:
     :description: Product Features
     :options:


### PR DESCRIPTION
this PR is needed https://github.com/ManageIQ/manageiq/pull/19531

```
/api/expressions?model=<model>&autocomplete_actions[]=<exp_type>&written_input[]=...
```

`<model>`  is base model - for example base model report 
(ManageIQ::Providers::InfraManager::Vm) in model class name in string 

`<autocomplete_actions>` - array of actions to determine which information should be retrieved by the API.

**Supported autocomplete actions:**
```
registry_value registry_data registry_key registry_operator
tag_value category tag_field tag_operator
exp_type entity field
operator expression_operator value check_operator count_operator
```

`<written_input>` - array of element with user input, for example: 
`Virtual Machine.Last Compliance History.Details`

# Examples:

## expression_type

**User Input:** `Virtual Machine`

```
/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine

=>

{
    "exp_type": [
        "Field",
        "Count of",
        "Tag",
        "Find"
    ]
}

```

**List only tag** (used for expression editor in group edit)

```
/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine&only_tag=true

=>

{
    "exp_type": [
        "Tag"
    ]
}

```

**SECONDARY (DISPLAY) FILTER**

```

/api/expressions?autocomplete_actions[]=exp_type&model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine&secondary_filter=true&columns_order[]=...&columns[]=...
```
NOTE:  it is columns_order is `@edit[:new][:field_order]` and columns  is`@edit[:new][:fields]`

## entity


**User Input** : NOTHING

```
/api/expressions?autocomplete_actions[]=entity&model=ManageIQ::Providers::InfraManager::Vm
=>
{
    "entity": [
        "Virtual Machine"
    ]
}

```


**User Input** : `Virtual Machine`

```
/api/expressions?autocomplete_actions[]=entity&model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine

=>

{
    "entity": [
        "Snapshots",
        "Compliance History",
        "Last Compliance History",
        "EVM Owner",
        "EVM Custom Attributes",
        "OS",
        ...
    ]
}
```

**User Input** :  `Virtual Machine` `Last Compliance History`

```
/api/expressions?autocomplete_actions[]=entity&model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine&written_input[]=Last Compliance History


=>

{
    "entity": [
        "Details"
        ...
    ]
}
```


**User Input** :  `Virtual Machine` `Last Compliance History` `Details`

```
http://localhost:3090/api/expressions?autocomplete_actions[]=entity&model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine&written_input[]=Last Compliance History&written_input[]=Details

=>

{
    "entity": []
}

```

## field

**User Input** :  NOTHING

```
/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&autocomplete_actions[]=field
=>
{
    "field": [
        "Id",
        "Vendor",
        "Format",
        "Version",
        "Name",
        "Description",
        "Location",
        "Configuration XML",
        "Autostart",
        ...
        ]
}
```

**User Input** :  `Virtual Machine`

```
/api/expressions?autocomplete_actions[]=field&model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine

=>

{
    "field": [
        "Id",
        "Vendor",
        "Format",
        "Version",
        "Name",
        "Description",
        "Location",
        "Configuration XML",
        "Autostart",
        ...
        ]
}

```


**User Input**: `Virtual Machine` `Last Compliance History`


```
/api/expressions?autocomplete_actions[]=field&model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine&written_input[]=Last Compliance History
=>

{
    "field": [
        "Id",
        "Resource",
        "Resource Type",
        "Compliant",
        "Activity Sample - Timestamp (Day/Time)",
        "Date Updated",
        "Event Type",
        "Href Slug",
        "Region Number",
        "Region Description"
    ]
}

```

**User Input**: `Virtual Machine` `Last Compliance History` `Details`

```

/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine&autocomplete_actions[]=field&written_input[]=Last Compliance History&written_input[]=Details`

{
    "field": [
        "Id",
        "Compliance",
        "Date Created",
        "Date Updated",
        "Miq Policy",
        "Miq Policy Desc",
        "Miq Policy Result",
        "Condition",
        "Condition Desc",
        "Condition Result",
        "Href Slug",
        "Region Number",
        "Region Description",
        "Asset Name"
    ]
}
```

## registry_key
**User Input**: NOTHING


```
/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&autocomplete_actions[]=registry_key

{
    "registry_key": [
        "HKLM\\SOFTWARE\\Microsoft\\Ole :",
        "HKLM\\SOFTWARE\\Microsoft\\Rpc :",
        "HKLM\\SYSTEM\\CurrentControlSet\\Services\\Browser :",
        "HKLM\\SYSTEM\\CurrentControlSet\\Services\\DHCP :",
        "HKLM\\SYSTEM\\CurrentControlSet\\Services\\Eventlog\\Application :",
        "HKLM\\SYSTEM\\CurrentControlSet\\Services\\Eventlog\\Security :",
        "HKLM\\SYSTEM\\CurrentControlSet\
        ...

```

## registry_operator, registry_value

**User Input**: `HKLM\\SYSTEM\\CurrentControlSet\\Services\\W32Time\\Parameters :`

```
/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&written_input[]=HKLM\\SOFTWARE\\Microsoft\\Ole :&autocomplete_actions[]=registry_operator&autocomplete_actions[]=registry_value

{
    "registry_operator": [
        "KEY_EXIST"
    ],
    "registry_value": [
        "NtpServer"
    ]
}

```

## registry_operator


**User Input**: `HKLM\\SYSTEM\\CurrentControlSet\\Services\\W32Time\\Parameters :` `NtpServer`

```
/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&written_input[]=HKLM\\SOFTWARE\\Microsoft\\Ole :&autocomplete_actions[]=registry_operator&written_input[]=EnableDCOM

{
    "registry_operator": [
        "VALUE_EXIST",
        "=",
        ...
    ]
}

```

## registry_data


**User Input**: `HKLM\\SYSTEM\\CurrentControlSet\\Services\\W32Time\\Parameters :` `NtpServer` `=`

 
```


/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&written_input[]=HKLM\\SOFTWARE\\Microsoft\\Ole :&written_input[]=EnableDCOM&autocomplete_actions[]=registry_data&written_input[]==

{
    "registry_data": [
        "Y"
    ]
}


```


## tag_field


**User Input**: `Virtual Machine` or NOTHING

```
./api/expressions?model=ManageIQ::Providers::InfraManager::Vm&written_input[]=Virtual Machine&autocomplete_actions[]=tag_field

{
    "tag_field": [
        "Provider",
        "Cluster / Deployment Role",
        "Host / Node",
        "Miq Group",
        "Resource Pool",
        "Service",
        "Datastore",
        "User",
        "Container",
        "Build"]
 }
 
```


## category

(it does not depend on user's input)

`/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&autocomplete_actions[]=category`


```
/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&autocomplete_actions[]=category


{
    "category": [
        "Auto Approve - Max CPU",
        "Auto Approve - Max Memory",
        "Auto Approve - Max Retirement Days",
        "Auto Approve - Max VM",
        "Cost Center",
        "Department",
        "EVM Operations",
        "Environment",
        "Exclusions",
       ..
}

```

## tag_value

**USER INPUT**: `Provider` `Auto Approve - Max CPU`


```
/api/expressions?model=ManageIQ::Providers::InfraManager::Vm&autocomplete_actions[]=tag_value&written_input[]=Provider&written_input[]=Auto Approve - Max CPU

{
    "tag_value": [
        "1",
        "2",
        "3",
        "4",
        "5",
        "tagnew"
    ]
}
```

## tag_operator, expression_operator, check_operator

(those don't depend on user's input)

```{
    "expression_operator": [
        "AND",
        "OR"
    ]
}

{
    "tag_operator": [
        "CONTAINS"
    ]
}
```


