### PR TITLE
[WIP] Change collection class to return policy sets

### DIFF
--- a/app/controllers/api/subcollections/policies.rb
+++ b/app/controllers/api/subcollections/policies.rb
@@ -27,8 +27,8 @@ module Api
       end
 
       def object_policies(object)
-        policy_klass = collection_class(:policies)
-        object.get_policies.select { |p| p.kind_of?(policy_klass) }
+        policy_profile_klass = collection_class(:policy_profiles)
+        object.get_policies.select { |p| p.kind_of?(policy_profile_klass) }
       end
 
       def policy_specified(id, data, collection, klass)


### PR DESCRIPTION
/api/vms/{id}/policies does not return the policies in the policy profiles assigned to the VM

but it would, if we had the right collection class
Fixes https://github.com/ManageIQ/manageiq-api/issues/745

WIP because it needs a spec