### PR TITLE
Add a providers create action for physical infra

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2467,6 +2467,8 @@
           :identifier: ems_container_new
         - :klass: ManageIQ::Providers::NetworkManager
           :identifier: ems_network_new
+        - :klass: ManageIQ::Providers::PhysicalInfraManager
+          :identifier: ems_physical_infra_new
         - :klass: Provider
           :identifier: provider_foreman_add_provider
       - :name: edit


### PR DESCRIPTION
The PhysicalInfra Manager type did not have a create action

Fixes https://github.com/ManageIQ/manageiq-api/issues/852