### PR TITLE
[Renderer] Handle :uses for :include_for_find

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -48,13 +48,14 @@ module Api
     def index
       klass = collection_class(@req.subject)
       res, subquery_count = collection_search(@req.subcollection?, @req.subject, klass)
+      res_count = (res.kind_of?(ActiveRecord::Relation) ? res.except(:select) : res).count
       opts = {
         :name                  => @req.subject,
         :is_subcollection      => @req.subcollection?,
         :expand_actions        => true,
         :expand_custom_actions => false,
         :expand_resources      => @req.expand?(:resources),
-        :counts                => Api::QueryCounts.new(klass.count, res.count, subquery_count)
+        :counts                => Api::QueryCounts.new(klass.count, res_count, subquery_count)
       }
       render_collection(@req.subject, res, opts)
     end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -575,13 +575,20 @@ module Api
       end
 
       def determine_include_for_find(klass)
-        virtual_attributes_for(klass) do |type, attr_name, attr_base|
+        attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
           next if attr_base.blank?
-          next if attr_base.include?(".") # FIXME: Allow nested relations
           next if virtual_attribute_accessor(type, attr_name)
           next if Rbac::Filterer::CLASSES_THAT_PARTICIPATE_IN_RBAC.include?(attr_base)
 
           attr_base
+        end
+
+        # Handle nested relationships and convert to a hash
+        if attrs
+          attrs.each_with_object({}) do |key, include_for_find|
+            nested = include_for_find
+            key.split(".").each { |k| nested = nested[k] ||= {} }
+          end
         end
       end
 

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -350,15 +350,19 @@ module Api
       def attr_virtual?(object, attr)
         return false if ID_ATTRS.include?(attr)
         primary = attr_split(attr).first
-        (object.class.respond_to?(:reflect_on_association) && object.class.reflect_on_association(primary)) ||
-          (object.class.respond_to?(:virtual_attribute?) && object.class.virtual_attribute?(primary)) ||
-          (object.class.respond_to?(:virtual_reflection?) && object.class.virtual_reflection?(primary))
+        klass   = object
+        klass   = object.class if object.kind_of?(ActiveRecord::Base)
+        (klass.respond_to?(:reflect_on_association) && klass.reflect_on_association(primary)) ||
+          (klass.respond_to?(:virtual_attribute?) && klass.virtual_attribute?(primary)) ||
+          (klass.respond_to?(:virtual_reflection?) && klass.virtual_reflection?(primary))
       end
 
       def attr_physical?(object, attr)
         return true if ID_ATTRS.include?(attr)
-        (object.class.respond_to?(:has_attribute?) && object.class.has_attribute?(attr)) &&
-          !(object.class.respond_to?(:virtual_attribute?) && object.class.virtual_attribute?(attr))
+        klass = object
+        klass = object.class if object.kind_of?(ActiveRecord::Base)
+        (klass.respond_to?(:has_attribute?) && klass.has_attribute?(attr)) &&
+          !(klass.respond_to?(:virtual_attribute?) && klass.virtual_attribute?(attr))
       end
 
       def attr_split(attr)

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -111,6 +111,83 @@ describe "Vms API" do
       end
     end
 
