### PR TITLE
fix rails 5.2 json parse

### DIFF
--- a/lib/api/create_constraint.rb
+++ b/lib/api/create_constraint.rb
@@ -1,7 +1,8 @@
 module Api
   class CreateConstraint
     def matches?(request)
-      Hash(JSON.parse(request.body.read)).fetch("action", "create").in?(%w(create add))
+      body = request.body.read
+      body.present? && Hash(JSON.parse(body)).fetch("action", "create").in?(%w[create add])
     ensure
       request.body.rewind
     end


### PR DESCRIPTION
JSON.parse('') was throwing error. this fixes it

```
  1) Creating responds with Bad Request if there are no resources at the top level
     Failure/Error:
Hash(JSON.parse(request.body.read)).fetch("action", "create")
                                   .in?(%w(create add))
     
     JSON::ParserError:
       765: unexpected token at ''
     # ./lib/api/create_constraint.rb:4:in `matches?'
```

@miq-bot add_label bug, rails-5-2
@miq-bot assign jrafanie