### PR TITLE
Added api for adding new physical storage

### DIFF
--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -12,6 +12,14 @@ module Api
       end
     end
 
+    def create_resource(_type, _id = nil, data = {})
+      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+      task_id = PhysicalStorage.create_physical_storage_queue(session[:userid], ext_management_system, data)
+      action_result(true, "Creating Physical Storage #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     private
 
     def ensure_resource_exists(type, id)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2280,6 +2280,8 @@
       - :name: read
         :identifier: physical_storage_show_list
       :post:
+      - :name: create
+        :identifier: physical_storage_new
       - :name: refresh
         :identifier: physical_storage_refresh
     :resource_actions:

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -1,4 +1,26 @@
 describe "Physical Storages API" do
+  context "POST /api/physical_storages" do
+    it "creates new storage" do
+      api_basic_authorize(collection_action_identifier(:physical_storages, :create))
+      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
+      request = {
+        "action"   => "create",
+        "resource" => {
+          "ems_id"                     => provider.id,
+          "name"                       => "test_storage",
+          "physical_storage_family_id" => "1",
+          "management_ip"              => "1.1.1.1",
+          "user"                       => "user",
+          "password"                   => "password"
+        }
+      }
+
+      post(api_physical_storages_url, :params => request)
+
+      expect_multiple_action_result(1, :success => true, :message => "Creating Physical Storage test_storage for Provider: #{provider.name}", :task => true)
+    end
+  end
+
   context "GET /api/physical_storages" do
     it "returns all physical_storages" do
       physical_storage = FactoryBot.create(:physical_storage)


### PR DESCRIPTION
As part of the storage modifications (see https://github.com/ManageIQ/manageiq-ui-classic/pull/7282 for the entire modifications details.) , we added the ability of directly adding physical storage for supporting storage managers.

This PR handles the required API mechanism.