### PR TITLE
Fix API action identifier verification check spec.

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -919,11 +919,17 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: configuration_script_view
+        :identifier:
+        - automation_manager_configuration_script_view
+        - ems_infra_show
+        - ems_block_storage_show
     :resource_actions:
       :get:
       - :name: read
-        :identifier: configuration_script_view
+        :identifier:
+        - automation_manager_configuration_script_view
+        - ems_infra_show
+        - ems_block_storage_show
   :configured_systems:
     :description: Configured Systems
     :options:
@@ -1111,23 +1117,23 @@
         :identifier: conversion_host_show_list
       :post:
       - :name: create
-        :identifier: conversion_host_new
+        :identifier: conversion_host_control
       - :name: edit
-        :identifier: conversion_host_edit
+        :identifier: conversion_host_control
       - :name: delete
-        :identifier: conversion_host_delete
+        :identifier: conversion_host_control
     :resource_actions:
       :get:
       - :name: read
         :identifier: conversion_host_show
       :post:
       - :name: edit
-        :identifier: conversion_host_edit
+        :identifier: conversion_host_control
       - :name: delete
-        :identifier: conversion_host_delete
+        :identifier: conversion_host_control
       :delete:
       - :name: delete
-        :identifier: conversion_host_delete
+        :identifier: conversion_host_control
     :tags_subcollection_actions:
       :post:
       - :name: assign
@@ -1892,22 +1898,37 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: load_balancer_show_list
+        :identifier:
+        - ems_infra_show_list
+        - ems_block_storage_show_list
+        - instance_show_list
       :post:
       - :name: query
-        :identifier: load_balancer_show_list
+        :identifier:
+        - ems_infra_show_list
+        - ems_block_storage_show_list
+        - instance_show_list
     :resource_actions:
       :get:
       - :name: read
-        :identifier: load_balancer_show
+        :identifier:
+        - ems_infra_show
+        - ems_block_storage_show
+        - instance_show
     :subcollection_actions:
       :get:
       - :name: read
-        :identifier: load_balancer_show
+        :identifier:
+        - ems_infra_show
+        - ems_block_storage_show
+        - instance_show
     :subresource_actions:
       :get:
       - :name: read
-        :identifier: load_balancer_show
+        :identifier:
+        - ems_infra_show
+        - ems_block_storage_show
+        - instance_show
   :measures:
     :description: Measures
     :identifier: measure
@@ -2616,7 +2637,7 @@
         :identifier: pxe_server_view
       :post:
       - :name: create
-        :identifier: pxe_server_create
+        :identifier: pxe_server_new
     :subresource_actions:
       :get:
       - :name: read
@@ -2627,7 +2648,7 @@
         :identifier: pxe_server_view
       :post:
       - :name: create
-        :identifier: pxe_server_create
+        :identifier: pxe_server_new
   :pxe_servers:
     :description: PXE Servers
     :identifier: pxe_server_accord
@@ -2644,7 +2665,7 @@
         :identifier: pxe_server_view
       :post:
       - :name: create
-        :identifier: pxe_server_create
+        :identifier: pxe_server_new
       - :name: edit
         :identifier: pxe_server_edit
       - :name: delete
@@ -2658,7 +2679,7 @@
         :identifier: pxe_server_edit
       :post:
       - :name: create
-        :identifier: pxe_server_create
+        :identifier: pxe_server_new
       - :name: edit
         :identifier: pxe_server_edit
       :delete:
@@ -4329,16 +4350,16 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: miq_widget_show_list
+        :identifier: miq_report_widget_editor
       :post:
       - :name: query
-        :identifier: miq_widget_show_list
+        :identifier: miq_report_widget_editor
       - :name: generate_content
         :identifier: widget_generate_content
     :resource_actions:
       :get:
       - :name: read
-        :identifier: miq_widget_show
+        :identifier: miq_report_widget_editor
       :post:
       - :name: generate_content
         :identifier: widget_generate_content

--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -52,9 +52,10 @@ describe 'API configuration (config/api.yml)' do
           end
           keys.each do |action_type|
             next unless cfg[action_type]
-            cfg[action_type].each_value do |_, method_cfg|
+            cfg[action_type].each do |_, method_cfg|
               method_cfg.each do |action_cfg|
                 next unless action_cfg[:identifier]
+
                 Array(action_cfg[:identifier]).each { |id| yield(set, id) }
               end
             end

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -2,7 +2,7 @@ describe "Widgets API" do
   context "GET /api/widgets" do
     it "returns all Widgets" do
       miq_widget = FactoryBot.create(:miq_widget)
-      api_basic_authorize('miq_widget_show_list')
+      api_basic_authorize(collection_action_identifier(:widgets, :read, :get))
 
       get(api_widgets_url)
 
@@ -18,7 +18,7 @@ describe "Widgets API" do
   context "GET /api/miq_widgets/:id" do
     it "returns a single Widget" do
       miq_widget = FactoryBot.create(:miq_widget)
-      api_basic_authorize('miq_widget_show')
+      api_basic_authorize(action_identifier(:widgets, :read, :resource_actions, :get))
 
       get(api_widget_url(nil, miq_widget))
 


### PR DESCRIPTION
Fix API action identifier verification check spec.

- We were not looking at all identifiers, essentially cross-checking only 79 out of 490 current identifiers.