### PR TITLE
AR VirtualAttribute queries + introspection

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -48,13 +48,14 @@ module Api
     def index
       klass = collection_class(@req.subject)
       res, subquery_count = collection_search(@req.subcollection?, @req.subject, klass)
+      res_count = (res.kind_of?(ActiveRecord::Relation) ? res.except(:select) : res).count
       opts = {
         :name                  => @req.subject,
         :is_subcollection      => @req.subcollection?,
         :expand_actions        => true,
         :expand_custom_actions => false,
         :expand_resources      => @req.expand?(:resources),
-        :counts                => Api::QueryCounts.new(klass.count, res.count, subquery_count)
+        :counts                => Api::QueryCounts.new(klass.count, res_count, subquery_count)
       }
       render_collection(@req.subject, res, opts)
     end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -575,13 +575,20 @@ module Api
       end
 
       def determine_include_for_find(klass)
-        virtual_attributes_for(klass) do |type, attr_name, attr_base|
+        attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
           next if attr_base.blank?
-          next if attr_base.include?(".") # FIXME: Allow nested relations
           next if virtual_attribute_accessor(type, attr_name)
           next if Rbac::Filterer::CLASSES_THAT_PARTICIPATE_IN_RBAC.include?(attr_base)
 
           attr_base
+        end
+
+        # Handle nested relationships and convert to a hash
+        if attrs
+          attrs.each_with_object({}) do |key, include_for_find|
+            nested = include_for_find
+            key.split(".").each { |k| nested = nested[k] ||= {} }
+          end
         end
       end
 

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -350,15 +350,19 @@ module Api
       def attr_virtual?(object, attr)
         return false if ID_ATTRS.include?(attr)
         primary = attr_split(attr).first
-        (object.class.respond_to?(:reflect_on_association) && object.class.reflect_on_association(primary)) ||
-          (object.class.respond_to?(:virtual_attribute?) && object.class.virtual_attribute?(primary)) ||
-          (object.class.respond_to?(:virtual_reflection?) && object.class.virtual_reflection?(primary))
+        klass   = object
+        klass   = object.class if object.kind_of?(ActiveRecord::Base)
+        (klass.respond_to?(:reflect_on_association) && klass.reflect_on_association(primary)) ||
+          (klass.respond_to?(:virtual_attribute?) && klass.virtual_attribute?(primary)) ||
+          (klass.respond_to?(:virtual_reflection?) && klass.virtual_reflection?(primary))
       end
 
       def attr_physical?(object, attr)
         return true if ID_ATTRS.include?(attr)
-        (object.class.respond_to?(:has_attribute?) && object.class.has_attribute?(attr)) &&
-          !(object.class.respond_to?(:virtual_attribute?) && object.class.virtual_attribute?(attr))
+        klass = object
+        klass = object.class if object.kind_of?(ActiveRecord::Base)
+        (klass.respond_to?(:has_attribute?) && klass.has_attribute?(attr)) &&
+          !(klass.respond_to?(:virtual_attribute?) && klass.virtual_attribute?(attr))
       end
 
       def attr_split(attr)


### PR DESCRIPTION
Alternative to https://github.com/ManageIQ/manageiq-api/pull/877

Uses introspection of the url params to determine which attributes can be either preloaded via `:include_for_find` or `:extra_cols`.


TODO
----

Follow PR most likely for these

- [x] Handle nested relations
- [ ] Handle `:uses` for `virtual_columns` https://github.com/ManageIQ/manageiq-api/pull/890
- [x] Ensure this works with multiple columns on the same relation (testing this in https://github.com/ManageIQ/manageiq-api/pull/890 as well)


Performance Numbers
-------------------

Before
------

```
$ bundle exec miqperf benchmark -ac 5 "/api/vms?expand=resources&attributes=name,hardware.cpu_sockets"
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2341 |     565 |      179.0 | 2594 |
|  792 |     563 |      165.0 | 1112 |
|  897 |     563 |      171.5 | 1112 |
|  746 |     563 |      153.9 | 1112 |
|  812 |     563 |      154.7 | 1112 |
```


After
-----

Address both slow scenarios in https://github.com/ManageIQ/manageiq-api/issues/872

(Note:  Both of these results were taken within the same server process, so the second set of results doesn't have a slower first request due to autoloading)

```
$ bundle exec miqperf benchmark -ac 5 "/api/vms?expand=resources,hardware&attributes=num_cpu,name"
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 1516 |      12 |         74 | 2041 |
|  359 |      10 |        7.7 |  559 |
|  197 |      10 |        7.3 |  559 |
|  259 |      10 |        7.9 |  559 |
|  198 |      10 |        7.3 |  559 |
```


```
$ bundle exec miqperf benchmark -ac 5 "/api/vms?expand=resources&attributes=name,hardware.cpu_sockets"
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  369 |      10 |         14 |  559 |
|  309 |      10 |        9.1 |  559 |
|  267 |      10 |        8.8 |  559 |
|  308 |      10 |        9.1 |  559 |
|  262 |      10 |        8.4 |  559 |
```



Links
-----

- Partially addresses https://github.com/ManageIQ/manageiq-api/issues/880 and https://github.com/ManageIQ/manageiq-api/issues/869
- Should fix https://github.com/ManageIQ/manageiq-api/issues/872 as well