### PR TITLE
Move API OpenID-Connect support to Apache configuration

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -147,7 +147,7 @@ module Api
 
       def authenticate_with_jwt
         timeout = ::Settings.api.authentication_timeout.to_i_with_method
-        user = User.authenticate(request.headers["X-REMOTE-USER"], "", request, :require_user => true)
+        user = User.authenticate(request.headers["X-REMOTE-USER"], "", request, :require_user => true, :timeout => timeout)
         auth_user(user.userid)
       rescue => e
         raise AuthenticationError, "Failed to Authenticate with JWT - error #{e}"

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -147,7 +147,7 @@ module Api
 
       def authenticate_with_jwt
         timeout = ::Settings.api.authentication_timeout.to_i_with_method
-        user = User.authenticate("", "", request, :require_user => true, :timeout => timeout)
+        user = User.authenticate(request.headers["X-REMOTE-USER"], "", request, :require_user => true)
         auth_user(user.userid)
       rescue => e
         raise AuthenticationError, "Failed to Authenticate with JWT - error #{e}"


### PR DESCRIPTION
Fixes ManageIQ/manageiq#19866

This PR, combined with others in other github repos, will move the support for the ManageIQ API out of code and into the Apache configuration.

**Dependent PRs**
https://github.com/ManageIQ/manageiq-appliance/pull/282
https://github.com/ManageIQ/manageiq/pull/20131
https://github.com/ManageIQ/manageiq-appliance_console/pull/117