### PR TITLE
[WIP] Expose the safe_delete operation on cloud volumes

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -2,6 +2,14 @@ module Api
   class CloudVolumesController < BaseController
     include Subcollections::Tags
 
+    def safe_delete_resource(type, id, _data = {})
+      delete_action_handler do
+        cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))
+        task_id = cloud_volume.safe_delete_volume_queue(User.current_user)
+        action_result(true, "Safely Deleting Cloud Volume #{cloud_volume.name}", :task_id => task_id)
+      end
+    end
+
     def delete_resource(type, id, _data = {})
       delete_action_handler do
         cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))

--- a/config/api.yml
+++ b/config/api.yml
@@ -750,6 +750,8 @@
         :identifier: cloud_volume_show_list
       - :name: delete
         :identifier: cloud_volume_delete
+      - :name: delete
+        :identifier: cloud_volume_safe_delete
     :resource_actions:
       :get:
       - :name: read
@@ -757,6 +759,8 @@
       :post:
       - :name: delete
         :identifier: cloud_volume_delete
+      - :name: delete
+        :identifier: cloud_volume_safe_delete
       :delete:
       - :name: delete
         :identifier: cloud_volume_delete


### PR DESCRIPTION
The new AutoSDE provider exposes a safe delete operation that takes care of cleaning up some stuff around cloud volumes (which I don't really understand). In order to make this work, the `safe_delete_volume_queue` should be implemented on the related model analogously to `delete_volume_queue`. 

@abellotti I'm not sure how the API should handle the fact that not all cloud volumes support this kind of delete. Would be much easier if the (safe) deletion could be decided on the model level, but I was told that both the safe and unsafe delete should be available for an AutoSDE cloud volume.