### PR TITLE
custom attribute find_by_data fails if the attribute has no `section`

### DIFF
--- a/app/controllers/api/subcollections/custom_attributes.rb
+++ b/app/controllers/api/subcollections/custom_attributes.rb
@@ -78,7 +78,7 @@ module Api
 
       def find_custom_attribute_by_data(object, data)
         object.custom_attributes.detect do |ca|
-          ca.section.to_s == data["section"].to_s && ca.name.downcase == data["name"].downcase
+          ca.name.downcase == data["name"].downcase
         end
       end
 


### PR DESCRIPTION
Unless the edit query for the custom attribute you're updating has a `data["section"]` property this will fail (since it's comparing `""` to `"metadata"` set as the default on https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/subcollections/custom_attributes.rb#L10). Since we have no validation on custom attributes that we will have a section set, I think we should change this logic (I mean axe it). The API specs for this are all passing and shouldn't be at the moment since they don't have the property set.

@miq-bot add_label bug 
https://bugzilla.redhat.com/show_bug.cgi?id=1827719 (5.11 but probably applies to the product at least as long as I've worked here)

since the docs also say `field_type, source and section are optional` it makes more sense just to take this out rather than adding the logic on the model to validate presence although I guess right now it's possible to have custom attributes with the same name (https://github.com/ManageIQ/manageiq/blob/master/app/models/custom_attribute.rb has no validations whatsoever) so maybe checking name equality is necessary but not sufficient? 

