### PR TITLE
create the resource action on a button before we try to update! it

### DIFF
--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -2,32 +2,31 @@ module Api
   class CustomButtonsController < BaseController
     def create_resource(_type, _id, data)
       CustomButton.transaction do
-        custom_button = CustomButton.new(data.except("resource_action", "options"))
-        custom_button.userid = User.current_user.userid
-        custom_button.options = data["options"].deep_symbolize_keys if data["options"]
-        custom_button.resource_action.update!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
-        custom_button.save!
-        custom_button
+        CustomButton.new(data.except("resource_action", "options")).tap do |cb|
+          cb.userid = User.current_user.userid
+          cb.options = data["options"].deep_symbolize_keys if data["options"]
+          cb.create_resource_action!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
+          cb.save!
+        end
       end
-    rescue
-      raise BadRequestError, "Failed to create new custom button - #{custom_button.errors.full_messages.join(", ")}"
+    rescue => err
+      raise BadRequestError, "Failed to create new custom button - #{err.message}"
     end
 
     def edit_resource(type, id, data)
       return if data.empty?
 
       CustomButton.transaction do
-        custom_button = fetch_custom_button(type, id)
-        updated_data = data['resource'] || data
-        if updated_data['resource_action'].present?
-          custom_button.resource_action = create_or_update_resource_action(updated_data['resource_action'])
+        fetch_custom_button(type, id).tap do |cb|
+          updated_data = (data['resource'] || data).dup
+          if (resource_action = updated_data.delete("resource_action")).present?
+            cb.resource_action = create_or_update_resource_action(resource_action)
+          end
+          cb.update!(updated_data.deep_symbolize_keys)
         end
-        updated_data.except!('resource_action')
-        custom_button.update!(updated_data.deep_symbolize_keys) if updated_data.present?
-        custom_button
       end
     rescue => err
-      raise BadRequestError, "Failed to update custom button - #{err}"
+      raise BadRequestError, "Failed to update custom button - #{err.message}"
     end
 
     def options
@@ -44,14 +43,11 @@ module Api
 
     def create_or_update_resource_action(data)
       return nil if data.empty?
-      id = data["id"]
+      id = data.delete("id")
       if id.present?
-        resource_action = ResourceAction.find(id)
-        data.except!("id")
-        resource_action.update!(data.deep_symbolize_keys)
-        resource_action
+        ResourceAction.find(id).tap { |ra| ra.attributes = data }
       else
-        ResourceAction.create(data)
+        ResourceAction.new(data)
       end
     end
 


### PR DESCRIPTION
we can't `update!` on nil so this lets us create without errors

@miq-bot add_label bug

also we can't use the current error handling cause the custom button doesn't exist if it fails inside the transaction 

technically found while looking at https://bugzilla.redhat.com/show_bug.cgi?id=1754554 but while I did mention it in that ticket it does not fix that since that's opened for hammer and isn't a bug on hammer. if someone were to try what's in that ticket on master they would run into this. although it's more general than stated in that ticket since the issue fixed here blocks any custom button create on any recent version over the api and only incidentally involves dialog ids or resource actions.