### PR TITLE
Added test for returning the policies contained in the policy profiles assigned to a Vm

### DIFF
--- a/spec/requests/policies_spec.rb
+++ b/spec/requests/policies_spec.rb
@@ -98,6 +98,36 @@ describe "Policies API" do
     expect_result_resources_to_include_data("resources", "guid" => Array.wrap(ps2.guid))
   end
 
+  def test_policy_profile_policies_query(object, api_object_policy_profiles_url)
+    api_basic_authorize
+
+    object.add_policy(ps1)
+    object.add_policy(ps2)
+
+    get api_object_policy_profiles_url, :params => {:expand => "resources", :attributes => "miq_policies"}
+
+    expected = {
+      "name"      => "policy_profiles",
+      "count"     => 2,
+      "resources" => a_collection_containing_exactly(
+        a_hash_including(
+          "guid"         => ps1.guid,
+          "miq_policies" => a_collection_containing_exactly(
+            a_hash_including("guid" => p1.guid),
+            a_hash_including("guid" => p2.guid)
+          )
+        ),
+        a_hash_including(
+          "guid"         => ps2.guid,
+          "miq_policies" => a_collection_containing_exactly(
+            a_hash_including("guid" => p3.guid)
+          )
+        )
+      )
+    }
+    expect(response.parsed_body).to include(expected)
+  end
+
   context "Policy collection" do
     it "query invalid policy" do
       api_basic_authorize action_identifier(:policies, :read, :resource_actions, :get)
@@ -376,6 +406,10 @@ describe "Policies API" do
 
     it "query Vm policy profiles" do
       test_policy_profile_query(vm, api_vm_policy_profiles_url(nil, vm))
+    end
+
+    it "query Vm policy profiles and related policies" do
+      test_policy_profile_policies_query(vm, api_vm_policy_profiles_url(nil, vm))
     end
   end
 


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/19930

Test case for -

http://localhost:3000/api/vms/10000000000229/policy_profiles?expand=resources&attributes=miq_policies

```json
{
    "name": "policy_profiles",
    "count": 8,
    "subcount": 1,
    "pages": 1,
    "resources": [
        {
            "href": "http://localhost:3000/api/vms/10000000000229/policy_profiles/10000000000056",
            "id": "10000000000056",
            "name": "GT Profile",
            "description": "GT Profile",
            "set_type": "MiqPolicySet",
            "created_on": "2020-02-21T21:56:30Z",
            "updated_on": "2020-02-21T22:02:42Z",
            "guid": "9369273d-9d21-4be3-b3f2-b29e7fc9188b",
            "read_only": null,
            "set_data": null,
            "mode": "compliance",
            "owner_type": null,
            "owner_id": null,
            "userid": null,
            "group_id": null,
            "miq_policies": [
                {
                    "href": "http://localhost:3000/api/policies/10000000000016",
                    "id": "10000000000016",
                    "name": "d75b2b62-c200-4f9b-ad0c-f3af76834bdb",
                    "description": "GT Compliance Policy",
                    "created_on": "2020-02-20T02:43:03Z",
                    "updated_on": "2020-02-20T02:43:03Z",
                    "expression": null,
                    "towhat": "Vm",
                    "guid": "d75b2b62-c200-4f9b-ad0c-f3af76834bdb",
                    "created_by": "admin",
                    "updated_by": "admin",
                    "notes": null,
                    "active": true,
                    "mode": "compliance",
                    "read_only": null
                },
                {
                    "href": "http://localhost:3000/api/policies/10000000000005",
                    "id": "10000000000005",
                    "name": "8d6e5091-d573-4fec-ae8f-fd7a74291956",
                    "description": "SmartState Analysis",
                    "created_on": "2019-04-23T16:53:57Z",
                    "updated_on": "2019-04-23T16:53:57Z",
                    "expression": null,
                    "towhat": "Vm",
                    "guid": "8d6e5091-d573-4fec-ae8f-fd7a74291956",
                    "created_by": "admin",
                    "updated_by": "admin",
                    "notes": null,
                    "active": true,
                    "mode": "control",
                    "read_only": null
                }
            ]
        }
    ],
    "actions": [
        {
            "name": "assign",
            "method": "post",
            "href": "http://localhost:3000/api/vms/10000000000229/policy_profiles"
        },
        {
            "name": "unassign",
            "method": "post",
            "href": "http://localhost:3000/api/vms/10000000000229/policy_profiles"
        },
        {
            "name": "resolve",
            "method": "post",
            "href": "http://localhost:3000/api/vms/10000000000229/policy_profiles"
        }
    ],
    "links": {
        "self": "http://localhost:3000/api/vms/10000000000229/policy_profiles?expand=resources&attributes=miq_policies&offset=0",
        "first": "http://localhost:3000/api/vms/10000000000229/policy_profiles?expand=resources&attributes=miq_policies&offset=0",
        "last": "http://localhost:3000/api/vms/10000000000229/policy_profiles?expand=resources&attributes=miq_policies&offset=0"
    }
}
```
Fixes https://github.com/ManageIQ/manageiq-api/issues/745