### PR TITLE
Expose the enablement of async notifications in /api/product_info

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -6,14 +6,14 @@ module Api
 
     def index
       res = {
-        :name          => ApiConfig.base.name,
-        :description   => ApiConfig.base.description,
-        :version       => ManageIQ::Api::VERSION,
-        :versions      => entrypoint_versions,
-        :settings      => user_settings,
-        :identity      => auth_identity,
-        :server_info   => server_info,
-        :product_info  => product_info_data
+        :name         => ApiConfig.base.name,
+        :description  => ApiConfig.base.description,
+        :version      => ManageIQ::Api::VERSION,
+        :versions     => entrypoint_versions,
+        :settings     => user_settings,
+        :identity     => auth_identity,
+        :server_info  => server_info,
+        :product_info => product_info_data
       }
       res[:authorization] = auth_authorization if attribute_selection.include?("authorization")
       res[:collections]   = entrypoint_collections
@@ -62,16 +62,17 @@ module Api
 
     def server_info
       {
-        :version         => Vmdb::Appliance.VERSION,
-        :build           => Vmdb::Appliance.BUILD,
-        :release         => Vmdb::Appliance.RELEASE,
-        :appliance       => MiqServer.my_server.name,
-        :time            => Time.now.utc.iso8601,
-        :server_href     => "#{@req.api_prefix}/servers/#{MiqServer.my_server.id}",
-        :zone_href       => "#{@req.api_prefix}/zones/#{MiqServer.my_server.zone.id}",
-        :region_href     => "#{@req.api_prefix}/regions/#{MiqRegion.my_region.id}",
-        :enterprise_href => "#{@req.api_prefix}/enterprises/#{MiqEnterprise.my_enterprise.id}",
-        :plugins         => plugin_info
+        :version                    => Vmdb::Appliance.VERSION,
+        :build                      => Vmdb::Appliance.BUILD,
+        :release                    => Vmdb::Appliance.RELEASE,
+        :appliance                  => MiqServer.my_server.name,
+        :time                       => Time.now.utc.iso8601,
+        :server_href                => "#{@req.api_prefix}/servers/#{MiqServer.my_server.id}",
+        :zone_href                  => "#{@req.api_prefix}/zones/#{MiqServer.my_server.zone.id}",
+        :region_href                => "#{@req.api_prefix}/regions/#{MiqRegion.my_region.id}",
+        :enterprise_href            => "#{@req.api_prefix}/enterprises/#{MiqEnterprise.my_enterprise.id}",
+        :plugins                    => plugin_info,
+        :asynchronous_notifications => ::Settings.server.asynchronous_notifications,
       }
     end
 


### PR DESCRIPTION
We don't want to expose the whole `/api/settings` for all users, but this boolean is actually harmless to have it accessible even without a login. We will need this information quite often, so I am planning to cache this data upon login and use it further.

Required for: https://github.com/ManageIQ/manageiq-ui-classic/pull/6816

```js
// curl -XGET http://admin:smartvm@localhost:3000/api | jq '.server_info'
{
  "version": "master",
  "build": "unknown_ada003b9a3",
  "release": "Kasparov",
  "appliance": "EVM",
  "time": "2020-04-06T11:32:48Z",
  "server_href": "http://localhost:3000/api/servers/1",
  "zone_href": "http://localhost:3000/api/zones/2",
  "region_href": "http://localhost:3000/api/regions/1",
  "enterprise_href": "http://localhost:3000/api/enterprises/1",
  "plugins": {} // ...,
  "asynchronous_notifications": true
}

```

cc @himdel 