### PR TITLE
Adding support for the request_download action on report results.

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -165,7 +165,9 @@ module Api
                           [@req.subject, request_type_target.last]
                         end
 
-        aspec = if @req.subcollection?
+        aspec = if request_is_for_resource_entity?
+                  collection_config.resource_entity_actions(@req.collection, @req.subcollection)
+                elsif @req.subcollection?
                   collection_config.typed_subcollection_actions(@req.collection, cname, target) ||
                     collection_config.typed_collection_actions(cname, target)
                 else
@@ -237,6 +239,7 @@ module Api
         if cname && @req.subcollection
           return [cname, ctype] if @req.subcollection == 'settings' && collection_option?(:settings)
           return [cname, ctype] if collection_option?(:arbitrary_resource_path)
+          return [cname, ctype] if request_is_for_resource_entity?
           ctype = "Sub-Collection"
           unless collection_config.subcollection?(cname, @req.subcollection)
             raise BadRequestError, "Unsupported #{ctype} #{@req.subcollection} specified"
@@ -297,6 +300,10 @@ module Api
         end
 
         raise BadRequestError, "Invalid collection_class #{param} specified for the #{@req.collection} collection"
+      end
+
+      def request_is_for_resource_entity?
+        collection_config.resource_entity?(@req.collection, @req.subcollection) && @req.subcollection_id.blank?
       end
     end
   end

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -240,6 +240,7 @@ module Api
           return [cname, ctype] if @req.subcollection == 'settings' && collection_option?(:settings)
           return [cname, ctype] if collection_option?(:arbitrary_resource_path)
           return [cname, ctype] if request_is_for_resource_entity?
+
           ctype = "Sub-Collection"
           unless collection_config.subcollection?(cname, @req.subcollection)
             raise BadRequestError, "Unsupported #{ctype} #{@req.subcollection} specified"

--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -20,6 +20,7 @@ module Api
         res[:message] = message if message.present?
         res[:result]  = options[:result] unless options[:result].nil?
         add_task_to_result(res, options[:task_id]) if options[:task_id].present?
+        add_task_results_href_to_result(res, options[:task_id]) if options[:task_results].present?
         add_tasks_to_result(res, options[:task_ids]) if options[:task_ids].present?
         add_parent_href_to_result(res, options[:parent_id]) if options[:parent_id].present?
         res
@@ -53,6 +54,11 @@ module Api
         hash[:tag_category] = tag_spec[:category] if tag_spec[:category].present?
         hash[:tag_name]     = tag_spec[:name] if tag_spec[:name].present?
         hash[:tag_href]     = "#{@req.api_prefix}/tags/#{tag_spec[:id]}" if tag_spec[:id].present?
+        hash
+      end
+
+      def add_task_results_href_to_result(hash, task_id)
+        hash[:task_results_href] = "#{@req.api_prefix}/tasks/#{task_id}/task_results"
         hash
       end
 

--- a/app/controllers/api/mixins/result_downloads.rb
+++ b/app/controllers/api/mixins/result_downloads.rb
@@ -1,0 +1,30 @@
+module Api
+  module Mixins
+    module ResultDownloads
+      COMMON_SUPPORTED_RESULT_TYPES = %w[txt csv].freeze
+
+      RESULT_TYPE_TO_CONTENT_TYPE = {
+        "txt" => "application/text",
+        "csv" => "application/csv",
+        "pdf" => "application/pdf"
+      }.freeze
+
+      def supported_result_types
+        @supported_result_types ||= begin
+          supported_types = COMMON_SUPPORTED_RESULT_TYPES.dup
+          supported_types << "pdf" if PdfGenerator.available?
+          supported_types
+        end
+      end
+
+      def validate_result_type(result_type)
+        raise "Missing result_type" if result_type.blank?
+
+        result_type = result_type.downcase
+        raise "Unsupported result_type #{result_type} specified, must be one of #{supported_result_types.join(", ")}." unless supported_result_types.include?(result_type)
+
+        result_type
+      end
+    end
+  end
+end

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class ResultsController < BaseController
     include Api::Mixins::ReportResultSet
