### PR TITLE
[renderer.rb] Don't re-Rbac: part deux

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -208,7 +208,7 @@ module Api
             return resource_attr unless rbac.send(:apply_rbac_directly?, klass)
             Rbac.filtered(resource_attr)
           # Don't re-do an Rbac query if it has already been done
-          elsif collection_class(@req.subject) != resource.class && rbac.send(:apply_rbac_directly?, resource.class)
+          elsif collection_class(@req.subject) != resource.class.base_model && rbac.send(:apply_rbac_directly?, resource.class)
             Rbac.filtered_object(resource).try(:public_send, attribute)
           else
             resource.public_send(attribute)


### PR DESCRIPTION
This is an update 1ad20d24 where it better supports skipping Rbac when the model has already been filteerd in the initial .collection_search.

By using `base_model`, we ensure that any subclass will still work, specifically with our STI classes like `Vm`.


Links
-----

* Partially addresses: https://github.com/ManageIQ/manageiq-api/issues/869
* Original Fix:  https://github.com/ManageIQ/manageiq-api/pull/557