### PR TITLE
update specs to reflect memory_mb rename and resize

### DIFF
--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Api::Filter do
     end
 
     it "does not support filtering by attributes of associations' associations" do
-      filters = ["host.hardware.memory_mb>1024"]
+      filters = ["host.hardware.ram_size_in_bytes>1024000000"]
 
       expect do
         described_class.parse(filters, Vm)

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -172,7 +172,7 @@ describe "Provision Requests API" do
   let(:dialog)     { FactoryBot.create(:miq_dialog_provision) }
 
   describe "Provision Requests" do
-    let(:hardware) { FactoryBot.create(:hardware, :memory_mb => 1024) }
+    let(:hardware) { FactoryBot.create(:hardware, :ram_size_in_bytes => 1_024_000_000) }
     let(:template) do
       FactoryBot.create(:template_vmware,
                          :name                  => "template1",

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -496,7 +496,7 @@ describe "Querying" do
     end
 
     it "does not support filtering by attributes of associations' associations" do
-      get api_vms_url, :params => { :expand => "resources", :filter => ["host.hardware.memory_mb>1024"] }
+      get api_vms_url, :params => {:expand => "resources", :filter => ["host.hardware.ram_size_in_bytes>1024000000"]}
 
       expect_bad_request(/Filtering of attributes with more than one association away is not supported/)
     end


### PR DESCRIPTION
at the moment memory_mb is an int which is problematic with aggregation and the byte conversion.

we cast it in hardware, and i'd like to get rid of the cast 

see https://github.com/ManageIQ/manageiq-schema/pull/485
and https://github.com/ManageIQ/manageiq/pull/20213

these will all need to be merged concurrently