### PR TITLE
Chargeback rate assignment

### DIFF
--- a/app/controllers/api/chargebacks_controller.rb
+++ b/app/controllers/api/chargebacks_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class ChargebacksController < BaseController
     include Subcollections::Rates
+    include Api::Mixins::ChargebackAssignment
   end
 end

--- a/app/controllers/api/container_images_controller.rb
+++ b/app/controllers/api/container_images_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ContainerImagesController < BaseController
+    include Subcollections::CustomAttributes
+
     def scan_resource(type, image_id, _payload)
       raise BadRequestError, "Must specify an id for scanning a #{type} resource" unless image_id
       api_action(type, image_id) do |klass|

--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -1,0 +1,352 @@
+module Api
+  module Mixins
+    module ChargebackAssignment
+      include Api::Mixins::Tags
+
+      PARAMETERS_KEYS = %w[resource tag].freeze
+      CHARGEBACK_RATE_KEY = 'chargeback'.freeze
+      ALLOWED_CLASSES_FOR = {
+        'resource' => {'Compute' => %w[Tenant ExtManagementSystem EmsCluster MiqEnterprise], 'Storage' => %w[Tenant MiqEnterprise Storage]},
+        'label'    => {'Compute' => %w[CustomAttribute], 'Storage' => %w[]}
+      }.freeze
+
+      ALLOWED_TAG_PREFIXES = {
+        'Compute' => %w[vm container_image],
+        'Storage' => %w[storage]
+      }.freeze
+
+      TYPES_OF_ASSIGNMENTS = %w[object label tag].freeze
+
+      def normalize_attr(attr, value)
+        value = assigments_to_result(value, []) if attr == "assigned_tos"
+
+        super(attr, value)
+      end
+
+      def label_record?(parameter_record)
+        return false unless parameter_record['resource']
+
+        resource_href = parameter_record['resource']['href']
+        href = Api::Href.new(resource_href)
+
+        klass = collection_class(href.subject)
+        klass == CustomAttribute
+      rescue => err
+        raise BadRequestError, "Cannot parse href '#{href.subject}': #{err}"
+      end
+
+      def determine_type(parameter_record)
+        return :label if label_record?(parameter_record)
+
+        type = PARAMETERS_KEYS.detect { |parameter_key| parameter_record.keys.sort == [CHARGEBACK_RATE_KEY, parameter_key].sort }
+
+        raise BadRequestError, "Cannot determine #{type} type of target resource." unless type
+
+        type
+      end
+
+      def target_classification_by(category_name, entry_name)
+        target_category = Classification.lookup_by_name(category_name)
+        if target_category
+          target_classification = target_category.find_entry_by_name(entry_name)
+          raise BadRequestError, "Cannot find tag '#{entry_name}' ." unless target_classification
+
+          target_classification
+        else
+          raise BadRequestError, "Cannot find '#{category_name}' category of tag '#{entry_name}'."
+        end
+      end
+
+      def tag_record_validation(record, rate_type)
+        return if record['assignment_prefix'].blank? && rate_type == "Storage"
+
+        raise BadRequestError, "'assignment_prefix' is missing for target record." unless record['assignment_prefix']
+        raise BadRequestError, "'#{record['assignment_prefix']}' assignment_prefix is not valid for target record." unless ALLOWED_TAG_PREFIXES[rate_type].include?(record['assignment_prefix'])
+      end
+
+      def target_from(target_href, assignment_type, rate_type)
+        raise BadRequestError, "'href' attribute expected for target resource" unless target_href
+
+        href = Api::Href.new(target_href)
+        klass = collection_class(href.subject)
+
+        target = klass.find(href.subject_id)
+
+        filter_resource(target, href.subject, klass)
+
+        validate_target_class(target, assignment_type, rate_type)
+
+        target
+      rescue => err
+        raise BadRequestError, "Cannot determine target resource for collection #{href.subject} and #{href.subject_id}: #{err.message}"
+      end
+
+      def target_add_label_defaults(target)
+        [target, 'container_image']
+      end
+
+      def tag_assigment(record, rate_type)
+        tag_record_validation(record, rate_type)
+        target_tag = parse_tag(record)
+        raise BadRequestError, "Unable to parse tag: #{record}" if target_tag[:category].nil? || target_tag[:name].nil?
+
+        target_classification_by(target_tag[:category], target_tag[:name])
+      end
+
+      def validate_target_class(target, assignment_type, rate_type)
+        base_class_name = target.class.base_class.name
+        raise BadRequestError, "Class '#{base_class_name}' of target resource is no valid." unless ALLOWED_CLASSES_FOR[assignment_type.to_s][rate_type].include?(base_class_name)
+      end
+
+      def chargeback_rate(parameter_record)
+        rate_id = parse_id(parameter_record[CHARGEBACK_RATE_KEY], :rates)
+        @chargeback_rate ||= {}
+        @chargeback_rate[rate_id] ||= ChargebackRate.find(rate_id)
+      end
+
+      def tag_target_assignment(record, _assignment_type, rate_type)
+        target = tag_assigment(record, rate_type)
+        [target, rate_type == "Storage" ? 'storage' : record['assignment_prefix']]
+      end
+
+      def label_target_assignment(record, assignment_type, rate_type)
+        target = target_from(record['href'], assignment_type, rate_type)
+        target_add_label_defaults(target)
+      end
+
+      def resource_target_assignment(record, assignment_type, rate_type)
+        target_from(record['href'], assignment_type, rate_type)
+      end
+
+      def target(parameter_record, assignment_type, rate_type)
+        target_assignment_method = "#{assignment_type}_target_assignment"
+        send(target_assignment_method, parameter_record[assignment_type.to_s], assignment_type, rate_type)
+      end
+
+      def convert_assignment_key_from(parameter_key)
+        parameter_key == 'resource' ? :object : parameter_key.to_sym
+      end
+
+      def rate_assignment(parameter_record, assignment_type, rate_type)
+        parameter_record['label'] = parameter_record.delete('resource') if assignment_type == :label
+
+        rate = chargeback_rate(parameter_record)
+
+        {:cb_rate => rate, convert_assignment_key_from(assignment_type) => target(parameter_record, assignment_type, rate_type)}
+      end
+
+      def determine_assignment_type(parameter_records)
+        assignment_types = parameter_records.map { |parameter_record| determine_type(parameter_record) }.uniq
+
+        raise BadRequestError, "More than one type of target resources are not expected." unless assignment_types.count == 1
+
+        assignment_types.first
+      end
+
+      def validate_target(record, assignment_type, second_value)
+        if record[assignment_type].kind_of?(Array) # labels and tags
+          klass = klass_for(assignment_type)
+          label_condition = assignment_type == :label ? (record[:label][0].resource_type == "ContainerImage") : true
+
+          label_condition && record[assignment_type][0].kind_of?(klass) && second_value && record[assignment_type][1] == second_value
+        else
+          klass = klass_for(assignment_type, second_value)
+          record[assignment_type].kind_of?(klass) && assignment_type == :object
+        end
+      end
+
+      def klass_for(assignment_type, object = nil)
+        case assignment_type
+        when :object
+          object.class.base_class
+        when :label
+          CustomAttribute
+        when :tag
+          Classification
+        end
+      end
+
+      def validate_targets_by_type(assignments, assignment_type)
+        second_value = assignments.first[:object] || assignments.first[assignment_type][1]
+        assignments.all? { |x| validate_target(x, assignment_type, second_value) }
+      end
+
+      def validate_uniqueness(assignments, assignment_type)
+        assignments.map { |x| x[assignment_type].try(:id) || x[assignment_type][0].id }.uniq.count == assignments.count
+      end
+
+      def validate_targets(assignments, parameter_key)
+        assignment_type = convert_assignment_key_from(parameter_key)
+
+        validate_uniqueness(assignments, assignment_type) && validate_targets_by_type(assignments, assignment_type)
+      end
+
+      KLASS_TO_COLLECTION = {'ExtManagementSystem' => 'providers',
+                             'Tenant'              => 'tenants',
+                             'EmsCluster'          => 'clusters',
+                             'MiqEnterprise'       => 'enterprises',
+                             'Storage'             => 'data_stores'}.freeze
+
+      def add_default_attributes_to_result(resource, collection)
+        columns = collection_config[collection]&.identifying_attrs&.split(',') || %w[name description]
+        columns.each do |column|
+          return {column => resource.try(column)} if resource.try(column)
+        end
+
+        {}
+      end
+
+      def result_assignment_href(record, key)
+        additional_attributes = {}
+        resource_id = nil
+        resource_collection = if key == :tag
+                                tag = record[key][0]&.tag
+                                resource_id = tag.id
+                                additional_attributes = {'name' => tag.classification.name, 'category' => tag.category.name}
+                                :tags
+                              elsif key == :object
+                                key = :resource
+                                resource_id = record[:object].id
+                                collection = KLASS_TO_COLLECTION[record[:object].class.base_class.name]
+                                additional_attributes = add_default_attributes_to_result(record[:object], collection)
+                                collection
+                              elsif key == :label
+                                key = :resource
+                                resource_id = record[:label][0].id
+                                collection = :custom_attributes
+                                additional_attributes = add_default_attributes_to_result(record[:label][0], collection)
+                                "container_images/#{record[:label][0].resource_id}/custom_attributes"
+                              end
+
+        {key => {:href => normalize_href(resource_collection, resource_id)}.merge(additional_attributes)}
+      end
+
+      def result_rate(rate)
+        {CHARGEBACK_RATE_KEY => {:href => normalize_href(:chargebacks, rate.id)}.merge(add_default_attributes_to_result(rate, :chargebacks))}
+      end
+
+      def result_assignment(record, key, with_rate)
+        result = result_assignment_href(record, key)
+        with_rate ? result_rate(record[:cb_rate]).merge(result) : result
+      end
+
+      def assigments_to_result(compute_assignments, assignment_keys = [:cb_rate])
+        return [] if compute_assignments.empty?
+
+        key = (compute_assignments.first.keys - assignment_keys).first
+
+        compute_assignments.map { |x| result_assignment(x, key, assignment_keys == [:cb_rate]) }
+      end
+
+      def fetch_rates_from_params(params_assignments)
+        rates_ids = params_assignments.map do |x|
+          raise BadRequestError, "Key 'chargeback' is missing any of target resources." unless x[CHARGEBACK_RATE_KEY]
+
+          parse_id(x[CHARGEBACK_RATE_KEY], :rates)
+        end
+        ChargebackRate.where(:id => rates_ids).pluck(:id, :rate_type)
+      end
+
+      def parse_params(parameter_records, rate_type)
+        assignment_type = determine_assignment_type(parameter_records)
+
+        parameter_records = parameter_records.map { |parameter_record| rate_assignment(parameter_record, assignment_type, rate_type) }
+
+        raise BadRequestError, "Input resources are not valid for #{assignment_type} rates." unless validate_targets(parameter_records, assignment_type)
+
+        parameter_records
+      end
+
+      def group_assignments_from(params_assignments)
+        grouped_rates_by_rate_type = {}
+        fetch_rates_from_params(params_assignments).each do |id, rate_type|
+          grouped_rates_by_rate_type[id] = rate_type
+        end
+
+        params_assignments.group_by { |x| grouped_rates_by_rate_type[x[CHARGEBACK_RATE_KEY]['id']] }
+      end
+
+      def parse_resource_assignments(params_assignments, rate)
+        raise BadRequestError, "Parameter 'assignments' is not passed." unless params_assignments
+        raise BadRequestError, "Parameter 'assignments' is empty." if params_assignments.empty?
+
+        assignments = params_assignments.map do |assignment|
+          assignment[CHARGEBACK_RATE_KEY] = {'id' => rate.id}
+          assignment
+        end
+
+        parse_params(assignments, rate.rate_type)
+      end
+
+      def parse_collection_assignments(params_assignments)
+        raise BadRequestError, "Parameter 'assignments' is not passed." unless params_assignments
+        raise BadRequestError, "Parameter 'assignments' is empty." if params_assignments.empty?
+
+        assignments = group_assignments_from(params_assignments)
+
+        parsed_assignments = {}
+        ChargebackRate::VALID_CB_RATE_TYPES.each do |rate_type|
+          parsed_assignments[rate_type] = parse_params(assignments[rate_type], rate_type) if assignments[rate_type]
+        end
+
+        parsed_assignments
+      end
+
+      def assign_resource(_type, rate_id, data)
+        rate = resource_search(rate_id, :chargebacks, ChargebackRate)
+
+        parsed_assignments = parse_resource_assignments(data['assignments'], rate)
+
+        assignments = ChargebackRate.set_assignments(rate.rate_type, parsed_assignments)
+        action_result(true, "Rates assigned successfully", :result => assigments_to_result(assignments))
+      rescue => err
+        action_result(false, err.message)
+      end
+
+      def assign_collection(_type, data = nil)
+        parsed_assignments = parse_collection_assignments(data['assignments'])
+
+        result = []
+
+        ChargebackRate::VALID_CB_RATE_TYPES.each do |rate_type|
+          if parsed_assignments[rate_type]
+            assignments = ChargebackRate.set_assignments(rate_type, parsed_assignments[rate_type])
+            result |= assigments_to_result(assignments)
+          end
+        end
+
+        action_result(true, "Rates assigned successfully", :result => result.flatten)
+      rescue => err
+        action_result(false, err.to_s)
+      end
+
+      def unassign_resource(type, rate_id, data)
+        klass = collection_class(type)
+        rate = resource_search(rate_id, :type, klass)
+        parsed_assignments = parse_resource_assignments(data['assignments'], rate)
+
+        assignments = ChargebackRate.unassign_rate_assignments(rate.rate_type, parsed_assignments)
+        action_result(true, "Rates unassigned successfully", :result => assigments_to_result(assignments))
+      rescue => err
+        action_result(false, err.to_s)
+      end
+
+      def unassign_collection(_type, data = nil)
+        parsed_assignments = parse_collection_assignments(data['assignments'])
+
+        result = []
+
+        ChargebackRate::VALID_CB_RATE_TYPES.each do |rate_type|
+          if parsed_assignments[rate_type]
+            assignments = ChargebackRate.unassign_rate_assignments(rate_type, parsed_assignments[rate_type])
+            result |= assigments_to_result(assignments)
+          end
+        end
+
+        action_result(true, "Rates unassigned successfully", :result => result)
+      rescue => err
+        action_result(false, err.to_s)
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -490,6 +490,10 @@
         :identifier: chargeback_rates_edit
       - :name: delete
         :identifier: chargeback_rates_delete
