### PR TITLE
Chargeback rate assignment was not returning hrefs and assignment_prefix for tags in responses

### DIFF
--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -18,7 +18,7 @@ module Api
       TYPES_OF_ASSIGNMENTS = %w[object label tag].freeze
 
       def normalize_attr(attr, value)
-        value = assigments_to_result(value, []) if attr == "assigned_tos"
+        value = assigments_to_result(value, []) if attr == "assigned_to"
 
         super(attr, value)
       end
@@ -201,8 +201,9 @@ module Api
         resource_id = nil
         resource_collection = if key == :tag
                                 tag = record[key][0]&.tag
+                                prefix = record[key][1]
                                 resource_id = tag.id
-                                additional_attributes = {'name' => tag.classification.name, 'category' => tag.category.name}
+                                additional_attributes = {'name' => tag.classification.name, 'category' => tag.category.name, :assignment_prefix => prefix}
                                 :tags
                               elsif key == :object
                                 key = :resource


### PR DESCRIPTION
Fixing missing href in chargeback assignments. Also, added assignmen_prefix to tag response

Before:
```
{
    "href": "http://localhost:3000/api/chargebacks/10000000000010",
    "id": "10000000000010",
    "guid": "b16ad36f-10d0-4880-b307-a8e5f74e07fc",
    "description": "Base Compute",
    "rate_type": "Compute",
    "created_on": "2020-03-17T15:38:22Z",
    "updated_on": "2020-03-17T15:38:42Z",
    "default": false,
    "assigned_to": [
        {
            "tag": [
                {
                    "id": "10000000000041",
                    "description": "Accounting",
                    "icon": null,
                    "read_only": false,
                    "syntax": "string",
                    "single_value": false,
                    "example_text": null,
                    "tag_id": "10000000000043",
                    "parent_id": "10000000000040",
                    "show": true,
                    "default": true,
                    "perf_by_tag": null
                },
                "vm"
            ]
        }
    ],
```
After:
```
{
    "href": "http://localhost:3000/api/chargebacks/10000000000010",
    "id": "10000000000010",
    "guid": "b16ad36f-10d0-4880-b307-a8e5f74e07fc",
    "description": "Base Compute",
    "rate_type": "Compute",
    "created_on": "2020-03-17T15:38:22Z",
    "updated_on": "2020-03-17T15:38:42Z",
    "default": false,
    "assigned_to": [
        {
            "tag": {
                "href": "http://localhost:3000/api/tags/10000000000024",
                "name": "prod",
                "category": "environment",
                "assignment_prefix": "vm"
            }
        }
    ],
```