### PR TITLE
Removing the disabled flag option for API actions.

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -175,7 +175,6 @@ module Api
                 end
         return if method_name == :get && aspec.nil?
         action_hash = fetch_action_hash(aspec, method_name, action_name)
-        raise BadRequestError, "Disabled action #{action_name}" if action_hash[:disabled]
         unless api_user_role_allows?(action_hash[:identifier])
           raise ForbiddenError, "Use of the #{action_name} action is forbidden"
         end
@@ -208,7 +207,6 @@ module Api
         end
 
         if action_hash.present?
-          raise BadRequestError, "Disabled Action #{aname} for the #{cname} #{type} specified" if action_hash[:disabled]
           unless api_user_role_allows?(action_hash[:identifier])
             raise ForbiddenError, "Use of Action #{aname} is forbidden"
           end
@@ -259,7 +257,6 @@ module Api
 
         action_hash = fetch_action_hash(aspec, mname, aname)
         raise BadRequestError, "Unsupported Action #{aname} for the #{cname} sub-collection" if action_hash.blank?
-        raise BadRequestError, "Disabled Action #{aname} for the #{cname} sub-collection" if action_hash[:disabled]
 
         unless api_user_role_allows?(action_hash[:identifier])
           raise ForbiddenError, "Use of Action #{aname} for the #{cname} sub-collection is forbidden"

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -482,6 +482,7 @@ module Api
           typed_action_definitions = action_definitions || fetch_typed_subcollection_actions(method, is_subcollection)
           typed_action_definitions.each.collect do |action|
             next unless api_user_role_allows?(action[:identifier]) && action_validated?(resource, action)
+
             build_resource_actions(action, method, href, cspec[:verbs])
           end
         end.flatten.uniq.compact

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -461,7 +461,7 @@ module Api
           next unless render_actions_for_method(cspec[:verbs], method)
           typed_action_definitions = fetch_typed_subcollection_actions(method, is_subcollection) || action_definitions
           typed_action_definitions.each.collect do |action|
-            if !action[:disabled] && api_user_role_allows?(action[:identifier])
+            if api_user_role_allows?(action[:identifier])
               {"name" => action[:name], "method" => method, "href" => (href ? href : collection)}
             end
           end
@@ -481,7 +481,7 @@ module Api
           next unless render_actions_for_method(cspec[:verbs], method)
           typed_action_definitions = action_definitions || fetch_typed_subcollection_actions(method, is_subcollection)
           typed_action_definitions.each.collect do |action|
-            next unless !action[:disabled] && api_user_role_allows?(action[:identifier]) && action_validated?(resource, action)
+            next unless api_user_role_allows?(action[:identifier]) && action_validated?(resource, action)
             build_resource_actions(action, method, href, cspec[:verbs])
           end
         end.flatten.uniq.compact

--- a/config/api.yml
+++ b/config/api.yml
@@ -760,9 +760,6 @@
       :post:
       - :name: query
         :identifier: ems_cluster_show_list
-      - :name: delete
-        :identifier: ems_cluster_delete
-        :disabled: true
     :resource_actions:
       :get:
       - :name: read
@@ -1710,35 +1707,8 @@
         :identifier: host_check_compliance
       - :name: query
         :identifier: host_show_list
-      - :name: add
-        :identifier: host_new
-        :disabled: true
       - :name: edit
         :identifier: host_edit
-      - :name: refresh
-        :identifier: host_refresh
-        :disabled: true
-      - :name: standby
-        :identifier: host_standby
-        :disabled: true
-      - :name: shutdown
-        :identifier: host_shutdown
-        :disabled: true
-      - :name: restart
-        :identifier: host_reboot
-        :disabled: true
-      - :name: poweron
-        :identifier: host_start
-        :disabled: true
-      - :name: poweroff
-        :identifier: host_stop
-        :disabled: true
-      - :name: reset
-        :identifier: host_reset
-        :disabled: true
-      - :name: delete
-        :identifier: host_delete
-        :disabled: true
     :resource_actions:
       :get:
       - :name: read
@@ -1748,27 +1718,6 @@
         :identifier: host_check_compliance
       - :name: edit
         :identifier: host_edit
-      - :name: refresh
-        :identifier: host_refresh
-        :disabled: true
-      - :name: standby
-        :identifier: host_standby
-        :disabled: true
-      - :name: shutdown
-        :identifier: host_shutdown
-        :disabled: true
-      - :name: restart
-        :identifier: host_reboot
-        :disabled: true
-      - :name: poweron
-        :identifier: host_start
-        :disabled: true
-      - :name: poweroff
-        :identifier: host_stop
-        :disabled: true
-      - :name: reset
-        :identifier: host_reset
-        :disabled: true
       :delete:
       - :name: delete
         :identifier: host_delete
@@ -2954,9 +2903,6 @@
       :post:
       - :name: query
         :identifier: resource_pool_show_list
-      - :name: delete
-        :identifier: resource_pool_delete
-        :disabled: true
     :resource_actions:
       :get:
       - :name: read
@@ -3901,12 +3847,6 @@
         :identifier: miq_template_check_compliance
       - :name: query
         :identifier: miq_template_show_list
-      - :name: refresh
-        :identifier: miq_template_refresh
-        :disabled: true
-      - :name: edit
-        :identifier: miq_template_edit
-        :disabled: true
       - :name: set_ownership
         :identifier: miq_template_ownership
       - :name: delete
@@ -3918,9 +3858,6 @@
       :post:
       - :name: check_compliance
         :identifier: miq_template_check_compliance
-      - :name: refresh
-        :identifier: miq_template_refresh
-        :disabled: true
       - :name: edit
         :identifier: miq_template_edit
       - :name: set_ownership
@@ -4146,9 +4083,6 @@
         :identifier:
         - vm_show_list
         - sui_vm_details_view
-      - :name: add
-        :identifier: vm_miq_request_new
-        :disabled: true
       - :name: edit
         :identifier: vm_edit
       - :name: add_lifecycle_event

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -137,7 +137,7 @@ module Api
           next unless action_definitions.present?
           action_definitions.each do |action|
             identifier = action[:identifier]
-            next if action[:disabled] || result.key?(identifier)
+            next if result.key?(identifier)
             result[identifier] = [collection, method, action]
           end
         end

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -138,6 +138,7 @@ module Api
           action_definitions.each do |action|
             identifier = action[:identifier]
             next if result.key?(identifier)
+
             result[identifier] = [collection, method, action]
           end
         end


### PR DESCRIPTION
Removing the disabled flag in the api.yml configuration file.

This was added during the infancy of the API when we identified actions we wanted to implement and obtained the related entitlement from the product features file, but did not yet implement them or were never asked for.

While it was useful to have, it does cause confusion while reading the api.yml and adds some complexity to the code base. This is no longer needed as the API has expanded since and has been enhanced over the years and actions added on an as-needed basis.