### PR TITLE
[WIP] Fix specs for subclassing of service orders

### DIFF
--- a/spec/requests/service_orders_spec.rb
+++ b/spec/requests/service_orders_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "service orders API" do
   it "can list all service orders" do
-    service_order = FactoryBot.create(:shopping_cart, :user => @user)
+    service_order = FactoryBot.create(:service_order_cart, :user => @user)
     api_basic_authorize collection_action_identifier(:service_orders, :read, :get)
 
     get api_service_orders_url
@@ -10,8 +10,8 @@ RSpec.describe "service orders API" do
   end
 
   it "won't show another user's service orders" do
-    shopping_cart_for_user = FactoryBot.create(:shopping_cart, :user => @user)
-    _shopping_cart_for_some_other_user = FactoryBot.create(:shopping_cart)
+    shopping_cart_for_user = FactoryBot.create(:service_order_cart, :user => @user)
+    _shopping_cart_for_some_other_user = FactoryBot.create(:service_order_cart)
     api_basic_authorize collection_action_identifier(:service_orders, :read, :get)
 
     get api_service_orders_url
@@ -37,7 +37,7 @@ RSpec.describe "service orders API" do
 
   it "cannot create multiple carts" do
     api_basic_authorize collection_action_identifier(:service_orders, :create)
-    FactoryBot.create(:shopping_cart, :user => @user)
+    FactoryBot.create(:service_order_cart, :user => @user)
 
     post(api_service_orders_url, :params => { :name => "Cart 2" })
 
@@ -118,7 +118,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can read a service order" do
-    service_order = FactoryBot.create(:service_order, :user => @user)
+    service_order = FactoryBot.create(:service_order_cart, :user => @user)
     api_basic_authorize action_identifier(:service_orders, :read, :resource_actions, :get)
 
     get api_service_order_url(nil, service_order)
@@ -128,7 +128,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can show the shopping cart" do
-    shopping_cart = FactoryBot.create(:shopping_cart, :user => @user)
+    shopping_cart = FactoryBot.create(:service_order_cart, :user => @user)
     api_basic_authorize action_identifier(:service_orders, :read, :resource_actions, :get)
 
     get api_service_order_url(nil, "cart")
@@ -149,7 +149,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can update a service order" do
-    service_order = FactoryBot.create(:service_order, :name => "old name", :user => @user)
+    service_order = FactoryBot.create(:service_order_cart, :name => "old name", :user => @user)
     api_basic_authorize action_identifier(:service_orders, :edit)
 
     post api_service_order_url(nil, service_order), :params => { :action => "edit", :resource => {:name => "new name"} }
@@ -159,8 +159,8 @@ RSpec.describe "service orders API" do
   end
 
   it "can update multiple service orders" do
-    service_order_1 = FactoryBot.create(:service_order, :user => @user, :name => "old name 1")
-    service_order_2 = FactoryBot.create(:service_order, :user => @user, :name => "old name 2")
+    service_order_1 = FactoryBot.create(:service_order_cart, :user => @user, :name => "old name 1")
+    service_order_2 = FactoryBot.create(:service_order_cart, :user => @user, :name => "old name 2")
     api_basic_authorize collection_action_identifier(:service_orders, :edit)
 
     post(
@@ -179,7 +179,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can delete a service order" do
-    service_order = FactoryBot.create(:service_order, :user => @user)
+    service_order = FactoryBot.create(:service_order_cart, :user => @user)
     api_basic_authorize action_identifier(:service_orders, :delete, :resource_actions, :delete)
 
     expect do
@@ -189,7 +189,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can delete a service order through POST" do
-    service_order = FactoryBot.create(:service_order, :user => @user)
+    service_order = FactoryBot.create(:service_order_cart, :user => @user)
     api_basic_authorize action_identifier(:service_orders, :delete)
 
     expect do
@@ -199,8 +199,8 @@ RSpec.describe "service orders API" do
   end
 
   it "can delete multiple service orders" do
-    service_order_1 = FactoryBot.create(:service_order, :user => @user, :name => "old name")
-    service_order_2 = FactoryBot.create(:service_order, :user => @user, :name => "old name")
+    service_order_1 = FactoryBot.create(:service_order_cart, :user => @user, :name => "old name")
+    service_order_2 = FactoryBot.create(:service_order_cart, :user => @user, :name => "old name")
     api_basic_authorize collection_action_identifier(:service_orders, :delete)
 
     expect do
@@ -222,7 +222,7 @@ RSpec.describe "service orders API" do
     context "with an appropriate role" do
       it "can list a shopping cart's service requests" do
         service_request = FactoryBot.create(:service_template_provision_request, :requester => @user)
-        _shopping_cart = FactoryBot.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
+        _shopping_cart = FactoryBot.create(:service_order_cart, :user => @user, :miq_requests => [service_request])
         api_basic_authorize action_identifier(:service_requests, :read, :subcollection_actions, :get)
 
         get(api_service_order_service_requests_url(nil, "cart"))
@@ -237,7 +237,7 @@ RSpec.describe "service orders API" do
 
       it "can show a shopping cart's service request" do
         service_request = FactoryBot.create(:service_template_provision_request, :requester => @user)
-        _shopping_cart = FactoryBot.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
+        _shopping_cart = FactoryBot.create(:service_order_cart, :user => @user, :miq_requests => [service_request])
         api_basic_authorize action_identifier(:service_requests, :read, :subresource_actions, :get)
 
         get(api_service_order_service_request_url(nil, "cart", service_request))
@@ -256,7 +256,7 @@ RSpec.describe "service orders API" do
         service_template.resource_actions << FactoryBot.create(:resource_action,
                                                                 :action => "Provision",
                                                                 :dialog => dialog)
-        shopping_cart = FactoryBot.create(:shopping_cart, :user => @user)
+        shopping_cart = FactoryBot.create(:service_order_cart, :user => @user)
         api_basic_authorize action_identifier(:service_requests, :add, :subcollection_actions)
 
         expect do
@@ -297,7 +297,7 @@ RSpec.describe "service orders API" do
                                                                   :action => "Provision",
                                                                   :dialog => dialog)
 
