### PR TITLE
Remove ability to delete a region

### DIFF
--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class RegionsController < BaseController
-    INVALID_REGIONS_ATTRS = ID_ATTRS + %w[created_at updated_at].freeze
+    INVALID_REGIONS_ATTRS = ID_ATTRS + %w[created_at updated_at region guid migrations_ran maintenance_zone_id].freeze
 
     # Edit an existing region (MiqRegion). Certain fields are meant for
     # internal use only and may not be edited. Attempting to edit one of

--- a/config/api.yml
+++ b/config/api.yml
@@ -2656,7 +2656,7 @@
     - :settings
     :options:
     - :collection
-    :verbs: *gpd
+    :verbs: *gp
     :klass: MiqRegion
     :collection_actions:
       :get:
@@ -2667,8 +2667,6 @@
         :identifier: region
       - :name: edit
         :identifier: region_edit
-      - :name: delete
-        :identifier: region_delete
     :resource_actions:
       :get:
       - :name: read
@@ -2676,11 +2674,6 @@
       :post:
       - :name: edit
         :identifier: region_edit
-      - :name: delete
-        :identifier: region_delete
-      :delete:
-      - :name: delete
-        :identifier: region_delete
   :reports:
     :description: Reports
     :identifier: miq_report

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -113,40 +113,10 @@ RSpec.describe "Regions API", :regions do
   end
 
   context "delete", :delete do
-    it "can delete a region with POST" do
-      api_basic_authorize action_identifier(:regions, :delete)
-      region = FactoryBot.create(:miq_region)
-
-      expect { post api_region_url(nil, region), :params => gen_request(:delete) }.to change(MiqRegion, :count).by(-1)
-      expect_single_action_result(:success => true, :message => /#{region.id}/)
-    end
-
-    it "can delete a region with DELETE" do
-      api_basic_authorize action_identifier(:regions, :delete)
-      region = FactoryBot.create(:miq_region)
-
-      expect { delete api_region_url(nil, region) }.to change(MiqRegion, :count).by(-1)
-      expect(response).to have_http_status(:no_content)
-    end
-
-    it "can delete multiple regions with POST" do
-      api_basic_authorize action_identifier(:regions, :delete)
-      regions = FactoryBot.create_list(:miq_region, 2)
-
-      options = [
-        {"href" => api_region_url(nil, regions.first)},
-        {"href" => api_region_url(nil, regions.last)}
-      ]
-
-      expect { post api_regions_url, :params => gen_request(:delete, options) }.to change(MiqRegion, :count).by(-2)
-      expect_multiple_action_result(regions.size)
-    end
-
-    it "forbids deletion of a region without an appropriate role" do
-      expect_forbidden_request do
-        region = FactoryBot.create(:miq_region, :description => "Current Region description")
-        delete(api_region_url(nil, region))
-      end
+    it "forbids deletion of a region" do
+      region = FactoryBot.create(:miq_region, :description => "Current Region description")
+      delete(api_region_url(nil, region))
+      expect(response).to have_http_status(:not_found)
     end
   end
 


### PR DESCRIPTION
Apparently allowing regions to be deleted was a Bad Idea. QE realized that deleting a region could break the app:

https://bugzilla.redhat.com/show_bug.cgi?id=1805844#c3

"Deleting the Region works too, but once we delete the only region on the appliance, the appliance crashes"

As per @carbonin:

"A region generally represents a database/installation of miq. The only reason you would have more than one would be if you are in the global region and those will be deleted when the subscription to the remote is removed. There is no other use case for deleting a region."

So, this PR removes the ability to delete a region.