+      - :name: assign
+        :identifier: chargeback_assignments
+      - :name: unassign
+        :identifier: chargeback_assignments
     :resource_actions:
       :get:
       - :name: read
@@ -499,6 +503,10 @@
         :identifier: chargeback_rates_edit
       - :name: delete
         :identifier: chargeback_rates_delete
+      - :name: assign
+        :identifier: chargeback_assignments
+      - :name: unassign
+        :identifier: chargeback_assignments
       :delete:
       - :name: delete
         :identifier: chargeback_rates_delete
@@ -974,6 +982,8 @@
     - :custom_actions
     :verbs: *gp
     :klass: ContainerImage
+    :subcollections:
+    - :custom_attributes
     :collection_actions:
       :get:
       - :name: read

--- a/spec/requests/chargebacks_spec.rb
+++ b/spec/requests/chargebacks_spec.rb
@@ -366,4 +366,19 @@ RSpec.describe "chargebacks API" do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  context "rate assignment" do
+    it_behaves_like "perform rate assign/unassign action", "Compute", :ext_management_system, :providers
+    it_behaves_like "perform rate assign/unassign action", "Compute", :tenant, :tenants
+    it_behaves_like "perform rate assign/unassign action", "Compute", :ems_cluster, :clusters
+    it_behaves_like "perform rate assign/unassign action", "Compute", :miq_enterprise, :enterprises
+    it_behaves_like "perform rate assign/unassign action", "Compute", :custom_attribute, :custom_attributes
+    it_behaves_like "perform rate assign/unassign action", "Compute", :tag, :tags, "vm"
+    it_behaves_like "perform rate assign/unassign action", "Compute", :tag, :tags, "container_image"
+
+    it_behaves_like "perform rate assign/unassign action", "Storage", :miq_enterprise, :enterprises
+    it_behaves_like "perform rate assign/unassign action", "Storage", :storage, :data_stores
+    it_behaves_like "perform rate assign/unassign action", "Storage", :tag, :tags, "storage"
+    it_behaves_like "perform rate assign/unassign action", "Storage", :tenant, :tenants
+  end
 end

