### PR TITLE
[V2V] ConversionHost - Validate resource is not already a conversion host

### DIFF
--- a/app/controllers/api/conversion_hosts_controller.rb
+++ b/app/controllers/api/conversion_hosts_controller.rb
@@ -48,6 +48,10 @@ module Api
 
       raise BadRequestError, "unsupported resource_type #{resource_type}" unless resource.supports_conversion_host?
 
+      conversion_host = ConversionHost.where(:resource => resource)
+
+      raise BadRequestError, "the resource '#{resource.name}' is already configured as a conversion host" unless conversion_host.empty?
+
       data['resource'] = resource
 
       api_action(type, id) do

--- a/spec/requests/conversion_hosts_spec.rb
+++ b/spec/requests/conversion_hosts_spec.rb
@@ -183,6 +183,18 @@ describe "ConversionHosts API" do
       expect(results['error']['message']).to eql("unsupported resource_type #{azure_vm.type}")
     end
 
+    it "raises an error if the resource is already configured as a conversion host" do
+      FactoryBot.create(:conversion_host, :resource => vm)
+      api_basic_authorize(collection_action_identifier(:conversion_hosts, :create))
+      post(api_conversion_hosts_url, :params => sample_conversion_host_from_vm)
+
+      expect(response).to have_http_status(400)
+
+      results = response.parsed_body
+      expect(results['error']['kind']).to eql('bad_request')
+      expect(results['error']['message']).to eql("the resource '#{vm.name}' is already configured as a conversion host")
+    end
+
     it "supports single conversion host creation" do
       api_basic_authorize(collection_action_identifier(:conversion_hosts, :create))
 


### PR DESCRIPTION
When one tries to add a conversion host by REST API while there is an existing conversion host with the same resource, the configuration process is executed, then the ConversionHost object creation fails because the resource is already associated to another conversion host. There are two wrong consequences to that:

1. The conversion host resource is configured a second time, breaking potentially the existing configuration and blocking migration.
2. There's no error message apart from log/evm.log.

This does not affect users configuring conversion hosts through the UI, as the list of resources is filtered. So, it is limited to API.

This pull request adds a validation at the API level that returns a BadRequestError (HTTP 400) if the resource is already used by a conversion host. This fails faster and doesn't trigger the configuration phase.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1810555