### PR TITLE
Updated the API to return nil virtual attributes and associations

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -268,7 +268,7 @@ module Api
                                 else
                                   fetch_indirect_virtual_attribute(type, resource, attr_base, attr_name, object_hash)
                                 end
-          result = result.deep_merge(value_result) unless value.nil?
+          result = result.deep_merge(Hash(value_result))
         end
         add_hash json, result
       end

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -112,6 +112,41 @@ describe "Querying" do
       expect(response.parsed_body).to include("id" => vm1.id.to_s, "retired" => nil, "smart" => nil)
     end
 
+    it 'returns nil virtual attributes when querying a resource' do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      get(api_vm_url(nil, vm1), :params => {:attributes => 'vmsafe_agent_port'})
+
+      expect(response.parsed_body).to include("id" => vm1.id.to_s, "vmsafe_agent_port" => nil)
+    end
+
+    it 'returns nil relationships when querying a resource' do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      get(api_vm_url(nil, vm1), :params => {:attributes => 'direct_service'})
+
+      expect(response.parsed_body).to include("id" => vm1.id.to_s, "direct_service" => nil)
+    end
+
+    it 'returns nil attributes of relationships when querying a resource' do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      zone = FactoryBot.create(:zone, :name => "query_zone")
+      vm   = FactoryBot.create(:vm_vmware, :host => FactoryBot.create(:host), :ems_id => FactoryBot.create(:ems_vmware, :zone => zone).id)
+
+      get(api_vm_url(nil, vm), :params => {:attributes => 'ext_management_system.last_compliance_status'})
+
+      expect(response.parsed_body).to include("id" => vm.id.to_s, "ext_management_system" => {"last_compliance_status" => nil})
+    end
+
+    it 'returns empty array for one-to-many relationships when querying a resource' do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      get(api_vm_url(nil, vm1), :params => {:attributes => 'files'})
+
+      expect(response.parsed_body).to include("id" => vm1.id.to_s, "files" => [])
+    end
+
     it "returns correct paging links" do
       create_vms_by_name %w(bb ff aa cc ee gg dd)
 

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -322,8 +322,8 @@ RSpec.describe "Requests API" do
       )
 
       expect(response.parsed_body).to match(expected_response)
-      expect(response.parsed_body).not_to include("workflow")
-      expect(response.parsed_body).not_to include("v_allowed_tags")
+      expect(response.parsed_body["workflow"]).to be_nil
+      expect(response.parsed_body["v_allowed_tags"]).to be_nil
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
- Updated the API so virtual attributes and associations (relationships) are returned even if nil.


Solves: https://github.com/ManageIQ/manageiq-api/issues/870
