### PR TITLE
Fix spec failure

### DIFF
--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Headers" do
       expect(response.headers.to_h).to include(expected)
       expect(content_security_policy_for("default-src")).to include("'self'")
       expect(content_security_policy_for("connect-src")).to include("'self'")
-      expect(content_security_policy_for("frame-src")).to include("'self'")
+      expect(content_security_policy_for("frame-src") || content_security_policy_for("child-src")).to include("'self'")
       expect(content_security_policy_for("script-src")).to include("'unsafe-eval'", "'unsafe-inline'", "'self'")
       expect(content_security_policy_for("style-src")).to include("'unsafe-inline'", "'self'")
     end


### PR DESCRIPTION
Check `"frame-src"` or `"child-src"`

Fixes 
```
 1) Headers Response Headers returns some headers related to security
     Failure/Error: #expect(content_security_policy_for("frame-src")).to include("'self'")
       expected nil to include "'self'", but it does not respond to `include?`
     # ./spec/requests/headers_spec.rb:85:in `block (3 levels) in <top (required)>'
```

@miq-bot add_label bug, test