### PR TITLE
Reset the User.current_user upon each incoming request

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -21,6 +21,7 @@ module Api
     include ActionController::RequestForgeryProtection
 
     before_action :log_request_initiated
+    before_action :clear_cached_current_user
     before_action :require_api_user_or_token, :except => [:options, :product_info]
     before_action :set_gettext_locale, :set_access_control_headers, :parse_api_request, :log_api_request
     before_action :validate_api_request, :except => [:product_info]

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -85,6 +85,10 @@ module Api
 
       private
 
+      def clear_cached_current_user
+        User.current_user = nil
+      end
+
       def api_token_mgr
         Environment.user_token_service.token_mgr('api')
       end


### PR DESCRIPTION
I was messing around `OPTIONS` requests and just for fun tried this:
```ruby
#  curl -XOPTIONS http://localhost:3000/api
    3: def options
    4:   binding.pry
 => 5:   head(:ok)
    6: end

[6] pry(#<Api::ApiController>)> current_user.name
=> "Administrator"
```

I was not able to reproduce it again, probably the thread recycling combined with a series of code reloading made this possible. This probably cannot happen in production and if yes, none of the unauthorized requests touch anything sensitive. We only allow unauthenticated `OPTIONS` requests for CORS pre-flight checks and to load some static data into angular forms. There's also the `product_info` endpoint which provides information about the appliance for unauthenticated users and it's currently used by the SUI login screen.

Even though this is not a vulnerability, it might become one in the future, so I'm preventively adding a new `before_action` that resets the `User.current_user` to `nil` before authenticating. Just in case :sweat_smile: 

@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @djberg96 
cc @jrafanie because of the possible `constant` problem as I was doing code reloads