### PR TITLE
Save the parent object before creating a child association

### DIFF
--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -6,8 +6,8 @@ module Api
         custom_button = CustomButton.new(data.except("resource_action", "options"))
         custom_button.userid = User.current_user.userid
         custom_button.options = data["options"].deep_symbolize_keys if data["options"]
-        custom_button.create_resource_action!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
         custom_button.save!
+        custom_button.create_resource_action!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
         custom_button
       end
     rescue => err


### PR DESCRIPTION
Rails 5.2 raises this error if you try to persist the child before creating the
parent: `Failed to create new custom button - You cannot call create unless the
parent is saved`

Followup to #814
Needed for Rails 5.2: https://github.com/ManageIQ/manageiq/issues/20032