### PR TITLE
Expose tag category description in chargeback_assignment

### DIFF
--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -203,7 +203,7 @@ module Api
                                 tag = record[key][0]&.tag
                                 prefix = record[key][1]
                                 resource_id = tag.id
-                                additional_attributes = {'name' => tag.classification.name, 'category' => tag.category.name, :assignment_prefix => prefix}
+                                additional_attributes = {'name' => tag.classification.name, 'description' => tag.classification.description, 'category' => tag.category.name, :assignment_prefix => prefix}
                                 :tags
                               elsif key == :object
                                 key = :resource


### PR DESCRIPTION
Extending work https://github.com/ManageIQ/manageiq-api/pull/824 to expose tag category description for tag assignments.

```
GET /api/chargebacks/2?attributes=assigned_to
```

```
{
    "href": "http://localhost:3090/api/chargebacks/1",
    "id": "1",
    "guid": "b47a0ef0-4335-11df-aba8-001d09066d98",
    "description": "Default",
    "rate_type": "Compute",
    "created_on": "2019-08-07T16:48:04Z",
    "updated_on": "2020-06-25T09:54:52Z",
    "default": true,
    "assigned_to": [
        {
            "tag": {
                "href": "http://localhost:3090/api/tags/279",
                "name": "10240",
                "description": "10GB",     <--- THIS IS NEWLY EXPOSED ATTRIBUTE
                "category": "quota_warn_memory",
                "assignment_prefix": "vm"
            }
        }
    ],
```