--- a/spec/support/shared_examples/assigments.rb
+++ b/spec/support/shared_examples/assigments.rb
@@ -1,0 +1,251 @@
+RSpec.shared_examples "perform rate assign/unassign action" do |rate_type, collection_name, collection, assignment_prefix|
+  let(:is_custom_attribute) { collection == :custom_attributes }
+  let(:is_tag) { collection == :tags }
+
+  let(:chargeback_rate) { FactoryBot.create(:chargeback_rate, :rate_type => rate_type) }
+
+  let(:chargeback_rate_parameters) { {:id => chargeback_rate.id} }
+
+  let(:action) { "assign" }
+  let(:rate_assign_parameters) do
+    {:action => action, :assignments => rate_assignments}
+  end
+
+  let(:assignment_type) do
+    return :label if is_custom_attribute
+    return :tag if is_tag
+
+    :object
+  end
+
+  let(:resource_1) do
+    case assignment_type
+    when :label then
+      custom_attribute_1
+    when :tag then
+      category = FactoryBot.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
+      FactoryBot.create(:classification, :name => "prod", :description => "Production", :parent_id => category.id)
+    when :object then
+      FactoryBot.create(collection_name)
+    end
+  end
+
+  let(:resource_2) do
+    case assignment_type
+    when :label then
+      custom_attribute_2
+    when :tag then
+      category = FactoryBot.create(:classification, :description => "Department", :name => "department", :single_value => true, :show => true)
+      FactoryBot.create(:classification, :name => "test", :description => "Test", :parent_id => category.id)
+    when :object then
+      FactoryBot.create(collection_name)
+    end
+  end
+
+  let(:custom_attribute_1) { FactoryBot.create(collection_name, :resource => container_image, :name => 'label_1', :value => 'docker_1') }
+  let(:custom_attribute_2) { FactoryBot.create(collection_name, :resource => container_image, :name => 'label_2', :value => 'docker_2') }
+  let(:container_image) { FactoryBot.create(:container_image) }
+  let(:custom_attribute_url) { api_container_image_custom_attributes_url(nil, container_image) }
+  let(:custom_attribute_result_key_1) do
+    chargeback_rate.send(:build_label_tag_path, custom_attribute_1, 'container_image')
+  end
+
+  let(:custom_attribute_result_key_2) do
+    chargeback_rate.send(:build_label_tag_path, custom_attribute_2, 'container_image')
+  end
+
+  let(:href_resource) do
+    case assignment_type
+    when :label then
+      custom_attribute_url
+    when :tag then
+      "/api/#{collection}"
+    when :object then
+      "/api/#{collection}"
+    end
+  end
+
+  let(:resource_id_1) { assignment_type == :tag ? resource_1.tag.id : resource_1.id }
+  let(:resource_id_2) { assignment_type == :tag ? resource_2.tag.id : resource_2.id }
+
+  let(:resource_params_1) do
+    href_params = {:href => "#{href_resource}/#{resource_id_1}"}
+    is_tag ? href_params.merge(:assignment_prefix => assignment_prefix) : href_params
+  end
+
+  let(:resource_params_2) do
+    href_params = {:href => "#{href_resource}/#{resource_id_2}"}
+    is_tag ? href_params.merge(:assignment_prefix => assignment_prefix) : href_params
+  end
+
+  let(:params_target_key) { is_tag ? :tag : :resource }
+
+  let(:rate_assignment_1) { {:chargeback => chargeback_rate_parameters, params_target_key => resource_params_1} }
+  let(:rate_assignment_2) { {:chargeback => chargeback_rate_parameters, params_target_key => resource_params_2} }
+  let(:rate_assignments) { [rate_assignment_1, rate_assignment_2] }
+
+  let(:result_key_1) do
+    case assignment_type
+    when :label then
+      custom_attribute_result_key_1
+    when :tag then
+      chargeback_rate.send(:build_tag_tagging_path, resource_1, assignment_prefix)
+    when :object then
+      "#{collection_name}/id/#{resource_1.id}"
+    end
+  end
+
+  let(:result_key_2) do
+    case assignment_type
+    when :label then
+      custom_attribute_result_key_2
+    when :tag then
+      chargeback_rate.send(:build_tag_tagging_path, resource_2, assignment_prefix)
+    when :object then
+      "#{collection_name}/id/#{resource_2.id}"
+    end
+  end
+
+  let(:expected_results) { {result_key_1 => [chargeback_rate], result_key_2 => [chargeback_rate]} }
+
+  it "assigns #{rate_type} rate to selected #{collection} on collection for #{collection_name}" do
+    api_basic_authorize collection_action_identifier(:chargebacks, :assign)
+
+    post(api_chargebacks_url, :params => rate_assign_parameters)
+
+    assignments = ChargebackRate.assignments
+    expect(expected_results).to include(assignments)
+    expect_hash_to_have_only_keys(expected_results, assignments.keys)
+    expect(response).to have_http_status(:ok)
+  end
+
+  context "validation errors" do
+    context "target type validation" do
+      let(:resource_params_2) { {:href => "api/containers/#{resource_id_2}"} }
+      it "assigns #{rate_type} rate to selected #{collection} on collection for #{collection_name}" do
+        api_basic_authorize collection_action_identifier(:chargebacks, :assign)
+        post(api_chargebacks_url, :params => rate_assign_parameters)
+        expect(response.parsed_body['success']).to be_falsey
+        message = response.parsed_body['message']
+
+        if collection_name == :tag && rate_type == "Compute"
+          expect(message).to a_string_matching(/'assignment_prefix' is missing for target record./)
+        elsif collection_name == :tag && rate_type == "Storage"
+          expect(message).to a_string_matching(/Unable to parse tag(.*)./)
+        elsif collection_name == :custom_attribute
+          expect(message).to a_string_matching(/More than one type of target resources are not expected./)
+        else
+          expect(message).to a_string_matching(/Cannot determine target resource for collection(.*)/)
+        end
+      end
+
+      context "set resource_params_2 as ext_management_system #{collection_name}" do
+        let(:ext_management_system) { FactoryBot.create(:ext_management_system) }
+        let(:resource_params_2) { {:href => "api/#{collection == :providers ? 'vms' : 'providers'}/#{ext_management_system.id}"} }
+
+        it "assigns #{rate_type} rate to selected #{collection} on collection for #{collection_name}" do
+          api_basic_authorize collection_action_identifier(:chargebacks, :assign)
+
+          post(api_chargebacks_url, :params => rate_assign_parameters)
+
+          expect(response.parsed_body['success']).to be_falsey
+          message = response.parsed_body['message']
+          if collection_name == :tag && rate_type == "Compute"
+            expect(message).to a_string_matching(/'assignment_prefix' is missing for target record./)
+          elsif collection_name == :tag && rate_type == "Storage"
+            expect(message).to a_string_matching(/Unable to parse tag(.*)./)
+          elsif rate_type == "Storage" && %i[miq_enterprise tenant].include?(collection_name)
+            expect(message).to a_string_matching(/Cannot determine target resource for collection(.*)/)
+          elsif %i[miq_enterprise ems_cluster tenant].include?(collection_name)
+            expect(message).to a_string_matching(/Input resources are not valid for resource rates./)
+          elsif collection_name == :custom_attribute
+            expect(message).to a_string_matching(/More than one type of target resources are not expected./)
+          else
+            expect(message).to a_string_matching(/Cannot determine target resource for collection(.*)/)
+          end
+        end
+      end
+    end
+  end
+
+  let(:target_resource_1) do
+    case assignment_type
+    when :label then
+      [resource_1, "container_image"]
+    when :tag then
+      [resource_1, assignment_prefix]
+    when :object then
+      resource_1
+    end
+  end
+
+  let(:target_resource_2) do
+    case assignment_type
+    when :label then
+      [resource_2, "container_image"]
+    when :tag then
+      [resource_2, assignment_prefix]
+    when :object then
+      resource_2
+    end
+  end
+
+  let(:assignment_paramaters_for_method) do
+    [
+      {:cb_rate => chargeback_rate, assignment_type => target_resource_1},
+      {:cb_rate => chargeback_rate, assignment_type => target_resource_2}
+    ]
+  end
+
+  context "unassign for #{collection_name}" do
+    let(:action) { "unassign" }
+    let(:rate_assignments) { [rate_assignment_1] }
+    let(:expected_results) { {result_key_2 => [chargeback_rate]} }
+
+    it "unassigns #{rate_type} rate from selected #{collection} on collection" do
+      api_basic_authorize collection_action_identifier(:chargebacks, :unassign)
+      ChargebackRate.set_assignments(rate_type, assignment_paramaters_for_method)
+
+      post(api_chargebacks_url, :params => rate_assign_parameters)
+
+      assignments = ChargebackRate.assignments
+      expect(expected_results).to include(assignments)
+      expect_hash_to_have_only_keys(expected_results, assignments.keys)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "on single #{rate_type} rate for #{collection_name}" do
+    let(:rate_assignments) { [{params_target_key => resource_params_1}] }
+    let(:expected_results) { {result_key_1 => [chargeback_rate]} }
+
+    it "assigns #{rate_type} rate to selected #{collection} " do
+      api_basic_authorize collection_action_identifier(:chargebacks, :assign)
+
+      post(api_chargeback_url(nil, chargeback_rate), :params => rate_assign_parameters)
+
+      assignments = ChargebackRate.assignments
+      expect(expected_results).to include(assignments)
+      expect_hash_to_have_only_keys(expected_results, assignments.keys)
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "unassign" do
+      let(:action) { "unassign" }
+      let(:rate_assignments) { [{params_target_key => resource_params_1}] }
+      let(:expected_results) { {result_key_2 => [chargeback_rate]} }
+
+      it "unassigns #{rate_type} rate from selected #{collection} on single resource" do
+        api_basic_authorize collection_action_identifier(:chargebacks, :unassign)
+
+        ChargebackRate.set_assignments(rate_type, assignment_paramaters_for_method)
+
+        post(api_chargeback_url(nil, chargeback_rate), :params => rate_assign_parameters)
+        assignments = ChargebackRate.assignments
+        expect(expected_results).to include(assignments)
+        expect_hash_to_have_only_keys(expected_results, assignments.keys)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Needed for PRs:
- [x] SPECS
- [x] https://github.com/ManageIQ/manageiq/pull/20136 Add method assigned_to to ChargebackRate model
- [x] https://github.com/ManageIQ/manageiq/pull/20135 Add 'unassign' support for chargeback (label) rate assignments


