### PR TITLE
Differentiate between ems_cloud and infra for rbac purposes for providers collection

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2384,7 +2384,17 @@
         - ems_infra_show_list
         - ems_block_storage_show_list
       - :name: create
-        :identifier: ems_infra_new
+        :identifiers:
+        - :klass: ManageIQ::Providers::InfraManager
+          :identifier: ems_infra_new
+        - :klass: ManageIQ::Providers::CloudManager
+          :identifier: ems_cloud_new
+        - :klass: ManageIQ::Providers::ContainerManager
+          :identifier: ems_container_new
+        - :klass: ManageIQ::Providers::NetworkManager
+          :identifier: ems_network_new
+        - :klass: Provider
+          :identifier: provider_foreman_add_provider
       - :name: edit
         :identifier: ems_infra_edit
       - :name: refresh

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -415,7 +415,7 @@ describe "Providers API" do
     end
 
     it 'creates valid foreman provider' do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "provider_foreman_add_provider"
 
       post(api_providers_url + '?provider_class=provider', :params => gen_request(:create, sample_foreman))
 
@@ -435,10 +435,10 @@ describe "Providers API" do
       get api_providers_url, :params => { :provider_class => 'provider' }
 
       expected = {
-        'resources' => [
-          {'href' => "#{api_provider_url(nil, provider)}?provider_class=provider"}
-        ],
-        'actions'   => [a_hash_including('href' => a_string_including('?provider_class=provider'))]
+        'resources' => [{'href' => "#{api_provider_url(nil, provider)}?provider_class=provider"}],
+        'actions'   => a_collection_including(
+          a_hash_including('href' => a_string_including('?provider_class=provider'))
+        )
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -500,7 +500,7 @@ describe "Providers API" do
     it 'allows provider specific attributes to be specified' do
       allow(ManageIQ::Providers::Azure::CloudManager).to receive(:api_allowed_attributes).and_return(%w(azure_tenant_id))
       tenant = FactoryBot.create(:cloud_tenant)
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_cloud_new"
 
       post(api_providers_url, :params => { "type"            => "ManageIQ::Providers::Azure::CloudManager",
                                            "name"            => "sample azure provider",
@@ -541,7 +541,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       post(api_providers_url, :params => sample_rhevm)
 
@@ -563,7 +563,7 @@ describe "Providers API" do
         let(:containers_class) { klass }
 
         it "supports creation with auth_key specified" do
-          api_basic_authorize collection_action_identifier(:providers, :create)
+          api_basic_authorize "ems_container_new"
 
           post(api_providers_url, :params => sample_containers.merge("credentials" => [containers_credentials]))
 
@@ -584,7 +584,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation via action" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       post(api_providers_url, :params => gen_request(:create, sample_rhevm))
 
@@ -600,8 +600,17 @@ describe "Providers API" do
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
     end
 
+    it "should fail single provider creation via action" do
+      api_basic_authorize "ems_cloud_new"
+
+      post(api_providers_url, :params => gen_request(:create, sample_rhevm))
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body).to include_error_with_message("Create action is forbidden for ManageIQ::Providers::Redhat::InfraManager requests")
+    end
+
     it "supports single provider creation with simple credentials" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       post(api_providers_url, :params => sample_vmware.merge("credentials" => default_credentials))
 
@@ -620,7 +629,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation with compound credentials" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       post(api_providers_url, :params => sample_rhevm.merge("credentials" => compound_credentials))
 
@@ -641,7 +650,7 @@ describe "Providers API" do
     end
 
     it "supports multiple provider creation" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       post(api_providers_url, :params => gen_request(:create, [sample_vmware, sample_rhevm]))
 
@@ -670,7 +679,7 @@ describe "Providers API" do
         end
 
         it "supports provider with multiple endpoints creation with hawkular" do
-          api_basic_authorize collection_action_identifier(:providers, :create)
+          api_basic_authorize "ems_container_new"
 
           post(api_providers_url, :params => gen_request(:create, sample_containers_multi_end_point_with_hawkular))
 
@@ -694,7 +703,7 @@ describe "Providers API" do
         end
 
         it "supports provider with multiple endpoints creation and prometheus" do
-          api_basic_authorize collection_action_identifier(:providers, :create)
+          api_basic_authorize "ems_container_new"
 
           post(api_providers_url, :params => gen_request(:create, sample_containers_multi_end_point_with_prometheus))
 

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -415,7 +415,7 @@ describe "Providers API" do
     end
 
     it 'creates valid foreman provider' do
-      api_basic_authorize "provider_foreman_add_provider"
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "Provider")
 
       post(api_providers_url + '?provider_class=provider', :params => gen_request(:create, sample_foreman))
 
@@ -500,7 +500,7 @@ describe "Providers API" do
     it 'allows provider specific attributes to be specified' do
       allow(ManageIQ::Providers::Azure::CloudManager).to receive(:api_allowed_attributes).and_return(%w(azure_tenant_id))
       tenant = FactoryBot.create(:cloud_tenant)
-      api_basic_authorize "ems_cloud_new"
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::CloudManager")
 
       post(api_providers_url, :params => { "type"            => "ManageIQ::Providers::Azure::CloudManager",
                                            "name"            => "sample azure provider",
@@ -541,7 +541,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation" do
-      api_basic_authorize "ems_infra_new"
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::InfraManager")
 
       post(api_providers_url, :params => sample_rhevm)
 
@@ -563,7 +563,7 @@ describe "Providers API" do
         let(:containers_class) { klass }
 
         it "supports creation with auth_key specified" do
-          api_basic_authorize "ems_container_new"
+          api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::ContainerManager")
 
           post(api_providers_url, :params => sample_containers.merge("credentials" => [containers_credentials]))
 
@@ -584,7 +584,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation via action" do
-      api_basic_authorize "ems_infra_new"
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::InfraManager")
 
       post(api_providers_url, :params => gen_request(:create, sample_rhevm))
 
@@ -601,7 +601,7 @@ describe "Providers API" do
     end
 
     it "should fail single provider creation via action" do
-      api_basic_authorize "ems_cloud_new"
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::CloudManager")
 
       post(api_providers_url, :params => gen_request(:create, sample_rhevm))
 
@@ -610,7 +610,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation with simple credentials" do
-      api_basic_authorize "ems_infra_new"
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::InfraManager")
 
       post(api_providers_url, :params => sample_vmware.merge("credentials" => default_credentials))
 
@@ -629,7 +629,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation with compound credentials" do
-      api_basic_authorize "ems_infra_new"
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::InfraManager")
 
       post(api_providers_url, :params => sample_rhevm.merge("credentials" => compound_credentials))
 
@@ -650,7 +650,7 @@ describe "Providers API" do
     end
 
     it "supports multiple provider creation" do
-      api_basic_authorize "ems_infra_new"
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::InfraManager")
 
       post(api_providers_url, :params => gen_request(:create, [sample_vmware, sample_rhevm]))
 
@@ -679,7 +679,7 @@ describe "Providers API" do
         end
 
         it "supports provider with multiple endpoints creation with hawkular" do
-          api_basic_authorize "ems_container_new"
+          api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::ContainerManager")
 
           post(api_providers_url, :params => gen_request(:create, sample_containers_multi_end_point_with_hawkular))
 
@@ -703,7 +703,7 @@ describe "Providers API" do
         end
 
         it "supports provider with multiple endpoints creation and prometheus" do
-          api_basic_authorize "ems_container_new"
+          api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::ContainerManager")
 
           post(api_providers_url, :params => gen_request(:create, sample_containers_multi_end_point_with_prometheus))
 

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -40,6 +40,13 @@ module Spec
           allow(::Api::ApiConfig.collections[collection][action_type]).to receive(method) { updated_method }
         end
 
+        def collection_action_classed_identifier(type, action, method, klass)
+          ::Api::ApiConfig
+            .collections[type][:collection_actions][method]
+            .detect { |spec| spec[:name] == action.to_s }[:identifiers]
+            .detect { |spec| spec[:klass] == klass.to_s }[:identifier]
+        end
+
         def action_identifier(type, action, selection = :resource_actions, method = :post)
           ::Api::ApiConfig
             .collections[type][selection][method]


### PR DESCRIPTION
You can add cloud providers without the rbac permissions to do so because we don't have a provider rbac check at the subclass level. 

@miq-bot add_label bug 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1766647 

~~Requires a follow-up refactor to clean up the added duplication since this check is present both on providers and requests now. For the purposes of this bug, I'd like to vote this gets merged as is and that I do the refactoring later.~~ just kidding