### PR TITLE
Allow to specify chargebacks by hrefs in rate assignment 

### DIFF
--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -99,7 +99,7 @@ module Api
       end
 
       def chargeback_rate(parameter_record)
-        rate_id = parse_id(parameter_record[CHARGEBACK_RATE_KEY], :rates)
+        rate_id = parse_id(parameter_record[CHARGEBACK_RATE_KEY], :chargebacks)
         @chargeback_rate ||= {}
         @chargeback_rate[rate_id] ||= ChargebackRate.find(rate_id)
       end
@@ -242,7 +242,7 @@ module Api
         rates_ids = params_assignments.map do |x|
           raise BadRequestError, "Key 'chargeback' is missing any of target resources." unless x[CHARGEBACK_RATE_KEY]
 
-          parse_id(x[CHARGEBACK_RATE_KEY], :rates)
+          parse_id(x[CHARGEBACK_RATE_KEY], :chargebacks)
         end
         ChargebackRate.where(:id => rates_ids).pluck(:id, :rate_type)
       end
@@ -263,7 +263,7 @@ module Api
           grouped_rates_by_rate_type[id] = rate_type
         end
 
-        params_assignments.group_by { |x| grouped_rates_by_rate_type[x[CHARGEBACK_RATE_KEY]['id']] }
+        params_assignments.group_by { |x| grouped_rates_by_rate_type[parse_id(x[CHARGEBACK_RATE_KEY], :chargebacks)] }
       end
 
       def parse_resource_assignments(params_assignments, rate)

--- a/spec/support/shared_examples/assigments.rb
+++ b/spec/support/shared_examples/assigments.rb
@@ -4,7 +4,8 @@ RSpec.shared_examples "perform rate assign/unassign action" do |rate_type, colle
 
   let(:chargeback_rate) { FactoryBot.create(:chargeback_rate, :rate_type => rate_type) }
 
-  let(:chargeback_rate_parameters) { {:id => chargeback_rate.id} }
+  let(:chargeback_rate_parameters) { {:href => "/api/chargebacks/#{chargeback_rate.id}"} }
+  let(:chargeback_rate_parameters_2) { {:id => chargeback_rate.id} }
 
   let(:action) { "assign" }
   let(:rate_assign_parameters) do
@@ -81,7 +82,7 @@ RSpec.shared_examples "perform rate assign/unassign action" do |rate_type, colle
   let(:params_target_key) { is_tag ? :tag : :resource }
 
   let(:rate_assignment_1) { {:chargeback => chargeback_rate_parameters, params_target_key => resource_params_1} }
-  let(:rate_assignment_2) { {:chargeback => chargeback_rate_parameters, params_target_key => resource_params_2} }
+  let(:rate_assignment_2) { {:chargeback => chargeback_rate_parameters_2, params_target_key => resource_params_2} }
   let(:rate_assignments) { [rate_assignment_1, rate_assignment_2] }
 
   let(:result_key_1) do


### PR DESCRIPTION
Original feature: https://github.com/ManageIQ/manageiq-api/pull/824

```
{
  "action" : "assign",
  "assignments" : [
   {
       "chargeback": {"href" : "http://localhost:3090/api/chargebacks/2"},
       "resource": {"id": "http://localhost:3090/api/data_stores/12"}
     }
  ]
}
```

this PR adds possibility and fixes parsing "http://localhost:3090/api/chargebacks/2" in href^^, there was used `:rates` in the code and we have to use `:chargebacks` for ChargebackRate model in order to assign chargeback rates. (chargebacks collection)

NOTE: When `{'id' : 2}` is used as chargeback rate identification (as  is described in https://github.com/ManageIQ/manageiq-api/pull/824) - then  assigning is working. 

@miq-bot assign @gtanzillo 
@miq-bot add_label jansa/yes, bug

