### PR TITLE
Allow set_ownership action for service templates

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -3614,6 +3614,7 @@
     - :subcollection
     - :show
     - :show_as_collection
+    - :custom_actions
     :verbs: *gpppd
     :klass: ServiceTemplate
     :subcollections:
@@ -3643,6 +3644,8 @@
         :identifier: svc_catalog_archive
       - :name: unarchive
         :identifier: svc_catalog_unarchive
+      - :name: set_ownership
+        :identifier: catalogitem_ownership
     :subcollection_actions:
       :post:
       - :name: edit
@@ -3676,6 +3679,8 @@
         :identifier: svc_catalog_archive
       - :name: unarchive
         :identifier: svc_catalog_unarchive
+      - :name: set_ownership
+        :identifier: catalogitem_ownership
       :delete:
       - :name: delete
         :identifier: catalogitem_delete

--- a/spec/requests/custom_actions_spec.rb
+++ b/spec/requests/custom_actions_spec.rb
@@ -162,7 +162,7 @@ describe "Custom Actions API" do
 
       expect_result_to_have_keys(%w(id href actions))
       action_specs = response.parsed_body["actions"]
-      expect(action_specs.size).to eq(3)
+      expect(action_specs.size).to eq(6)
       expect(action_specs.first["name"]).to eq("edit")
     end
 

--- a/spec/requests/set_ownership_spec.rb
+++ b/spec/requests/set_ownership_spec.rb
@@ -3,11 +3,15 @@
 #
 # set_ownership action availability to:
 # - Services                /api/services/:id
+# - Service Templates       /api/service_templates/:id
 # - Vms                     /api/vms/:id
 # - Templates               /api/templates/:id
 #
 describe "Set Ownership" do
-  RESOURCES = {:services => :service, :vms => :vm, :templates => :template_vmware}.freeze
+  RESOURCES = {:services          => :service,
+               :vms               => :vm,
+               :templates         => :template_vmware,
+               :service_templates => :service_template}.freeze
 
   RESOURCES.each do |collection_name, factory_name|
     it_behaves_like "endpoints with set_ownership action", collection_name, factory_name


### PR DESCRIPTION
When set ownership screen is saved on catalog item, there is error message:

<img width="1208" alt="Screenshot 2020-07-24 at 21 03 03" src="https://user-images.githubusercontent.com/14937244/88426212-19b00580-cdf1-11ea-8c23-2e944a69b37a.png">

Custom actions for service template were not added in api.yml.

@miq-bot assign @gtanzillo 
@miq-bot add_label bug
