### PR TITLE
Allow PATCH/PUT editing of zones

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -4553,7 +4553,7 @@
     - :collection
     :subcollections:
     - :settings
-    :verbs: *gpd
+    :verbs: *gpppd
     :klass: Zone
     :collection_actions:
       :get:
@@ -4577,6 +4577,12 @@
         :identifier: zone_edit
       - :name: delete
         :identifier: zone_delete
+      :patch:
+      - :name: edit
+        :identifier: zone_edit
+      :put:
+      - :name: edit
+        :identifier: zone_edit
       :delete:
       - :name: delete
         :identifier: zone_delete


### PR DESCRIPTION
I was trying to find out why this wasn't working yesterday :laughing: and then I figured out it's not even implemented :see_no_evil: 

Related issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6917

@miq-bot add_label enhancement
@miq-bot assign @abellotti 
cc @gtanzillo 