+    context "with direct virtual column with :uses => Array ('os_image_name')" do
+      before { add_hardware_and_os_to_vms }
+
+      it "removes N+1's from the index query for subcollections/virtual_attributes" do
+        api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+        query_match = query_match_regexp("vms", "hardwares", "operating_systems")
+
+        expect {
+          get api_vms_url, :params => {
+            :expand     => "resources",
+            :attributes => "os_image_name,name"
+          }
+        }.to make_database_queries(:count => 3, :matching => query_match)
+      end
+    end
+
+    context "with direct virtual column with :uses => String/Symbol ('v_owning_cluster')" do
+      let!(:vm3) { FactoryBot.create(:vm_vmware, :ems_id => ems.id, :ems_cluster => FactoryBot.create(:ems_cluster)) }
+
+      it "removes N+1's from the index query for subcollections/virtual_attributes" do
+        api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+        query_match = query_match_regexp("vms", "ems_clusters")
+
+        expect {
+          get api_vms_url, :params => {
+            :expand     => "resources",
+            :attributes => "v_owning_cluster,name"
+          }
+        }.to make_database_queries(:count => 3, :matching => query_match)
+      end
+    end
+
+    context "with direct virtual column with :uses => Hash ('has_rdm_disk')" do
+      before do
+        vm3      = FactoryBot.create(:vm_vmware, :name => "myvmware", :ems_id => ems.id)
+        hardware = FactoryBot.create(:hardware, :vm_or_template => vm3, :host => host)
+        Disk.create(:hardware => hardware)
+        Disk.create(:hardware => hardware, :disk_type => "rdm")
+      end
+
+      it "removes N+1's from the index query for subcollections/virtual_attributes" do
+        api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+        query_match = query_match_regexp("vms", "hardwares", "disks")
+
+        expect {
+          get api_vms_url, :params => {
+            :expand     => "resources",
+            :attributes => "has_rdm_disk,name"
+          }
+          # ActiveRecord does a few extra queries when doing this relation + includes
+        }.to make_database_queries(:count => 5, :matching => query_match)
+      end
+    end
+
+    context "with multiple direct virtual columns" do
+      before do
+        add_hardware_and_os_to_vms
+
+        vm3      = FactoryBot.create(:vm_vmware, :name => "myvmware", :ems_id => ems.id)
+        hardware = FactoryBot.create(:hardware, :vm_or_template => vm3, :host => host)
+        Disk.create(:hardware => hardware)
+        Disk.create(:hardware => hardware, :disk_type => "rdm")
+      end
+
+      it "removes N+1's from the index query for subcollections/virtual_attributes" do
+        api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+        query_match = query_match_regexp("vms", "operating_systems", "computer_systems", "hardwares", "disks")
+
+        expect {
+          get api_vms_url, :params => {
+            :expand     => "resources",
+            :attributes => "os_image_name,has_rdm_disk,lans,name"
+          }
+        }.to make_database_queries(:count => 5, :matching => query_match)
+      end
+    end
+
     context "with indirect virtual attribute ('hardware.cpu_sockets')" do
       before { add_hardware_and_os_to_vms }
 


### PR DESCRIPTION
Built off of https://github.com/ManageIQ/manageiq-api/pull/887 (just the [last commit](https://github.com/NickLaMuro/manageiq-api/compare/include-for-find-uses%5E...include-for-find-uses))

Makes use of the `.virtual_includes` to determine what relationships need to be preloaded to for `virtual_columns` that make use of the `:uses` query.

Unfortunately, there are multiple permutations of how value of `:uses` can be assigned:

- As a `String`/`Symbol` representing a single `ActiveRecord` relation
- An `Array` of relations that are based off the base model.
- A `Hash` that represents a tree of relations starting from the base model

Since each of these need to be supported, there needs to be a common data structure that they all can be converted to in the case that multiple attributes are included, and `Hash` is that data structure.


TODO
----

~~That said, merging two hashes without overwriting the contents of the previous is also not easy, so currently that type is left unimplemented for the time being.~~

This was solved using `ActiveRecord::VirtualAttributes::VirtualFields.merge_includes`:

https://github.com/ManageIQ/activerecord-virtual_attributes/blob/3f9a03eef94cfc946342c5deddd88ee6447e2877/lib/active_record/virtual_attributes/virtual_fields.rb#L80-L90


Links
-----

- Base PR:  https://github.com/ManageIQ/manageiq-api/pull/887
- Consise diff:  https://github.com/NickLaMuro/manageiq-api/compare/include-for-find-uses%5E%5E...include-for-find-uses
- Partially addresses #880 and #869
- Should fix #872 as well