### PR TITLE
Fix CI: Remove non-existent identifiers in miq_product_features.yml

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -539,8 +539,6 @@
       - :name: read
         :identifier: cloud_network_show_list
       :post:
-      - :name: add
-        :identifier: instance_add_cloud_network
       - :name: create
         :identifier: cloud_network_new
       - :name: edit
@@ -2466,7 +2464,6 @@
         :identifier:
         - ems_infra_show_list
         - ems_block_storage_show_list
-        - api_provider_show_list
       :post:
       - :name: change_password
         :identifier: ems_infra_change_password


### PR DESCRIPTION
This https://github.com/ManageIQ/manageiq-api/pull/840 fix test which checks whether identifiers from `api.yml` exist in also in `miq_product_features.yml`.

The test found[(CI failure) ](https://travis-ci.com/github/ManageIQ/manageiq-api/jobs/342141092) that `instance_add_cloud_network , api_provider_show_list`  don't exist in `miq_product_features.yml`. 

This PR removes them as they were added [here](https://github.com/ManageIQ/manageiq-api/pull/825) 

`instance_add_cloud_network`  - it looks like that it is just duplicating `create` so it can be removed.

`api_provider_show_list`  - this doesn't exist in `miq_product_features.yml` and we have already features to show list of providers. (`ems_infra_show_list, ems_cloud_show_list, ..`)

@gubbe505  is it ok to remove `api_provider_show_list`  or do you have any plans to add `api_provider_show_list ` to `miq_product_features.yml` in https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_product_features.yml for some action ?

thanks



@miq-bot assign @abellotti 
@miq-bot add_label bug, jansa/yes





 