### PR TITLE
[BaseController::Render] Cache role allows

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -514,7 +514,13 @@ module Api
 
         return custom_api_user_role_allows?(action_identifier) if custom_api_user_role_allows_method?(action_identifier)
 
-        Array(action_identifier).any? { |identifier| User.current_user.role_allows?(:identifier => identifier) }
+        @role_allows_cache ||= {}
+        Array(action_identifier).any? do |identifier|
+          unless @role_allows_cache.key?(identifier)
+            @role_allows_cache[identifier] = User.current_user.role_allows?(:identifier => identifier)
+          end
+          @role_allows_cache[identifier]
+        end
       end
 
       def render_actions(physical_attrs)


### PR DESCRIPTION
When rendering a collection, the `User.role_allows?` call is hit for every single record for every single action for a given collection item.

Since this is only a "role specific" check, and not item specific, there is no reason to repeat this work for each record, and so this cache can save a noticeable amount of time on larger datasets.

Before
------

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 3205 |      14 |         26 | 1732 |
| 1241 |      11 |        7.0 |  286 |
| 1609 |      11 |        6.6 |  286 |
| 1277 |      11 |        6.5 |  286 |
| 1192 |      11 |        6.4 |  286 |

After
-----

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2803 |      14 |         26 | 1732 |
| 1010 |      11 |        6.8 |  286 |
|  999 |      11 |        6.4 |  286 |
| 1004 |      11 |        6.7 |  286 |
| 1007 |      11 |        6.6 |  286 |

Uses the following query:

    curl -XGET "http://user:pass@example.com/api/vms?expand=resources&filter[]=active=true"