### PR TITLE
Default zone needs to exist otherwise provider creation fails

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -17,6 +17,8 @@ describe "Providers API" do
   ENDPOINT_ATTRS = Api::ProvidersController::ENDPOINT_ATTRS
   CREDENTIALS_ATTR = Api::ProvidersController::CREDENTIALS_ATTR
 
+  before { Zone.seed }
+
   let(:default_credentials) { {"userid" => "admin1", "password" => "password1"} }
   let(:metrics_credentials) { {"userid" => "admin2", "password" => "password2", "auth_type" => "metrics"} }
   let(:compound_credentials) { [default_credentials, metrics_credentials] }


### PR DESCRIPTION
When not specified (as in the tests) the API tries to create the provider or manager using the default zone.  When the default zone doesn't exist the API tries to create with :zone => nil which will fail after my validation is added to core.