### PR TITLE
Extend the existing provider editing endpoint with DDF support

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -47,7 +47,12 @@ module Api
       raise BadRequestError, "Provider type cannot be updated" if data.key?(TYPE_ATTR)
 
       provider = resource_search(id, type, collection_class(:providers))
-      edit_provider(provider, data)
+
+      if data.delete(DDF_ATTR)
+        edit_provider_ddf(provider, data)
+      else
+        edit_provider(provider, data)
+      end
     end
 
     def refresh_resource(type, id = nil, _data = nil)
@@ -226,6 +231,12 @@ module Api
     rescue => err
       provider.try(:destroy)
       raise BadRequestError, "Could not create the new provider - #{err}"
+    end
+
+    def edit_provider_ddf(provider, data)
+      provider.edit_with_params(data)
+    rescue => err
+      raise BadRequestError, "Could not update the provider - #{err}"
     end
 
     def edit_provider(provider, data)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2274,7 +2274,7 @@
     :options:
     - :collection
     - :custom_actions
-    :verbs: *gpd
+    :verbs: *gpppd
     :klass: ExtManagementSystem
     :subcollections:
     - :tags
@@ -2341,6 +2341,12 @@
       :delete:
       - :name: delete
         :identifier: ems_infra_delete
+      :patch:
+      - :name: edit
+        :identifier: ems_infra_edit
+      :put:
+      - :name: edit
+        :identifier: ems_infra_edit
     :tags_subcollection_actions:
       :post:
       - :name: assign

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -731,6 +731,31 @@ describe "Providers API" do
         .and_return([OvirtSDK4::ProbeResult.new(:version => '3')])
     end
 
+    it 'invokes the DDF creation when ddf=true' do
+      api_basic_authorize collection_action_identifier(:providers, :edit)
+
+      provider = FactoryBot.create(:ems_cloud)
+
+      expect_any_instance_of(ManageIQ::Providers::Amazon::CloudManager).to receive(:edit_with_params).and_return(:yay => :yay)
+
+      post(api_provider_url(nil, provider), :params => gen_request(:edit, "name" => "updated provider name", 'ddf' => true))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq('yay' => 'yay')
+    end
+
+    it 'handles errors when ddf=true' do
+      api_basic_authorize collection_action_identifier(:providers, :edit)
+
+      provider = FactoryBot.create(:ems_cloud)
+
+      expect_any_instance_of(ManageIQ::Providers::Amazon::CloudManager).to receive(:edit_with_params).and_raise('RandomError')
+
+      post(api_provider_url(nil, provider), :params => gen_request(:edit, "name" => "updated provider name", 'ddf' => true))
+
+      expect_bad_request(/Could not update the provider/)
+    end
+
     it "rejects resource edits without appropriate role" do
       api_basic_authorize
 


### PR DESCRIPTION
First of all, were not completely RESTful in this area, PUT/PATCH methods weren't supported on providers at all, so I fixed this. Then analogously with the [create endpoint](https://github.com/ManageIQ/manageiq-api/pull/723) I added a test against a `ddf` attribute. If this attribute is set, we're calling the new methods for editing a provider. If not, we're falling back to the old world and so keeping the compatibility.

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818
@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @abellotti 
@miq-bot add_label enhancement