### PR TITLE
[Renderer] Fix duplicate includes with extra_cols

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -583,7 +583,7 @@ module Api
 
       def determine_include_for_find(klass)
         attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
-          if klass.virtual_includes(attr_name) && attr_base.blank?
+          if klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name) && attr_base.blank?
             attr_name
           else
             next if attr_base.blank?


### PR DESCRIPTION
When using just `klass.virtual_includes`, it only checks to see if the given `virtual_attribute`/`virtual_column` also includes associated with it.  On the surface, that seems like a sufficient check, but since a `virtual_attribute` can have a `:uses` associated with it, as well as `:arel`, that means the column could be included as both an entry to `:extra_cols`, and for `:include_for_find`.

The problem with certain columns for `:include_for_find` is that they can very easily lead to "LEFT JOIN bombs", as in the example shown in the specs.

Background:
-----------

`virtual_total :total_vms` and `virtual_aggregate :aggregate_vm_cpus` both use the `:vms` relationship on `ExtManagementSystem`, but the latter also has a secondary relationship to hardware, and is aliased as `:vm_hardwares` as a `.includes` target.  The resulting options that would be passed to Rbac would be:

```ruby
{
  :user             => #<User id: 1, name: "Administrator", ... >,
  :offset           => 0,
  :limit            => 1000,
  :extra_cols       => [:aggregate_vm_cpus, :total_vms],
  :include_for_find => {
    :vm_hardwares => {},
    :vms          => {}
  }
}
```

As a result, both of those two columns combined in this fashion previously caused the `vms` table to be `LEFT OUTER JOIN`'d twice, meaning it included all of the columns of that table (60+) twice for each row.  On a large dataset, with LEFT OUTER JOINS also causing a huge matrix of multiple number of duplicate rows meaning the SQL query for even a system with 1000+ Vms can be crippled with this one query.

This change just ensures that we are avoiding the `:include_for_find` when that will be present and gathered via a `:extra_cols` elsewhere, hopefully avoiding some of these "LEFT JOIN bombs" as a result.


Links
-----

* Fixes https://github.com/ManageIQ/manageiq-api/issues/923