### PR TITLE
Expose DDF for creating snapshots when calling OPTIONS

### DIFF
--- a/app/controllers/api/subcollections/snapshots.rb
+++ b/app/controllers/api/subcollections/snapshots.rb
@@ -47,6 +47,12 @@ module Api
         action_result(false, e.to_s)
       end
 
+      def snapshots_subcollection_options(parent)
+        raise BadRequestError, "No DDF specified for snapshots in #{parent}" unless parent.respond_to?(:params_for_create_snapshot)
+
+        {:snapshot_form_schema => parent.params_for_create_snapshot}
+      end
+
       private
 
       def snapshot_ident(parent)

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -301,6 +301,17 @@ module Api
       end
     end
 
+    def options
+      return super unless @req.subcollection?
+
+      # Try to look for subcollection specific options
+      subcollection_options_method = "#{@req.subject}_subcollection_options"
+      return super unless respond_to?(subcollection_options_method)
+
+      vm = resource_search(params[:c_id], @req.collection, collection_class(@req.collection))
+      render_options(@req.collection.to_sym, send(subcollection_options_method, vm))
+    end
+
     private
 
     def miq_server_message(miq_server)

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -2153,6 +2153,19 @@ describe "Vms API" do
     end
   end
 
+  describe "/api/vms/:id/options" do
+    it 'returns the snapshot DDF schema for the given VM' do
+      api_basic_authorize
+
+      vm = FactoryBot.create(:vm_vmware)
+
+      options(api_vm_snapshots_url(nil, vm))
+
+      expect(response.parsed_body['data']['snapshot_form_schema']).to be_an_instance_of(Hash)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "/api/vms central admin" do
     let(:resource_type) { "vm" }
 


### PR DESCRIPTION
Exposing the DDF for creating a snapshot when sending an `OPTIONS` request to a `/api/vms/:id/snapshots` subcollection URL.

@miq-bot assign @lpichler 
@miq-bot add_label enhancement