### PR TITLE
Specify what is missing if tag assignment failed

### DIFF
--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -87,7 +87,7 @@ module Api
           success = true
         else
           desc = "Assigning #{tag_ident(tag_spec)}"
-          Classification.classify(ci, tag_spec[:category], tag_spec[:name])
+          desc += Classification.classify(ci, tag_spec[:category], tag_spec[:name])
           success = ci_is_tagged_with?(ci, tag_spec)
         end
         action_result(success, desc, :parent_id => ci.id)

--- a/spec/requests/tag_collections_spec.rb
+++ b/spec/requests/tag_collections_spec.rb
@@ -795,6 +795,8 @@ describe "Tag Collections API" do
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
+      expect(response.parsed_body["results"][1]['message']).to include("FAILED. Tag name '#{bad_tag[:name]}' not found  in region #{zone.region_id}")
+      expect(response.parsed_body["results"][2]['message']).to include("SUCCESS")
     end
 
     it 'fails without an appropriate role' do


### PR DESCRIPTION
Specify what is missing if tag assignment failed

Required: https://github.com/ManageIQ/manageiq/pull/20216

**Example:**
curl --user admin:smartvm -i -X POST -d '{"action":"assign","resources":[{"category":"team","name":"it_pnp"}]}' http://localhost:3000/api/vms/54/tags
**BEFORE:**
{"results":[{"success":false,"message":"Assigning Tag: category:'team' name:'it_pnp'", ...}
**AFTER:**
{"results":[{"success":false,"message":"Assigning Tag: category:'team' name:'it_pnp' - FAILED. Tag category 'team' not found in region 0", ...}

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1792106