### PR TITLE
add trace for easier debugging from failed service template create

### DIFF
--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -16,6 +16,7 @@ module Api
       catalog_item_type = ServiceTemplate.class_from_request_data(data)
       catalog_item_type.create_catalog_item(data.deep_symbolize_keys, User.current_user.userid)
     rescue => err
+      $api_log.error("Service template create failed with #{err} at #{err.backtrace.first}")
       raise BadRequestError, "Could not create Service Template - #{err}"
     end
 


### PR DESCRIPTION
otherwise this rescue is at the best, incredibly user unfriendly because it'll fail in core but good luck knowing where:

`NoMethodError: undefined method 'base_class'`

as opposed to 

```
NoMethodError: undefined method `base_class' 
from /Users/drewmu/manageiq/app/models/mixins/service_mixin.rb:16:in `add_resource'
```