### PR TITLE
Add the custom_attributes subcollection to hosts collection

### DIFF
--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -4,6 +4,7 @@ module Api
     AUTH_TYPE_ATTR = "auth_type".freeze
     DEFAULT_AUTH_TYPE = "default".freeze
 
+    include Subcollections::CustomAttributes
     include Subcollections::Lans
     include Subcollections::Policies
     include Subcollections::PolicyProfiles

--- a/config/api.yml
+++ b/config/api.yml
@@ -1670,6 +1670,7 @@
     - :policies
     - :policy_profiles
     - :lans
+    - :custom_attributes
     :collection_actions:
       :get:
       - :name: read
@@ -1763,6 +1764,14 @@
       :get:
       - :name: read
         :identifier: host_show
+    :custom_attributes_subcollection_actions:
+      :post:
+      - :name: add
+        :identifier: host_edit
+      - :name: edit
+        :identifier: host_edit
+      - :name: delete
+        :identifier: host_edit
   :instances:
     :description: Instances
     :identifier: instance

--- a/spec/requests/hosts_spec.rb
+++ b/spec/requests/hosts_spec.rb
@@ -136,4 +136,126 @@ RSpec.describe "hosts API" do
       end
     end
   end
+
+  context "CustomAttributes subcollection" do
+    let(:host) { FactoryBot.create(:host_with_authentication) }
+
+    let(:ca1) { FactoryBot.create(:custom_attribute, :name => "name1", :value => "value1") }
+    let(:ca2) { FactoryBot.create(:custom_attribute, :name => "name2", :value => "value2") }
+    let(:ca1_url)        { api_host_custom_attribute_url(nil, host, ca1) }
+    let(:ca2_url)        { api_host_custom_attribute_url(nil, host, ca2) }
+
+    it "getting custom_attributes from a host with no custom_attributes" do
+      api_basic_authorize
+
+      get(api_host_custom_attributes_url(nil, host))
+
+      expect_empty_query_result(:custom_attributes)
+    end
+
+    it "getting custom_attributes from a host" do
+      api_basic_authorize
+      host.custom_attributes = [ca1, ca2]
+
+      get api_host_custom_attributes_url(nil, host)
+
+      expect_query_result(:custom_attributes, 2)
+      expect_result_resources_to_include_hrefs("resources",
+                                               [api_host_custom_attribute_url(nil, host, ca1),
+                                                api_host_custom_attribute_url(nil, host, ca2)])
+    end
+
+    it "getting custom_attributes from a host in expanded form" do
+      api_basic_authorize
+      host.custom_attributes = [ca1, ca2]
+
+      get api_host_custom_attributes_url(nil, host), :params => { :expand => "resources" }
+
+      expect_query_result(:custom_attributes, 2)
+      expect_result_resources_to_include_data("resources", "name" => %w(name1 name2))
+    end
+
+    it "getting custom_attributes from a host using expand" do
+      api_basic_authorize action_identifier(:hosts, :read, :resource_actions, :get)
+      host.custom_attributes = [ca1, ca2]
+
+      get api_host_url(nil, host), :params => { :expand => "custom_attributes" }
+
+      expect_single_resource_query("guid" => host.guid)
+      expect_result_resources_to_include_data("custom_attributes", "name" => %w(name1 name2))
+    end
+
+    it "delete a custom_attribute without appropriate role" do
+      api_basic_authorize
+      host.custom_attributes = [ca1]
+
+      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:delete, nil, host_url))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "delete a custom_attribute from a host via the delete action" do
+      api_basic_authorize action_identifier(:hosts, :edit)
+      host.custom_attributes = [ca1]
+
+      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:delete, nil, ca1_url))
+
+      expect(response).to have_http_status(:ok)
+      expect(host.reload.custom_attributes).to be_empty
+    end
+
+    it "add custom attribute to a hosts without a name" do
+      api_basic_authorize action_identifier(:hosts, :edit)
+
+      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:add, "value" => "value1"))
+
+      expect_bad_request("Must specify a name")
+    end
+
+    it "add custom attributes to a host" do
+      api_basic_authorize action_identifier(:hosts, :edit)
+
+      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:add, [{"name" => "name1", "value" => "value1"},
+                                                                                {"name" => "name2", "value" => "value2"}]))
+
+      expect(response).to have_http_status(:ok)
+      expect_result_resources_to_include_data("results", "name" => %w(name1 name2))
+      expect(host.custom_attributes.size).to eq(2)
+      expect(host.custom_attributes.pluck(:value).sort).to eq(%w(value1 value2))
+    end
+
+    it "edit a custom attribute by name" do
+      api_basic_authorize action_identifier(:hosts, :edit)
+      host.custom_attributes = [ca1]
+
+      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:edit, "name" => "name1", "value" => "value one"))
+
+      expect(response).to have_http_status(:ok)
+      expect_result_resources_to_include_data("results", "value" => ["value one"])
+      expect(host.reload.custom_attributes.first.value).to eq("value one")
+    end
+
+    it "edit a custom attribute by href" do
+      api_basic_authorize action_identifier(:hosts, :edit)
+      host.custom_attributes = [ca1]
+
+      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:edit, "href" => ca1_url, "value" => "new value1"))
+
+      expect(response).to have_http_status(:ok)
+      expect_result_resources_to_include_data("results", "value" => ["new value1"])
+      expect(host.reload.custom_attributes.first.value).to eq("new value1")
+    end
+
+    it "edit multiple custom attributes" do
+      api_basic_authorize action_identifier(:hosts, :edit)
+      host.custom_attributes = [ca1, ca2]
+
+      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:edit, [{"name" => "name1", "value" => "new value1"},
+                                                                                 {"name" => "name2", "value" => "new value2"}]))
+
+      expect(response).to have_http_status(:ok)
+      expect_result_resources_to_include_data("results", "value" => ["new value1", "new value2"])
+      expect(host.reload.custom_attributes.pluck(:value).sort).to eq(["new value1", "new value2"])
+    end
+  end
 end

