### PR TITLE
Add async KeyPair deletion

### DIFF
--- a/app/controllers/api/auth_key_pairs_controller.rb
+++ b/app/controllers/api/auth_key_pairs_controller.rb
@@ -1,4 +1,13 @@
 module Api
   class AuthKeyPairsController < BaseController
+    def delete_resource(type, id, _data = {})
+      delete_action_handler do
+        key_pair = resource_search(id, type, collection_class(type))
+        raise "Delete not supported for #{key_pair.name}" unless key_pair.respond_to?(:delete_key_pair_queue)
+
+        task_id = key_pair.delete_key_pair_queue(current_user.userid)
+        action_result(true, "Deleting #{key_pair.name}", :task_id => task_id)
+      end
+    end
   end
 end

--- a/spec/requests/auth_key_pairs_spec.rb
+++ b/spec/requests/auth_key_pairs_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Auth Key Pairs API" do
-  let(:akp) { FactoryBot.create(:auth_key_pair_cloud) }
+  let(:akp) { FactoryBot.create(:auth_key_pair_cloud, :resource => FactoryBot.create(:ems_cloud)) }
 
   describe 'GET /api/auth_key_pairs' do
     before { akp }
@@ -68,6 +68,22 @@ RSpec.describe "Auth Key Pairs API" do
 
       auth_key_pair = ManageIQ::Providers::CloudManager::AuthKeyPair.find(response.parsed_body['results'].first["id"])
       expect(auth_key_pair.name).to eq('foo')
+    end
+
+    it 'can delete auth_key_pairs' do
+      api_basic_authorize action_identifier(:auth_key_pairs, :delete)
+
+      post(api_auth_key_pair_url(nil, akp), :params => {'action' => 'delete'})
+
+      expect_single_action_result(:success => true, :message => "Deleting", :task => true)
+    end
+
+    it 'will not allow unauthorized key pairs delete' do
+      api_basic_authorize action_identifier(:auth_key_pairs, :edit)
+
+      expect_forbidden_request do
+        post(api_auth_key_pair_url(nil, akp), :params => {'action' => 'delete'})
+      end
     end
   end
 


### PR DESCRIPTION
Deletion of auth key pairs should be done via queue worker, just as it is being done in UI controller at the moment.

@miq-bot add_label enhancement