-        shopping_cart = FactoryBot.create(:shopping_cart, :user => @user)
+        shopping_cart = FactoryBot.create(:service_order_cart, :user => @user)
         api_basic_authorize action_identifier(:service_requests, :add, :subcollection_actions)
 
         expect do
@@ -336,7 +336,7 @@ RSpec.describe "service orders API" do
 
       it "can remove a service request from a shopping cart" do
         service_request = FactoryBot.create(:service_template_provision_request, :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
+        shopping_cart = FactoryBot.create(:service_order_cart, :user => @user, :miq_requests => [service_request])
         api_basic_authorize action_identifier(:service_requests, :remove, :subresource_actions)
 
         post(api_service_order_service_request_url(nil, "cart", service_request), :params => { :action => :remove })
@@ -356,7 +356,7 @@ RSpec.describe "service orders API" do
         service_request_1, service_request_2 = FactoryBot.create_list(:service_template_provision_request,
                                                                        2,
                                                                        :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart,
+        shopping_cart = FactoryBot.create(:service_order_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
         api_basic_authorize action_identifier(:service_requests, :remove, :subcollection_actions)
@@ -397,7 +397,7 @@ RSpec.describe "service orders API" do
         service_request_1, service_request_2 = FactoryBot.create_list(:service_template_provision_request,
                                                                        2,
                                                                        :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart,
+        shopping_cart = FactoryBot.create(:service_order_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
         api_basic_authorize action_identifier(:service_requests, :remove, :subcollection_actions)
@@ -438,7 +438,7 @@ RSpec.describe "service orders API" do
         service_request_1, service_request_2 = FactoryBot.create_list(:service_template_provision_request,
                                                                        2,
                                                                        :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart,
+        shopping_cart = FactoryBot.create(:service_order_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
         api_basic_authorize action_identifier(:service_orders, :clear)
@@ -456,7 +456,7 @@ RSpec.describe "service orders API" do
 
       it "notifies that a shopping cart cannot be cleared if it has already been checked out" do
         service_request = FactoryBot.create(:service_template_provision_request, :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
+        shopping_cart = FactoryBot.create(:service_order_cart, :user => @user, :miq_requests => [service_request])
         api_basic_authorize action_identifier(:service_orders, :clear)
 
         shopping_cart.checkout
@@ -476,7 +476,7 @@ RSpec.describe "service orders API" do
         service_request_1, service_request_2 = FactoryBot.create_list(:service_template_provision_request,
                                                                        2,
                                                                        :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart,
+        shopping_cart = FactoryBot.create(:service_order_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
         api_basic_authorize action_identifier(:service_orders, :order)
@@ -495,7 +495,7 @@ RSpec.describe "service orders API" do
     context "without an appropriate role" do
       it "will not list a shopping cart's service requests" do
         service_request = FactoryBot.create(:service_template_provision_request, :requester => @user)
-        _shopping_cart = FactoryBot.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
+        _shopping_cart = FactoryBot.create(:service_order_cart, :user => @user, :miq_requests => [service_request])
         api_basic_authorize
 
         get(api_service_order_service_requests_url(nil, "cart"))
@@ -505,7 +505,7 @@ RSpec.describe "service orders API" do
 
       it "will not show a service orders's shopping cart" do
         service_request = FactoryBot.create(:service_template_provision_request, :requester => @user)
-        _shopping_cart = FactoryBot.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
+        _shopping_cart = FactoryBot.create(:service_order_cart, :user => @user, :miq_requests => [service_request])
         api_basic_authorize
 
         get(api_service_order_service_request_url(nil, "cart", service_request))
@@ -519,7 +519,7 @@ RSpec.describe "service orders API" do
         service_template.resource_actions << FactoryBot.create(:resource_action,
                                                                 :action => "Provision",
                                                                 :dialog => dialog)
-        shopping_cart = FactoryBot.create(:shopping_cart, :user => @user)
+        shopping_cart = FactoryBot.create(:service_order_cart, :user => @user)
         api_basic_authorize
 
         post(
@@ -545,7 +545,7 @@ RSpec.describe "service orders API" do
         service_template_2.resource_actions << FactoryBot.create(:resource_action,
                                                                   :action => "Provision",
                                                                   :dialog => dialog)
-        shopping_cart = FactoryBot.create(:shopping_cart, :user => @user)
+        shopping_cart = FactoryBot.create(:service_order_cart, :user => @user)
         api_basic_authorize
 
         expect do
@@ -566,7 +566,7 @@ RSpec.describe "service orders API" do
 
       it "will not remove a service request from a shopping cart" do
         service_request = FactoryBot.create(:service_template_provision_request, :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
+        shopping_cart = FactoryBot.create(:service_order_cart, :user => @user, :miq_requests => [service_request])
         api_basic_authorize
 
         post(api_service_order_service_request_url(nil, "cart", service_request), :params => { :action => :remove })
@@ -579,7 +579,7 @@ RSpec.describe "service orders API" do
         service_request_1, service_request_2 = FactoryBot.create_list(:service_template_provision_request,
                                                                        2,
                                                                        :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart,
+        shopping_cart = FactoryBot.create(:service_order_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
         api_basic_authorize
@@ -603,7 +603,7 @@ RSpec.describe "service orders API" do
         service_request_1, service_request_2 = FactoryBot.create_list(:service_template_provision_request,
                                                                        2,
                                                                        :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart,
+        shopping_cart = FactoryBot.create(:service_order_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
         api_basic_authorize
@@ -618,7 +618,8 @@ RSpec.describe "service orders API" do
         service_request_1, service_request_2 = FactoryBot.create_list(:service_template_provision_request,
                                                                        2,
                                                                        :requester => @user)
-        shopping_cart = FactoryBot.create(:shopping_cart,
+        shopping_cart = FactoryBot.create(:service_order_cart,
+                                           :state        => ServiceOrder::STATE_CART,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
         api_basic_authorize
@@ -639,8 +640,8 @@ RSpec.describe "service orders API" do
 
   context 'Copy Service Order' do
     before do
-      @service_order = FactoryBot.create(:service_order, :user => @user)
-      @service_order2 = FactoryBot.create(:service_order, :user => @user)
+      @service_order = FactoryBot.create(:service_order_cart, :user => @user)
+      @service_order2 = FactoryBot.create(:service_order_cart, :user => @user)
     end
 
     it 'forbids service order copy without an appropriate role' do


### PR DESCRIPTION
We added ServiceOrder sub-classes and the API specs need to reflect all that...

I'm opening this as WIP cause there's a couple issues that have to get addressed first:

[create_service_order is using the base class](https://github.com/ManageIQ/manageiq-api/blob/9d146dc4207a3482a60e74e01d227ca46236bf18/app/controllers/api/service_orders_controller.rb#L64) which it can't now and I guess we have to pass the type in the call to get the class

[the api says `the default state for a service order is 'cart'`](https://github.com/ManageIQ/manageiq-api/blob/ce6ad2837d61acf9bcbc75792f7796611fc74def/spec/requests/service_orders_spec.rb#L100) so, I dunno, the [factory shouldn't maybe be creating things with the default set to ordered](https://github.com/ManageIQ/manageiq/blob/ec56ab47c4baa27b12cd00d67e49e8f2a1109321/spec/factories/service_order.rb#L11) 
