### PR TITLE
[Renderer] Properly handle CLASSES_THAT_PARTICIPATE_IN_RBAC for `include_for_find`

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -574,6 +574,13 @@ module Api
         results.empty? ? nil : results
       end
 
+      def attr_base_uses_rbac?(attr_base)
+        attr_base.split(".").any? do |relation|
+          relation_class = relation.singularize.classify
+          Rbac::Filterer::CLASSES_THAT_PARTICIPATE_IN_RBAC.include?(relation_class)
+        end
+      end
+
       def determine_include_for_find(klass)
         attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
           if klass.virtual_includes(attr_name) && attr_base.blank?
@@ -581,7 +588,7 @@ module Api
           else
             next if attr_base.blank?
             next if virtual_attribute_accessor(type, attr_name)
-            next if Rbac::Filterer::CLASSES_THAT_PARTICIPATE_IN_RBAC.include?(attr_base)
+            next if attr_base_uses_rbac?(attr_base)
 
             attr_base
           end

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -108,6 +108,29 @@ describe "Vms API" do
             :attributes => "operating_system.computer_system.created_at,name"
           }
         }.to make_database_queries(:count => 3, :matching => query_match)
+
+        expected = {
+          "resources" => a_collection_including(
+            a_hash_including(
+              "name"             => vm.name,
+              "operating_system" => {
+                "computer_system" => {
+                  "created_at" => vm.operating_system.computer_system.created_at.to_formatted_s(:iso8601)
+                }
+              }
+            ),
+            a_hash_including(
+              "name"             => vm1.name,
+              "operating_system" => {
+                "computer_system" => {
+                  "created_at" => vm1.operating_system.computer_system.created_at.to_formatted_s(:iso8601)
+                }
+              }
+            )
+          )
+        }
+
+        expect(response.parsed_body).to include(expected)
       end
     end
 
@@ -124,6 +147,15 @@ describe "Vms API" do
             :attributes => "os_image_name,name"
           }
         }.to make_database_queries(:count => 3, :matching => query_match)
+
+        expected = {
+          "resources" => a_collection_including(
+            a_hash_including("name" => vm.name, "os_image_name" => vm.os_image_name),
+            a_hash_including("name" => vm1.name, "os_image_name" => vm1.os_image_name)
+          )
+        }
+
+        expect(response.parsed_body).to include(expected)
       end
     end
 
@@ -140,6 +172,15 @@ describe "Vms API" do
             :attributes => "v_owning_cluster,name"
           }
         }.to make_database_queries(:count => 3, :matching => query_match)
+
+        expected = {
+          "resources" => a_collection_including(
+            a_hash_including("name" => vm.name, "v_owning_cluster" => vm.v_owning_cluster),
+            a_hash_including("name" => vm1.name, "v_owning_cluster" => vm1.v_owning_cluster)
+          )
+        }
+
+        expect(response.parsed_body).to include(expected)
       end
     end
 
@@ -162,6 +203,15 @@ describe "Vms API" do
           }
           # ActiveRecord does a few extra queries when doing this relation + includes
         }.to make_database_queries(:count => 5, :matching => query_match)
+
+        expected = {
+          "resources" => a_collection_including(
+            a_hash_including("name" => vm.name, "has_rdm_disk" => vm.has_rdm_disk),
+            a_hash_including("name" => vm1.name, "has_rdm_disk" => vm1.has_rdm_disk)
+          )
+        }
+
+        expect(response.parsed_body).to include(expected)
       end
     end
 
@@ -185,6 +235,15 @@ describe "Vms API" do
             :attributes => "os_image_name,has_rdm_disk,lans,name"
           }
         }.to make_database_queries(:count => 5, :matching => query_match)
+
+        expected = {
+          "resources" => a_collection_including(
+            a_hash_including("name" => vm.name, "os_image_name" => vm.os_image_name, "has_rdm_disk" => vm.has_rdm_disk, "lans" => vm.lans),
+            a_hash_including("name" => vm1.name, "os_image_name" => vm1.os_image_name, "has_rdm_disk" => vm1.has_rdm_disk, "lans" => vm1.lans)
+          )
+        }
+
+        expect(response.parsed_body).to include(expected)
       end
     end
 
@@ -201,6 +260,15 @@ describe "Vms API" do
             :attributes => "hardware.cpu_sockets,name"
           }
         }.to make_database_queries(:count => 3, :matching => query_match)
+
+        expected = {
+          "resources" => a_collection_including(
+            a_hash_including("name" => vm.name, "hardware" => {"cpu_sockets" => vm.hardware.cpu_sockets}),
+            a_hash_including("name" => vm1.name, "hardware" => {"cpu_sockets" => vm1.hardware.cpu_sockets})
+          )
+        }
+
+        expect(response.parsed_body).to include(expected)
       end
     end
 
@@ -217,6 +285,15 @@ describe "Vms API" do
             :attributes => "num_cpu,name"
           }
         }.to make_database_queries(:count => 3, :matching => query_match)
+
+        expected = {
+          "resources" => a_collection_including(
+            a_hash_including("name" => vm.name, "num_cpu" => vm.num_cpu),
+            a_hash_including("name" => vm1.name, "num_cpu" => vm1.num_cpu)
+          )
+        }
+
+        expect(response.parsed_body).to include(expected)
       end
     end
   end


### PR DESCRIPTION
In the previous two PRs:

- #887
- #890

A line was added to handle `Rbac::Filterer::CLASSES_THAT_PARTICIPATE_IN_RBAC` when working with `.include_for_find`.

Unfortunately, this was added to work only with attribute names that didn't include a `"."` in it, which unsupported originally, but was subsequently supported in this commit:

https://github.com/ManageIQ/manageiq-api/commit/8f507ea452b7a413e309851be36ae72f6fdcbddf

(see the removed "FIXME" line)

As a result, the line didn't faile, but fore attributes like `"hardware.host.name"`, it would try matching on `"hardware.host"` instead of `"hardware"` and `"host"` individually.

Furthermore, `CLASSES_THAT_PARTICIPATE_IN_RBAC` also is a String list of _**class names**_ and not relations, so this also was a incorrect check from the beginning.


Links
-----

- #887
- #890