### PR TITLE
Expose POST/PATCH/PUT/DELETE actions on Cloud Tenants

### DIFF
--- a/app/controllers/api/cloud_tenants_controller.rb
+++ b/app/controllers/api/cloud_tenants_controller.rb
@@ -2,5 +2,41 @@ module Api
   class CloudTenantsController < BaseController
     include Subcollections::SecurityGroups
     include Subcollections::Tags
+
+    def create_resource(_type, _id, data = {})
+      ext_management_system = resource_search(data['ems_id'], :providers, collection_class(:providers))
+      data.delete('ems_id')
+
+      task_id = CloudTenant.create_cloud_tenant_queue(session[:userid], ext_management_system, data)
+      action_result(true, "Creating Cloud Tenant #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def edit_resource(type, id, data = {})
+      raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
+      cloud_tenant = resource_search(id, type, collection_class(:cloud_tenants))
+
+      task_id = cloud_tenant.update_cloud_tenant_queue(current_user.userid, data)
+      action_result(true, "Updating #{cloud_tenant_ident(cloud_tenant)}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def delete_resource(type, id, _data = {})
+      delete_action_handler do
+        cloud_tenant = resource_search(id, type, collection_class(type))
+        raise "Delete not supported for #{cloud_tenant.name}" unless cloud_tenant.respond_to?(:delete_cloud_tenant_queue)
+
+        task_id = cloud_tenant.delete_key_pair_queue(current_user.userid)
+        action_result(true, "Deleting #{cloud_tenant.name}", :task_id => task_id)
+      end
+    end
+
+    private
+
+    def cloud_tenant_ident(cloud_tenant)
+      "Cloud Tenant id:#{cloud_tenant.id} name: '#{cloud_tenant.name}'"
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -717,7 +717,7 @@
     - :collection
     - :subcollection
     - :custom_actions
-    :verbs: *gp
+    :verbs: *gpppd
     :klass: CloudTenant
     :subcollections:
     - :network_services
@@ -731,10 +731,28 @@
       :post:
       - :name: query
         :identifier: cloud_tenant_show_list
+      - :name: create
+        :identifier: cloud_tenant_new
+      - :name: delete
+        :identifier: cloud_tenant_delete
     :resource_actions:
       :get:
       - :name: read
         :identifier: cloud_tenant_show
+      :post:
+      - :name: edit
+        :identifier: cloud_tenant_edit
+      - :name: delete
+        :identifier: cloud_tenant_delete
+      :patch:
+      - :name: edit
+        :identifier: cloud_tenant_edit
+      :put:
+      - :name: edit
+        :identifier: cloud_tenant_edit
+      :delete:
+      - :name: delete
+        :identifier: cloud_tenant_delete
     :subcollection_actions:
       :get:
       - :name: read

--- a/spec/requests/cloud_tenants_spec.rb
+++ b/spec/requests/cloud_tenants_spec.rb
@@ -47,6 +47,58 @@ RSpec.describe 'CloudTenants API' do
     end
   end
 
+  describe 'POST /api/cloud_tenants' do
+    it 'creates a cloud tenant' do
+      ems = FactoryBot.create(:ems_openstack)
+      api_basic_authorize collection_action_identifier(:cloud_tenants, :create, :post)
+
+      post(api_cloud_tenants_url, :params => {:name => 'foo', :ems_id => ems.id})
+
+      expected = {
+        'results' => [a_hash_including(
+          'success' => true,
+          'message' => a_string_including('Creating Cloud Tenant'),
+          'task_id' => a_kind_of(String)
+        )]
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  [:patch, :put].each do |request|
+    describe "#{request.to_s.upcase} /api/cloud_tenants/:id" do
+      it 'updates a cloud tenant' do
+        cloud_tenant = FactoryBot.create(:cloud_tenant, :ext_management_system => FactoryBot.create(:ems_openstack))
+        api_basic_authorize action_identifier(:cloud_tenants, :edit)
+
+        send(request, api_cloud_tenant_url(nil, cloud_tenant), :params => [:name => 'foo'])
+
+        expected = {
+          'success' => true,
+          'message' => a_string_including('Updating Cloud Tenant'),
+          'task_id' => a_kind_of(String)
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+    end
+  end
+
+  describe 'DELETE /api/cloud_tenants/:id' do
+    it 'deletes a cloud tenant' do
+      cloud_tenant = FactoryBot.create(:cloud_tenant, :ext_management_system => FactoryBot.create(:ems_openstack))
+
+      api_basic_authorize action_identifier(:cloud_tenants, :delete, :resource_actions, :delete)
+
+      delete(api_cloud_tenant_url(nil, cloud_tenant))
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
   context 'security groups subcollection' do
     before do
       @cloud_tenant = FactoryBot.create(:cloud_tenant)


### PR DESCRIPTION
There was a read-only access to cloud tenants, but the UI requires the ability add/edit/delete them.

@miq-bot add_label enhancement