### PR TITLE
[Renderer] Use next, not return

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -609,9 +609,9 @@ module Api
 
       def determine_extra_cols(klass)
         virtual_attributes_for(klass) do |type, attr_name, attr_base|
-          return if attr_base.present?
-          return if virtual_attribute_accessor(type, attr_name)
-          return unless klass.attribute_supported_by_sql?(attr_name)
+          next if attr_base.present?
+          next if virtual_attribute_accessor(type, attr_name)
+          next unless klass.attribute_supported_by_sql?(attr_name)
 
           attr_name.to_sym
         end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1588,26 +1588,42 @@ describe "Providers API" do
   end
 
   context 'GET /api/providers' do
-    # Make sure we don't add :include_for_find for columns that end up in
-    # :extra_cols, since that is wasted includes.
-    it "loads multiple direct virtual attributes with includes properly" do
-      ems_1 = FactoryBot.create(:ext_management_system)
-      ems_2 = FactoryBot.create(:ext_management_system)
-      vm_1  = FactoryBot.create(:vm_vmware, :name => "myvmware_1", :ems_id => ems_1.id)
-      vm_2  = FactoryBot.create(:vm_vmware, :name => "myvmware_2", :ems_id => ems_2.id)
-      vm_3  = FactoryBot.create(:vm_vmware, :name => "myvmware_3", :ems_id => ems_2.id)
+    context "with multiple direct virtual attributes" do
+      before do
+        api_basic_authorize action_identifier(:providers, :read, :collection_actions, :get)
 
-      query_match = /SELECT.*FROM\s"(?:ext_management_systems|vms)"(?!(?:.+LEFT OUTER JOIN))/m
+        ems_1 = FactoryBot.create(:ext_management_system)
+        ems_2 = FactoryBot.create(:ext_management_system)
+        FactoryBot.create(:vm_vmware, :name => "myvmware_1", :ems_id => ems_1.id)
+        FactoryBot.create(:vm_vmware, :name => "myvmware_2", :ems_id => ems_1.id)
+        FactoryBot.create(:vm_vmware, :name => "myvmware_3", :ems_id => ems_2.id)
+        FactoryBot.create(:vm_vmware, :name => "myvmware_4", :ems_id => ems_2.id)
+        FactoryBot.create(:vm_vmware, :name => "myvmware_5", :ems_id => ems_2.id)
+      end
 
-      api_basic_authorize action_identifier(:providers, :read, :collection_actions, :get)
+      # Make sure we don't add :include_for_find for columns that end up in
+      # :extra_cols, since that is wasted includes.
+      it "avoids doing a LEFT OUTER JOIN" do
+        query_match = /^SELECT.*FROM\s"(?:ext_management_systems|vms)".+LEFT OUTER JOIN/m
 
-      expect {
-        get api_providers_url, :params => {
-          :expand     => "resources",
-          :attributes => "name,aggregate_vm_cpus,total_vms"
-        }
+        expect {
+          get api_providers_url, :params => {
+            :expand     => "resources",
+            :attributes => "name,aggregate_vm_cpus,total_vms"
+          }
+        }.to make_database_queries(:count => 0, :matching => query_match)
+      end
 
-      }.to make_database_queries(:count => 3, :matching => query_match)
+      it "avoids an N+1" do
+        query_match = /^SELECT.*FROM\s"(?:ext_management_systems|vms)"/m
+
+        expect {
+          get api_providers_url, :params => {
+            :expand     => "resources",
+            :attributes => "name,aggregate_vm_cpus,total_vms"
+          }
+        }.to make_database_queries(:count => 3, :matching => query_match)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes Jansa Failures: https://github.com/ManageIQ/manageiq-api/pull/933#issuecomment-715313395

In the context of this block, using `return` will eject from the iteration of the block, AND also the method, so in all of usages of `return` previously, it will `nil`, which is a valid return value for the method.

With `next`, it will just skip anything after the `yield` and move on to the next item in the iterator (which isn't obvious we are in one with this code change).  This is the behavior that was intended, but because the specs around this allow skipped at the proper times with the previous implementation, it wasn't know that this was a problem.

`next` is also used in the `determine_include_for_find` method, so this should be a relatively safe and tested change.


Links
-----

* Noticed in https://github.com/ManageIQ/manageiq-api/pull/933