### PR TITLE
Validate report in report results in subcollection results

### DIFF
--- a/app/controllers/api/subcollections/results.rb
+++ b/app/controllers/api/subcollections/results.rb
@@ -2,7 +2,9 @@ module Api
   module Subcollections
     module Results
       def find_results(id)
-        MiqReportResult.for_user(User.current_user).find(id)
+        report_id = @req.collection_id
+        MiqReport.find(report_id)
+        MiqReportResult.with_report(report_id).for_user(User.current_user).find(id)
       end
 
       def results_query_resource(object)

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -83,6 +83,23 @@ RSpec.describe "reports API" do
       expect(response).to have_http_status(:ok)
     end
 
+    it "cannot find report to fetch report's result" do
+      report_result = report.miq_report_results.first
+      table = Ruport::Data::Table.new(
+          :column_names => %w(foo),
+          :data         => [%w(bar), %w(baz)]
+      )
+      allow(report).to receive(:table).and_return(table)
+      allow_any_instance_of(MiqReportResult).to receive(:report_results).and_return(report)
+
+      api_basic_authorize
+
+      other_report = FactoryBot.create(:miq_report_with_results)
+      get(api_report_result_url(nil, other_report, report_result))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
     it "can fetch all the results" do
       result = report.miq_report_results.first
       api_basic_authorize collection_action_identifier(:results, :read, :get)


### PR DESCRIPTION
`/api/reports/507/results/24219?hash_attribute=result_set&sort_by=vm_name`

such query should failswhen `report_id = 507` doesn't exists of or it is not report of result (id: 24219)


@miq-bot assign @abellotti 
@miq-bot add_label jasna/yes, bug



