### PR TITLE
Make the auth key pair creating asynchronous

### DIFF
--- a/app/controllers/api/auth_key_pairs_controller.rb
+++ b/app/controllers/api/auth_key_pairs_controller.rb
@@ -1,5 +1,19 @@
 module Api
   class AuthKeyPairsController < BaseController
+    def create_resource(_type, _id = nil, data = {})
+      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+
+      klass = ManageIQ::Providers::CloudManager::AuthKeyPair.class_by_ems(ext_management_system)
+
+      validate = klass.validate_create_key_pair(ext_management_system)
+      raise validate[:message] unless validate[:available]
+
+      task_id = klass.create_key_pair_queue(session[:userid], ext_management_system, data)
+      action_result(true, "Creating Cloud Key Pair #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     def delete_resource(type, id, _data = {})
       delete_action_handler do
         key_pair = resource_search(id, type, collection_class(type))


### PR DESCRIPTION
The keypair creation was only defined implicitly in the API, which means that the request payload was mapped to the database. However, this never actually creates a keypair in the provider which is a bug. As a solution I'm using the same method I found in the UI controller that returns with a task...

Fixes https://github.com/ManageIQ/manageiq-api/issues/918

@miq-bot add_label bug
fyi @agrare 