### PR TITLE
Expose the DDF schema for CloudVolume subclasses via OPTIONS

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -2,6 +2,20 @@ module Api
   class CloudVolumesController < BaseController
     include Subcollections::Tags
 
+    def create_resource(_type, _id = nil, data = {})
+      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+
+      klass = CloudVolume.class_by_ems(ext_management_system)
+
+      validate = klass.validate_create_volume(ext_management_system)
+      raise validate[:message] unless validate[:available]
+
+      task_id = klass.create_volume_queue(session[:userid], ext_management_system, data)
+      action_result(true, "Creating Cloud Volume #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     def delete_resource(type, id, _data = {})
       delete_action_handler do
         cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -9,5 +9,19 @@ module Api
         action_result(true, "Deleting Cloud Volume #{cloud_volume.name}", :task_id => task_id)
       end
     end
+
+    def options
+      return super unless params[:ems_id]
+
+      ems = ExtManagementSystem.find(params[:ems_id])
+
+      raise BadRequestError, "No CloudVolume support for - #{klass}" unless defined?(ems.class::CloudVolume)
+
+      klass = ems.class::CloudVolume
+
+      raise BadRequestError, "No DDF specified for - #{klass}" unless klass.respond_to?(:params_for_create)
+
+      render_options(:cloud_volumes, :form_schema => klass.params_for_create(ems))
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -801,6 +801,8 @@
       - :name: read
         :identifier: cloud_volume_show_list
       :post:
+      - :name: create
+        :identifier: cloud_volume_new
       - :name: query
         :identifier: cloud_volume_show_list
       - :name: delete

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -128,4 +128,38 @@ describe "Cloud Volumes API" do
     expect(response.parsed_body).to include(expected)
     expect(response).to have_http_status(:ok)
   end
+
+  it 'it can create cloud volumes through POST' do
+    zone = FactoryBot.create(:zone, :name => "api_zone")
+    provider = FactoryBot.create(:ems_autosde, :zone => zone)
+
+    api_basic_authorize collection_action_identifier(:cloud_volumes, :create, :post)
+
+    post(api_cloud_volumes_url, :params => {:ems_id => provider.id, :name => 'foo', :size => 1234})
+
+    expected = {
+      'results' => a_collection_containing_exactly(
+        a_hash_including(
+          'success' => true,
+          'message' => a_string_including('Creating Cloud Volume')
+        )
+      )
+    }
+
+    expect(response.parsed_body).to include(expected)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns a DDF schema when available via OPTIONS' do
+    zone = FactoryBot.create(:zone, :name => "api_zone")
+    provider = FactoryBot.create(:ems_autosde, :zone => zone)
+
+    allow(provider.class::CloudVolume).to receive(:params_for_create).and_return('foo')
+
+    options(api_cloud_volumes_url, :params => {:ems_id => provider.id})
+    options("#{api_cloud_volumes_url}?ems_id=#{provider.id}")
+
+    expect(response.parsed_body['data']['form_schema']).to eq('foo')
+    expect(response).to have_http_status(:ok)
+  end
 end


### PR DESCRIPTION
Similarly to the provider forms, the CloudVolume forms also have provider-specific fields that we're moving to `params_for_create` methods under the provider-specific subclasses. This change exposes these schemas through the OPTIONS endpoint. The only necessary param is the `id` of a StorageManager that will be selected from a dropdown defined in the common schema. 

The current name of the param is `ems_id` but I'm open for better ideas. Also I'm not sure if all the storage manager subclasses follow the `"#{provider.class}::CloudVolume"` convention on which this PR heavily relies.

```js
// OPTIONS /api/cloud_volumes?ems_id=XY
{
  // ...
  "form_schema": {
    fields: [
      // ...
    ]
  }  
}
```

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7334

@miq-bot add_reviewer @agrare 
@miq-bot add_label enhancement