### PR TITLE
Display provider authentications and endpoints when asking for it

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -10,6 +10,8 @@ module Api
     ENDPOINT_ATTRS    = %w(verify_ssl hostname url ipaddress port security_protocol certificate_authority).freeze
     RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"].freeze
 
+    include Subcollections::Authentications
+    include Subcollections::Endpoints
     include Subcollections::Policies
     include Subcollections::PolicyProfiles
     include Subcollections::Tags

--- a/app/controllers/api/subcollections/endpoints.rb
+++ b/app/controllers/api/subcollections/endpoints.rb
@@ -1,0 +1,6 @@
+module Api
+  module Subcollections
+    module Endpoints
+    end
+  end
+end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1546,6 +1546,32 @@ describe "Providers API" do
     end
   end
 
+  context 'GET /api/providers/:id' do
+    it 'includes endpoints and authentications attributes when explcitly asked' do
+      ems = FactoryBot.create(:ext_management_system)
+      api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
+
+      get(api_provider_url(nil, ems), :params => {:attributes => 'endpoints,authentications'})
+
+      expect(response.parsed_body['authentications']).to be_an_instance_of(Array)
+      expect(response.parsed_body['endpoints']).to be_an_instance_of(Array)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'does not include endpoints and authentications attributes by default' do
+      ems = FactoryBot.create(:ext_management_system)
+      api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
+
+      get(api_provider_url(nil, ems))
+
+      expect(response.parsed_body['authentications']).to be_nil
+      expect(response.parsed_body['endpoints']).to be_nil
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   context 'GET /api/providers/:id/vms' do
     it 'returns the vms for a provider with an appropriate role' do
       ems = FactoryBot.create(:ext_management_system)


### PR DESCRIPTION
In order to allow to edit providers through DDF, I need a way to expose the unprotected non-password fields of provider endpoints through the API. When editing something, I need to pre-fill the form with some of the values that are provided below. This seemed like the simplest solution and the protected fields are somehow omitted from the result automagically. The userid was sanitized by me, obviously, we need that in the form as it actually arrives from the API. 

```js
// GET /api/providers/35\?attributes\=authentications,endpoints
{
  "href": "http://localhost:3000/api/providers/35",
  "id": "35",
  "name": "ec2-old",
  "created_on": "2020-02-16T09:26:05Z",
  "updated_on": "2020-02-16T09:26:05Z",
  "guid": "603e26d0-272b-4415-b972-8ea5ecb42bf3",
  "zone_id": "2",
  "type": "ManageIQ::Providers::Amazon::CloudManager",
  "api_version": null,
  "uid_ems": null,
  "host_default_vnc_port_start": null,
  "host_default_vnc_port_end": null,
  "provider_region": "us-east-2",
  "last_refresh_error": null,
  "last_refresh_date": null,
  "provider_id": null,
  "realm": null,
  "tenant_id": "1",
  "project": null,
  "parent_ems_id": null,
  "subscription": null,
  "last_metrics_error": null,
  "last_metrics_update_date": null,
  "last_metrics_success_date": null,
  "tenant_mapping_enabled": null,
  "enabled": true,
  "options": {},
  "zone_before_pause_id": null,
  "last_inventory_date": null,
  "authentications": [
    {
      "href": "http://localhost:3000/api/authentications/16",
      "id": "16",
      "name": "ManageIQ::Providers::Amazon::CloudManager ec2-old",
      "authtype": "default",
      "userid": "********************",
      "resource_id": "35",
      "resource_type": "ExtManagementSystem",
      "created_on": "2020-02-16T09:26:05Z",
      "updated_on": "2020-02-16T09:26:06Z",
      "last_valid_on": "2020-02-16T09:26:06Z",
      "last_invalid_on": null,
      "credentials_changed_on": "2020-02-16T09:26:05Z",
      "status": "Valid",
      "status_details": "Ok",
      "type": "AuthUseridPassword",
      "fingerprint": null,
      "challenge": null,
      "login": null,
      "public_key": null,
      "htpassd_users": [],
      "ldap_id": [],
      "ldap_email": [],
      "ldap_name": [],
      "ldap_preferred_user_name": [],
      "ldap_bind_dn": null,
      "ldap_insecure": null,
      "ldap_url": null,
      "request_header_challenge_url": null,
      "request_header_login_url": null,
      "request_header_headers": [],
      "request_header_preferred_username_headers": [],
      "request_header_name_headers": [],
      "request_header_email_headers": [],
      "open_id_sub_claim": null,
      "open_id_user_info": null,
      "open_id_authorization_endpoint": null,
      "open_id_token_endpoint": null,
      "open_id_extra_scopes": [],
      "open_id_extra_authorize_parameters": null,
      "certificate_authority": null,
      "google_hosted_domain": null,
      "github_organizations": [],
      "rhsm_sku": null,
      "rhsm_pool_id": null,
      "rhsm_server": null,
      "manager_ref": null,
      "options": null,
      "evm_owner_id": null,
      "miq_group_id": "2",
      "tenant_id": "1",
      "become_username": null
    }
  ],
  "endpoints": [
    {
      "id": "16",
      "role": "default",
      "ipaddress": null,
      "hostname": null,
      "port": null,
      "resource_type": "ExtManagementSystem",
      "resource_id": "35",
      "created_at": "2020-02-16T09:26:05Z",
      "updated_at": "2020-02-16T09:26:05Z",
      "verify_ssl": 1,
      "url": "",
      "security_protocol": null,
      "api_version": null,
      "path": "",
      "certificate_authority": null
    }
  ],
  "actions": [
    {
      "name": "change_password",
      "method": "post",
      "href": "http://localhost:3000/api/providers/35"
    },
    {
      "name": "edit",
      "method": "post",
      "href": "http://localhost:3000/api/providers/35"
    },
    {
      "name": "refresh",
      "method": "post",
      "href": "http://localhost:3000/api/providers/35"
    },
    {
      "name": "delete",
      "method": "post",
      "href": "http://localhost:3000/api/providers/35"
    },
    {
      "name": "delete",
      "method": "delete",
      "href": "http://localhost:3000/api/providers/35"
    }
  ]
}
```

@agrare if this really works as it seems, we might be able to simplify the endpoint/authentication creation in the provider codebases. 

@Fryguy @lpichler @abellotti what do you think, is this *The Right Way&trade;*? 

@miq-bot add_reviewer @abellotti 
@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_label question, enhancement
Parent issue: https://github.com/ManageIQ/manageiq/issues/18818