### PR TITLE
create the resource action after save for custom buttons

### DIFF
--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -6,8 +6,8 @@ module Api
         custom_button = CustomButton.new(data.except("resource_action", "options"))
         custom_button.userid = User.current_user.userid
         custom_button.options = data["options"].deep_symbolize_keys if data["options"]
-        custom_button.create_resource_action!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
         custom_button.save!
+        custom_button.create_resource_action!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
         custom_button
       end
     rescue => err


### PR DESCRIPTION
otherwise this fails with `Failed to create new custom button - You cannot call create unless the parent is saved` on rails 5.2 🤮 

Keenan caught it in https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/325865143#L2435 

@miq-bot add_label jansa/yes, ivanchuk/yes
@miq-bot add_reviewer @jrafanie 
@miq-bot add_label bug

Followup to #814
Needed for Rails 5.2: https://github.com/ManageIQ/manageiq/issues/20032