### PR TITLE
[V2V] Renaming openstack_tls_ca_cert variable

### DIFF
--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -14,7 +14,7 @@ module Api
     #   * vmware_vddk_package_url
     #   * vmware_ssh_private_key
     #   * conversion_host_ssh_private_key
-    #   * openstack_tls_ca_certs
+    #   * tls_ca_certs
     #   * auth_user
     #
     # Example:


### PR DESCRIPTION
In order to have a consistent wizard for oVirt and OpenStack conversion hosts, we ask for the provider endpoint TLS CA certificate for both. This means that the specific variable openstack_tls_ca_cert should be renamed to something more generic. We decided that it would be tls_ca_cert. This pull request renames the variable.

Depends on: https://github.com/ManageIQ/manageiq/pull/19787
RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789479