### PR TITLE
[WIP] Adding support for primary resource options

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -112,6 +112,10 @@ module Api
       end
     end
 
+    def options_resource
+      render_resource_options(@req.collection, params[:c_id])
+    end
+
     def settings
       id       = @req.collection_id
       type     = @req.collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       collection_name_pluralized, resource_name = Api::Routing.inflections_for_named_route_helpers(collection_name.to_s)
 
       scope collection_name, :controller => collection_name do
+        match "/:c_id", :action => :options_resource, :via => :options unless collection.options.include?(:arbitrary_resource_path)
         collection.verbs.each do |verb|
           if collection.options.include?(:primary)
             case verb


### PR DESCRIPTION
Prototype - NOT for merging.

Adding support for primary resource options via /api/collection/:id

```
{
  "actions": {
    "post": {
      "refresh": {
        "available": true
      },
      "shutdown_guest": {
        "available": false,
        "reason": "The VM is not powered on"
      },
      "reboot_guest": {
        "available": false,
        "reason": "The VM is not powered on"
      },
      "start": {
        "available": true
      },
      "stop": {
        "available": false,
        "reason": "The VM is not powered on"
      },
      ...
    }
  }
}
```

Prototype - proposal of general signature on OPTIONS /api/collection/:id, organized by HTTP
method, then hash of actions so callers can just access the individual action.

Implementation uses helper methods available there on vms and cloud instances, not sure if that can
be generalized for all collections otherwise we'd need to drive this capability via the api.yml config 
per collections.

Also would need to expose the custom button actions here too.