This API add endpoints to chargeback rate assignments.

Note: Chargeback rate is represented by /api/chargebacks endpoint it in api. (not `/api/rates`)

**Listings assignments:**

Single resource
```
We need to add assigned_to attribute:
 
GET /api/chargebacks/2?attributes=assigned_to

response:
{
    "href": "http://localhost:3090/api/chargebacks/2",
    "id": "2",
    "guid": "7d7aaf20-5214-11df-a888-001d09066d98",
    "description": "Default",
    "rate_type": "Storage",
    "created_on": "2019-08-07T16:48:04Z",
    "updated_on": "2020-04-20T13:27:07Z",
    "default": true,
    "assigned_to": [
        {
            "tag": {
                "href": "http://localhost:3090/api/tags/48",
                "name": "finance",
                "category": "department"
            }
        },
        {
            "tag": {
                "href": "http://localhost:3090/api/tags/26",
                "name": "test",
                "category": "environment"
            }
        }
    ],
    ..
}
```
Collection

```
http://localhost:3090/api/chargebacks?expand=resources&attributes=assigned_to

{
    "name": "chargebacks",
    "count": 10,
    "subcount": 1,
    "subquery_count": 1,
    "pages": 1,
    "resources": [
        {
            "href": "http://localhost:3090/api/chargebacks/1",
            "id": "1",
            "guid": "b47a0ef0-4335-11df-aba8-001d09066d98",
            "description": "Default",
            "rate_type": "Compute",
            "created_on": "2019-08-07T16:48:04Z",
            "updated_on": "2020-04-20T13:27:07Z",
            "default": true,
            "assigned_to": [
                {
                    "tag": {
                        "href": "http://localhost:3090/api/tags/48"
                    }
                }
            ]

,,
}
```


