### PR TITLE
Wrap possible autoloaded models in interlock loading

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -134,12 +134,24 @@ module Api
       klass.params_for_create
     end
 
+    def leaf_subclasses
+      ActiveSupport::Dependencies.interlock.loading do
+        ManageIQ::Providers::BaseManager.leaf_subclasses
+      end
+    end
+
+    def supported_types_for_create
+      ActiveSupport::Dependencies.interlock.loading do
+        ExtManagementSystem.supported_types_for_create
+      end
+    end
+
     def providers_options
-      providers_options = ManageIQ::Providers::BaseManager.leaf_subclasses.inject({}) do |po, ems|
+      providers_options = leaf_subclasses.inject({}) do |po, ems|
         po.merge(ems.ems_type => ems.options_description)
       end
 
-      supported_providers = ExtManagementSystem.supported_types_for_create.map do |klass|
+      supported_providers = supported_types_for_create.map do |klass|
         if klass.supports_regions?
           regions = klass.parent::Regions.all.sort_by { |r| r[:description] }.map { |r| r.slice(:name, :description) }
         end


### PR DESCRIPTION
Since we don't eager load the models that could be loaded here, we need to wrap
these calls in the interlock loading to ensure rails' interlock knows we're
loading code in this block, so two threads don't try to autoload at the same
time.

Fixes timing issues resulting in errors of the variety:

```
LoadError (Unable to autoload constant ManageIQ::Providers::Openstack::StorageManager::CinderManager, expected /home/mmarosi/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/bundler/gems/manageiq-providers-openstack-4481f21d2ebe/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb to define it)
```

Fixes https://github.com/ManageIQ/manageiq/issues/19772

In that issue, we had 3 requests happen in 3 threads at the same time:
```
[----] I, [2020-01-28T16:39:43.358817 #6310:3fd8bc363880]  INFO -- : Started GET "/ems_cloud/ems_cloud_form_fields/new" for ::1 at 2020-01-28 16:39:43 -0500
[----] I, [2020-01-28T16:39:43.394484 #6310:3fd8bc363754]  INFO -- : Started OPTIONS "/api/providers" for ::1 at 2020-01-28 16:39:43 -0500
[----] I, [2020-01-28T16:39:43.690661 #6310:3fd8bc3633a8]  INFO -- : Started OPTIONS "/api/providers" for ::1 at 2020-01-28 16:39:43 -0500
```

We were able to reduce that issue to this recreation script run locally against `rails
server`:

```ruby
threads = []
threads << Thread.new do
  `curl -k -L -u admin:smartvm -i -X GET http://localhost:3000/ems_cloud/ems_cloud_form_fields/new`
end

2.times do
  threads << Thread.new do
    `curl -k -L -u admin:smartvm -i -X OPTIONS http://localhost:3000/api/providers`
  end
end

threads.join
```