### PR TITLE
Added a general rescue for ActiveRecord::RecordInvalid errors

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -37,6 +37,7 @@ module Api
     rescue_from(NoMethodError)                  { |e| api_error(:internal_server_error, e) }
     rescue_from(ActiveRecord::RecordNotFound)   { |e| api_error(:not_found, e) }
     rescue_from(ActiveRecord::StatementInvalid) { |e| api_error(:bad_request, e) }
+    rescue_from(ActiveRecord::RecordInvalid)    { |e| api_error(:bad_request, e) }
     rescue_from(JSON::ParserError)              { |e| api_error(:bad_request, e) }
     rescue_from(MultiJson::LoadError)           { |e| api_error(:bad_request, e) }
     rescue_from(ForbiddenError)                 { |e| api_error(:forbidden, e) }

--- a/spec/requests/service_catalogs_spec.rb
+++ b/spec/requests/service_catalogs_spec.rb
@@ -173,6 +173,17 @@ describe "Service Catalogs API" do
       expect(response).to have_http_status(:not_found)
     end
 
+    it "returns a bad_request for invalid edits" do
+      api_basic_authorize collection_action_identifier(:service_catalogs, :edit)
+
+      sc1 = FactoryBot.create(:service_template_catalog, :name => "sc1", :description => "sc description one")
+      FactoryBot.create(:service_template_catalog, :name => "sc2", :description => "sc description two")
+
+      post(api_service_catalog_url(nil, sc1), :params => gen_request(:edit, "name" => "sc2"))
+
+      expect_bad_request("Validation failed: ServiceTemplateCatalog: Name has already been taken")
+    end
+
     it "supports single resource edit" do
       api_basic_authorize collection_action_identifier(:service_catalogs, :edit)
 


### PR DESCRIPTION
Added a general rescue from ActiveRecord::RecordInvalid to properly  the API's 400 bad_request when badly formed records fail with ActiveRecord validations.

Solves: #574