### PR TITLE
Return an empty collection, instead of 500 server error, for providers that don't support configured_systems or configuration_profiles subcollections

### DIFF
--- a/app/controllers/api/subcollections/configuration_profiles.rb
+++ b/app/controllers/api/subcollections/configuration_profiles.rb
@@ -2,7 +2,11 @@ module Api
   module Subcollections
     module ConfigurationProfiles
       def configuration_profiles_query_resource(object)
-        object.configuration_profiles
+        if object.respond_to?(:configuration_profiles)
+          object.configuration_profiles
+        else
+          raise ActiveRecord::RecordNotFound, "configuration_profiles not applicable"
+        end
       end
     end
   end

--- a/app/controllers/api/subcollections/configuration_profiles.rb
+++ b/app/controllers/api/subcollections/configuration_profiles.rb
@@ -2,11 +2,7 @@ module Api
   module Subcollections
     module ConfigurationProfiles
       def configuration_profiles_query_resource(object)
-        if object.respond_to?(:configuration_profiles)
-          object.configuration_profiles
-        else
-          raise ActiveRecord::RecordNotFound, "configuration_profiles not applicable"
-        end
+        object.respond_to?(:configuration_profiles) ? object.configuration_profiles : []
       end
     end
   end

--- a/app/controllers/api/subcollections/configured_systems.rb
+++ b/app/controllers/api/subcollections/configured_systems.rb
@@ -2,7 +2,11 @@ module Api
   module Subcollections
     module ConfiguredSystems
       def configured_systems_query_resource(object)
-        object.configured_systems
+        if object.respond_to?(:configured_systems)
+          object.configured_systems
+        else
+          raise ActiveRecord::RecordNotFound, "configured_systems not applicable"
+        end
       end
     end
   end

--- a/app/controllers/api/subcollections/configured_systems.rb
+++ b/app/controllers/api/subcollections/configured_systems.rb
@@ -2,11 +2,7 @@ module Api
   module Subcollections
     module ConfiguredSystems
       def configured_systems_query_resource(object)
-        if object.respond_to?(:configured_systems)
-          object.configured_systems
-        else
-          raise ActiveRecord::RecordNotFound, "configured_systems not applicable"
-        end
+        object.respond_to?(:configured_systems) ? object.configured_systems : []
       end
     end
   end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1808,6 +1808,7 @@ describe "Providers API" do
   context 'configuration_profiles subcollection' do
     let(:configuration_profile) { FactoryBot.create(:configuration_profile, :manager => ems) }
     let(:ems) { FactoryBot.create(:configuration_manager) }
+    let(:ems_vmware) { FactoryBot.create(:ems_vmware) }
 
     context 'GET /api/providers/:id/configuration_profiles' do
       it 'returns the configuration_profiles with an appropriate role' do
@@ -1828,6 +1829,15 @@ describe "Providers API" do
         get(api_provider_configuration_profiles_url(nil, ems))
 
         expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns a 404 for a provider that does not support configuration_profiles" do
+        api_basic_authorize subcollection_action_identifier(:providers, :configuration_profiles, :read, :get)
+
+        ems_vmware
+        get(api_provider_configuration_profiles_url(nil, ems_vmware))
+
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -1854,6 +1864,7 @@ describe "Providers API" do
   context 'configured_systems subcollection' do
     let(:configured_system) { FactoryBot.create(:configured_system, :manager => ems) }
     let(:ems) { FactoryBot.create(:configuration_manager) }
+    let(:ems_vmware) { FactoryBot.create(:ems_vmware) }
 
     context 'GET /api/providers/:id/configured_systems' do
       it 'returns the configured_systems with an appropriate role' do
@@ -1874,6 +1885,15 @@ describe "Providers API" do
         get(api_provider_configured_systems_url(nil, ems))
 
         expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns a 404 for a provider that does not support configured_systems" do
+        api_basic_authorize subcollection_action_identifier(:providers, :configured_systems, :read, :get)
+
+        ems_vmware
+        get(api_provider_configured_systems_url(nil, ems_vmware))
+
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1831,13 +1831,14 @@ describe "Providers API" do
         expect(response).to have_http_status(:forbidden)
       end
 
-      it "returns a 404 for a provider that does not support configuration_profiles" do
+      it "returns an empty collection for a provider that does not support configuration_profiles" do
         api_basic_authorize subcollection_action_identifier(:providers, :configuration_profiles, :read, :get)
 
         ems_vmware
         get(api_provider_configuration_profiles_url(nil, ems_vmware))
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include("resources" => [])
       end
     end
 
@@ -1887,13 +1888,14 @@ describe "Providers API" do
         expect(response).to have_http_status(:forbidden)
       end
 
-      it "returns a 404 for a provider that does not support configured_systems" do
+      it "returns an empty collection for a provider that does not support configured_systems" do
         api_basic_authorize subcollection_action_identifier(:providers, :configured_systems, :read, :get)
 
         ems_vmware
         get(api_provider_configured_systems_url(nil, ems_vmware))
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include("resources" => [])
       end
     end
 


### PR DESCRIPTION
Before:
`curl --user admin:smartvm http://localhost:3000/api/providers/1000000000004/configuration_profiles -k`
```json
{"error":{"kind":"internal_server_error","message":"undefined method `configuration_profiles' for #\u003cManageIQ::Providers::Google::CloudManager:0x000055ba49eb1168\u003e","klass":"NoMethodError"}}  
```
`curl --user admin:smartvm http://localhost:3000/api/providers/1000000000004/configured_systems -k `
```json
{"error":{"kind":"internal_server_error","message":"undefined method `configured_systems' for #\u003cManageIQ::Providers::Google::CloudManager:0x000055b866e0e178\u003e","klass":"NoMethodError"}} 
```
After:
```json
curl --user admin:smartvm http://localhost:3000/api/providers/1000000000004/configuration_profiles
{
    "name": "configuration_profiles",
    "count": 0,
    "subcount": 0,
    "pages": 0,
    "resources": [],
    "links": {
        "self": "http://localhost:3000/api/providers/1000000000004/configuration_profiles?offset=0",
        "first": "http://localhost:3000/api/providers/1000000000004/configuration_profiles?offset=0",
        "last": "http://localhost:3000/api/providers/1000000000004/configuration_profiles?offset=0"
    }
}
```
```json
curl --user admin:smartvm http://localhost:3000/api/providers/1000000000004/configured_systems
{
    "name": "configured_systems",
    "count": 143,
    "subcount": 0,
    "pages": 1,
    "resources": [],
    "links": {
        "self": "http://localhost:3000/api/providers/1000000000004/configured_systems?offset=0",
        "first": "http://localhost:3000/api/providers/1000000000004/configured_systems?offset=0",
        "last": "http://localhost:3000/api/providers/1000000000004/configured_systems?offset=0"
    }
}
```
/cc @lpichler 

