### PR TITLE
force updated service template photo encoding

### DIFF
--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -21,6 +21,7 @@ module Api
 
     def edit_resource(type, id, data)
       catalog_item = resource_search(id, type, collection_class(:service_templates))
+      decode_picture(data) if data["picture"]
       catalog_item.update_catalog_item(data.deep_symbolize_keys, User.current_user.userid)
     rescue => err
       raise BadRequestError, "Could not update Service Template - #{err}"
@@ -51,6 +52,10 @@ module Api
 
     def set_additional_attributes
       @additional_attributes = %w(config_info)
+    end
+
+    def decode_picture(data)
+      data["picture"]["content"] = Base64.strict_decode64(data["picture"]["content"])
     end
   end
 end

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -134,6 +134,14 @@ describe "Service Templates API" do
         }
       }
     end
+    let(:updated_picture) do
+      {
+        :picture => {
+          :content   => "aW1hZ2U=",
+          :extension => "jpg"
+        }
+      }
+    end
 
     it "rejects requests without appropriate role" do
       api_basic_authorize
@@ -152,6 +160,17 @@ describe "Service Templates API" do
 
       expect_single_resource_query("id" => st.id.to_s, "href" => api_service_template_url(nil, st), "name" => "Updated Template Name")
       expect(st.reload.name).to eq("Updated Template Name")
+    end
+
+    it "supports picture update with base 64 decoded content" do
+      api_basic_authorize collection_action_identifier(:service_templates, :edit)
+
+      st = FactoryBot.create(:service_template)
+      post(api_service_template_url(nil, st), :params => gen_request(:edit, updated_picture))
+
+      st.reload
+      expect(st.picture.md5).to eq("78805a221a988e79ef3f42d7c5bfd418")
+      expect(st.picture.content).to eq("image")
     end
 
     it "supports edits of multiple resources" do


### PR DESCRIPTION
the content encoding for service template pictures is thus: `"content": "<base 64 encoded image here>"` which means that before we run any backend method to create pictures we should make sure that the content is decoded properly since all main does is a `new` which won't do anything with the encoding.

otherwise getting the image back via the image_href returns not an image but base64 encoded content

also please note there's existing UI bug where if you do this with a jpg the picture won't show up correctly (we allow both png and jpg and the pngs show up okay s far as i can tell)

it's for https://bugzilla.redhat.com/show_bug.cgi?id=1770197

@miq-bot add_label bug
(hammer?)