### PR TITLE
Call instance method for vm retire queueing

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -499,7 +499,7 @@ module Api
     def request_retire(virtual_machine)
       desc = "#{vm_ident(virtual_machine)} request retire"
 
-      task_id = queue_object_action(virtual_machine, desc, queue_options("make_retire_request", "automate"))
+      task_id = queue_object_action(virtual_machine, desc, :method_name => "make_retire_request", :role => "automate", :args => [User.current_user.id])
       action_result(true, desc, :task_id => task_id)
     rescue StandardError => err
       action_result(false, err.to_s)


### PR DESCRIPTION
Because of the fact that the entire retirement mechanism is built around a class method, when we introduced vm retirement queuing we should've also included an instance call to the class method. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1805119

Introduced in https://github.com/ManageIQ/manageiq-api/pull/662

@miq-bot assign @lpichler  

## Depends on: 
https://github.com/ManageIQ/manageiq/pull/19855