### PR TITLE
fix alert definitions specs

### DIFF
--- a/spec/requests/alert_definitions_spec.rb
+++ b/spec/requests/alert_definitions_spec.rb
@@ -53,7 +53,7 @@ describe "Alerts Definitions API" do
       "id"          => alert_definition.id.to_s,
       "description" => alert_definition.description,
       "guid"        => alert_definition.guid,
-      "expression"  => {"exp" => {"=" => {"field" => "Vm-name", "value" => "foo"}}, "context_type" => nil}
+      "expression"  => {"col_details" => nil, "context_type" => nil, "exp" => {"=" => {"field" => "Vm-name", "value" => "foo"}}, "ruby" => nil}
     )
   end
 
@@ -256,7 +256,7 @@ describe "Alerts Definitions API" do
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
-      "miq_expression" => {"exp" => exp, "context_type" => nil}
+      "miq_expression" => {"col_details" => nil, "context_type" => nil, "exp" => {"=" => {"field" => "Vm-name", "value" => "foo"}}, "ruby" => nil}
     )
   end
 


### PR DESCRIPTION
recent policy changes mean that we need to update these tests, broken in https://github.com/ManageIQ/manageiq/pull/20381

cross repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/159 

~~related to https://github.com/ManageIQ/manageiq/pull/20430 but doesn't need to be merged alongside (the repo will be red till both are merged though)~~ as Keenan pointed out, they're totally unrelated, but they broke in the same PR as what 20430 is tryin' to fix (the totally unrelated related changes)