### PR TITLE
ServiceOrder base class is no longer valid, prefer ServiceOrderCart

### DIFF
--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -61,7 +61,7 @@ module Api
     end
 
     def create_service_order(data)
-      ServiceOrder.new(data).tap do |service_order|
+      ServiceOrderCart.new(data).tap do |service_order|
         service_order.assign_user
         service_order.save!
       end

--- a/spec/requests/service_orders_spec.rb
+++ b/spec/requests/service_orders_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "service orders API" do
     expected = {
       'error' => a_hash_including(
         'kind'    => 'bad_request',
-        'message' => /Validation failed: ServiceOrder: State has already been taken/
+        'message' => /Validation failed: ServiceOrderCart: State has already been taken/
       )
     }
     expect(response).to have_http_status(:bad_request)


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq/pull/19795/files#diff-f5aafc4dc4e7284f971559aef2bb6a64R21