### PR TITLE
Adding support for check_compliance action on cloud template resources

### DIFF
--- a/app/controllers/api/cloud_templates_controller.rb
+++ b/app/controllers/api/cloud_templates_controller.rb
@@ -1,4 +1,28 @@
 module Api
   class CloudTemplatesController < BaseController
+    def check_compliance_resource(type, id, _data = nil)
+      api_action(type, id) do |klass|
+        cloud_template = resource_search(id, type, klass)
+        api_log_info("Checking compliance of #{cloud_template_ident(cloud_template)}")
+        request_compliance_check(cloud_template)
+      end
+    end
+
+    private
+
+    def cloud_template_ident(cloud_template)
+      "CloudTemplate id:#{cloud_template.id} name:'#{cloud_template.name}'"
+    end
+
+
+    def request_compliance_check(cloud_template)
+      desc = "#{cloud_template_ident(cloud_template)} check compliance requested"
+      raise "#{cloud_template_ident(cloud_template)} has no compliance policies assigned" unless cloud_template.has_compliance_policies?
+
+      task_id = queue_object_action(cloud_template, desc, :method_name => "check_compliance")
+      action_result(true, desc, :task_id => task_id)
+    rescue StandardError => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -609,12 +609,17 @@
       - :name: read
         :identifier: image_show_list
       :post:
+      - :name: check_compliance
+        :identifier: image_check_compliance
       - :name: query
         :identifier: image_show_list
     :resource_actions:
       :get:
       - :name: read
         :identifier: image_show
+      :post:
+      - :name: check_compliance
+        :identifier: image_check_compliance
     :subcollection_actions:
       :get:
       - :name: read

--- a/spec/requests/cloud_templates_spec.rb
+++ b/spec/requests/cloud_templates_spec.rb
@@ -203,4 +203,6 @@ RSpec.describe "Cloud Templates API" do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  it_behaves_like "a check compliance action", "cloud_template", :template_cloud, "Vm"
 end

--- a/spec/support/shared_examples/check_compliance_action.rb
+++ b/spec/support/shared_examples/check_compliance_action.rb
@@ -46,7 +46,7 @@ RSpec.shared_examples "a check compliance action" do |model, factory, event_clas
 
     post(instance_url, :params => gen_request(:check_compliance))
 
-    expect_single_action_result(:success => false, :message => /#{model} id:#{instance.id} .* has no compliance policies assigned/i, :href => instance_url)
+    expect_single_action_result(:success => false, :message => /#{model.camelize} id:#{instance.id} .* has no compliance policies assigned/i, :href => instance_url)
   end
 
   it "to a single #{model} with a compliance policy" do
@@ -56,7 +56,7 @@ RSpec.shared_examples "a check compliance action" do |model, factory, event_clas
 
     post(instance_url, :params => gen_request(:check_compliance))
 
-    expect_single_action_result(:success => true, :message => /#{model} id:#{instance.id} .* check compliance requested/i, :href => instance_url, :task => true)
+    expect_single_action_result(:success => true, :message => /#{model.camelize} id:#{instance.id} .* check compliance requested/i, :href => instance_url, :task => true)
   end
 
   it "to multiple #{model.pluralize} without appropriate role" do
@@ -77,14 +77,14 @@ RSpec.shared_examples "a check compliance action" do |model, factory, event_clas
     expected = {
       "results" => a_collection_containing_exactly(
         a_hash_including(
-          "message"   => a_string_matching(/#{model} id:#{instance1.id} .* check compliance requested/i),
+          "message"   => a_string_matching(/#{model.camelize} id:#{instance1.id} .* check compliance requested/i),
           "task_id"   => a_kind_of(String),
           "task_href" => a_string_matching(api_tasks_url),
           "success"   => true,
           "href"      => instance1_url
         ),
         a_hash_including(
-          "message" => a_string_matching(/#{model} id:#{instance2.id} .* has no compliance policies assigned/i),
+          "message" => a_string_matching(/#{model.camelize} id:#{instance2.id} .* has no compliance policies assigned/i),
           "success" => false,
           "href"    => instance2_url
         )


### PR DESCRIPTION
- Adding support for check_compliance action on cloud template resources.
  - /api/cloud_templates/:id  - action "check_compliance"
  - /api/cloud_templates      - action "check_compliance" for bulk requests
- Added Specs

https://github.com/ManageIQ/manageiq-api/issues/790