### PR TITLE
allow specification of sort_order with abbreviation or full form

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -3,7 +3,7 @@ module Api
     module Parameters
       module ResultsController
         def sort_order
-          params['sort_order'] == 'desc' ? :descending : :ascending
+          %w[desc descending].include?(params['sort_order']) ? :descending : :ascending
         end
 
         def param_result_set?
@@ -93,8 +93,7 @@ module Api
         arel = klass.arel_attribute(attr)
         if order
           arel = arel.lower if options.map(&:downcase).include?("ignore_case")
-          arel = arel.desc if order.downcase == "desc"
-          arel = arel.asc if order.downcase == "asc"
+          arel = %w[desc descending].include?(order.downcase) ? arel.desc : arel.asc
         else
           arel = arel.asc
         end

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -245,22 +245,26 @@ describe "Querying" do
   describe "Sorting vms by attribute" do
     before { api_basic_authorize collection_action_identifier(:vms, :read, :get) }
 
-    it "supports ascending order" do
-      create_vms_by_name %w(cc aa bb)
+    %w[asc ascending].each do |sort_order|
+      it "orders with sort_order of #{sort_order}" do
+        create_vms_by_name %w[cc aa bb]
 
-      get api_vms_url, :params => { :sort_by => "name", :sort_order => "asc", :expand => "resources" }
+        get api_vms_url, :params => {:sort_by => "name", :sort_order => sort_order, :expand => "resources"}
 
-      expect_query_result(:vms, 3, 3)
-      expect_result_resources_to_match_hash([{"name" => "aa"}, {"name" => "bb"}, {"name" => "cc"}])
+        expect_query_result(:vms, 3, 3)
+        expect_result_resources_to_match_hash([{"name" => "aa"}, {"name" => "bb"}, {"name" => "cc"}])
+      end
     end
 
-    it "supports decending order" do
-      create_vms_by_name %w(cc aa bb)
+    %w[desc descending].each do |sort_order|
+      it "orders with sort_order of #{sort_order}" do
+        create_vms_by_name %w[cc aa bb]
 
-      get api_vms_url, :params => { :sort_by => "name", :sort_order => "desc", :expand => "resources" }
+        get api_vms_url, :params => {:sort_by => "name", :sort_order => sort_order, :expand => "resources"}
 
-      expect_query_result(:vms, 3, 3)
-      expect_result_resources_to_match_hash([{"name" => "cc"}, {"name" => "bb"}, {"name" => "aa"}])
+        expect_query_result(:vms, 3, 3)
+        expect_result_resources_to_match_hash([{"name" => "cc"}, {"name" => "bb"}, {"name" => "aa"}])
+      end
     end
 
     it "supports case insensitive ordering" do


### PR DESCRIPTION
allow ascending and descending in full as sort options

there's an open Jason issue about it and I need a commit for the day, sorry for going for the 🍒 

fixes https://github.com/ManageIQ/manageiq-api/issues/867