+    include Api::Mixins::ResultDownloads
 
     before_action :set_additional_attributes, :only => [:index, :show]
 
@@ -16,7 +17,33 @@ module Api
       MiqReportResult.for_user(User.current_user).find(id)
     end
 
+    def request_download_resource(_type, id, data)
+      result      = find_results(id)
+      result_type = validate_result_type(data["result_type"])
+      desc        = "Requesting a download of a #{result_type} report for #{result_ident(result)}"
+      session_id  = "#{request.uuid}-#{SecureRandom.hex(4)}" # Adding a random hex suffix for bulk requests
+
+      task_id = if result_type == "pdf"
+                  task = MiqTask.new(:name              => "Generate Report result [#{result_type}]: '#{result.report.name}'",
+                                     :miq_report_result => result,
+                                     :userid            => User.current_user.userid)
+                  task.update_status("Finished", "Ok", "Complete")
+                  task.id
+                else
+                  result.async_generate_result(result_type, :userid => User.current_user.userid, :session_id => session_id)
+                end
+      MiqTask.find(task_id).update_context(:result_id => result.id, :result_type => result_type, :session_id => session_id)
+
+      action_result(true, desc, :task_id => task_id, :task_results => task_id)
+    rescue StandardError => err
+      action_result(false, err.to_s)
+    end
+
     private
+
+    def result_ident(result)
+      "Result id:#{result.id} name:'#{result.name}'"
+    end
 
     def set_additional_attributes
       @additional_attributes = %w(result_set)

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -17,8 +17,8 @@ module Api
       MiqReportResult.for_user(User.current_user).find(id)
     end
 
-    def request_download_resource(_type, id, data)
-      result      = find_results(id)
+    def request_download_resource(_type, result_id, data)
+      result      = find_results(result_id)
       result_type = validate_result_type(data["result_type"])
       desc        = "Requesting a download of a #{result_type} report for #{result_ident(result)}"
       session_id  = "#{request.uuid}-#{SecureRandom.hex(4)}" # Adding a random hex suffix for bulk requests
@@ -35,7 +35,7 @@ module Api
       MiqTask.find(task_id).update_context(:result_id => result.id, :result_type => result_type, :session_id => session_id)
 
       action_result(true, desc, :task_id => task_id, :task_results => task_id)
-    rescue StandardError => err
+    rescue => err
       action_result(false, err.to_s)
     end
 

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class TasksController < BaseController
+    include Api::Mixins::ResultDownloads
+
     def find_collection(klass)
       return klass.where(:userid => [current_user.userid]) if current_user.only_my_user_tasks?
 
@@ -10,6 +12,35 @@ module Api
       return klass.find_by(key_id => id, :userid => [current_user.userid]) if current_user.only_my_user_tasks?
 
       super
+    end
+
+    def render_task_results_entity
+      id = params[:c_id]
+      task = find_resource(collection_class(:tasks), :id, id)
+      raise "Missing context_data in #{task_ident(task)}" if task.context_data.blank?
+
+      result_id = task.context_data[:result_id]
+      raise "Missing result_id in #{task_ident(task)}" if result_id.blank?
+
+      result_type = task.context_data[:result_type]
+      raise "Missing result_type in #{task_ident(task)}" if result_type.blank?
+
+      session_id = task.context_data[:session_id]
+      raise "Missing session_id in #{task_ident(task)}" if session_id.blank?
+
+      validate_result_type(result_type)
+      task_results = result_type == "pdf" ? task.miq_report_result.to_pdf : task.task_results
+      filename     = "results_#{result_id}_report.#{result_type}"
+      content_type = RESULT_TYPE_TO_CONTENT_TYPE[result_type]
+      send_data(task_results, :filename => filename, :disposition => "attachment", :content_type => content_type)
+    rescue => err
+      raise BadRequestError, err
+    end
+
+    private
+
+    def task_ident(task)
+      "Task id:#{task.id} name:'#{task.name}'"
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2997,9 +2997,14 @@
       :post:
       - :name: query
         :identifier: miq_report_view
+      - :name: request_download
+        :identifier: miq_report_view
     :resource_actions:
       :get:
       - :name: read
