### PR TITLE
/api/product_info - fix missing support_website, support_website_text

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -80,8 +80,8 @@ module Api
         :name                 => Vmdb::Appliance.PRODUCT_NAME,
         :name_full            => I18n.t("product.name_full"),
         :copyright            => I18n.t("product.copyright"),
-        :support_website      => I18n.t("product.support_website"),
-        :support_website_text => I18n.t("product.support_website_text"),
+        :support_website      => ::Settings.docs.product_support_website,
+        :support_website_text => ::Settings.docs.product_support_website_text,
         :branding_info        => branding_info
       }
     end

--- a/spec/requests/entrypoint_spec.rb
+++ b/spec/requests/entrypoint_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe "API entrypoint" do
         "name"                 => Vmdb::Appliance.PRODUCT_NAME,
         "name_full"            => I18n.t("product.name_full"),
         "copyright"            => I18n.t("product.copyright"),
-        "support_website"      => I18n.t("product.support_website"),
-        "support_website_text" => I18n.t("product.support_website_text")
+        "support_website"      => ::Settings.docs.product_support_website,
+        "support_website_text" => ::Settings.docs.product_support_website_text
       )
     )
 


### PR DESCRIPTION
The i18n.t version was removed in https://github.com/ManageIQ/manageiq/pull/19881,
in favor of using Settings in https://github.com/ManageIQ/manageiq-ui-classic/pull/6718.

But the API is still using it, updating to do the same thing.
(The SUI is using this for a menu item.)

Cc @mzazrivec @simaishi 

@miq-bot add_label bug, jansa/yes?