### PR TITLE
Adding support for check_compliance action on providers

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -123,6 +123,14 @@ module Api
       action_result(false, err.to_s)
     end
 
+    def check_compliance_resource(type, id, _data = nil)
+      api_action(type, id) do |klass|
+        provider = resource_search(id, type, klass)
+        api_log_info("Checking compliance of #{provider_ident(provider)}")
+        request_compliance_check(provider)
+      end
+    end
+
     private
 
     def authorize_provider(typed_provider_klass)
@@ -346,6 +354,16 @@ module Api
         end
       end
       @collection_klasses[:providers] = Provider
+    end
+
+    def request_compliance_check(provider)
+      desc = "#{provider_ident(provider)} check compliance requested"
+      raise "#{provider_ident(provider)} has no compliance policies assigned" if provider.compliance_policies.blank?
+
+      task_id = queue_object_action(provider, desc, :method_name => "check_compliance")
+      action_result(true, desc, :task_id => task_id)
+    rescue StandardError => err
+      action_result(false, err.to_s)
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2388,6 +2388,10 @@
       :post:
       - :name: change_password
         :identifier: ems_infra_change_password
+      - :name: check_compliance
+        :identifier:
+        - ems_infra_check_compliance
+        - ems_cloud_check_compliance
       - :name: query
         :identifier:
         - ems_infra_show_list
@@ -2423,6 +2427,10 @@
       :post:
       - :name: change_password
         :identifier: ems_infra_change_password
+      - :name: check_compliance
+        :identifier:
+        - ems_infra_check_compliance
+        - ems_cloud_check_compliance
       - :name: edit
         :identifier: ems_infra_edit
       - :name: refresh

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1903,4 +1903,7 @@ describe "Providers API" do
       expect(response.parsed_body).to include("resources" => [])
     end
   end
+
+  it_behaves_like "a check compliance action", "provider", :ems_infra, "ExtManagementSystem"
+  it_behaves_like "a check compliance action", "provider", :ems_cloud, "ExtManagementSystem"
 end


### PR DESCRIPTION
- Adding support for check_compliance action on provider resources.
  - /api/providers/:id  - action "check_compliance"
  - /api/providers      - action "check_compliance" for bulk requests
- Added Specs

- [x] Depends on https://github.com/ManageIQ/manageiq/pull/20080.

https://github.com/ManageIQ/manageiq-api/issues/790

@miq-bot assign @abellotti 