+        :identifier: miq_report_view
+      :post:
+      - :name: request_download
         :identifier: miq_report_view
   :roles:
     :description: Roles
@@ -3866,6 +3871,15 @@
       :delete:
       - :name: delete
         :identifier: miq_task_delete
+    :resource_entities:
+      - :name: task_results
+        :entity_actions:
+          :get:
+          - :name: read
+            :identifier:
+            - miq_task_all_ui
+            - miq_task_my_ui
+            - miq_report_view
   :templates:
     :description: Templates
     :identifier: miq_template

--- a/config/api.yml
+++ b/config/api.yml
@@ -3872,14 +3872,14 @@
       - :name: delete
         :identifier: miq_task_delete
     :resource_entities:
-      - :name: task_results
-        :entity_actions:
-          :get:
-          - :name: read
-            :identifier:
-            - miq_task_all_ui
-            - miq_task_my_ui
-            - miq_report_view
+    - :name: task_results
+      :entity_actions:
+        :get:
+        - :name: read
+          :identifier:
+          - miq_task_all_ui
+          - miq_task_my_ui
+          - miq_report_view
   :templates:
     :description: Templates
     :identifier: miq_template

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,12 @@ Rails.application.routes.draw do
             when :get
               root :action => :index, :as => collection_name
               get "/:c_id", :action => :show, :as => resource_name
+              Array(collection[:resource_entities]).each do |entity|
+                if entity.try(:fetch_path, :entity_actions, :get)
+                  name = entity[:name]
+                  get "/:c_id/#{name}", :action => "render_#{name}_entity".to_sym, :as => "#{name}_entity"
+                end
+              end
             when :put
               put "/:c_id", :action => :update
             when :patch

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -62,6 +62,22 @@ module Api
       typed_subcollection_actions(collection_name, subcollection_name).try(:fetch_path, method.to_sym)
     end
 
+    def resource_entities(collection_name)
+      Array(self[collection_name][:resource_entities])
+    end
+
+    def resource_entity(collection_name, entity_name)
+      resource_entities(collection_name).find { |entity| entity[:name] == entity_name.to_s }
+    end
+
+    def resource_entity?(collection_name, entity_name)
+      resource_entity(collection_name, entity_name).present?
+    end
+
+    def resource_entity_actions(collection_name, entity_name)
+      resource_entity(collection_name, entity_name).try(:fetch_path, :entity_actions)
+    end
+
     def names_for_feature(product_feature_name)
       names_for_features[product_feature_name]
     end

--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -59,6 +59,21 @@ describe 'API configuration (config/api.yml)' do
               end
             end
           end
+          add_resource_entity_identifiers(cfg, set)
+        end
+      end
+
+      def add_resource_entity_identifiers(cfg, set)
+        return if cfg["resource_entities"].blank?
+
+        cfg["resource_entities"].each do |entity|
+          entity[:entity_actions].each do |_, method_cfg|
+            method_cfg.each do |action_cfg|
+              next unless action_cfg[:identifier]
+
+              Array(action_cfg[:identifier]).each { |id| set.add(id) }
+            end
+          end
         end
       end
     end

--- a/spec/requests/result_downloads_spec.rb
+++ b/spec/requests/result_downloads_spec.rb
@@ -182,11 +182,9 @@ PDF Report"
       task = MiqTask.find(task_id)
       expect(task.context_data).to_not be_nil
       expect(task.context_data).to include(
-        {
-          :result_id   => result_1.id,
-          :result_type => "txt",
-          :session_id  => a_string_matching(/[a-z0-9\-]*/)
-        }
+        :result_id   => result_1.id,
+        :result_type => "txt",
+        :session_id  => a_string_matching(/[a-z0-9\-]*/)
       )
     end
   end

