### PR TITLE
DDF: schema-based validation and revised create/update for providers

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -478,23 +478,28 @@ describe "Providers API" do
       post(api_providers_url, :params => {'ddf'             => true,
                                           'name'            => 'Amazon Test',
                                           'type'            => 'ManageIQ::Providers::Amazon::CloudManager',
-                                          'zone_name'       => @zone.name,
+                                          'zone_id'         => @zone.id,
                                           'provider_region' => 'us-east-1',
-                                          'endpoints'       => {
-                                            'default' => {
-                                              'userid'   => 'foo',
-                                              'password' => 'bar',
+                                          'endpoints'       => [
+                                            {
+                                              'role' => 'default'
                                             }
-                                          }})
+                                          ]})
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq('results' => ['yay'])
     end
 
-    it 'handles errors when ddf=true' do
+    it 'handles generic errors when ddf=true' do
       api_basic_authorize collection_action_identifier(:providers, :create)
       post(api_providers_url, :params => {'ddf' => true})
       expect_bad_request(/Could not create the new provider/)
+    end
+
+    it 'handles validation errors when ddf=true' do
+      api_basic_authorize collection_action_identifier(:providers, :create)
+      post(api_providers_url, :params => {'ddf' => true, 'type' => 'ManageIQ::Providers::Amazon::CloudManager', 'foo' => 'bar'})
+      expect_bad_request(/Invalid attributes specified in the request/)
     end
 
     it 'allows provider specific attributes to be specified' do


### PR DESCRIPTION
I made some [changes](https://github.com/ManageIQ/manageiq/pull/20157) in the `create_from_params` and `edit_with_params` methods and I'm adjusting the callsites in this repo. I also created a validation for the incoming params based on the DDF schema. Basically any field that's not specified in the schema (with some exceptions like `name` or `zone_id`) is invalid. The 
validation error follows the logic from the legacy API implementation.

I created a `fetch_deep_keys` method that recursively retrieves all the keys with a dot-notation from a nested hash structure, this is something we might want to extract somewhere in the future.

Depends on: https://github.com/ManageIQ/manageiq/pull/20157 and https://github.com/ManageIQ/manageiq/pull/20154

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818

@miq-bot add_label enhancement, pending core
@miq-bot add_reviewer @agrare 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_reviewer @abellotti 
@miq-bot add_reviewer @lpichler 