--- a/spec/requests/hosts_spec.rb
+++ b/spec/requests/hosts_spec.rb
@@ -169,20 +169,20 @@ RSpec.describe "hosts API" do
       api_basic_authorize
       host.custom_attributes = [ca1, ca2]
 
-      get api_host_custom_attributes_url(nil, host), :params => { :expand => "resources" }
+      get api_host_custom_attributes_url(nil, host), :params => {:expand => "resources"}
 
       expect_query_result(:custom_attributes, 2)
-      expect_result_resources_to_include_data("resources", "name" => %w(name1 name2))
+      expect_result_resources_to_include_data("resources", "name" => %w[name1 name2])
     end
 
     it "getting custom_attributes from a host using expand" do
       api_basic_authorize action_identifier(:hosts, :read, :resource_actions, :get)
       host.custom_attributes = [ca1, ca2]
 
-      get api_host_url(nil, host), :params => { :expand => "custom_attributes" }
+      get api_host_url(nil, host), :params => {:expand => "custom_attributes"}
 
       expect_single_resource_query("guid" => host.guid)
-      expect_result_resources_to_include_data("custom_attributes", "name" => %w(name1 name2))
+      expect_result_resources_to_include_data("custom_attributes", "name" => %w[name1 name2])
     end
 
     it "delete a custom_attribute without appropriate role" do
@@ -215,13 +215,13 @@ RSpec.describe "hosts API" do
     it "add custom attributes to a host" do
       api_basic_authorize action_identifier(:hosts, :edit)
 
-      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:add, [{"name" => "name1", "value" => "value1"},
-                                                                                {"name" => "name2", "value" => "value2"}]))
+      params = gen_request(:add, [{"name" => "name1", "value" => "value1"}, {"name" => "name2", "value" => "value2"}])
+      post(api_host_custom_attributes_url(nil, host), :params => params)
 
       expect(response).to have_http_status(:ok)
-      expect_result_resources_to_include_data("results", "name" => %w(name1 name2))
+      expect_result_resources_to_include_data("results", "name" => %w[name1 name2])
       expect(host.custom_attributes.size).to eq(2)
-      expect(host.custom_attributes.pluck(:value).sort).to eq(%w(value1 value2))
+      expect(host.custom_attributes.pluck(:value).sort).to eq(%w[value1 value2])
     end
 
     it "edit a custom attribute by name" do
@@ -250,8 +250,8 @@ RSpec.describe "hosts API" do
       api_basic_authorize action_identifier(:hosts, :edit)
       host.custom_attributes = [ca1, ca2]
 
-      post(api_host_custom_attributes_url(nil, host), :params => gen_request(:edit, [{"name" => "name1", "value" => "new value1"},
-                                                                                 {"name" => "name2", "value" => "new value2"}]))
+      params = gen_request(:edit, [{"name" => "name1", "value" => "new value1"}, {"name" => "name2", "value" => "new value2"}])
+      post(api_host_custom_attributes_url(nil, host), :params => params)
 
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_data("results", "value" => ["new value1", "new value2"])


### PR DESCRIPTION
The `hosts` collection doesn't support the `custom_attributes` subcollection, while the model `Host` class supports custom attributes. This pull requests adds it.

It's totally inspired from what is done for `vms` collection, including specs.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1816003