### PR TITLE
Call the `key?` method on objects safely when trying to normalize

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -24,7 +24,7 @@ module Api
         is_ar = obj.kind_of?(ActiveRecord::Base)
         attrs.each do |k|
           next if Api.encrypted_attribute?(k) && api_resource_action_options.exclude?("include_encrypted_attributes")
-          next if is_ar ? !obj.respond_to?(k) : !obj.key?(k)
+          next if is_ar ? !obj.respond_to?(k) : !obj.try(:key?, k)
           result[k] = normalize_attr(k, is_ar ? obj.try(k) : obj[k])
         end
         result


### PR DESCRIPTION
I'm dealing with fetching automate results for the [new dialog editor](https://github.com/ManageIQ/manageiq-ui-classic/pull/6506) and found this issue. When you try to normalize an object that's not a hash, it crashes with a `NoMethodError` as the `key?` method might not be implemented on it. In this case (I guess) we also want to omit the object from the normalized result.

@miq-bot add_label enhancement, ivanchuk/no
@miq-bot assign @lpichler 