**Creating assignments(assign rate to any target resource):**
We support more type of assignments:
For Compute Rates

- Enterprise

Single Resource
```
POST /api/chargebacks/1

{
  "action" : "assign",
  "assignments" : [
   {
       "resource": {"href": "http://localhost:3090/api/enterprises/1"}
     }
  ]
}

Response
{
    "success": true,
    "message": "Rates assigned successfully",
    "result": [
        {
            "chargeback": {
                "href": "http://localhost:3090/api/chargebacks/1",
                "description": "Default"
            },
            "resource": {
                "href": "http://localhost:3090/api/enterprises/1",
                "name": "Enterprise"
            }
        }
    ]
}
```

Collection
```
POST /api/chargebacks
{
  "action" : "assign",
  "assignments" : [
   {
       "chargeback": { "id" : 1},
       "resource": {"href": "http://localhost:3090/api/enterprices/1"}
     }
  ]
}

Response

{
    "success": true,
    "message": "Rates assigned successfully",
    "result": [
            {
                "chargeback": {
                    "href": "http://localhost:3090/api/chargebacks/1",
                    "description": "Default"
                },
                "resource": {
                    "href": "http://localhost:3090/api/enterprises/1",
                    "name": "Enterprise"
                }
            }
        ]
}

```



- Selected Providers
```
POST /api/chargebacks/1
{
  "action" : "assign",
  "assignments" : [
    { "resource" : { "href" : "/api/providers/1" } }
  ]
}

```

