### PR TITLE
Adding support for check_compliance action on host resources.

### DIFF
--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -23,5 +23,29 @@ module Api
         host.update_authentication(all_credentials) if all_credentials.present?
       end
     end
+
+    def check_compliance_resource(type, id, _data = nil)
+      api_action(type, id) do |klass|
+        host = resource_search(id, type, klass)
+        api_log_info("Checking compliance of #{host_ident(host)}")
+        request_compliance_check(host)
+      end
+    end
+
+    private
+
+    def host_ident(host)
+      "Host id:#{host.id} name:'#{host.name}'"
+    end
+
+    def request_compliance_check(host)
+      desc = "#{host_ident(host)} check compliance requested"
+      raise "#{host_ident(host)} has no compliance policies assigned" if host.compliance_policies.blank?
+
+      task_id = queue_object_action(host, desc, :method_name => "check_compliance")
+      action_result(true, desc, :task_id => task_id)
+    rescue StandardError => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1676,6 +1676,8 @@
       - :name: read
         :identifier: host_show_list
       :post:
+      - :name: check_compliance
+        :identifier: host_check_compliance
       - :name: query
         :identifier: host_show_list
       - :name: add
@@ -1712,6 +1714,8 @@
       - :name: read
         :identifier: host_show
       :post:
+      - :name: check_compliance
+        :identifier: host_check_compliance
       - :name: edit
         :identifier: host_edit
       - :name: refresh

--- a/spec/requests/hosts_spec.rb
+++ b/spec/requests/hosts_spec.rb
@@ -258,4 +258,6 @@ RSpec.describe "hosts API" do
       expect(host.reload.custom_attributes.pluck(:value).sort).to eq(["new value1", "new value2"])
     end
   end
+
+  it_behaves_like "a check compliance action", "host", :host, "Host"
 end


### PR DESCRIPTION
- Adding support for check_compliance action on host resources.
  - /api/hosts/:id  - action "check_compliance"
  - /api/hosts      - action "check_compliance" for bulk requests
- Added Specs

https://github.com/ManageIQ/manageiq-api/issues/790