### PR TITLE
Adding support for OIDCProviderTokenEndpoint, OIDCOAuthIntrospectionEndpoint and OIDCScope

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -214,12 +214,14 @@ module Api
       def oidc_provider_metadata
         @oidc_provider_metadata ||= begin
           oidc_provider_metadata_url = httpd_oidc_config_param("OIDCProviderMetadataURL")
-          return {} if oidc_provider_metadata_url.blank?
-
-          uri = URI.parse(oidc_provider_metadata_url)
-          http = Net::HTTP.new(uri.host, uri.port)
-          response = http.request(Net::HTTP::Get.new(uri.request_uri))
-          JSON.parse(response.body)
+          if oidc_provider_metadata_url.blank?
+            {}
+          else
+            uri = URI.parse(oidc_provider_metadata_url)
+            http = Net::HTTP.new(uri.host, uri.port)
+            response = http.request(Net::HTTP::Get.new(uri.request_uri))
+            JSON.parse(response.body)
+          end
         end
       end
 

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -301,7 +301,7 @@ module Api
 
       def user_details_from_jwt(token_info)
         user_attrs = {
-          :username  => token_info["username"],
+          :username  => token_info["preferred_username"],
           :fullname  => token_info["name"],
           :firstname => token_info["given_name"],
           :lastname  => token_info["family_name"],

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -204,7 +204,7 @@ module Api
       end
 
       def httpd_oidc_config_param(name)
-        param_spec = httpd_oidc_config.find { |line| line =~ /#{name} .*/i }
+        param_spec = httpd_oidc_config.find { |line| line =~ /^#{name} .*/i }
         return "" if param_spec.blank?
 
         param_match = param_spec.match(/^#{name} (.*)/i)

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -48,7 +48,7 @@ module Api
             begin
               timeout = ::Settings.api.authentication_timeout.to_i_with_method
 
-              if oidc_configuration?
+              if !User.admin?(u) && oidc_configuration?
                 # Basic auth, user/password but configured against OpenIDC.
                 # Let's authenticate as such and get a JWT for that user.
                 #

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -219,6 +219,7 @@ module Api
           else
             uri = URI.parse(oidc_provider_metadata_url)
             http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = (uri.scheme == "https")
             response = http.request(Net::HTTP::Get.new(uri.request_uri))
             JSON.parse(response.body)
           end


### PR DESCRIPTION
Adding support for OIDCProviderTokenEndpoint, OIDCOAuthIntrospectionEndpoint and OIDCScope

- Adding support for OIDCProviderTokenEndpoint and OIDCOAuthIntrospectionEndpoint
  if defined before resorting to the related token_endpoint and token_introspection_endpoint
  keys returned by the provider metadata URL.

- Also specifying the scope for the provider calls to get and verify jwt tokens if defined
  in the OIDCScope parameter
