### PR TITLE
Make travis happy by not trying to build a dead route for reports

### DIFF
--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -81,8 +81,10 @@ module Api
                         :value => data['interval']['value']}
       }
 
-      email_url_prefix = url_for(:controller => "/report",
-                                 :action     => "show_saved") + "/"
+      # FIXME: the ReportController#show_saved route doesn't exist, it has to be reimplemented
+      # for more information see https://github.com/ManageIQ/manageiq-ui-classic/issues/7126
+      # email_url_prefix = url_for_only_path(:controller => "report", :action => "show_saved") + "/"
+      email_url_prefix = "/report/show_saved/"
 
       schedule_options = {
         :send_email       => data['send_email'] || false,


### PR DESCRIPTION
The `url_for` doesn't work because the `show_report` route is dead. Its method has been deleted years ago, the route has been cleaned up just now. There's an issue to track the missing feature: https://github.com/ManageIQ/manageiq-ui-classic/issues/7126