### PR TITLE
Remove old usage currency factories in chargebacks spec

### DIFF
--- a/spec/requests/chargebacks_spec.rb
+++ b/spec/requests/chargebacks_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can list of all currencies" do
-    currency = FactoryBot.create(:chargeback_rate_detail_currency)
+    currency = FactoryBot.create(:currency)
 
     api_basic_authorize
     get '/api/currencies'
@@ -85,7 +85,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can show an individual currency" do
-    currency = FactoryBot.create(:chargeback_rate_detail_currency)
+    currency = FactoryBot.create(:currency)
 
     api_basic_authorize
     get "/api/currencies/#{currency.id}"


### PR DESCRIPTION
related to https://github.com/ManageIQ/manageiq-api/pull/713



@miq-bot add_label technical debt

@miq-bot assign @martinpovolny 