### PR TITLE
Add name to valid edit attrs for vms

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -14,9 +14,9 @@ module Api
     include Subcollections::Software
     include Subcollections::Tags
 
-    VALID_EDIT_ATTRS = %w(description child_resources parent_resource).freeze
-    RELATIONSHIP_COLLECTIONS = %w(vms templates).freeze
     DEFAULT_ROLE = 'ems_operations'.freeze
+    RELATIONSHIP_COLLECTIONS = %w[vms templates].freeze
+    VALID_EDIT_ATTRS = %w[description name child_resources parent_resource].freeze
 
     def start_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -66,6 +66,7 @@ describe "Vms API" do
         :params => {
           :action          => 'edit',
           :description     => 'bar',
+          :name            => 'drew was here',
           :child_resources => children,
           :custom_1        => 'foobar',
           :custom_9        => 'fizzbuzz',
@@ -80,11 +81,12 @@ describe "Vms API" do
       expect(response.parsed_body).to include(expected)
       expect(vm.reload.children).to match_array(new_vms)
       expect(vm.parent).to eq(vm_openstack2)
+      expect(vm.name).to eq('drew was here')
       expect(vm.custom_1).to eq('foobar')
       expect(vm.custom_9).to eq('fizzbuzz')
     end
 
-    it 'only allows edit of custom_1, description, parent, and children' do
+    it 'only allows edit of custom_1, description, name, parent, and children' do
       api_basic_authorize collection_action_identifier(:vms, :edit)
 
       post(api_vm_url(nil, vm), :params => { :action => 'edit', :name => 'foo', :autostart => true, :power_state => 'off' })
@@ -92,7 +94,7 @@ describe "Vms API" do
       expected = {
         'error' => a_hash_including(
           'kind'    => 'bad_request',
-          'message' => 'Cannot edit VM - Cannot edit values name, autostart, power_state'
+          'message' => 'Cannot edit VM - Cannot edit values autostart, power_state'
         )
       }
       expect(response).to have_http_status(:bad_request)


### PR DESCRIPTION
We allow description edit but not name, and our docs say we do let people edit names[1], so. 

https://github.com/ManageIQ/manageiq-api/commit/8fc36e415d32ce643dc1930b043012a1958380da# is where this came from if you're interested but it's clearly a trivial change and i'm counting it as part of the work described in https://bugzilla.redhat.com/show_bug.cgi?id=1428250#c12

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1833362

@miq-bot add_label bug, jansa/yes?

[1] https://www.manageiq.org/docs/reference/latest/doc-REST_API/miq/index#updating-resources

