### PR TITLE
[WIP] Add include_for_find support via 'expand'

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -100,6 +100,16 @@ module Api
         end
         arel
       end
+
+      def determine_include_for_find(klass)
+        return nil unless klass.respond_to?(:reflect_on_association)
+
+        relations = @req.derived_include_for_find.select do |relation|
+                      klass.reflect_on_association(relation)
+                    end
+
+        relations.empty? ? nil : relations
+      end
     end
   end
 end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -185,6 +185,7 @@ module Api
         options[:filter] = miq_expression if miq_expression
         options[:offset] = params['offset'] if params['offset']
         options[:limit] = params['limit'] if params['limit']
+        options[:include_for_find] = determine_include_for_find(klass)
 
         filter_results(miq_expression, res, options)
       end

--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -37,6 +37,10 @@ module Api
       @attributes ||= @params['attributes'].to_s.split(',')
     end
 
+    def derived_include_for_find
+      @derived_include_for_find ||= expand_requested.reject { |item| item == "resource" }
+    end
+
     def base
       url.partition(fullpath)[0] # http://target
     end

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -82,6 +82,11 @@ describe "Vms API" do
                                    [{"vendor" => "openstack"},
                                     {"vendor" => "openstack"}])
     end
+
+    include_examples "for 'expand' query optimizations" do
+      let!(:includes)   { "hardware" }
+      let!(:attributes) { "num_cpu,name" }
+    end
   end
 
   context 'Vm edit' do

--- a/spec/support/shared_examples/expand_resources_includes.rb
+++ b/spec/support/shared_examples/expand_resources_includes.rb
@@ -1,0 +1,29 @@
+RSpec.shared_context "for 'expand' query optimizations" do
+  context "expand attribute query optimizations" do
+    let(:resource)  { :vms }
+    let(:index_url) { api_vms_url }
+
+    it "removes N+1's from the index query for subcollections/virtual_attributes" do
+      api_basic_authorize action_identifier(resource, :read, :resource_actions, :get)
+
+      expands    = ["resources"]
+      from_match = [resource]
+
+      if defined?(includes)
+        expands    << includes
+        from_match << includes
+      end
+
+      attrs                = defined?(attributes)  ? attributes  : "resources"
+      query_match          = /SELECT.*FROM\s"(?:#{from_match.join("|")})"/m
+      expected_query_count = defined?(query_count) ? query_count : 10
+
+      expect {
+        get index_url, :params => {
+          :expand     => expands.join(','),
+          :attributes => attrs
+        }
+      }.to make_database_queries(:count => expected_query_count, :matching => query_match)
+    end
+  end
+end


### PR DESCRIPTION
**Note: Requires https://github.com/ManageIQ/manageiq-api/pull/874 to be fully effective.**

Allows for opt in of `:include_for_find` option for `Rbac::Filterer` via the `expand` request parameter.

Include for find will effectively add a `.include` to the base query done in `collection_search`, which in cases like this:

```
/api/vms?expand=resources,hardware&attributes=num_cpu,name
```

Can avoid an N+1 on the associated resource (in the above case, `hardware`).


### Example response

For the above query

```
{
    "actions": [
        {
            "href": "http://localhost:3000/api/vms",
            "method": "post",
            "name": "query"
        },
        {
            "href": "http://localhost:3000/api/vms",
            "method": "post",
            "name": "edit"
        },
        {
            "href": "http://localhost:3000/api/vms",
            "method": "post",
            "name": "add_lifecycle_event"
        },
				...
    ],
    "count": 123,
    "links": {
        "first": "http://localhost:3000/api/vms?expand=resources,hardware&attributes=num_cpu,name&offset=0",
        "last": "http://localhost:3000/api/vms?expand=resources,hardware&attributes=num_cpu,name&offset=0",
        "self": "http://localhost:3000/api/vms?expand=resources,hardware&attributes=num_cpu,name&offset=0"
    },
    "name": "vms",
    "pages": 1,
    "resources": [
        {
            "href": "http://localhost:3000/api/vms/101",
            "id": "101",
            "name": "cluster-vm-us-east-101",
            "num_cpu": 16
        },
        {
            "href": "http://localhost:3000/api/vms/103",
            "id": "102",
            "name": "cluster-vm-us-east-102",
            "num_cpu": 8
        },
        {
            "href": "http://localhost:3000/api/vms/103",
            "id": "103",
            "name": "cluster-vm-us-east-103",
            "num_cpu": 16
        },
        ...
    ],
    "subcount": 123
}

```


Performance Results
-------------------

Not, that to gain any performance benefit from this PR using the `/api/vm` endpoint, https://github.com/ManageIQ/manageiq-api/pull/874 must be included as well.

### Before

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 4241 |    1118 |      527.5 | 3147 |
| 2192 |    1116 |      460.4 | 1665 |
| 2132 |    1116 |      512.0 | 1665 |
| 2463 |    1116 |      469.7 | 1665 |
| 2592 |    1116 |      549.0 | 1665 |

### After https://github.com/ManageIQ/manageiq-api/pull/874 only (not this PR)

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2627 |     565 |      272.7 | 2594 |
|  925 |     563 |      171.4 | 1112 |
| 1078 |     563 |      217.9 | 1112 |
|  886 |     563 |      160.5 | 1112 |
| 1156 |     563 |      248.3 | 1112 |


### After https://github.com/ManageIQ/manageiq-api/pull/874 + https://github.com/ManageIQ/manageiq-api/pull/877

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 1738 |      12 |         35 | 2041 |
|  260 |      10 |        9.8 |  559 |
|  262 |      10 |        9.2 |  559 |
|  257 |      10 |        9.6 |  559 |
|  259 |      10 |       10.0 |  559 |


Links
-----
- Partially fixes https://github.com/ManageIQ/manageiq-api/issues/880