### PR TITLE
[WIP][ZonesController] Allow authentications to be created/edited via a single zone update

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -46,9 +46,13 @@ module Api
 
       def edit_resource(type, id, data)
         klass = collection_class(type)
+        sc_data = subcollection_data(type, data)
         resource = resource_search(id, type, klass)
-        resource.update!(data.except(*ID_ATTRS))
-        resource
+        klass.transaction do
+          resource.update!(data.except(*ID_ATTRS))
+          add_subcollection_data_to_resource(resource, type, sc_data)
+          resource
+        end
       end
 
       def delete_resource(type, id = nil, _data = nil)

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -21,11 +21,13 @@ module Api
         end
         validate_type(klass, data['type']) if data['type']
         resource = klass.new(data)
-        if resource.save
-          add_subcollection_data_to_resource(resource, type, subcollection_data)
-          resource
-        else
-          raise BadRequestError, "Failed to add a new #{type} resource - #{resource.errors.full_messages.join(', ')}"
+        klass.transaction do
+          if resource.save
+            add_subcollection_data_to_resource(resource, type, subcollection_data)
+            resource
+          else
+            raise BadRequestError, "Failed to add a new #{type} resource - #{resource.errors.full_messages.join(', ')}"
+          end
         end
       end
 

--- a/app/controllers/api/subcollections/authentications.rb
+++ b/app/controllers/api/subcollections/authentications.rb
@@ -11,6 +11,22 @@ module Api
       rescue => err
         action_result(false, err.to_s)
       end
+
+      def authentications_assign_resource(parent, _type, _id, data)
+        authentication_data = data.except("href").with_indifferent_access
+        validate_authentication_type(authentication_data)
+
+        parent.update_authentication(authentication_data, {:save => true})
+      end
+
+      private
+
+      # Requires implementing valid_authentication_types in included subclass
+      def validate_authentication_type(data)
+        if data.keys != 1 && !valid_authentication_types.include?(data.keys.first)
+          raise BadRequestError, "Invalid type specified for authentication"
+        end
+      end
     end
   end
 end

--- a/app/controllers/api/zones_controller.rb
+++ b/app/controllers/api/zones_controller.rb
@@ -3,6 +3,7 @@ module Api
     include Subcollections::Authentications
 
     INVALID_ZONES_ATTRS = ID_ATTRS + %w[created_on updated_on].freeze
+    VALID_AUTH_TYPES    = %w[windows_domain].freeze
 
     # Edit an existing zone. Certain fields are meant for internal use only
     # and may not be edited. Attempting to edit one of the forbidden fields
@@ -29,6 +30,10 @@ module Api
       return nil unless data
 
       data.keys.select { |key| INVALID_ZONES_ATTRS.include?(key) }.compact.join(", ")
+    end
+
+    def valid_authentication_types
+      VALID_AUTH_TYPES
     end
   end
 end

--- a/app/controllers/api/zones_controller.rb
+++ b/app/controllers/api/zones_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ZonesController < BaseController
+    include Subcollections::Authentications
+
     INVALID_ZONES_ATTRS = ID_ATTRS + %w[created_on updated_on].freeze
 
     # Edit an existing zone. Certain fields are meant for internal use only

--- a/config/api.yml
+++ b/config/api.yml
@@ -275,6 +275,8 @@
       :post:
       - :name: create
         :identifier: embedded_automation_manager_credentials_add
+      - :name: edit
+        :identifier: embedded_automation_manager_credentials_edit
   :automate:
     :description: Automate
     :options:
@@ -4800,6 +4802,7 @@
     - :collection
     :subcollections:
     - :settings
+    - :authentications
     :verbs: *gpppd
     :klass: Zone
     :collection_actions:


### PR DESCRIPTION
This hopefully will address https://github.com/ManageIQ/manageiq-api/issues/898 but arguably should be split up into multiple PRs.

This does the following:

- Updates `Api::BaseController::Generic#add_resource` and `Api::BaseController::Generic#edit_resource` to work within a transaction
- Updates `Api::BaseController::Generic#edit_resource` to `add_subcollection_data_to_resource` (`.add_resource` already had this functionality)
- Refactored some code around `add_subcollection_data_to_resource`
  - just allowed for it to be shared between `.edit_resource` and `.add_resource`, no functional changes made
- Added `Authentications` as a subcollection for `Zone`
- Added `authentications_assign_resource` to the `Subcollections::Authentications`, allowing for authentications to be created/edit via a zone action (and within a transaction).


The last item there is what was required for https://github.com/ManageIQ/manageiq-api/issues/898

Example Request
---------------

```
# POST /api/zones/X
{
  "action": "edit",
  "resource": {
    "description": "Updated Zone Description",
    "authentications": [{
      "href": "/",
      "windows_domain": {
        "userid": "foo",
        "password": "bar"
      }
    }]
  }
}
```