### PR TITLE
Placeholder string for Float::INFINITY in response

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -46,6 +46,8 @@ module Api
           normalize_url(value)
         elsif Api.encrypted_attribute?(attr)
           normalize_encrypted(value)
+        elsif value == Float::INFINITY
+          Float::INFINITY.to_s
         elsif Api.resource_attribute?(attr)
           normalize_resource(value)
         else

--- a/spec/requests/chargebacks_spec.rb
+++ b/spec/requests/chargebacks_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe "chargebacks API" do
 
   def convert_to_response_hash(resource)
     resource.attributes.map do |attribute_name, attribute_value|
-      attribute_value = attribute_value.to_s if attribute_value.present? && (attribute_name.include?("id"))
-      attribute_value = nil if attribute_value == Float::INFINITY
-      attribute_value = attribute_value.strftime("%FT%TZ") if attribute_value.is_a?(ActiveSupport::TimeWithZone)
+      attribute_value = attribute_value.to_s if attribute_value.present? && (attribute_name.include?("id") || attribute_value == Float::INFINITY)
+      attribute_value = attribute_value.strftime("%FT%TZ") if attribute_value.kind_of?(ActiveSupport::TimeWithZone)
       {attribute_name => attribute_value}
     end.reduce(:merge)
   end
@@ -36,7 +35,7 @@ RSpec.describe "chargebacks API" do
                                                             "detail_currency"  => expected_currency,
                                                             "detail_measure"   => expected_measure)
 
-    expect_result_to_match_hash(response.parsed_body, "count"  => 1)
+    expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)
   end
 


### PR DESCRIPTION
Chargeback tiers use`Float::INFINITY` in `finish` column but `Float::INFINITY` doesn't have representation in JSON. 
There is used "infinity" instead of `null`(before) because `null` just represents `null` values 


```
GET /api/rates/1850?expand=resources&attributes=chargeback_rate,detail_measure,detail_currency,chargeable_field,chargeback_tiers
```


```
{
    "name": "rates",
    "count": 138,
    "subcount": 138,
    "pages": 1,
    "resources": [
        {
            "href": "http://localhost:3090/api/rates/544",
            "id": "544",
            "enabled": true,
            "description": "Allocated CPU Count",
            "group": "cpu",
            "source": null,
            "metric": "derived_vm_numvcpus",
            "per_time": "hourly",
            "per_unit": "cpu",
            "friendly_rate": "Hourly @ 1.0 + 0.0 per Cpu from 0.0 to Infinity",
            "chargeback_rate_id": "8",
            "created_on": "2018-06-01T11:24:52Z",
            "updated_on": "2018-06-01T11:24:52Z",
            "chargeback_rate_detail_measure_id": null,
            "chargeback_rate_detail_currency_id": "1",
            "chargeable_field_id": "3",
            "sub_metric": null,
            "chargeback_tiers": [
                {
                    "id": "11010",
                    "chargeback_rate_detail_id": "544",
                    "start": 0.0,
                    "finish": "infinity",
                    "fixed_rate": 1.0,

```

See finish. 


@miq-bot assign @abellotti 