--- a/spec/requests/result_downloads_spec.rb
+++ b/spec/requests/result_downloads_spec.rb
@@ -1,0 +1,313 @@
+RSpec.describe "results request downloads" do
+  let(:columns_1) { %w[name size] }
+  let(:result_set_1) do
+    [
+      {"name" => "VM2", "size" => 115_533},
+      {"name" => "VM1", "size" => 332_233},
+      {"name" => "VG1", "size" => 112_233}
+    ]
+  end
+
+  let(:task_results_1_txt) do
+    "------------------------+
+|   VMware VM Summary   |
++-----------------------+
+|  VM Name |  Size      |
++-----------------------+
+| VM2      | 115_533    |
+| VM1      | 332_233    |
+| VG1      | 112_233    |
++-----------------------+"
+  end
+
+  let(:task_results_1_csv) do
+    "\"VM Name\", \"Size\"
+VM2,115_533
+VM1,332_233
+VG1,112_233"
+  end
+
+  let(:task_results_1_pdf) do
+    "%PDF-1.5
+PDF Report"
+  end
+
+  let(:col_formats_1) { Array.new(columns_1.count) }
+  let(:result_1) { FactoryBot.create(:miq_report_result, :miq_group => @group) }
+  let(:report_1) do
+    report = MiqReport.create(
+      :name          => "VMs based on Disk Type",
+      :title         => "VMs using thin provisioned disks",
+      :rpt_group     => "Custom",
+      :rpt_type      => "Custom",
+      :db            => "VmInfra",
+      :cols          => ["name"],
+      :col_order     => ["name"],
+      :headers       => ["Name"],
+      :order         => "Ascending",
+      :template_type => "report"
+    )
+    report.generate_table(:userid => @user.userid)
+    report
+  end
+
+  let(:task_1) { FactoryBot.create(:miq_task) }
+  let(:result_1) { report_1.build_create_results({:userid => @user.userid}, task_1.id) }
+
+  def task_results_url(task)
+    "#{api_task_url(nil, task)}/task_results"
+  end
+
+  context "request downloads" do
+    it "fail if not authorized" do
+      result = FactoryBot.create(:miq_report_with_results, :miq_group => @group).miq_report_results.first
+
+      api_basic_authorize
+
+      post(api_result_url(nil, result), :params => gen_request(:request_download, :result_type => "txt"))
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "fail with unrelated authorization" do
+      result = FactoryBot.create(:miq_report_with_results, :miq_group => @group).miq_report_results.first
+
+      api_basic_authorize :some_unrelated_entitlement
+
+      post(api_result_url(nil, result), :params => gen_request(:request_download, :result_type => "txt"))
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "fail if result_type is not specified" do
+      result = FactoryBot.create(:miq_report_with_results, :miq_group => @group).miq_report_results.first
+
+      api_basic_authorize action_identifier(:results, :request_download, :resource_actions, :post)
+
+      post(api_result_url(nil, result), :params => gen_request(:request_download))
+      expect_single_action_result(:success => false, :message => "Missing result_type")
+    end
+
+    it "fail if result_type is bogus and the PdfGenerator is not available" do
+      expect(PdfGenerator.instance).to receive(:available?).and_return(false)
+
+      result = FactoryBot.create(:miq_report_with_results, :miq_group => @group).miq_report_results.first
+
+      api_basic_authorize action_identifier(:results, :request_download, :resource_actions, :post)
+
+      post(api_result_url(nil, result), :params => gen_request(:request_download, :result_type => "bogus"))
+      expect_single_action_result(:success => false, :message => "Unsupported result_type bogus specified, must be one of txt, csv.")
+    end
+
+    it "fail if result_type is bogus and the PdfGenerator is available" do
+      expect(PdfGenerator.instance).to receive(:available?).and_return(true)
+
+      result = FactoryBot.create(:miq_report_with_results, :miq_group => @group).miq_report_results.first
+
+      api_basic_authorize action_identifier(:results, :request_download, :resource_actions, :post)
+
+      post(api_result_url(nil, result), :params => gen_request(:request_download, :result_type => "bogus"))
+      expect_single_action_result(:success => false, :message => "Unsupported result_type bogus specified, must be one of txt, csv, pdf.")
+    end
+
+    it "succeeds if result_type is txt" do
+      api_basic_authorize action_identifier(:results, :request_download, :resource_actions, :post)
+
+      post(api_result_url(nil, result_1), :params => gen_request(:request_download, :result_type => "txt"))
+
+      expected = {
+        "success"           => true,
+        "message"           => "Requesting a download of a txt report for Result id:#{result_1.id} name:'#{result_1.name}'",
+        "task_id"           => /\d+/,
+        "task_href"         => a_string_matching(api_tasks_url),
+        "task_results_href" => a_string_matching(api_tasks_url)
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it "succeeds if result_type is csv" do
+      api_basic_authorize action_identifier(:results, :request_download, :resource_actions, :post)
+
+      post(api_result_url(nil, result_1), :params => gen_request(:request_download, :result_type => "csv"))
+
+      expected = {
+        "success"           => true,
+        "message"           => "Requesting a download of a csv report for Result id:#{result_1.id} name:'#{result_1.name}'",
+        "task_id"           => /\d+/,
+        "task_href"         => a_string_matching(api_tasks_url),
+        "task_results_href" => a_string_matching(api_tasks_url)
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it "succeeds if result_type is txt and task references match" do
+      api_basic_authorize action_identifier(:results, :request_download, :resource_actions, :post)
+
+      post(api_result_url(nil, result_1), :params => gen_request(:request_download, :result_type => "txt"))
+
+      expect(response).to have_http_status(:ok)
+      expected = {
+        "success" => true,
+        "message" => "Requesting a download of a txt report for Result id:#{result_1.id} name:'#{result_1.name}'",
+        "task_id" => /\d+/
+      }
+      expect(response.parsed_body).to include(expected)
+
+      task_id  = response.parsed_body["task_id"]
+      expected = {
+        "task_href"         => a_string_matching(api_task_url(nil, task_id)),
+        "task_results_href" => a_string_matching("#{api_task_url(nil, task_id)}/task_results")
+      }
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it "succeeds and properly defines the task context data" do
+      api_basic_authorize action_identifier(:results, :request_download, :resource_actions, :post)
+
+      post(api_result_url(nil, result_1), :params => gen_request(:request_download, :result_type => "txt"))
+
+      expect(response).to have_http_status(:ok)
+      expected = {
+        "success" => true,
+        "message" => "Requesting a download of a txt report for Result id:#{result_1.id} name:'#{result_1.name}'",
+        "task_id" => /\d+/
+      }
+      expect(response.parsed_body).to include(expected)
+
+      task_id = response.parsed_body["task_id"]
+      expect(MiqTask.exists?(task_id)).to be_truthy
+
+      task = MiqTask.find(task_id)
+      expect(task.context_data).to_not be_nil
+      expect(task.context_data).to include(
+        {
+          :result_id   => result_1.id,
+          :result_type => "txt",
+          :session_id  => a_string_matching(/[a-z0-9\-]*/)
+        }
+      )
+    end
+  end
+
+  context "fetching task results" do
+    it "fail if not authorized" do
+      api_basic_authorize
+
+      get(task_results_url(task_1))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "fail if authorized with an unrelated entitlement" do
+      api_basic_authorize :some_unrelated_entitlement
+
+      get(task_results_url(task_1))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "succeeds with the proper authorization" do
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.update_context(:result_id => result_1.id, :result_type => "txt", :session_id => "ab-cd")
+      task_1.task_results = task_results_1_txt
+      get(task_results_url(task_1))
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "fails for a report task with missing context_data" do
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.context_data = nil
+      task_1.task_results = task_results_1_txt
+      get(task_results_url(task_1))
+
+      expect_bad_request("Missing context_data in Task id:#{task_1.id} name:'#{task_1.name}'")
+    end
+
+    it "fails for a report task with a missing result_id" do
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.update_context(:result_type => "txt", :session_id => "ab-cd")
+      task_1.task_results = task_results_1_txt
+      get(task_results_url(task_1))
+
+      expect_bad_request("Missing result_id in Task id:#{task_1.id} name:'#{task_1.name}'")
+    end
+
+    it "fails for a report task with a missing result_type" do
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.update_context(:result_id => result_1.id, :session_id => "ab-cd")
+      task_1.task_results = task_results_1_txt
+      get(task_results_url(task_1))
+
+      expect_bad_request("Missing result_type in Task id:#{task_1.id} name:'#{task_1.name}'")
+    end
+
+    it "fails for a report task with a missing session_id" do
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.update_context(:result_id => result_1.id, :result_type => "txt")
+      task_1.task_results = task_results_1_txt
+      get(task_results_url(task_1))
+
+      expect_bad_request("Missing session_id in Task id:#{task_1.id} name:'#{task_1.name}'")
+    end
+
+    it "succeeds for a txt download" do
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.update_context(:result_id => result_1.id, :result_type => "txt", :session_id => "ab-cd")
+      task_1.task_results = task_results_1_txt
+      get(task_results_url(task_1))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.header["Content-Type"]).to eq("application/text")
+      expect(response.header["Content-Disposition"]).to eq("attachment; filename=\"results_#{result_1.id}_report.txt\"")
+      expect(response.body).to eq(task_results_1_txt)
+    end
+
+    it "succeeds for a csv download" do
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.update_context(:result_id => result_1.id, :result_type => "csv", :session_id => "ab-cd")
+      task_1.task_results = task_results_1_csv
+      get(task_results_url(task_1))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.header["Content-Type"]).to eq("application/csv")
+      expect(response.header["Content-Disposition"]).to eq("attachment; filename=\"results_#{result_1.id}_report.csv\"")
+      expect(response.body).to eq(task_results_1_csv)
+    end
+
+    it "fails for a pdf download if the PdfGenerator is not available" do
+      expect(PdfGenerator.instance).to receive(:available?).and_return(false)
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.update_context(:result_id => result_1.id, :result_type => "pdf", :session_id => "ab-cd")
+      task_1.miq_report_result = result_1
+      get(task_results_url(task_1))
+
+      expect_bad_request("Unsupported result_type pdf specified, must be one of txt, csv.")
+    end
+
+    it "succeeds for a pdf download if the PdfGenerator is available" do
+      expect(PdfGenerator.instance).to receive(:available?).and_return(true)
+      allow_any_instance_of(MiqReportResult).to receive(:to_pdf).and_return(task_results_1_pdf)
+      api_basic_authorize entity_action_identifier(:tasks, :task_results, :read, :get).first
+
+      task_1.update_context(:result_id => result_1.id, :result_type => "pdf", :session_id => "ab-cd")
+      task_1.miq_report_result = result_1
+      get(task_results_url(task_1))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.header["Content-Type"]).to eq("application/pdf")
+      expect(response.header["Content-Disposition"]).to eq("attachment; filename=\"results_#{result_1.id}_report.pdf\"")
+      expect(response.body).to eq(task_results_1_pdf)
+    end
+  end
+end

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -44,6 +44,13 @@ module Spec
           identifier_from_multiple_class_list(::Api::ApiConfig.collections[type][:collection_actions][method], action, klass)
         end
 
+        def entity_action_identifier(type, entity, action, method = :post)
+          ::Api::ApiConfig
+            .collections[type][:resource_entities]
+            .detect { |spec| spec[:name] == entity.to_s}[:entity_actions][method]
+            .detect { |spec| spec[:name] == action.to_s }[:identifier]
+        end
+
         def action_identifier(type, action, selection = :resource_actions, method = :post)
           ::Api::ApiConfig
             .collections[type][selection][method]

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -47,7 +47,7 @@ module Spec
         def entity_action_identifier(type, entity, action, method = :post)
           ::Api::ApiConfig
             .collections[type][:resource_entities]
-            .detect { |spec| spec[:name] == entity.to_s}[:entity_actions][method]
+            .detect { |spec| spec[:name] == entity.to_s }[:entity_actions][method]
             .detect { |spec| spec[:name] == action.to_s }[:identifier]
         end
 


### PR DESCRIPTION
Adding support for the request_download action on report results:
- Creates a Task for the download
- Supports result_type of txt, csv and pdf
- Downloads available via the task's task_results_href
- Added result_downloads specs
- Enhanced api identifier specs to include resource entity identifiers

Solves: https://github.com/ManageIQ/manageiq-api/issues/827
