### PR TITLE
add functionality to retire vms in future

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -274,11 +274,22 @@ module Api
       action_result(false, "Failed to set miq_server - #{err}")
     end
 
-    def request_retire_resource(type, id, _data = nil)
+    def request_retire_resource(type, id, data = nil)
       api_action(type, id) do |klass|
         vm = resource_search(id, type, klass)
-        api_log_info("Retiring request of vm #{vm_ident(vm)}")
-        request_retire(vm)
+        msg = "Retiring request of vm #{vm_ident(vm)}"
+        if data && data["date"]
+          opts = {}
+          opts[:date] = data["date"]
+          opts[:warn] = data["warn"] if data["warn"]
+          msg << " on: #{opts}"
+          api_log_info(msg)
+          request_retire(vm, opts)
+        else
+          msg << " immediately."
+          api_log_info(msg)
+          request_retire(vm)
+        end
       end
     end
 
@@ -505,10 +516,13 @@ module Api
       action_result(false, err.to_s)
     end
 
-    def request_retire(virtual_machine)
+    def request_retire(virtual_machine, opts = nil)
       desc = "#{vm_ident(virtual_machine)} request retire"
-
-      task_id = queue_object_action(virtual_machine, desc, :method_name => "make_retire_request", :role => "automate", :args => [User.current_user.id])
+      task_id = if opts
+                  queue_object_action(virtual_machine, desc, :method_name => "retire", :role => "automate", :args => [opts])
+                else
+                  queue_object_action(virtual_machine, desc, :method_name => "make_retire_request", :role => "automate", :args => [User.current_user.id])
+                end
       action_result(true, desc, :task_id => task_id)
     rescue StandardError => err
       action_result(false, err.to_s)

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1117,6 +1117,14 @@ describe "Vms API" do
           expect(response.parsed_body).to include(expected)
         end
 
+        it "in the future" do
+          api_basic_authorize action_identifier(:vms, :request_retire)
+          date = 2.weeks.from_now
+          post(vm_url, :params => gen_request(:request_retire, :date => date.iso8601))
+
+          expect_single_action_result(:success => true, :message => /#{vm.id}.* request retire/i, :href => api_vm_url(nil, vm))
+        end
+
         it "queues retirement task" do
           api_basic_authorize(action_identifier(:vms, :request_retire))
           message = "VM id:#{vm.id} name:'#{vm.name}' request retire"


### PR DESCRIPTION
`make_retire_request` is the wrong thing to queue for future retirement, the method that handles things in the future is just `retire` so we should be queuing it with the args set properly 

yes yes, i completely forgot we do this on the api too, i'm sorry 

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1827787

@miq-bot add_label bug 