### PR TITLE
Save visibility content as a symbol not as a string

### DIFF
--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -2,6 +2,7 @@ module Api
   class CustomButtonsController < BaseController
     def create_resource(_type, _id, data)
       CustomButton.transaction do
+        data["visibility"] = data["visibility"].deep_symbolize_keys if data["visibility"].present?
         custom_button = CustomButton.new(data.except("resource_action", "options"))
         custom_button.userid = User.current_user.userid
         custom_button.options = data["options"].deep_symbolize_keys if data["options"]

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'CustomButtons API' do
       expect(response).to have_http_status(:ok)
       custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
       expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")
-      expect(custom_button.visibility['roles']).to eq(['_ALL_'])
+      expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
       expect(response.parsed_body['results'].first).to include(cb_rec.except('resource_action', 'uri_attributes'))
     end
 


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6991

Steps to reproduce:

Automation -> Generic Objects -> Add Button Group to a Generic Object -> Add Buttons to this group
Services -> My Services -> click to a Service that has an Instance of that Generic Object
click on Instances
click on one Instance
see buttons (Karel is a button and Arya a button group)

Before:
<img width="1676" alt="Screenshot 2020-04-24 at 14 48 33" src="https://user-images.githubusercontent.com/9210860/80214255-cfc15300-863a-11ea-99d9-592dd8f59cea.png">
<img width="1671" alt="Screenshot 2020-04-24 at 14 48 46" src="https://user-images.githubusercontent.com/9210860/80214260-d223ad00-863a-11ea-8593-10cfeb8efc98.png">

After:
<img width="1670" alt="Screenshot 2020-04-24 at 14 15 00" src="https://user-images.githubusercontent.com/9210860/80211492-22e4d700-8636-11ea-99d2-a0872ebc180b.png">
<img width="1651" alt="Screenshot 2020-04-24 at 14 15 33" src="https://user-images.githubusercontent.com/9210860/80211505-2710f480-8636-11ea-8462-9f97cc5a7702.png">

Problem with disabled buttons on summary page is fixed in https://github.com/ManageIQ/manageiq-ui-classic/pull/6992

@miq-bot add_label bug, jansa/yes, ivanchuk/yes, wip