### PR TITLE
Adding support for check_compliance action on templates

### DIFF
--- a/app/controllers/api/templates_controller.rb
+++ b/app/controllers/api/templates_controller.rb
@@ -7,5 +7,29 @@ module Api
     def edit_resource(type, id = nil, data = {})
       super(type, id, data.extract!('name', 'description'))
     end
+
+    def check_compliance_resource(type, id, _data = nil)
+      api_action(type, id) do |klass|
+        template = resource_search(id, type, klass)
+        api_log_info("Checking compliance of #{template_ident(template)}")
+        request_compliance_check(template)
+      end
+    end
+
+    private
+
+    def template_ident(template)
+      "Template id:#{template.id} name:'#{template.name}'"
+    end
+
+    def request_compliance_check(template)
+      desc = "#{template_ident(template)} check compliance requested"
+      raise "#{template_ident(template)} has no compliance policies assigned" unless template.has_compliance_policies?
+
+      task_id = queue_object_action(template, desc, :method_name => "check_compliance")
+      action_result(true, desc, :task_id => task_id)
+    rescue StandardError => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -3821,6 +3821,8 @@
       - :name: read
         :identifier: miq_template_show_list
       :post:
+      - :name: check_compliance
+        :identifier: miq_template_check_compliance
       - :name: query
         :identifier: miq_template_show_list
       - :name: refresh
@@ -3838,6 +3840,8 @@
       - :name: read
         :identifier: miq_template_show
       :post:
+      - :name: check_compliance
+        :identifier: miq_template_check_compliance
       - :name: refresh
         :identifier: miq_template_refresh
         :disabled: true

--- a/spec/requests/templates_spec.rb
+++ b/spec/requests/templates_spec.rb
@@ -55,6 +55,101 @@ RSpec.describe "Templates API" do
     end
   end
 
+  context "check compliance action" do
+    let(:template)             { FactoryBot.create(:template) }
+    let(:template1)            { FactoryBot.create(:template) }
+    let(:template2)            { FactoryBot.create(:template) }
+    let(:invalid_template_url) { api_template_url(nil, ApplicationRecord.id_in_region(999_999, ApplicationRecord.my_region_number)) }
+    let(:template_url)         { api_template_url(nil, template) }
+    let(:template1_url)        { api_template_url(nil, template1) }
+    let(:template2_url)        { api_template_url(nil, template2) }
+    let!(:event_definition)    { FactoryBot.create(:miq_event_definition, :name => "vm_compliance_check") }
+    let!(:policy_content) do
+      content = FactoryBot.create(:miq_policy_content, :qualifier => "failure", :failure_sequence => 1)
+      content.miq_action = FactoryBot.create(:miq_action, :name => "compliance_failed", :action_type => "default")
+      content.miq_event_definition = event_definition
+      content
+    end
+
+    let!(:compliance_policy) do
+      policy = FactoryBot.create(:miq_policy, :mode => "compliance", :towhat => "Vm", :description => "check_compliance", :active => true)
+      policy.conditions << FactoryBot.create(:condition)
+      policy.miq_policy_contents << policy_content
+      policy.sync_events([event_definition])
+      policy
+    end
+
+    it "to an invalid template" do
+      api_basic_authorize action_identifier(:templates, :check_compliance)
+
+      post(invalid_template_url, :params => gen_request(:check_compliance))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "to an invalid template without appropriate role" do
+      api_basic_authorize
+
+      post(invalid_template_url, :params => gen_request(:check_compliance))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "to a single template without compliance policies assigned" do
+      api_basic_authorize action_identifier(:templates, :check_compliance)
+
+      post(template_url, :params => gen_request(:check_compliance))
+
+      expect_single_action_result(:success => false, :message => /template id:#{template.id} .* has no compliance policies assigned/i, :href => api_template_url(nil, template))
+    end
+
+    it "to a single template with a compliance policy" do
+      api_basic_authorize action_identifier(:templates, :check_compliance)
+
+      template.add_policy(compliance_policy)
+
+      post(template_url, :params => gen_request(:check_compliance))
+
+      expect_single_action_result(:success => true, :message => /template id:#{template.id} .* check compliance requested/i, :href => api_template_url(nil, template), :task => true)
+    end
+
+    it "to multiple templates without appropriate role" do
+      api_basic_authorize
+
+      post(api_templates_url, :params => gen_request(:check_compliance, [{"href" => template1_url}, {"href" => template2_url}]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "to multiple templates" do
+      api_basic_authorize collection_action_identifier(:templates, :check_compliance)
+
+      template1.add_policy(compliance_policy)
+
+      post(api_templates_url, :params => gen_request(:check_compliance, [{"href" => template1_url}, {"href" => template2_url}]))
+
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including(
+            "message"   => a_string_matching(/Template id:#{template1.id} .* check compliance requested/i),
+            "task_id"   => a_kind_of(String),
+            "task_href" => a_string_matching(api_tasks_url),
+            "success"   => true,
+            "href"      => api_template_url(nil, template1)
+          ),
+          a_hash_including(
+            "message" => a_string_matching(/Template id:#{template2.id} .* has no compliance policies assigned/i),
+            "success" => false,
+            "href"    => api_template_url(nil, template2)
+          )
+        )
+      }
+
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "tags subcollection" do
     it "can list a template's tags" do
       template = FactoryBot.create(:template)


### PR DESCRIPTION
- Adding support for check_compliance action on template resources
  - /api/templates/:id  - action **check_compliance**
  - /api/templates       - action **check_compliance** for bulk requests
- Added Specs

For https://github.com/ManageIQ/manageiq-api/issues/790