### PR TITLE
Adding support for check_compliance action on container resources.

### DIFF
--- a/app/controllers/api/container_groups_controller.rb
+++ b/app/controllers/api/container_groups_controller.rb
@@ -1,4 +1,27 @@
 module Api
   class ContainerGroupsController < BaseController
+    def check_compliance_resource(type, id, _data = nil)
+      api_action(type, id) do |klass|
+        container_group = resource_search(id, type, klass)
+        api_log_info("Checking compliance of #{container_group_ident(container_group)}")
+        request_compliance_check(container_group)
+      end
+    end
+
+    private
+
+    def container_group_ident(container_group)
+      "ContainerGroup id:#{container_group.id} name:'#{container_group.name}'"
+    end
+
+    def request_compliance_check(container_group)
+      desc = "#{container_group_ident(container_group)} check compliance requested"
+      raise "#{container_group_ident(container_group)} has no compliance policies assigned" if container_group.compliance_policies.blank?
+
+      task_id = queue_object_action(container_group, desc, :method_name => "check_compliance")
+      action_result(true, desc, :task_id => task_id)
+    rescue StandardError => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/app/controllers/api/container_images_controller.rb
+++ b/app/controllers/api/container_images_controller.rb
@@ -17,10 +17,28 @@ module Api
       end
     end
 
+    def check_compliance_resource(type, id, _data = nil)
+      api_action(type, id) do |klass|
+        container_image = resource_search(id, type, klass)
+        api_log_info("Checking compliance of #{container_image_ident(container_image)}")
+        request_compliance_check(container_image)
+      end
+    end
+
     private
 
     def container_image_ident(image)
       "ContainerImage id:#{image.id} name:'#{image.name}'"
+    end
+
+    def request_compliance_check(container_image)
+      desc = "#{container_image_ident(container_image)} check compliance requested"
+      raise "#{container_image_ident(container_image)} has no compliance policies assigned" if container_image.compliance_policies.blank?
+
+      task_id = queue_object_action(container_image, desc, :method_name => "check_compliance")
+      action_result(true, desc, :task_id => task_id)
+    rescue StandardError => err
+      action_result(false, err.to_s)
     end
   end
 end

--- a/app/controllers/api/container_nodes_controller.rb
+++ b/app/controllers/api/container_nodes_controller.rb
@@ -1,4 +1,27 @@
 module Api
   class ContainerNodesController < BaseController
+    def check_compliance_resource(type, id, _data = nil)
+      api_action(type, id) do |klass|
+        container_node = resource_search(id, type, klass)
+        api_log_info("Checking compliance of #{container_node_ident(container_node)}")
+        request_compliance_check(container_node)
+      end
+    end
+
+    private
+
+    def container_node_ident(container_node)
+      "ContainerNode id:#{container_node.id} name:'#{container_node.name}'"
+    end
+
+    def request_compliance_check(container_node)
+      desc = "#{container_node_ident(container_node)} check compliance requested"
+      raise "#{container_node_ident(container_node)} has no compliance policies assigned" if container_node.compliance_policies.blank?
+
+      task_id = queue_object_action(container_node, desc, :method_name => "check_compliance")
+      action_result(true, desc, :task_id => task_id)
+    rescue StandardError => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -955,12 +955,17 @@
       - :name: read
         :identifier: container_group_show_list
       :post:
+      - :name: check_compliance
+        :identifier: container_group_check_compliance
       - :name: query
         :identifier: container_group_show_list
     :resource_actions:
       :get:
       - :name: read
         :identifier: container_group_show
+      :post:
+      - :name: check_compliance
+        :identifier: container_group_check_compliance
   :container_images:
     :description: Container Images
     :identifier: container_image
@@ -973,11 +978,16 @@
       :get:
       - :name: read
         :identifier: container_image_show_list
+      :post:
+      - :name: check_compliance
+        :identifier: container_image_check_compliance
     :resource_actions:
       :get:
       - :name: read
         :identifier: container_image_show
       :post:
+      - :name: check_compliance
+        :identifier: container_image_check_compliance
       - :name: scan
         :identifier: container_image_scan
   :container_nodes:
@@ -993,12 +1003,17 @@
       - :name: read
         :identifier: container_node_show_list
       :post:
+      - :name: check_compliance
+        :identifier: container_node_check_compliance
       - :name: query
         :identifier: container_node_show_list
     :resource_actions:
       :get:
       - :name: read
         :identifier: container_node_show
+      :post:
+      - :name: check_compliance
+        :identifier: container_node_check_compliance
   :container_projects:
     :description: Container Projects
     :identifier: container_project

--- a/spec/requests/container_groups_spec.rb
+++ b/spec/requests/container_groups_spec.rb
@@ -45,4 +45,6 @@ describe "Container Groups API" do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  it_behaves_like "a check compliance action", "container_group", :container_group, "ContainerGroup"
 end

--- a/spec/requests/container_images_spec.rb
+++ b/spec/requests/container_images_spec.rb
@@ -94,4 +94,6 @@ describe "Container Images API" do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  it_behaves_like "a check compliance action", "container_image", :container_image, "ContainerImage"
 end

--- a/spec/requests/container_nodes_spec.rb
+++ b/spec/requests/container_nodes_spec.rb
@@ -46,4 +46,6 @@ RSpec.describe 'Container Nodes API' do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  it_behaves_like "a check compliance action", "container_node", :container_node, "ContainerNode"
 end


### PR DESCRIPTION
- Adding support for check_compliance action on container resources. 
  - /api/container_groups/:id  - action "check_compliance"
  - /api/container_groups      - action "check_compliance" for bulk requests

  - /api/container_images/:id  - action "check_compliance"
  - /api/container_images      - action "check_compliance" for bulk requests

  - /api/container_nodes/:id  - action "check_compliance"
  - /api/container_nodes      - action "check_compliance" for bulk requests

- Added Specs

https://github.com/ManageIQ/manageiq-api/issues/790