### PR TITLE
[WIP] Replace towhat with target_class_name

### DIFF
--- a/app/controllers/api/policies_controller.rb
+++ b/app/controllers/api/policies_controller.rb
@@ -3,7 +3,7 @@ module Api
     include Subcollections::Conditions
     include Subcollections::Events
     include Subcollections::PolicyActions
-    REQUIRED_FIELDS = %w(name mode description towhat conditions_ids policy_contents).freeze
+    REQUIRED_FIELDS = %w(name mode description target_class_name conditions_ids policy_contents).freeze
 
     def create_resource(type, _id, data = {})
       assert_id_not_specified(data, type)
@@ -27,11 +27,11 @@ module Api
     private
 
     def create_policy(data)
-      policy = MiqPolicy.create!(:name        => data.delete("name"),
-                                 :description => data.delete("description"),
-                                 :towhat      => data.delete("towhat"),
-                                 :mode        => data.delete("mode"),
-                                 :active      => true)
+      policy = MiqPolicy.create!(:name              => data.delete("name"),
+                                 :description       => data.delete("description"),
+                                 :target_class_name => data.delete("target_class_name"),
+                                 :mode              => data.delete("mode"),
+                                 :active            => true)
       add_policies_content(data, policy)
       policy.conditions = Condition.where(:id => data.delete("conditions_ids")) if data["conditions_ids"]
       policy

--- a/spec/requests/conditions_spec.rb
+++ b/spec/requests/conditions_spec.rb
@@ -21,10 +21,10 @@ describe "Conditions API" do
   context "Condition CRUD" do
     let(:sample_condition) do
       {
-        :name        => "name",
-        :description => "description",
-        :expression  => {"=" => {"field" => "ContainerImage-architecture", "value" => "dsa"}},
-        :towhat      => "ExtManagementSystem"
+        :name              => "name",
+        :description       => "description",
+        :expression        => {"=" => {"field" => "ContainerImage-architecture", "value" => "dsa"}},
+        :target_class_name => "ExtManagementSystem"
       }
     end
     let(:condition) { FactoryBot.create(:condition) }

--- a/spec/requests/policies_spec.rb
+++ b/spec/requests/policies_spec.rb
@@ -417,11 +417,11 @@ describe "Policies API" do
     end
     let(:sample_policy) do
       {
-        "description"    => "sample policy",
-        "name"           => "sample policy",
-        "mode"           => "compliance",
-        "towhat"         => "ExtManagementSystem",
-        "conditions_ids" => [conditions.first.id, conditions.second.id],
+        "description"       => "sample policy",
+        "name"              => "sample policy",
+        "mode"              => "compliance",
+        "target_class_name" => "ExtManagementSystem",
+        "conditions_ids"    => [conditions.first.id, conditions.second.id],
       }
     end
 
@@ -430,7 +430,7 @@ describe "Policies API" do
       post(api_policies_url, :params => sample_policy.merge!(miq_policy_contents))
       policy = MiqPolicy.find(response.parsed_body["results"].first["id"])
       expect(response.parsed_body["results"].first["name"]).to eq("sample policy")
-      expect(response.parsed_body["results"].first["towhat"]).to eq("ExtManagementSystem")
+      expect(response.parsed_body["results"].first["target_class_name"]).to eq("ExtManagementSystem")
       expect(policy).to be_truthy
       expect(policy.conditions.count).to eq(2)
       expect(policy.actions.count).to eq(1)


### PR DESCRIPTION
- [ ] Depends on [core](https://github.com/ManageIQ/manageiq/pull/18165)
- [ ] Depends on [schema](https://github.com/ManageIQ/manageiq-schema/pull/314)
- [ ] To be merged with the [ui-classic PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/6742)
- [ ] Will need to deprecate any public interfaces and accept the old `towhat` until the next version that removes it.
- [x] [Cross repo test](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/82)

Related: https://github.com/ManageIQ/manageiq/issues/18222