### PR TITLE
Added api for remove physical storage

### DIFF
--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -29,7 +29,7 @@ module Api
         begin
           physical_storage = resource_search(id, type, klass)
           unless physical_storage.supports?(:delete)
-            error_msg = "#{physical_storage.name} raised the following error: " + physical_storage.unsupported_reason(:delete)
+            error_msg = "Failed to delete #{physical_storage.name}: #{physical_storage.unsupported_reason(:delete)}"
             raise error_msg
           end
           msg = "Detaching #{physical_storage_ident(physical_storage)}"

--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -20,6 +20,26 @@ module Api
       action_result(false, err.to_s)
     end
 
+    def delete_resource(type, id, _data = nil)
+      raise BadRequestError, "Must specify an id for deleting a #{type} resource" if id.blank?
+
+      api_action(type, id) do |klass|
+        begin
+          physical_storage = resource_search(id, type, klass)
+          unless physical_storage.supports?(:delete)
+            error_msg = "#{physical_storage.type} provider type does not support deleting. #{physical_storage.name} could not be deleted."
+            raise error_msg
+          end
+          msg = "Detaching #{physical_storage_ident(physical_storage)}"
+          api_log_info(msg)
+          task_id = physical_storage.delete_physical_storage_queue(User.current_user)
+          action_result(true, msg, :task_id => task_id)
+        rescue => err
+          action_result(false, err.to_s)
+        end
+      end
+    end
+
     private
 
     def ensure_resource_exists(type, id)

--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -23,6 +23,8 @@ module Api
     def delete_resource(type, id, _data = nil)
       raise BadRequestError, "Must specify an id for deleting a #{type} resource" if id.blank?
 
+      ensure_resource_exists(type, id) if single_resource?
+
       api_action(type, id) do |klass|
         begin
           physical_storage = resource_search(id, type, klass)

--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -27,7 +27,7 @@ module Api
         begin
           physical_storage = resource_search(id, type, klass)
           unless physical_storage.supports?(:delete)
-            error_msg = "#{physical_storage.type} provider type does not support deleting. #{physical_storage.name} could not be deleted."
+            error_msg = "#{physical_storage.name} raised the following error: " + physical_storage.unsupported_reason(:delete)
             raise error_msg
           end
           msg = "Detaching #{physical_storage_ident(physical_storage)}"

--- a/config/api.yml
+++ b/config/api.yml
@@ -2317,6 +2317,8 @@
         :identifier: physical_storage_new
       - :name: refresh
         :identifier: physical_storage_refresh
+      - :name: delete
+        :identifier: physical_storage_delete
     :resource_actions:
       :get:
       - :name: read
@@ -2324,6 +2326,8 @@
       :post:
       - :name: refresh
         :identifier: physical_storage_refresh
+      - :name: delete
+        :identifier: physical_storage_delete
   :physical_switches:
     :description: Physical Switches
     :identifier: physical_switch

--- a/config/api.yml
+++ b/config/api.yml
@@ -2305,7 +2305,7 @@
     :identifier: physical_storage
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: PhysicalStorage
     :subcollections:
     :collection_actions:

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -21,7 +21,24 @@ describe "Physical Storages API" do
     end
   end
 
-  context "Delete physical storage" do
+  context "Physical Storages delete action" do
+    it "with an invalid id" do
+      api_basic_authorize(action_identifier(:physical_storages, :delete, :resource_actions, :post))
+
+      post(api_physical_storage_url(nil, 999_999), :params => gen_request(:delete))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "rejects Delete for unsupported physical storage" do
+      physical_storage = FactoryBot.create(:physical_storage, :name => 'test_storage')
+      api_basic_authorize('physical_storage_delete')
+
+      post(api_physical_storage_url(nil, physical_storage), :params => gen_request(:delete))
+
+      expect_single_action_result(:success => false, :message => /Feature not available/i, :href => api_physical_storage_url(nil, physical_storage))
+    end
+
     it "Deletion of a single Physical Storage" do
       provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
       physical_storage = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage", :name => 'test_storage', :ext_management_system => provider)

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -21,6 +21,44 @@ describe "Physical Storages API" do
     end
   end
 
+  context "Delete physical storage" do
+    it "Deletion of a single Physical Storage" do
+      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
+      physical_storage = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage", :name => 'test_storage', :ext_management_system => provider)
+      api_basic_authorize('physical_storage_delete')
+
+      post(api_physical_storage_url(nil, physical_storage), :params => gen_request(:delete))
+
+      expect_single_action_result(:success => true, :message => /Detaching Physical Storage id:#{physical_storage.id}/i, :href => api_physical_storage_url(nil, physical_storage))
+    end
+
+    it "Delete of multiple Physical Storages" do
+      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
+      physical_storage = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage", :name => 'test_storage', :ext_management_system => provider)
+      physical_storage_two = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage", :name => 'test_storage', :ext_management_system => provider)
+      api_basic_authorize('physical_storage_delete')
+
+      post(api_physical_storages_url, :params => gen_request(:delete, [{"href" => api_physical_storage_url(nil, physical_storage)}, {"href" => api_physical_storage_url(nil, physical_storage_two)}]))
+
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including(
+            "href"    => api_physical_storage_url(nil, physical_storage),
+            "message" => a_string_matching(/Detaching Physical Storage id:#{physical_storage.id}/i),
+            "success" => true
+          ),
+          a_hash_including(
+            "href"    => api_physical_storage_url(nil, physical_storage_two),
+            "message" => a_string_matching(/Detaching Physical Storage id:#{physical_storage_two.id}/i),
+            "success" => true
+          )
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   context "GET /api/physical_storages" do
     it "returns all physical_storages" do
       physical_storage = FactoryBot.create(:physical_storage)


### PR DESCRIPTION
Adding functionality for deleting supported physical storages via rest-API

<img width="626" alt="22" src="https://user-images.githubusercontent.com/53213107/96684306-1098eb00-1384-11eb-96c5-c9b7be4bd357.png">
<img width="706" alt="11" src="https://user-images.githubusercontent.com/53213107/96684312-11ca1800-1384-11eb-89ed-7218befaaf56.png">


links
-----------
the following are related PRs:
https://github.com/ManageIQ/manageiq/pull/20713
https://github.com/ManageIQ/manageiq-providers-autosde/pull/38
https://github.com/ManageIQ/manageiq-ui-classic/pull/7433