- Selected Clusters
```
POST /api/chargebacks/1
{
  "action" : "assign",
  "assignments" : [
    { "resource" : { "href" : "/api/clusters/1" } }
  ]
}

```
- Tagged VMs
NOTE:
`assignment_prefix` is required for "tag" target resource.
`assignment_prefix` is 'vm' to determine that type of assignment is Tagged VMs.
Valid values  are  for `vm`, `container_image` and `storage' for `assignment_prefix`.

```
POST /api/chargebacks
{
  "action" : "assign",
  "assignments" : [
   {
       "chargeback": { "id" : 1},
       "tag": { "category" : "department", "name" : "finance", "assignment_prefix": "vm" }
     },
     {
       "chargeback": { "id" : 3},
       "tag": { "category" : "prov_max_retirement_days", "name" : "30", "assignment_prefix": "vm" }
     }
  ]
}

response

{
    "success": true,
    "message": "Rates assigned successfully",
    "result": [
            {
                "chargeback": {
                    "href": "http://localhost:3090/api/chargebacks/1",
                    "description": "Default"
                },
                "tag": {
                    "href": "http://localhost:3090/api/tags/48",
                    "name": "finance",
                    "category": "department"
                }
            },
            {
                "chargeback": {
                    "href": "http://localhost:3090/api/chargebacks/3",
                    "description": "Default Container Image Rate"
                },
                "tag": {
                    "href": "http://localhost:3090/api/tags/122",
                    "name": "30",
                    "category": "prov_max_retirement_days"
                }
            }
        ]
...


```

- Tagged Containers
NOTE:
`assignment_prefix` is required for "tag" target resource.
`assignment_prefix` is 'container_image' to determine that type of assignment is Tagged VMs.
Valid values  are  for `vm`, `container_image` and `storage' for `assignment_prefix`.

```
POST /api/chargebacks
{
  "action" : "assign",
  "assignments" : [
   {
       "chargeback": { "id" : 1},
       "tag": { "category" : "department", "name" : "finance", "assignment_prefix": "container_image" }
     },
     {
       "chargeback": { "id" :1},
       "tag": { "category" : "environment", "name" : "test", "assignment_prefix": "container_image" }
     }
  ]
}

```

- Labels
```
POST /api/chargebacks
{
  "action" : "assign",
  "assignments" : 
  [	
        { 
              "chargeback": { "id" : 1}, "resource": { "href":                         "http://localhost:3090/api/container_images/934/custom_attributes/30331" } 
        },
        { "chargeback": { "id" : 1}, "resource": { "href": "http://localhost:3090/api/container_images/934/custom_attributes/30324" } 
         }
  ]
}

```
- Tenants

```
POST /api/chargebacks
{
  "action" : "assign",
  "assignments" : 
  [
      { "chargeback": { "id" : 1}, "resource": { "href": "http://localhost:3090/api/tenants/1" } },
      { "chargeback": { "id" : 1}, "resource": { "href": "http://localhost:3090/api/tenants/2" } }
  ]
}
```
For Storage Rates
- Enterprise
same as in compute rates

- Selected Datastores
```
POST /api/chargebacks
{
  "action" : "assign",
  "assignments" : 
  [
        {
             "resource": {"href": "http://localhost:3090/api/data_stores/14"}
        }
  ]
}
```

- Tagged Datastores

NOTE:
`assignment_prefix` is required for "tag" target resource.
`assignment_prefix` is 'storage'(only) to determine that type of assignment is Tagged Datastores.


```
POST /api/chargebacks
{
  "action" : "assign",
  "assignments" : [

     {
       "chargeback": { "id" : 2},
       "tag": { "category" : "environment", "name" : "test",  "assignment_prefix": "storage"}
     },
     ...
```

- Tenants
same as in compute rates

Note: Single resource and collections are supported on each bullet.


**Removing assignments(unassign rate to any target resource):**


POST `/api/chargebacks`

Examples of request body of by assignment type:

Unassign tag based assignments (Tagged Vms,..)

```

{
  "action" : "unassign",
  "assignments" : 
  [
       {
         "tag": 
               {
                        "href": "http://localhost:3090/api/tags/26"
                }
       }
  ]
}
```

Unassign resource based assignments (Tagged Vms,..)


```
POST api/chargebacks/2

{
  "action" : "unassign",
  "assignments" : [
   {
     "tag": {
       "href": "http://localhost:3090/api/tags/26"
      }
   }
  ]
}

```

