### PR TITLE
Deprecate load balancers

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -81,6 +81,12 @@ module Api
         $api_log.info("MIQ(#{self.class.name}.#{method}) #{msg}")
       end
 
+      def api_log_warn(msg)
+        method = api_get_method_name(caller.first, __method__)
+
+        $api_log.warn("MIQ(#{self.class.name}.#{method}) #{msg}")
+      end
+
       private
 
       def log_request_body

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -152,12 +152,19 @@ module Api
         validate_method_action(:delete, "delete")
       end
 
+      def validate_deprecation
+        api_log_warn("Collection '%s' is deprecated" % @req.collection) if collection_option?(:deprecated)
+        api_log_warn("Subcollection '%s' is deprecated" % @req.subcollection) if @req.subcollection? && collection_config.option?(@req.subcollection, :deprecated)
+      end
+
       def validate_method_action(method_name, action_name)
+        validate_deprecation
         cname, target = if collection_option?(:arbitrary_resource_path)
                           [@req.collection, (@req.collection_id ? :resource : :collection)]
                         else
                           [@req.subject, request_type_target.last]
                         end
+
         aspec = if @req.subcollection?
                   collection_config.typed_subcollection_actions(@req.collection, cname, target) ||
                     collection_config.typed_collection_actions(cname, target)

--- a/config/api.yml
+++ b/config/api.yml
@@ -1790,6 +1790,7 @@
   :load_balancers:
     :description: Load Balancers
     :options:
+    - :deprecated
     - :collection
     - :subcollection
     - :custom_actions


### PR DESCRIPTION
Add deprecation mechanism to the config file.

Replacement for https://github.com/ManageIQ/manageiq-api/pull/714 

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1754844

ping @lpichler 

Do we want to check for the deprecation on more places?