### PR TITLE
Change the zone param to zone_name in DDF provider validation

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -116,7 +116,7 @@ module Api
 
     def verify_credentials_resource(_type, _id, data = {})
       klass = fetch_provider_klass(collection_class(:providers), data)
-      zone_name = fetch_zone(data).name
+      zone_name = data.delete('zone_name')
       task_id = klass.verify_credentials_task(current_user, zone_name, data)
       action_result(true, 'Credentials sent for verification', :task_id => task_id)
     rescue => err


### PR DESCRIPTION
A little naming problem in the area, the sent param is `zone_name` instead of `zone`

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818
@miq-bot assign @lpichler 