### PR TITLE
[WIP] Check that object we're normalizing does in fact respond to key?

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -24,7 +24,8 @@ module Api
         is_ar = obj.kind_of?(ActiveRecord::Base)
         attrs.each do |k|
           next if Api.encrypted_attribute?(k) && api_resource_action_options.exclude?("include_encrypted_attributes")
-          next if is_ar ? !obj.respond_to?(k) : !obj.key?(k)
+          next if is_ar ? !obj.respond_to?(k) : !obj.try(:key?, k)
+
           result[k] = normalize_attr(k, is_ar ? obj.try(k) : obj[k])
         end
         result


### PR DESCRIPTION
This normalizing thingy is kinda fragile and should probably use `try` to try to make it worse

 `ERROR -- : MIQ(Api::ServiceDialogsController.api_error) NoMethodError: undefined method 'key?' for #<MiqAeMethodService::MiqAeService
ManageIQ_Providers_Vmware_InfraManager_Template:0x000000000ce32270>` 

👻 🏃‍♀ 👟 


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1789915 (Tuan says it worked 💀 )


Well I can reproduce part of it:
`$evm=MiqAeMethodService::MiqAeService.new(MiqAeEngine::MiqAeWorkspaceRuntime.new)`
`h = $evm.vmdb('Host', 1)`

It won't be ar_based and it won't be a hashlike thing.