### PR TITLE
Add action "revoke sessions" to users_controllers

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -4238,6 +4238,7 @@
         :identifier: rbac_user_tags_edit
       - :name: unassign_tags
         :identifier: rbac_user_tags_edit
+      - :name: revoke_sessions
     :resource_actions:
       :get:
       - :name: read
@@ -4247,6 +4248,7 @@
         :identifier: rbac_user_edit
       - :name: delete
         :identifier: rbac_user_delete
+      - :name: revoke_sessions
       - :name: set_current_group
       :delete:
       - :name: delete


### PR DESCRIPTION
Add endpoint to revoke user's session as described here in this issue: https://github.com/ManageIQ/manageiq-api/issues/884

Current Signature:
https://github.com/ManageIQ/manageiq-api/pull/900#issuecomment-707271568

## Links
Issue - https://github.com/ManageIQ/manageiq-api/issues/884 
Parent Issue - https://github.com/ManageIQ/manageiq/issues/20378
Next Issue (follow up) - https://github.com/ManageIQ/manageiq-api/issues/885

## Needs to be merged before (reason for WIP)
- [x] https://github.com/ManageIQ/manageiq/pull/20601
- [x] https://github.com/ManageIQ/manageiq/pull/20633
- [x] https://github.com/ManageIQ/manageiq/pull/20692
 
