### PR TITLE
Automatically generate an OpenApi specification

### DIFF
--- a/config/openapi.json
+++ b/config/openapi.json
@@ -1,15 +1,12 @@
 {
   "openapi": "3.0.0",
   "info": {
+    "version": "4.4.0-pre",
+    "title": "API",
+    "description": "REST API"
   },
-  "security": [
-
-  ],
   "paths": {
   },
-  "servers": [
-
-  ],
   "components": {
     "parameters": {
     },

--- a/config/openapi.json
+++ b/config/openapi.json
@@ -66,314 +66,6 @@
         },
         "additionalProperties": false
       },
-      "MiqAction": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "action_type": {
-            "type": "string"
-          },
-          "options": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqAlertStatusAction": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "action_type": {
-            "type": "string"
-          },
-          "user_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "comment": {
-            "type": "string"
-          },
-          "assignee_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "miq_alert_status_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqAlertSet": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "set_type": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "read_only": {
-            "type": "boolean"
-          },
-          "set_data": {
-            "type": "string"
-          },
-          "mode": {
-            "type": "string"
-          },
-          "owner_type": {
-            "type": "string"
-          },
-          "owner_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "userid": {
-            "type": "string"
-          },
-          "group_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqAlert": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "options": {
-            "type": "string"
-          },
-          "db": {
-            "type": "string"
-          },
-          "miq_expression": {
-            "type": "string"
-          },
-          "responds_to_events": {
-            "type": "string"
-          },
-          "enabled": {
-            "type": "boolean"
-          },
-          "read_only": {
-            "type": "boolean"
-          },
-          "hash_expression": {
-            "type": "string"
-          },
-          "severity": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqAlertStatus": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "miq_alert_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_type": {
-            "type": "string"
-          },
-          "evaluated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "result": {
-            "type": "boolean"
-          },
-          "url": {
-            "type": "string"
-          },
-          "severity": {
-            "type": "string"
-          },
-          "acknowledged": {
-            "type": "boolean"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "description": {
-            "type": "string"
-          },
-          "resolved": {
-            "type": "boolean"
-          },
-          "event_ems_ref": {
-            "type": "string"
-          },
-          "assignee_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ManageIQ_Providers_CloudManager_AuthKeyPair": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "authtype": {
-            "type": "string"
-          },
-          "userid": {
-            "type": "string"
-          },
-          "password": {
-            "type": "string"
-          },
-          "resource_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_type": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_valid_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_invalid_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "credentials_changed_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "type": "string"
-          },
-          "status_details": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "auth_key": {
-            "type": "string"
-          },
-          "fingerprint": {
-            "type": "string"
-          },
-          "service_account": {
-            "type": "string"
-          },
-          "public_key": {
-            "type": "string"
-          },
-          "manager_ref": {
-            "type": "string"
-          },
-          "options": {
-            "type": "string"
-          },
-          "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "become_username": {
-            "type": "string"
-          },
-          "become_password": {
-            "type": "string"
-          },
-          "auth_key_password": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "become_method": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
       "Authentication": {
         "type": "object",
         "properties": {
@@ -467,138 +159,6 @@
             "type": "string"
           },
           "become_method": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqAeDomain": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "updated_by": {
-            "type": "string"
-          },
-          "updated_by_user_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "priority": {
-            "type": "integer"
-          },
-          "enabled": {
-            "type": "boolean"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "commit_sha": {
-            "type": "string"
-          },
-          "commit_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "commit_message": {
-            "type": "string"
-          },
-          "git_repository_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ref": {
-            "type": "string"
-          },
-          "ref_type": {
-            "type": "string"
-          },
-          "last_import_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "source": {
-            "type": "string"
-          },
-          "top_level_namespace": {
-            "type": "string"
-          },
-          "ancestry": {
-            "type": "string"
-          },
-          "domain_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "relative_path": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqAeClass": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "inherits": {
-            "type": "string"
-          },
-          "visibility": {
-            "type": "string"
-          },
-          "owner": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "namespace_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "updated_by": {
-            "type": "string"
-          },
-          "updated_by_user_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "domain_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "relative_path": {
             "type": "string"
           }
         },
@@ -778,89 +338,6 @@
         },
         "additionalProperties": false
       },
-      "Disk": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "device_name": {
-            "type": "string"
-          },
-          "device_type": {
-            "type": "string"
-          },
-          "location": {
-            "type": "string"
-          },
-          "filename": {
-            "type": "string"
-          },
-          "hardware_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "mode": {
-            "type": "string"
-          },
-          "controller_type": {
-            "type": "string"
-          },
-          "size": {
-            "type": "integer"
-          },
-          "free_space": {
-            "type": "integer"
-          },
-          "size_on_disk": {
-            "type": "integer"
-          },
-          "present": {
-            "type": "boolean"
-          },
-          "start_connected": {
-            "type": "boolean"
-          },
-          "auto_detect": {
-            "type": "boolean"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "disk_type": {
-            "type": "string"
-          },
-          "storage_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "backing_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "backing_type": {
-            "type": "string"
-          },
-          "storage_profile_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "bootable": {
-            "type": "boolean"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "thin": {
-            "type": "boolean"
-          },
-          "format": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
       "ChargeableField": {
         "type": "object",
         "properties": {
@@ -914,7 +391,63 @@
         },
         "additionalProperties": false
       },
-      "CloudDatabaseFlavor": {
+      "ChargebackRateDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "metric": {
+            "type": "string"
+          },
+          "per_time": {
+            "type": "string"
+          },
+          "per_unit": {
+            "type": "string"
+          },
+          "friendly_rate": {
+            "type": "string"
+          },
+          "chargeback_rate_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "chargeback_rate_detail_measure_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "chargeback_rate_detail_currency_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "chargeable_field_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "sub_metric": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChargebackRateDetailMeasure": {
         "type": "object",
         "properties": {
           "id": {
@@ -923,32 +456,22 @@
           "name": {
             "type": "string"
           },
-          "type": {
+          "units": {
             "type": "string"
           },
-          "ems_ref": {
+          "units_display": {
             "type": "string"
           },
-          "cpus": {
+          "step": {
             "type": "integer"
           },
-          "memory": {
-            "type": "integer"
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
           },
-          "max_size": {
-            "type": "integer"
-          },
-          "max_connections": {
-            "type": "integer"
-          },
-          "performance": {
-            "type": "string"
-          },
-          "enabled": {
-            "type": "boolean"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
           }
         },
         "additionalProperties": false
@@ -999,6 +522,45 @@
             "$ref": "#/components/schemas/ID"
           },
           "cloud_database_server_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudDatabaseFlavor": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "cpus": {
+            "type": "integer"
+          },
+          "memory": {
+            "type": "integer"
+          },
+          "max_size": {
+            "type": "integer"
+          },
+          "max_connections": {
+            "type": "integer"
+          },
+          "performance": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "ems_id": {
             "$ref": "#/components/schemas/ID"
           }
         },
@@ -1209,322 +771,6 @@
         },
         "additionalProperties": false
       },
-      "ManageIQ_Providers_CloudManager_Template": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "vendor": {
-            "type": "string",
-            "description": "The vendor for the VM, e.g. azure, amazon, etc."
-          },
-          "format": {
-            "type": "string",
-            "description": "The format of the VM's disk, such as vmdk, qcow2, and tier1."
-          },
-          "version": {
-            "type": "string",
-            "description": "The version of the VM definition."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the VM/Template."
-          },
-          "description": {
-            "type": "string",
-            "description": "A description of the VM that is typically set by the provider, but may also be edited."
-          },
-          "location": {
-            "type": "string",
-            "description": "The location of the VM, or its underlying storage."
-          },
-          "config_xml": {
-            "type": "string",
-            "description": "The VM or Template configuration in XML format. Deprecated."
-          },
-          "autostart": {
-            "type": "string",
-            "description": "Indicates whether or not the VM is set to autostart."
-          },
-          "host_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "last_sync_on": {
-            "type": "string",
-            "description": "Timestamp for last SmartState analysis synchronization.",
-            "format": "date-time"
-          },
-          "created_on": {
-            "type": "string",
-            "description": "The timestamp the VM was added to the app inventory.",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "description": "The last timestamp the VM was modified within the app.",
-            "format": "date-time"
-          },
-          "storage_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "guid": {
-            "type": "string",
-            "description": "A value used to uniquely identify the VM internally."
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "last_scan_on": {
-            "type": "string",
-            "description": "Timestamp for last SmartState analysis scan.",
-            "format": "date-time"
-          },
-          "last_scan_attempt_on": {
-            "type": "string",
-            "description": "Timestamp for last attempt to perform SmartState Analysis.",
-            "format": "date-time"
-          },
-          "uid_ems": {
-            "type": "string",
-            "description": "A globally unique reference for the VM across EMS."
-          },
-          "retires_on": {
-            "type": "string",
-            "description": "Timestamp the VM is to be retired.",
-            "format": "date-time"
-          },
-          "retired": {
-            "type": "boolean",
-            "description": "Indicates whether or not the VM is retired."
-          },
-          "boot_time": {
-            "type": "string",
-            "description": "The last time the VM was started.",
-            "format": "date-time"
-          },
-          "tools_status": {
-            "type": "string",
-            "description": "Status of guest tools."
-          },
-          "standby_action": {
-            "type": "string",
-            "description": "Action taken when VM is put into standby mode."
-          },
-          "power_state": {
-            "type": "string",
-            "description": "The current power state, typically 'on' or 'off'."
-          },
-          "state_changed_on": {
-            "type": "string",
-            "description": "The timestamp of the last power state change.",
-            "format": "date-time"
-          },
-          "previous_state": {
-            "type": "string",
-            "description": "The previous power state change."
-          },
-          "connection_state": {
-            "type": "string",
-            "description": "Indicates the connection state of the VM, e.g. connected, disconnected, etc."
-          },
-          "last_perf_capture_on": {
-            "type": "string",
-            "description": "Timestamp for last performance metrics capture.",
-            "format": "date-time"
-          },
-          "registered": {
-            "type": "boolean",
-            "description": "Indicates whether the VM registered to a Provider. Deprecated."
-          },
-          "busy": {
-            "type": "boolean",
-            "description": "Indicates whether or not the VM is being scanned for SmartState analysis. Deprecated."
-          },
-          "smart": {
-            "type": "boolean",
-            "description": "Indicates whether or not smart proxy is enabled. Deprecated."
-          },
-          "memory_reserve": {
-            "type": "integer",
-            "description": "Amount of memory that is guaranteed available for the VM."
-          },
-          "memory_reserve_expand": {
-            "type": "boolean",
-            "description": "Amount the memory can grow beyond its normal limits if there are unreserved resources available."
-          },
-          "memory_limit": {
-            "type": "integer",
-            "description": "The absolute memory limit for the VM."
-          },
-          "memory_shares": {
-            "type": "integer",
-            "description": "The number of memory shares allocated. Used to determine resource allocation in case of resource contention."
-          },
-          "memory_shares_level": {
-            "type": "string",
-            "description": "Memory shares allocation level."
-          },
-          "cpu_reserve": {
-            "type": "integer",
-            "description": "Amount of CPU that is guaranteed available for the VM."
-          },
-          "cpu_reserve_expand": {
-            "type": "boolean",
-            "description": "Amount the CPU can grow beyond its normal limits if there are unreserved resources available."
-          },
-          "cpu_limit": {
-            "type": "integer",
-            "description": "The CPU utilization limit for the VM."
-          },
-          "cpu_shares": {
-            "type": "integer",
-            "description": "The number of CPU shares allocated. Used to determine resource allocation in case of resource contention."
-          },
-          "cpu_shares_level": {
-            "type": "string",
-            "description": "CPU shares allocation level."
-          },
-          "cpu_affinity": {
-            "type": "string",
-            "description": "A comma separated list of host CPUs to schedule the VM on."
-          },
-          "ems_created_on": {
-            "type": "string",
-            "description": "The timestamp the VM or Templated was created on the EMS itself.",
-            "format": "date-time"
-          },
-          "template": {
-            "type": "boolean",
-            "description": "Indicates whether this is a VM or template."
-          },
-          "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "linked_clone": {
-            "type": "boolean",
-            "description": "Indicates whether the VM is a linked clone, i.e its disk is a referencing disk pointing to snapshot of another VM."
-          },
-          "fault_tolerance": {
-            "type": "boolean",
-            "description": "Indicates whether or not the VM is fault tolerant, i.e. if one host crashes it will immediately pick up on another host in the cluster."
-          },
-          "type": {
-            "type": "string",
-            "description": "An internal class name that includes the provider type."
-          },
-          "ems_ref": {
-            "type": "string",
-            "description": "A native unique reference for the VM within the EMS."
-          },
-          "ems_cluster_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "retirement_warn": {
-            "type": "integer",
-            "description": "Warning message when VM was put into retirement."
-          },
-          "retirement_last_warn": {
-            "type": "string",
-            "description": "Date of last retirement warning.",
-            "format": "date-time"
-          },
-          "vnc_port": {
-            "type": "integer",
-            "description": "Port or port range used for VNC connections."
-          },
-          "flavor_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "availability_zone_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud": {
-            "type": "boolean",
-            "description": "Indicates whether or not the VM/Template is cloud or infra."
-          },
-          "retirement_state": {
-            "type": "string",
-            "description": "The current retirement state."
-          },
-          "cloud_network_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_subnet_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "raw_power_state": {
-            "type": "string",
-            "description": "The power state refreshed from the EMS."
-          },
-          "publicly_available": {
-            "type": "boolean",
-            "description": "Indicates whether the VM is public or private."
-          },
-          "orchestration_stack_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "retirement_requester": {
-            "type": "string",
-            "description": "Userid of the user who requested retirement."
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "deprecated": {
-            "type": "boolean",
-            "description": "Indicates whether or not a template is deprecated."
-          },
-          "storage_profile_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cpu_hot_add_enabled": {
-            "type": "boolean",
-            "description": "Indicates if CPUs can be added to the VM while it is powered on."
-          },
-          "cpu_hot_remove_enabled": {
-            "type": "boolean",
-            "description": "Indicates if a CPU can be removed from a VM while powered on."
-          },
-          "memory_hot_add_enabled": {
-            "type": "boolean",
-            "description": "Indicates whether or not memory can be hot added to the running VM."
-          },
-          "memory_hot_add_limit": {
-            "type": "integer",
-            "description": "The maximum amount of memory, in MB, that can be added to a running VM."
-          },
-          "memory_hot_add_increment": {
-            "type": "integer",
-            "description": "Memory in MB that can be added to a running VM must be in increments of this value."
-          },
-          "hostname": {
-            "type": "string"
-          },
-          "ems_ref_type": {
-            "type": "string"
-          },
-          "restart_needed": {
-            "type": "boolean"
-          },
-          "ancestry": {
-            "type": "string"
-          },
-          "placement_group_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
       "CloudTenant": {
         "type": "object",
         "properties": {
@@ -1559,6 +805,73 @@
           },
           "parent_id": {
             "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudVolume": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_volume_snapshot_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "volume_type": {
+            "type": "string"
+          },
+          "bootable": {
+            "type": "boolean"
+          },
+          "creation_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "iops": {
+            "type": "integer"
+          },
+          "encrypted": {
+            "type": "boolean"
+          },
+          "multi_attachment": {
+            "type": "boolean"
+          },
+          "storage_resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "storage_service_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "health_state": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -1640,139 +953,6 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
-          }
-        },
-        "additionalProperties": false
-      },
-      "CloudVolume": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "size": {
-            "type": "integer"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "availability_zone_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_volume_snapshot_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "volume_type": {
-            "type": "string"
-          },
-          "bootable": {
-            "type": "boolean"
-          },
-          "creation_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "iops": {
-            "type": "integer"
-          },
-          "encrypted": {
-            "type": "boolean"
-          },
-          "multi_attachment": {
-            "type": "boolean"
-          },
-          "storage_resource_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "storage_service_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "health_state": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "EmsCluster": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "ha_enabled": {
-            "type": "boolean"
-          },
-          "ha_admit_control": {
-            "type": "boolean"
-          },
-          "ha_max_failures": {
-            "type": "integer"
-          },
-          "drs_enabled": {
-            "type": "boolean"
-          },
-          "drs_automation_level": {
-            "type": "string"
-          },
-          "drs_migration_threshold": {
-            "type": "integer"
-          },
-          "last_perf_capture_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "effective_cpu": {
-            "type": "integer"
-          },
-          "effective_memory": {
-            "type": "integer"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "ems_ref_type": {
-            "type": "string"
-          },
-          "hidden": {
-            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -1911,6 +1091,83 @@
             "$ref": "#/components/schemas/ID"
           },
           "target_platform": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConfigurationScript": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "variables": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "survey_spec": {
+            "type": "string"
+          },
+          "inventory_root_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_script_source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "run_by_userid": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "string"
+          },
+          "payload_type": {
+            "type": "string"
+          },
+          "credentials": {
+            "type": "object"
+          },
+          "context": {
+            "type": "object"
+          },
+          "output": {
+            "type": "object"
+          },
+          "status": {
+            "type": "string"
+          },
+          "miq_task_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "payload_valid": {
+            "type": "boolean"
+          },
+          "payload_error": {
             "type": "string"
           }
         },
@@ -2059,83 +1316,6 @@
         },
         "additionalProperties": false
       },
-      "ConfigurationScript": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "manager_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "manager_ref": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "variables": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "survey_spec": {
-            "type": "string"
-          },
-          "inventory_root_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "parent_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "configuration_script_source_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "run_by_userid": {
-            "type": "string"
-          },
-          "payload": {
-            "type": "string"
-          },
-          "payload_type": {
-            "type": "string"
-          },
-          "credentials": {
-            "type": "object"
-          },
-          "context": {
-            "type": "object"
-          },
-          "output": {
-            "type": "object"
-          },
-          "status": {
-            "type": "string"
-          },
-          "miq_task_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "payload_valid": {
-            "type": "boolean"
-          },
-          "payload_error": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
       "ConfiguredSystem": {
         "type": "object",
         "properties": {
@@ -2225,6 +1405,135 @@
           },
           "orchestration_stack_id": {
             "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Container": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "restart_count": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "backing_ref": {
+            "type": "string"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "container_image_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "finished_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "exit_code": {
+            "type": "integer"
+          },
+          "signal": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "last_state": {
+            "type": "string"
+          },
+          "last_reason": {
+            "type": "string"
+          },
+          "last_started_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_finished_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_exit_code": {
+            "type": "integer"
+          },
+          "last_signal": {
+            "type": "integer"
+          },
+          "last_message": {
+            "type": "string"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "request_cpu_cores": {
+            "type": "number"
+          },
+          "request_memory_bytes": {
+            "type": "integer"
+          },
+          "limit_cpu_cores": {
+            "type": "number"
+          },
+          "limit_memory_bytes": {
+            "type": "integer"
+          },
+          "image": {
+            "type": "string"
+          },
+          "image_pull_policy": {
+            "type": "string"
+          },
+          "memory": {
+            "type": "string"
+          },
+          "cpu_cores": {
+            "type": "number"
+          },
+          "container_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "privileged": {
+            "type": "boolean"
+          },
+          "run_as_user": {
+            "type": "integer"
+          },
+          "run_as_non_root": {
+            "type": "boolean"
+          },
+          "capabilities_add": {
+            "type": "string"
+          },
+          "capabilities_drop": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -2644,135 +1953,6 @@
         },
         "additionalProperties": false
       },
-      "Container": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "restart_count": {
-            "type": "integer"
-          },
-          "state": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "backing_ref": {
-            "type": "string"
-          },
-          "last_perf_capture_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "type": {
-            "type": "string"
-          },
-          "container_image_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "reason": {
-            "type": "string"
-          },
-          "started_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "finished_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "exit_code": {
-            "type": "integer"
-          },
-          "signal": {
-            "type": "integer"
-          },
-          "message": {
-            "type": "string"
-          },
-          "last_state": {
-            "type": "string"
-          },
-          "last_reason": {
-            "type": "string"
-          },
-          "last_started_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_finished_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_exit_code": {
-            "type": "integer"
-          },
-          "last_signal": {
-            "type": "integer"
-          },
-          "last_message": {
-            "type": "string"
-          },
-          "deleted_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "request_cpu_cores": {
-            "type": "number"
-          },
-          "request_memory_bytes": {
-            "type": "integer"
-          },
-          "limit_cpu_cores": {
-            "type": "number"
-          },
-          "limit_memory_bytes": {
-            "type": "integer"
-          },
-          "image": {
-            "type": "string"
-          },
-          "image_pull_policy": {
-            "type": "string"
-          },
-          "memory": {
-            "type": "string"
-          },
-          "cpu_cores": {
-            "type": "number"
-          },
-          "container_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "privileged": {
-            "type": "boolean"
-          },
-          "run_as_user": {
-            "type": "integer"
-          },
-          "run_as_non_root": {
-            "type": "boolean"
-          },
-          "capabilities_add": {
-            "type": "string"
-          },
-          "capabilities_drop": {
-            "type": "string"
-          },
-          "command": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
       "Currency": {
         "type": "object",
         "properties": {
@@ -2839,6 +2019,59 @@
             "type": "string"
           },
           "serialized_value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomButton": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "applies_to_class": {
+            "type": "string"
+          },
+          "visibility_expression": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "wait_for_complete": {
+            "type": "boolean"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "applies_to_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "enablement_expression": {
+            "type": "string"
+          },
+          "disabled_text": {
             "type": "string"
           }
         },
@@ -3058,59 +2291,6 @@
         },
         "additionalProperties": false
       },
-      "CustomButton": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "applies_to_class": {
-            "type": "string"
-          },
-          "visibility_expression": {
-            "type": "string"
-          },
-          "options": {
-            "type": "string"
-          },
-          "userid": {
-            "type": "string"
-          },
-          "wait_for_complete": {
-            "type": "boolean"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "name": {
-            "type": "string"
-          },
-          "visibility": {
-            "type": "string"
-          },
-          "applies_to_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "enablement_expression": {
-            "type": "string"
-          },
-          "disabled_text": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
       "CustomizationScript": {
         "type": "object",
         "properties": {
@@ -3184,23 +2364,79 @@
         },
         "additionalProperties": false
       },
-      "Storage": {
+      "Dialog": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "name": {
+          "description": {
             "type": "string"
           },
-          "store_type": {
+          "buttons": {
             "type": "string"
           },
-          "total_space": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "label": {
+            "type": "string"
+          },
+          "system": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Disk": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "device_name": {
+            "type": "string"
+          },
+          "device_type": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "hardware_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "controller_type": {
+            "type": "string"
+          },
+          "size": {
             "type": "integer"
           },
           "free_space": {
             "type": "integer"
+          },
+          "size_on_disk": {
+            "type": "integer"
+          },
+          "present": {
+            "type": "boolean"
+          },
+          "start_connected": {
+            "type": "boolean"
+          },
+          "auto_detect": {
+            "type": "boolean"
           },
           "created_on": {
             "type": "string",
@@ -3210,134 +2446,136 @@
             "type": "string",
             "format": "date-time"
           },
-          "multiplehostaccess": {
-            "type": "integer"
-          },
-          "location": {
+          "disk_type": {
             "type": "string"
           },
-          "last_scan_on": {
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "backing_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "backing_type": {
+            "type": "string"
+          },
+          "storage_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "bootable": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "thin": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmsCluster": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
             "type": "string",
             "format": "date-time"
           },
-          "uncommitted": {
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ha_enabled": {
+            "type": "boolean"
+          },
+          "ha_admit_control": {
+            "type": "boolean"
+          },
+          "ha_max_failures": {
+            "type": "integer"
+          },
+          "drs_enabled": {
+            "type": "boolean"
+          },
+          "drs_automation_level": {
+            "type": "string"
+          },
+          "drs_migration_threshold": {
             "type": "integer"
           },
           "last_perf_capture_on": {
             "type": "string",
             "format": "date-time"
           },
-          "directory_hierarchy_supported": {
-            "type": "boolean"
+          "effective_cpu": {
+            "type": "integer"
           },
-          "thin_provisioning_supported": {
-            "type": "boolean"
-          },
-          "raw_disk_mappings_supported": {
-            "type": "boolean"
-          },
-          "master": {
-            "type": "boolean"
+          "effective_memory": {
+            "type": "integer"
           },
           "ems_ref": {
             "type": "string"
           },
-          "storage_domain_type": {
+          "type": {
             "type": "string"
           },
-          "status": {
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "hidden": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmsFolder": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
             "type": "string"
           },
           "ems_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "ems_ref_type": {
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
             "type": "string"
           },
-          "maintenance": {
-            "type": "boolean"
-          },
-          "maintenance_reason": {
+          "ems_ref": {
             "type": "string"
           },
           "type": {
             "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqEnterprise": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
           },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "settings": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqEventDefinitionSet": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "set_type": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "read_only": {
+          "hidden": {
             "type": "boolean"
           },
-          "set_data": {
+          "ems_ref_type": {
             "type": "string"
-          },
-          "mode": {
-            "type": "string"
-          },
-          "owner_type": {
-            "type": "string"
-          },
-          "owner_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "userid": {
-            "type": "string"
-          },
-          "group_id": {
-            "$ref": "#/components/schemas/ID"
           }
         },
         "additionalProperties": false
@@ -3506,16 +2744,13 @@
         },
         "additionalProperties": false
       },
-      "MiqEventDefinition": {
+      "ExtManagementSystem": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
           "name": {
-            "type": "string"
-          },
-          "description": {
             "type": "string"
           },
           "created_on": {
@@ -3529,44 +2764,113 @@
           "guid": {
             "type": "string"
           },
-          "event_type": {
+          "zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
             "type": "string"
           },
-          "definition": {
+          "api_version": {
             "type": "string"
           },
-          "default": {
+          "uid_ems": {
+            "type": "string"
+          },
+          "host_default_vnc_port_start": {
+            "type": "integer"
+          },
+          "host_default_vnc_port_end": {
+            "type": "integer"
+          },
+          "provider_region": {
+            "type": "string"
+          },
+          "last_refresh_error": {
+            "type": "string"
+          },
+          "last_refresh_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "provider_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "realm": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "project": {
+            "type": "string"
+          },
+          "parent_ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "subscription": {
+            "type": "string"
+          },
+          "last_metrics_error": {
+            "type": "string"
+          },
+          "last_metrics_update_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_metrics_success_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tenant_mapping_enabled": {
             "type": "boolean"
           },
           "enabled": {
             "type": "boolean"
+          },
+          "options": {
+            "type": "string"
+          },
+          "zone_before_pause_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_inventory_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capabilities": {
+            "type": "object"
+          },
+          "last_refresh_success_date": {
+            "type": "string",
+            "format": "date-time"
           }
         },
         "additionalProperties": false
       },
-      "MiqProductFeature": {
+      "Firmware": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "identifier": {
-            "type": "string"
-          },
           "name": {
             "type": "string"
           },
-          "description": {
+          "build": {
             "type": "string"
           },
-          "feature_type": {
+          "version": {
             "type": "string"
           },
-          "protected": {
-            "type": "boolean"
+          "release_date": {
+            "type": "string",
+            "format": "date-time"
           },
-          "parent_id": {
+          "resource_id": {
             "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
           },
           "created_at": {
             "type": "string",
@@ -3576,10 +2880,7 @@
             "type": "string",
             "format": "date-time"
           },
-          "hidden": {
-            "type": "boolean"
-          },
-          "tenant_id": {
+          "guest_device_id": {
             "$ref": "#/components/schemas/ID"
           }
         },
@@ -3646,45 +2947,6 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Firmware": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "build": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "release_date": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "resource_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_type": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "guest_device_id": {
-            "$ref": "#/components/schemas/ID"
           }
         },
         "additionalProperties": false
@@ -3806,7 +3068,7 @@
         },
         "additionalProperties": false
       },
-      "EmsFolder": {
+      "GenericObject": {
         "type": "object",
         "properties": {
           "id": {
@@ -3815,31 +3077,22 @@
           "name": {
             "type": "string"
           },
-          "ems_id": {
+          "uid": {
+            "type": "string"
+          },
+          "generic_object_definition_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "created_on": {
+          "created_at": {
             "type": "string",
             "format": "date-time"
           },
-          "updated_on": {
+          "updated_at": {
             "type": "string",
             "format": "date-time"
           },
-          "uid_ems": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "hidden": {
-            "type": "boolean"
-          },
-          "ems_ref_type": {
-            "type": "string"
+          "properties": {
+            "type": "object"
           }
         },
         "additionalProperties": false
@@ -3870,7 +3123,7 @@
         },
         "additionalProperties": false
       },
-      "GenericObject": {
+      "GuestApplication": {
         "type": "object",
         "properties": {
           "id": {
@@ -3879,56 +3132,60 @@
           "name": {
             "type": "string"
           },
-          "uid": {
+          "vendor": {
             "type": "string"
           },
-          "generic_object_definition_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "properties": {
-            "type": "object"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqGroup": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
+          "version": {
+            "type": "string"
           },
           "description": {
             "type": "string"
           },
-          "group_type": {
+          "package_name": {
             "type": "string"
           },
-          "sequence": {
+          "product_icon": {
+            "type": "string"
+          },
+          "transform": {
+            "type": "string"
+          },
+          "language": {
             "type": "integer"
           },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "settings": {
+          "typename": {
             "type": "string"
           },
-          "tenant_id": {
+          "vm_or_template_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "detailed_description": {
+          "product_key": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "arch": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "release": {
+            "type": "string"
+          },
+          "install_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "container_image_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "build_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "url": {
             "type": "string"
           }
         },
@@ -4026,112 +3283,6 @@
           },
           "speed": {
             "type": "integer"
-          }
-        },
-        "additionalProperties": false
-      },
-      "HostAggregate": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "HostInitiatorGroup": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "physical_storage_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "HostInitiator": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "physical_storage_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "type": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "host_cluster_name": {
-            "type": "string"
-          },
-          "host_initiator_group_id": {
-            "$ref": "#/components/schemas/ID"
           }
         },
         "additionalProperties": false
@@ -4252,6 +3403,652 @@
           },
           "ems_ref_type": {
             "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HostAggregate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HostInitiator": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "physical_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "host_cluster_name": {
+            "type": "string"
+          },
+          "host_initiator_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HostInitiatorGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IsoImage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pxe_image_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Lan": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "switch_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "allow_promiscuous": {
+            "type": "boolean"
+          },
+          "forged_transmits": {
+            "type": "boolean"
+          },
+          "mac_changes": {
+            "type": "boolean"
+          },
+          "computed_allow_promiscuous": {
+            "type": "boolean"
+          },
+          "computed_forged_transmits": {
+            "type": "boolean"
+          },
+          "computed_mac_changes": {
+            "type": "boolean"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LoadBalancer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "retirement_requester": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManageIQ_Providers_CloudManager_AuthKeyPair": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "authtype": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_valid_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_invalid_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "credentials_changed_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          },
+          "status_details": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "auth_key": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "service_account": {
+            "type": "string"
+          },
+          "public_key": {
+            "type": "string"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "become_username": {
+            "type": "string"
+          },
+          "become_password": {
+            "type": "string"
+          },
+          "auth_key_password": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "become_method": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManageIQ_Providers_CloudManager_Template": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vendor": {
+            "type": "string",
+            "description": "The vendor for the VM, e.g. azure, amazon, etc."
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the VM's disk, such as vmdk, qcow2, and tier1."
+          },
+          "version": {
+            "type": "string",
+            "description": "The version of the VM definition."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the VM/Template."
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the VM that is typically set by the provider, but may also be edited."
+          },
+          "location": {
+            "type": "string",
+            "description": "The location of the VM, or its underlying storage."
+          },
+          "config_xml": {
+            "type": "string",
+            "description": "The VM or Template configuration in XML format. Deprecated."
+          },
+          "autostart": {
+            "type": "string",
+            "description": "Indicates whether or not the VM is set to autostart."
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_sync_on": {
+            "type": "string",
+            "description": "Timestamp for last SmartState analysis synchronization.",
+            "format": "date-time"
+          },
+          "created_on": {
+            "type": "string",
+            "description": "The timestamp the VM was added to the app inventory.",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "description": "The last timestamp the VM was modified within the app.",
+            "format": "date-time"
+          },
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string",
+            "description": "A value used to uniquely identify the VM internally."
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_scan_on": {
+            "type": "string",
+            "description": "Timestamp for last SmartState analysis scan.",
+            "format": "date-time"
+          },
+          "last_scan_attempt_on": {
+            "type": "string",
+            "description": "Timestamp for last attempt to perform SmartState Analysis.",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string",
+            "description": "A globally unique reference for the VM across EMS."
+          },
+          "retires_on": {
+            "type": "string",
+            "description": "Timestamp the VM is to be retired.",
+            "format": "date-time"
+          },
+          "retired": {
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is retired."
+          },
+          "boot_time": {
+            "type": "string",
+            "description": "The last time the VM was started.",
+            "format": "date-time"
+          },
+          "tools_status": {
+            "type": "string",
+            "description": "Status of guest tools."
+          },
+          "standby_action": {
+            "type": "string",
+            "description": "Action taken when VM is put into standby mode."
+          },
+          "power_state": {
+            "type": "string",
+            "description": "The current power state, typically 'on' or 'off'."
+          },
+          "state_changed_on": {
+            "type": "string",
+            "description": "The timestamp of the last power state change.",
+            "format": "date-time"
+          },
+          "previous_state": {
+            "type": "string",
+            "description": "The previous power state change."
+          },
+          "connection_state": {
+            "type": "string",
+            "description": "Indicates the connection state of the VM, e.g. connected, disconnected, etc."
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "description": "Timestamp for last performance metrics capture.",
+            "format": "date-time"
+          },
+          "registered": {
+            "type": "boolean",
+            "description": "Indicates whether the VM registered to a Provider. Deprecated."
+          },
+          "busy": {
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is being scanned for SmartState analysis. Deprecated."
+          },
+          "smart": {
+            "type": "boolean",
+            "description": "Indicates whether or not smart proxy is enabled. Deprecated."
+          },
+          "memory_reserve": {
+            "type": "integer",
+            "description": "Amount of memory that is guaranteed available for the VM."
+          },
+          "memory_reserve_expand": {
+            "type": "boolean",
+            "description": "Amount the memory can grow beyond its normal limits if there are unreserved resources available."
+          },
+          "memory_limit": {
+            "type": "integer",
+            "description": "The absolute memory limit for the VM."
+          },
+          "memory_shares": {
+            "type": "integer",
+            "description": "The number of memory shares allocated. Used to determine resource allocation in case of resource contention."
+          },
+          "memory_shares_level": {
+            "type": "string",
+            "description": "Memory shares allocation level."
+          },
+          "cpu_reserve": {
+            "type": "integer",
+            "description": "Amount of CPU that is guaranteed available for the VM."
+          },
+          "cpu_reserve_expand": {
+            "type": "boolean",
+            "description": "Amount the CPU can grow beyond its normal limits if there are unreserved resources available."
+          },
+          "cpu_limit": {
+            "type": "integer",
+            "description": "The CPU utilization limit for the VM."
+          },
+          "cpu_shares": {
+            "type": "integer",
+            "description": "The number of CPU shares allocated. Used to determine resource allocation in case of resource contention."
+          },
+          "cpu_shares_level": {
+            "type": "string",
+            "description": "CPU shares allocation level."
+          },
+          "cpu_affinity": {
+            "type": "string",
+            "description": "A comma separated list of host CPUs to schedule the VM on."
+          },
+          "ems_created_on": {
+            "type": "string",
+            "description": "The timestamp the VM or Templated was created on the EMS itself.",
+            "format": "date-time"
+          },
+          "template": {
+            "type": "boolean",
+            "description": "Indicates whether this is a VM or template."
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "linked_clone": {
+            "type": "boolean",
+            "description": "Indicates whether the VM is a linked clone, i.e its disk is a referencing disk pointing to snapshot of another VM."
+          },
+          "fault_tolerance": {
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is fault tolerant, i.e. if one host crashes it will immediately pick up on another host in the cluster."
+          },
+          "type": {
+            "type": "string",
+            "description": "An internal class name that includes the provider type."
+          },
+          "ems_ref": {
+            "type": "string",
+            "description": "A native unique reference for the VM within the EMS."
+          },
+          "ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_warn": {
+            "type": "integer",
+            "description": "Warning message when VM was put into retirement."
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "description": "Date of last retirement warning.",
+            "format": "date-time"
+          },
+          "vnc_port": {
+            "type": "integer",
+            "description": "Port or port range used for VNC connections."
+          },
+          "flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud": {
+            "type": "boolean",
+            "description": "Indicates whether or not the VM/Template is cloud or infra."
+          },
+          "retirement_state": {
+            "type": "string",
+            "description": "The current retirement state."
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_subnet_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "raw_power_state": {
+            "type": "string",
+            "description": "The power state refreshed from the EMS."
+          },
+          "publicly_available": {
+            "type": "boolean",
+            "description": "Indicates whether the VM is public or private."
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_requester": {
+            "type": "string",
+            "description": "Userid of the user who requested retirement."
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Indicates whether or not a template is deprecated."
+          },
+          "storage_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cpu_hot_add_enabled": {
+            "type": "boolean",
+            "description": "Indicates if CPUs can be added to the VM while it is powered on."
+          },
+          "cpu_hot_remove_enabled": {
+            "type": "boolean",
+            "description": "Indicates if a CPU can be removed from a VM while powered on."
+          },
+          "memory_hot_add_enabled": {
+            "type": "boolean",
+            "description": "Indicates whether or not memory can be hot added to the running VM."
+          },
+          "memory_hot_add_limit": {
+            "type": "integer",
+            "description": "The maximum amount of memory, in MB, that can be added to a running VM."
+          },
+          "memory_hot_add_increment": {
+            "type": "integer",
+            "description": "Memory in MB that can be added to a running VM must be in increments of this value."
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "restart_needed": {
+            "type": "boolean"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "placement_group_id": {
+            "$ref": "#/components/schemas/ID"
           }
         },
         "additionalProperties": false
@@ -4572,157 +4369,235 @@
         },
         "additionalProperties": false
       },
-      "IsoImage": {
+      "Metric": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "name": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capture_interval": {
+            "type": "integer"
+          },
+          "resource_type": {
             "type": "string"
           },
-          "pxe_image_type_id": {
+          "resource_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "storage_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Lan": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
+          "cpu_usage_rate_average": {
+            "type": "number"
           },
-          "switch_id": {
-            "$ref": "#/components/schemas/ID"
+          "cpu_usagemhz_rate_average": {
+            "type": "number"
           },
-          "name": {
-            "type": "string"
+          "mem_usage_absolute_average": {
+            "type": "number"
           },
-          "tag": {
-            "type": "string"
+          "disk_usage_rate_average": {
+            "type": "number"
+          },
+          "net_usage_rate_average": {
+            "type": "number"
+          },
+          "sys_uptime_absolute_latest": {
+            "type": "number"
           },
           "created_on": {
             "type": "string",
             "format": "date-time"
           },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
+          "derived_cpu_available": {
+            "type": "number"
           },
-          "uid_ems": {
-            "type": "string"
+          "derived_memory_available": {
+            "type": "number"
           },
-          "allow_promiscuous": {
-            "type": "boolean"
+          "derived_memory_used": {
+            "type": "number"
           },
-          "forged_transmits": {
-            "type": "boolean"
+          "derived_cpu_reserved": {
+            "type": "number"
           },
-          "mac_changes": {
-            "type": "boolean"
+          "derived_memory_reserved": {
+            "type": "number"
           },
-          "computed_allow_promiscuous": {
-            "type": "boolean"
-          },
-          "computed_forged_transmits": {
-            "type": "boolean"
-          },
-          "computed_mac_changes": {
-            "type": "boolean"
-          },
-          "parent_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_ref": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "LoadBalancer": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "type": {
-            "type": "string"
-          },
-          "retired": {
-            "type": "boolean"
-          },
-          "retires_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retirement_warn": {
+          "derived_vm_count_on": {
             "type": "integer"
           },
-          "retirement_last_warn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retirement_state": {
-            "type": "string"
-          },
-          "retirement_requester": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ChargebackRateDetailMeasure": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "units": {
-            "type": "string"
-          },
-          "units_display": {
-            "type": "string"
-          },
-          "step": {
+          "derived_host_count_on": {
             "type": "integer"
           },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
+          "derived_vm_count_off": {
+            "type": "integer"
           },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
+          "derived_host_count_off": {
+            "type": "integer"
+          },
+          "derived_storage_total": {
+            "type": "number"
+          },
+          "derived_storage_free": {
+            "type": "number"
+          },
+          "capture_interval_name": {
+            "type": "string"
+          },
+          "assoc_ids": {
+            "type": "string"
+          },
+          "cpu_ready_delta_summation": {
+            "type": "number"
+          },
+          "cpu_system_delta_summation": {
+            "type": "number"
+          },
+          "cpu_wait_delta_summation": {
+            "type": "number"
+          },
+          "resource_name": {
+            "type": "string"
+          },
+          "cpu_used_delta_summation": {
+            "type": "number"
+          },
+          "tag_names": {
+            "type": "string"
+          },
+          "parent_host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "derived_storage_vm_count_registered": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_used_registered": {
+            "type": "number"
+          },
+          "derived_storage_used_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_used_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_registered": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_mem_registered": {
+            "type": "number"
+          },
+          "derived_storage_mem_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_mem_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_disk_registered": {
+            "type": "number"
+          },
+          "derived_storage_disk_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_disk_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_managed": {
+            "type": "number"
+          },
+          "derived_storage_used_managed": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_managed": {
+            "type": "number"
+          },
+          "derived_storage_mem_managed": {
+            "type": "number"
+          },
+          "derived_storage_disk_managed": {
+            "type": "number"
+          },
+          "min_max": {
+            "type": "string"
+          },
+          "intervals_in_rollup": {
+            "type": "integer"
+          },
+          "mem_vmmemctl_absolute_average": {
+            "type": "number"
+          },
+          "mem_vmmemctltarget_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapin_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapout_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapped_absolute_average": {
+            "type": "number"
+          },
+          "mem_swaptarget_absolute_average": {
+            "type": "number"
+          },
+          "disk_devicelatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_kernellatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_queuelatency_absolute_average": {
+            "type": "number"
+          },
+          "derived_vm_used_disk_storage": {
+            "type": "number"
+          },
+          "derived_vm_allocated_disk_storage": {
+            "type": "number"
+          },
+          "derived_vm_numvcpus": {
+            "type": "number"
+          },
+          "time_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "derived_host_sockets": {
+            "type": "integer"
+          },
+          "derived_host_count_total": {
+            "type": "integer"
+          },
+          "derived_vm_count_total": {
+            "type": "integer"
+          },
+          "disk_totalreadlatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_totalwritelatency_absolute_average": {
+            "type": "number"
           }
         },
         "additionalProperties": false
@@ -4969,391 +4844,92 @@
         },
         "additionalProperties": false
       },
-      "Metric": {
+      "MiqAction": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "capture_interval": {
-            "type": "integer"
-          },
-          "resource_type": {
+          "name": {
             "type": "string"
           },
-          "resource_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cpu_usage_rate_average": {
-            "type": "number"
-          },
-          "cpu_usagemhz_rate_average": {
-            "type": "number"
-          },
-          "mem_usage_absolute_average": {
-            "type": "number"
-          },
-          "disk_usage_rate_average": {
-            "type": "number"
-          },
-          "net_usage_rate_average": {
-            "type": "number"
-          },
-          "sys_uptime_absolute_latest": {
-            "type": "number"
+          "description": {
+            "type": "string"
           },
           "created_on": {
             "type": "string",
             "format": "date-time"
           },
-          "derived_cpu_available": {
-            "type": "number"
-          },
-          "derived_memory_available": {
-            "type": "number"
-          },
-          "derived_memory_used": {
-            "type": "number"
-          },
-          "derived_cpu_reserved": {
-            "type": "number"
-          },
-          "derived_memory_reserved": {
-            "type": "number"
-          },
-          "derived_vm_count_on": {
-            "type": "integer"
-          },
-          "derived_host_count_on": {
-            "type": "integer"
-          },
-          "derived_vm_count_off": {
-            "type": "integer"
-          },
-          "derived_host_count_off": {
-            "type": "integer"
-          },
-          "derived_storage_total": {
-            "type": "number"
-          },
-          "derived_storage_free": {
-            "type": "number"
-          },
-          "capture_interval_name": {
-            "type": "string"
-          },
-          "assoc_ids": {
-            "type": "string"
-          },
-          "cpu_ready_delta_summation": {
-            "type": "number"
-          },
-          "cpu_system_delta_summation": {
-            "type": "number"
-          },
-          "cpu_wait_delta_summation": {
-            "type": "number"
-          },
-          "resource_name": {
-            "type": "string"
-          },
-          "cpu_used_delta_summation": {
-            "type": "number"
-          },
-          "tag_names": {
-            "type": "string"
-          },
-          "parent_host_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "parent_ems_cluster_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "parent_storage_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "parent_ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "derived_storage_vm_count_registered": {
-            "type": "number"
-          },
-          "derived_storage_vm_count_unregistered": {
-            "type": "number"
-          },
-          "derived_storage_vm_count_unmanaged": {
-            "type": "number"
-          },
-          "derived_storage_used_registered": {
-            "type": "number"
-          },
-          "derived_storage_used_unregistered": {
-            "type": "number"
-          },
-          "derived_storage_used_unmanaged": {
-            "type": "number"
-          },
-          "derived_storage_snapshot_registered": {
-            "type": "number"
-          },
-          "derived_storage_snapshot_unregistered": {
-            "type": "number"
-          },
-          "derived_storage_snapshot_unmanaged": {
-            "type": "number"
-          },
-          "derived_storage_mem_registered": {
-            "type": "number"
-          },
-          "derived_storage_mem_unregistered": {
-            "type": "number"
-          },
-          "derived_storage_mem_unmanaged": {
-            "type": "number"
-          },
-          "derived_storage_disk_registered": {
-            "type": "number"
-          },
-          "derived_storage_disk_unregistered": {
-            "type": "number"
-          },
-          "derived_storage_disk_unmanaged": {
-            "type": "number"
-          },
-          "derived_storage_vm_count_managed": {
-            "type": "number"
-          },
-          "derived_storage_used_managed": {
-            "type": "number"
-          },
-          "derived_storage_snapshot_managed": {
-            "type": "number"
-          },
-          "derived_storage_mem_managed": {
-            "type": "number"
-          },
-          "derived_storage_disk_managed": {
-            "type": "number"
-          },
-          "min_max": {
-            "type": "string"
-          },
-          "intervals_in_rollup": {
-            "type": "integer"
-          },
-          "mem_vmmemctl_absolute_average": {
-            "type": "number"
-          },
-          "mem_vmmemctltarget_absolute_average": {
-            "type": "number"
-          },
-          "mem_swapin_absolute_average": {
-            "type": "number"
-          },
-          "mem_swapout_absolute_average": {
-            "type": "number"
-          },
-          "mem_swapped_absolute_average": {
-            "type": "number"
-          },
-          "mem_swaptarget_absolute_average": {
-            "type": "number"
-          },
-          "disk_devicelatency_absolute_average": {
-            "type": "number"
-          },
-          "disk_kernellatency_absolute_average": {
-            "type": "number"
-          },
-          "disk_queuelatency_absolute_average": {
-            "type": "number"
-          },
-          "derived_vm_used_disk_storage": {
-            "type": "number"
-          },
-          "derived_vm_allocated_disk_storage": {
-            "type": "number"
-          },
-          "derived_vm_numvcpus": {
-            "type": "number"
-          },
-          "time_profile_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "derived_host_sockets": {
-            "type": "integer"
-          },
-          "derived_host_count_total": {
-            "type": "integer"
-          },
-          "derived_vm_count_total": {
-            "type": "integer"
-          },
-          "disk_totalreadlatency_absolute_average": {
-            "type": "number"
-          },
-          "disk_totalwritelatency_absolute_average": {
-            "type": "number"
-          }
-        },
-        "additionalProperties": false
-      },
-      "NetworkRouter": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_network_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "admin_state_up": {
-            "type": "boolean"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "status": {
-            "type": "string"
-          },
-          "extra_attributes": {
-            "type": "string"
-          },
-          "network_group_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "NetworkService": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
+          "updated_on": {
             "type": "string",
             "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "shared": {
-            "type": "boolean"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Network": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "hardware_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "device_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "description": {
-            "type": "string"
           },
           "guid": {
             "type": "string"
           },
-          "dhcp_enabled": {
-            "type": "boolean"
-          },
-          "ipaddress": {
+          "action_type": {
             "type": "string"
           },
-          "subnet_mask": {
-            "type": "string"
-          },
-          "lease_obtained": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "lease_expires": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "default_gateway": {
-            "type": "string"
-          },
-          "dhcp_server": {
-            "type": "string"
-          },
-          "dns_server": {
-            "type": "string"
-          },
-          "hostname": {
-            "type": "string"
-          },
-          "domain": {
-            "type": "string"
-          },
-          "ipv6address": {
+          "options": {
             "type": "string"
           }
         },
         "additionalProperties": false
       },
-      "NotificationRecipient": {
+      "MiqAeClass": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "notification_id": {
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "inherits": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "namespace_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "user_id": {
+          "updated_by": {
+            "type": "string"
+          },
+          "updated_by_user_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "seen": {
-            "type": "boolean"
+          "domain_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "relative_path": {
+            "type": "string"
           }
         },
         "additionalProperties": false
       },
-      "OrchestrationStack": {
+      "MiqAeDomain": {
         "type": "object",
         "properties": {
           "id": {
@@ -5362,344 +4938,358 @@
           "name": {
             "type": "string"
           },
-          "type": {
-            "type": "string"
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
           },
           "description": {
             "type": "string"
           },
-          "status": {
+          "display_name": {
             "type": "string"
           },
-          "ems_ref": {
+          "updated_by": {
+            "type": "string"
+          },
+          "updated_by_user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "priority": {
+            "type": "integer"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "commit_sha": {
+            "type": "string"
+          },
+          "commit_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "commit_message": {
+            "type": "string"
+          },
+          "git_repository_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "ref_type": {
+            "type": "string"
+          },
+          "last_import_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "source": {
+            "type": "string"
+          },
+          "top_level_namespace": {
             "type": "string"
           },
           "ancestry": {
             "type": "string"
           },
-          "ems_id": {
+          "domain_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "orchestration_template_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retired": {
-            "type": "boolean"
-          },
-          "retires_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retirement_warn": {
-            "type": "integer"
-          },
-          "retirement_last_warn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retirement_state": {
+          "relative_path": {
             "type": "string"
-          },
-          "retirement_requester": {
-            "type": "string"
-          },
-          "status_reason": {
-            "type": "string"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_group": {
-            "type": "string"
-          },
-          "start_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "finish_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "configuration_script_base_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "verbosity": {
-            "type": "integer"
-          },
-          "hosts": {
-            "type": "string"
-          },
-          "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "configuration_script_id": {
-            "$ref": "#/components/schemas/ID"
           }
         },
         "additionalProperties": false
       },
-      "OrchestrationTemplate": {
+      "MiqAlert": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "name": {
-            "type": "string"
-          },
-          "type": {
+          "guid": {
             "type": "string"
           },
           "description": {
             "type": "string"
           },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "options": {
+            "type": "string"
+          },
+          "db": {
+            "type": "string"
+          },
+          "miq_expression": {
+            "type": "string"
+          },
+          "responds_to_events": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "hash_expression": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAlertSet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "set_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "set_data": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "owner_type": {
+            "type": "string"
+          },
+          "owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAlertStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_alert_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "evaluated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "result": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "acknowledged": {
+            "type": "boolean"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "resolved": {
+            "type": "boolean"
+          },
+          "event_ems_ref": {
+            "type": "string"
+          },
+          "assignee_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAlertStatusAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "action_type": {
+            "type": "string"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "assignee_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_alert_status_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqDialog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "dialog_type": {
+            "type": "string"
+          },
           "content": {
             "type": "string"
           },
-          "md5": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "draft": {
+          "default": {
             "type": "boolean"
           },
-          "orderable": {
+          "filename": {
+            "type": "string"
+          },
+          "file_mtime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqEnterprise": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "settings": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqEventDefinition": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "definition": {
+            "type": "string"
+          },
+          "default": {
             "type": "boolean"
           },
-          "ems_ref": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
+          "enabled": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
       },
-      "PhysicalChassis": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "physical_rack_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "vendor": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "health_state": {
-            "type": "string"
-          },
-          "overall_health_state": {
-            "type": "string"
-          },
-          "management_module_slot_count": {
-            "type": "integer"
-          },
-          "switch_slot_count": {
-            "type": "integer"
-          },
-          "fan_slot_count": {
-            "type": "integer"
-          },
-          "blade_slot_count": {
-            "type": "integer"
-          },
-          "powersupply_slot_count": {
-            "type": "integer"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "parent_physical_chassis_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PhysicalRack": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "ems_ref": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PhysicalServerProfile": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "assigned_server_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "associated_server_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PhysicalServer": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "health_state": {
-            "type": "string"
-          },
-          "power_state": {
-            "type": "string"
-          },
-          "hostname": {
-            "type": "string"
-          },
-          "product_name": {
-            "type": "string"
-          },
-          "manufacturer": {
-            "type": "string"
-          },
-          "machine_type": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "serial_number": {
-            "type": "string"
-          },
-          "field_replaceable_unit": {
-            "type": "string"
-          },
-          "raw_power_state": {
-            "type": "string"
-          },
-          "vendor": {
-            "type": "string"
-          },
-          "physical_rack_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_compliance_name": {
-            "type": "string"
-          },
-          "ems_compliance_status": {
-            "type": "string"
-          },
-          "physical_chassis_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PhysicalStorageFamily": {
+      "MiqEventDefinitionSet": {
         "type": "object",
         "properties": {
           "id": {
@@ -5708,104 +5298,60 @@
           "name": {
             "type": "string"
           },
-          "version": {
+          "description": {
             "type": "string"
           },
-          "ems_id": {
+          "set_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "set_data": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "owner_type": {
+            "type": "string"
+          },
+          "owner_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "ems_ref": {
+          "userid": {
             "type": "string"
           },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "capabilities": {
-            "type": "object"
+          "group_id": {
+            "$ref": "#/components/schemas/ID"
           }
         },
         "additionalProperties": false
       },
-      "PhysicalStorage": {
+      "MiqGroup": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "ems_ref": {
+          "description": {
             "type": "string"
           },
-          "uid_ems": {
+          "group_type": {
             "type": "string"
           },
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "access_state": {
-            "type": "string"
-          },
-          "health_state": {
-            "type": "string"
-          },
-          "overall_health_state": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "physical_rack_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "drive_bays": {
-            "type": "integer"
-          },
-          "enclosures": {
-            "type": "integer"
-          },
-          "canister_slots": {
-            "type": "integer"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "physical_chassis_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "total_space": {
-            "type": "integer"
-          },
-          "physical_storage_family_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "capabilities": {
-            "type": "object"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PhysicalSwitch": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ports": {
+          "sequence": {
             "type": "integer"
           },
           "created_on": {
@@ -5816,64 +5362,13 @@
             "type": "string",
             "format": "date-time"
           },
-          "uid_ems": {
+          "settings": {
             "type": "string"
           },
-          "allow_promiscuous": {
-            "type": "boolean"
-          },
-          "forged_transmits": {
-            "type": "boolean"
-          },
-          "mac_changes": {
-            "type": "boolean"
-          },
-          "switch_uuid": {
-            "type": "string"
-          },
-          "shared": {
-            "type": "boolean"
-          },
-          "mtu": {
-            "type": "integer"
-          },
-          "ems_id": {
+          "tenant_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "type": {
-            "type": "string"
-          },
-          "health_state": {
-            "type": "string"
-          },
-          "power_state": {
-            "type": "string"
-          },
-          "host_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Picture": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "extension": {
-            "type": "string"
-          },
-          "md5": {
+          "detailed_description": {
             "type": "string"
           }
         },
@@ -5979,114 +5474,14 @@
         },
         "additionalProperties": false
       },
-      "ExtManagementSystem": {
+      "MiqProductFeature": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "name": {
+          "identifier": {
             "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "zone_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "api_version": {
-            "type": "string"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "host_default_vnc_port_start": {
-            "type": "integer"
-          },
-          "host_default_vnc_port_end": {
-            "type": "integer"
-          },
-          "provider_region": {
-            "type": "string"
-          },
-          "last_refresh_error": {
-            "type": "string"
-          },
-          "last_refresh_date": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "provider_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "realm": {
-            "type": "string"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "project": {
-            "type": "string"
-          },
-          "parent_ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "subscription": {
-            "type": "string"
-          },
-          "last_metrics_error": {
-            "type": "string"
-          },
-          "last_metrics_update_date": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_metrics_success_date": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "tenant_mapping_enabled": {
-            "type": "boolean"
-          },
-          "enabled": {
-            "type": "boolean"
-          },
-          "options": {
-            "type": "string"
-          },
-          "zone_before_pause_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "last_inventory_date": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "capabilities": {
-            "type": "object"
-          },
-          "last_refresh_success_date": {
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqDialog": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
           },
           "name": {
             "type": "string"
@@ -6094,21 +5489,14 @@
           "description": {
             "type": "string"
           },
-          "dialog_type": {
+          "feature_type": {
             "type": "string"
           },
-          "content": {
-            "type": "string"
-          },
-          "default": {
+          "protected": {
             "type": "boolean"
           },
-          "filename": {
-            "type": "string"
-          },
-          "file_mtime": {
-            "type": "string",
-            "format": "date-time"
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
           },
           "created_at": {
             "type": "string",
@@ -6117,6 +5505,12 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "hidden": {
+            "type": "boolean"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
           }
         },
         "additionalProperties": false
@@ -6201,233 +5595,6 @@
           },
           "parent_id": {
             "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PxeImageType": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "provision_type": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PxeImage": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "pxe_server_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "pxe_menu_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "pxe_image_type_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "kernel": {
-            "type": "string"
-          },
-          "kernel_options": {
-            "type": "string"
-          },
-          "initrd": {
-            "type": "string"
-          },
-          "default_for_windows": {
-            "type": "boolean"
-          },
-          "path": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PxeMenu": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "file_name": {
-            "type": "string"
-          },
-          "contents": {
-            "type": "string"
-          },
-          "pxe_server_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PxeServer": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "uri_prefix": {
-            "type": "string"
-          },
-          "uri": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_refresh_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "visibility": {
-            "type": "string"
-          },
-          "access_url": {
-            "type": "string"
-          },
-          "pxe_directory": {
-            "type": "string"
-          },
-          "customization_directory": {
-            "type": "string"
-          },
-          "windows_images_directory": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "TenantQuota": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "unit": {
-            "type": "string"
-          },
-          "value": {
-            "type": "number"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "warn_value": {
-            "type": "number"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ChargebackRateDetail": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "enabled": {
-            "type": "boolean"
-          },
-          "description": {
-            "type": "string"
-          },
-          "group": {
-            "type": "string"
-          },
-          "source": {
-            "type": "string"
-          },
-          "metric": {
-            "type": "string"
-          },
-          "per_time": {
-            "type": "string"
-          },
-          "per_unit": {
-            "type": "string"
-          },
-          "friendly_rate": {
-            "type": "string"
-          },
-          "chargeback_rate_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "chargeback_rate_detail_measure_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "chargeback_rate_detail_currency_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "chargeable_field_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "sub_metric": {
-            "type": "string"
           }
         },
         "additionalProperties": false
@@ -6578,75 +5745,53 @@
         },
         "additionalProperties": false
       },
-      "MiqRequestTask": {
+      "MiqReportResult": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "description": {
+          "name": {
             "type": "string"
           },
-          "state": {
-            "type": "string"
+          "miq_report_id": {
+            "$ref": "#/components/schemas/ID"
           },
-          "request_type": {
-            "type": "string"
+          "miq_task_id": {
+            "$ref": "#/components/schemas/ID"
           },
           "userid": {
             "type": "string"
           },
-          "options": {
+          "report_source": {
+            "type": "string"
+          },
+          "db": {
+            "type": "string"
+          },
+          "report": {
             "type": "string"
           },
           "created_on": {
             "type": "string",
             "format": "date-time"
           },
-          "updated_on": {
+          "scheduled_on": {
             "type": "string",
             "format": "date-time"
           },
-          "message": {
-            "type": "string"
+          "last_run_on": {
+            "type": "string",
+            "format": "date-time"
           },
-          "status": {
-            "type": "string"
+          "last_accessed_on": {
+            "type": "string",
+            "format": "date-time"
           },
-          "type": {
-            "type": "string"
+          "report_rows_per_detail_row": {
+            "type": "integer"
           },
-          "miq_request_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "source_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "source_type": {
-            "type": "string"
-          },
-          "destination_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "destination_type": {
-            "type": "string"
-          },
-          "miq_request_task_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "phase": {
-            "type": "string"
-          },
-          "phase_context": {
-            "type": "string"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cancelation_status": {
-            "type": "string"
-          },
-          "conversion_host_id": {
+          "miq_group_id": {
             "$ref": "#/components/schemas/ID"
           }
         },
@@ -6736,70 +5881,26 @@
         },
         "additionalProperties": false
       },
-      "ResourceAction": {
+      "MiqRequestTask": {
         "type": "object",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "action": {
+          "description": {
             "type": "string"
           },
-          "dialog_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_type": {
+          "state": {
             "type": "string"
           },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "ae_namespace": {
+          "request_type": {
             "type": "string"
           },
-          "ae_class": {
+          "userid": {
             "type": "string"
           },
-          "ae_instance": {
+          "options": {
             "type": "string"
-          },
-          "ae_message": {
-            "type": "string"
-          },
-          "ae_attributes": {
-            "type": "string"
-          },
-          "configuration_template_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "configuration_template_type": {
-            "type": "string"
-          },
-          "configuration_script_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ResourcePool": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
           },
           "created_on": {
             "type": "string",
@@ -6809,140 +5910,47 @@
             "type": "string",
             "format": "date-time"
           },
-          "uid_ems": {
+          "message": {
             "type": "string"
           },
-          "memory_reserve": {
-            "type": "integer"
-          },
-          "memory_reserve_expand": {
-            "type": "boolean"
-          },
-          "memory_limit": {
-            "type": "integer"
-          },
-          "memory_shares": {
-            "type": "integer"
-          },
-          "memory_shares_level": {
-            "type": "string"
-          },
-          "cpu_reserve": {
-            "type": "integer"
-          },
-          "cpu_reserve_expand": {
-            "type": "boolean"
-          },
-          "cpu_limit": {
-            "type": "integer"
-          },
-          "cpu_shares": {
-            "type": "integer"
-          },
-          "cpu_shares_level": {
-            "type": "string"
-          },
-          "is_default": {
-            "type": "boolean"
-          },
-          "vapp": {
-            "type": "boolean"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "ems_ref_type": {
+          "status": {
             "type": "string"
           },
           "type": {
             "type": "string"
           },
-          "cpu_cores_available": {
-            "type": "number"
-          },
-          "cpu_cores_reserve": {
-            "type": "number"
-          },
-          "cpu_cores_limit": {
-            "type": "number"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqReportResult": {
-        "type": "object",
-        "properties": {
-          "id": {
+          "miq_request_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "name": {
-            "type": "string"
-          },
-          "miq_report_id": {
+          "source_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "miq_task_id": {
+          "source_type": {
+            "type": "string"
+          },
+          "destination_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "userid": {
+          "destination_type": {
             "type": "string"
           },
-          "report_source": {
-            "type": "string"
-          },
-          "db": {
-            "type": "string"
-          },
-          "report": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "scheduled_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_run_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_accessed_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "report_rows_per_detail_row": {
-            "type": "integer"
-          },
-          "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqUserRole": {
-        "type": "object",
-        "properties": {
-          "id": {
+          "miq_request_task_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "name": {
+          "phase": {
             "type": "string"
           },
-          "read_only": {
-            "type": "boolean"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "settings": {
+          "phase_context": {
             "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cancelation_status": {
+            "type": "string"
+          },
+          "conversion_host_id": {
+            "$ref": "#/components/schemas/ID"
           }
         },
         "additionalProperties": false
@@ -7036,148 +6044,6 @@
           },
           "search_key": {
             "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SecurityGroup": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "cloud_network_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "orchestration_stack_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "network_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "network_router_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_subnet_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_group_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SecurityPolicy": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "sequence_number": {
-            "type": "integer"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "additionalProperties": false
-      },
-      "SecurityPolicyRule": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "security_policy_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "sequence_number": {
-            "type": "integer"
-          },
-          "status": {
-            "type": "string"
-          },
-          "action": {
-            "type": "string"
-          },
-          "direction": {
-            "type": "string"
-          },
-          "ip_protocol": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "sources_excluded": {
-            "type": "boolean"
-          },
-          "destinations_excluded": {
-            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -7302,421 +6168,6 @@
         },
         "additionalProperties": false
       },
-      "ServiceTemplateCatalog": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Dialog": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "description": {
-            "type": "string"
-          },
-          "buttons": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "label": {
-            "type": "string"
-          },
-          "system": {
-            "type": "boolean"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ServiceOffering": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "extra": {
-            "type": "object"
-          },
-          "deleted_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ServiceOrder": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "user_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "user_name": {
-            "type": "string"
-          },
-          "state": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "placed_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ServiceParametersSet": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "service_offering_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "extra": {
-            "type": "object"
-          },
-          "deleted_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ServiceTemplateProvisionRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "description": {
-            "type": "string"
-          },
-          "approval_state": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "fulfilled_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "requester_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "requester_name": {
-            "type": "string"
-          },
-          "request_type": {
-            "type": "string"
-          },
-          "request_state": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "options": {
-            "type": "string"
-          },
-          "userid": {
-            "type": "string"
-          },
-          "source_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "source_type": {
-            "type": "string"
-          },
-          "destination_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "destination_type": {
-            "type": "string"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "service_order_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "process": {
-            "type": "boolean"
-          },
-          "cancelation_status": {
-            "type": "string"
-          },
-          "initiated_by": {
-            "type": "string"
-          },
-          "parent_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ServiceTemplate": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "service_template_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "options": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "display": {
-            "type": "boolean"
-          },
-          "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "service_type": {
-            "type": "string"
-          },
-          "prov_type": {
-            "type": "string"
-          },
-          "provision_cost": {
-            "type": "number"
-          },
-          "service_template_catalog_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "long_description": {
-            "type": "string"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "generic_subtype": {
-            "type": "string"
-          },
-          "deleted_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "internal": {
-            "type": "boolean"
-          },
-          "zone_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "currency_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "price": {
-            "type": "number"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Service": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "service_template_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "options": {
-            "type": "string"
-          },
-          "visible": {
-            "type": "boolean"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "retired": {
-            "type": "boolean"
-          },
-          "retires_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retirement_warn": {
-            "type": "integer"
-          },
-          "retirement_last_warn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retirement_state": {
-            "type": "string"
-          },
-          "retirement_requester": {
-            "type": "string"
-          },
-          "tenant_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ancestry": {
-            "type": "string"
-          },
-          "initiator": {
-            "type": "string",
-            "description": "Entity that initiated the service creation"
-          },
-          "lifecycle_state": {
-            "type": "string"
-          },
-          "currency_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "price": {
-            "type": "number"
-          }
-        },
-        "additionalProperties": false
-      },
       "MiqShortcut": {
         "type": "object",
         "properties": {
@@ -7740,293 +6191,6 @@
           },
           "sequence": {
             "type": "integer"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Snapshot": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "uid": {
-            "type": "string"
-          },
-          "parent_uid": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "current": {
-            "type": "integer"
-          },
-          "total_size": {
-            "type": "integer"
-          },
-          "filename": {
-            "type": "string"
-          },
-          "create_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "disks": {
-            "type": "string"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "parent_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "vm_or_template_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "ems_ref_type": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "GuestApplication": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "vendor": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "package_name": {
-            "type": "string"
-          },
-          "product_icon": {
-            "type": "string"
-          },
-          "transform": {
-            "type": "string"
-          },
-          "language": {
-            "type": "integer"
-          },
-          "typename": {
-            "type": "string"
-          },
-          "vm_or_template_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "product_key": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
-          },
-          "arch": {
-            "type": "string"
-          },
-          "host_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "release": {
-            "type": "string"
-          },
-          "install_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "container_image_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "build_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      },
-      "StorageResource": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "logical_free": {
-            "type": "integer"
-          },
-          "logical_total": {
-            "type": "integer"
-          },
-          "physical_storage_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "capabilities": {
-            "type": "object"
-          }
-        },
-        "additionalProperties": false
-      },
-      "StorageService": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "version": {
-            "type": "integer"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "ems_ref": {
-            "type": "string"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "capabilities": {
-            "type": "object"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Switch": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
-          },
-          "ports": {
-            "type": "integer"
-          },
-          "created_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "uid_ems": {
-            "type": "string"
-          },
-          "allow_promiscuous": {
-            "type": "boolean"
-          },
-          "forged_transmits": {
-            "type": "boolean"
-          },
-          "mac_changes": {
-            "type": "boolean"
-          },
-          "switch_uuid": {
-            "type": "string"
-          },
-          "shared": {
-            "type": "boolean"
-          },
-          "mtu": {
-            "type": "integer"
-          },
-          "ems_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "type": {
-            "type": "string"
-          },
-          "health_state": {
-            "type": "string"
-          },
-          "power_state": {
-            "type": "string"
-          },
-          "host_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Tag": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "name": {
-            "type": "string"
           }
         },
         "additionalProperties": false
@@ -8414,6 +6578,1870 @@
         },
         "additionalProperties": false
       },
+      "MiqUserRole": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "settings": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqWidget": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "miq_schedule_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_generated_content_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "miq_task_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Network": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "hardware_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "device_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "dhcp_enabled": {
+            "type": "boolean"
+          },
+          "ipaddress": {
+            "type": "string"
+          },
+          "subnet_mask": {
+            "type": "string"
+          },
+          "lease_obtained": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lease_expires": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "default_gateway": {
+            "type": "string"
+          },
+          "dhcp_server": {
+            "type": "string"
+          },
+          "dns_server": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "ipv6address": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NetworkRouter": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "admin_state_up": {
+            "type": "boolean"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "status": {
+            "type": "string"
+          },
+          "extra_attributes": {
+            "type": "string"
+          },
+          "network_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NetworkService": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "shared": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NotificationRecipient": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "notification_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "seen": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OrchestrationStack": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "orchestration_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "retirement_requester": {
+            "type": "string"
+          },
+          "status_reason": {
+            "type": "string"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group": {
+            "type": "string"
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "finish_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "configuration_script_base_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "verbosity": {
+            "type": "integer"
+          },
+          "hosts": {
+            "type": "string"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_script_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OrchestrationTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "md5": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "orderable": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalChassis": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "physical_rack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "overall_health_state": {
+            "type": "string"
+          },
+          "management_module_slot_count": {
+            "type": "integer"
+          },
+          "switch_slot_count": {
+            "type": "integer"
+          },
+          "fan_slot_count": {
+            "type": "integer"
+          },
+          "blade_slot_count": {
+            "type": "integer"
+          },
+          "powersupply_slot_count": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "parent_physical_chassis_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalRack": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ems_ref": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalServer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "product_name": {
+            "type": "string"
+          },
+          "manufacturer": {
+            "type": "string"
+          },
+          "machine_type": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "serial_number": {
+            "type": "string"
+          },
+          "field_replaceable_unit": {
+            "type": "string"
+          },
+          "raw_power_state": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "physical_rack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_compliance_name": {
+            "type": "string"
+          },
+          "ems_compliance_status": {
+            "type": "string"
+          },
+          "physical_chassis_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalServerProfile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "assigned_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "associated_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalStorage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "access_state": {
+            "type": "string"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "overall_health_state": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_rack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "drive_bays": {
+            "type": "integer"
+          },
+          "enclosures": {
+            "type": "integer"
+          },
+          "canister_slots": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "physical_chassis_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "total_space": {
+            "type": "integer"
+          },
+          "physical_storage_family_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "capabilities": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalStorageFamily": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capabilities": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalSwitch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ports": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "allow_promiscuous": {
+            "type": "boolean"
+          },
+          "forged_transmits": {
+            "type": "boolean"
+          },
+          "mac_changes": {
+            "type": "boolean"
+          },
+          "switch_uuid": {
+            "type": "string"
+          },
+          "shared": {
+            "type": "boolean"
+          },
+          "mtu": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Picture": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "string"
+          },
+          "md5": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PxeImage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "pxe_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pxe_menu_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "pxe_image_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "kernel": {
+            "type": "string"
+          },
+          "kernel_options": {
+            "type": "string"
+          },
+          "initrd": {
+            "type": "string"
+          },
+          "default_for_windows": {
+            "type": "boolean"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PxeImageType": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provision_type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PxeMenu": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "file_name": {
+            "type": "string"
+          },
+          "contents": {
+            "type": "string"
+          },
+          "pxe_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PxeServer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uri_prefix": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_refresh_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "access_url": {
+            "type": "string"
+          },
+          "pxe_directory": {
+            "type": "string"
+          },
+          "customization_directory": {
+            "type": "string"
+          },
+          "windows_images_directory": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ResourceAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "action": {
+            "type": "string"
+          },
+          "dialog_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ae_namespace": {
+            "type": "string"
+          },
+          "ae_class": {
+            "type": "string"
+          },
+          "ae_instance": {
+            "type": "string"
+          },
+          "ae_message": {
+            "type": "string"
+          },
+          "ae_attributes": {
+            "type": "string"
+          },
+          "configuration_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_template_type": {
+            "type": "string"
+          },
+          "configuration_script_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ResourcePool": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "memory_reserve": {
+            "type": "integer"
+          },
+          "memory_reserve_expand": {
+            "type": "boolean"
+          },
+          "memory_limit": {
+            "type": "integer"
+          },
+          "memory_shares": {
+            "type": "integer"
+          },
+          "memory_shares_level": {
+            "type": "string"
+          },
+          "cpu_reserve": {
+            "type": "integer"
+          },
+          "cpu_reserve_expand": {
+            "type": "boolean"
+          },
+          "cpu_limit": {
+            "type": "integer"
+          },
+          "cpu_shares": {
+            "type": "integer"
+          },
+          "cpu_shares_level": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "vapp": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "cpu_cores_available": {
+            "type": "number"
+          },
+          "cpu_cores_reserve": {
+            "type": "number"
+          },
+          "cpu_cores_limit": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SecurityGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "network_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "network_router_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_subnet_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SecurityPolicy": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SecurityPolicyRule": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "security_policy_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "direction": {
+            "type": "string"
+          },
+          "ip_protocol": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "sources_excluded": {
+            "type": "boolean"
+          },
+          "destinations_excluded": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Service": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "service_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "options": {
+            "type": "string"
+          },
+          "visible": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "retirement_requester": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "initiator": {
+            "type": "string",
+            "description": "Entity that initiated the service creation"
+          },
+          "lifecycle_state": {
+            "type": "string"
+          },
+          "currency_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "price": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceOffering": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "extra": {
+            "type": "object"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceOrder": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "user_name": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "placed_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceParametersSet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_offering_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "extra": {
+            "type": "object"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "service_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "options": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "display": {
+            "type": "boolean"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_type": {
+            "type": "string"
+          },
+          "prov_type": {
+            "type": "string"
+          },
+          "provision_cost": {
+            "type": "number"
+          },
+          "service_template_catalog_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "long_description": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "generic_subtype": {
+            "type": "string"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "internal": {
+            "type": "boolean"
+          },
+          "zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "currency_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "price": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceTemplateCatalog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceTemplateProvisionRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "approval_state": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fulfilled_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requester_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "requester_name": {
+            "type": "string"
+          },
+          "request_type": {
+            "type": "string"
+          },
+          "request_state": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "destination_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "destination_type": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_order_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "process": {
+            "type": "boolean"
+          },
+          "cancelation_status": {
+            "type": "string"
+          },
+          "initiated_by": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Snapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid": {
+            "type": "string"
+          },
+          "parent_uid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "current": {
+            "type": "integer"
+          },
+          "total_size": {
+            "type": "integer"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "create_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "disks": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vm_or_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Storage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "store_type": {
+            "type": "string"
+          },
+          "total_space": {
+            "type": "integer"
+          },
+          "free_space": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "multiplehostaccess": {
+            "type": "integer"
+          },
+          "location": {
+            "type": "string"
+          },
+          "last_scan_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uncommitted": {
+            "type": "integer"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "directory_hierarchy_supported": {
+            "type": "boolean"
+          },
+          "thin_provisioning_supported": {
+            "type": "boolean"
+          },
+          "raw_disk_mappings_supported": {
+            "type": "boolean"
+          },
+          "master": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "storage_domain_type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "maintenance": {
+            "type": "boolean"
+          },
+          "maintenance_reason": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "StorageResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "logical_free": {
+            "type": "integer"
+          },
+          "logical_total": {
+            "type": "integer"
+          },
+          "physical_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capabilities": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "StorageService": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capabilities": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Switch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ports": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "allow_promiscuous": {
+            "type": "boolean"
+          },
+          "forged_transmits": {
+            "type": "boolean"
+          },
+          "mac_changes": {
+            "type": "boolean"
+          },
+          "switch_uuid": {
+            "type": "string"
+          },
+          "shared": {
+            "type": "boolean"
+          },
+          "mtu": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "Tenant": {
         "type": "object",
         "properties": {
@@ -8478,6 +8506,38 @@
           },
           "source_id": {
             "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TenantQuota": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "warn_value": {
+            "type": "number"
           }
         },
         "additionalProperties": false
@@ -8921,66 +8981,6 @@
             "type": "string"
           },
           "host_initiator_group_id": {
-            "$ref": "#/components/schemas/ID"
-          }
-        },
-        "additionalProperties": false
-      },
-      "MiqWidget": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "guid": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "content_type": {
-            "type": "string"
-          },
-          "options": {
-            "type": "string"
-          },
-          "visibility": {
-            "type": "string"
-          },
-          "user_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "resource_type": {
-            "type": "string"
-          },
-          "miq_schedule_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "enabled": {
-            "type": "boolean"
-          },
-          "read_only": {
-            "type": "boolean"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_generated_content_on": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "miq_task_id": {
             "$ref": "#/components/schemas/ID"
           }
         },

--- a/config/openapi.json
+++ b/config/openapi.json
@@ -1,0 +1,8770 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+  },
+  "secuirty": [
+
+  ],
+  "paths": {
+  },
+  "servers": [
+
+  ],
+  "components": {
+    "parameters": {
+    },
+    "schemas": {
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "acctid": {
+            "type": "integer"
+          },
+          "homedir": {
+            "type": "string"
+          },
+          "local": {
+            "type": "boolean"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "accttype": {
+            "type": "string"
+          },
+          "vm_or_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "expires": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "last_logon": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "action_type": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAlertStatusAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "action_type": {
+            "type": "string"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "assignee_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_alert_status_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAlertSet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "set_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "set_data": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "owner_type": {
+            "type": "string"
+          },
+          "owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAlert": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "options": {
+            "type": "string"
+          },
+          "db": {
+            "type": "string"
+          },
+          "miq_expression": {
+            "type": "string"
+          },
+          "responds_to_events": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "hash_expression": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAlertStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_alert_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "evaluated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "result": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "acknowledged": {
+            "type": "boolean"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "resolved": {
+            "type": "boolean"
+          },
+          "event_ems_ref": {
+            "type": "string"
+          },
+          "assignee_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManageIQ::Providers::CloudManager::AuthKeyPair": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "authtype": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_valid_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_invalid_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "credentials_changed_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          },
+          "status_details": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "auth_key": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "service_account": {
+            "type": "string"
+          },
+          "public_key": {
+            "type": "string"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "become_username": {
+            "type": "string"
+          },
+          "become_password": {
+            "type": "string"
+          },
+          "auth_key_password": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "become_method": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Authentication": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "authtype": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_valid_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_invalid_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "credentials_changed_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          },
+          "status_details": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "auth_key": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "service_account": {
+            "type": "string"
+          },
+          "public_key": {
+            "type": "string"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "become_username": {
+            "type": "string"
+          },
+          "become_password": {
+            "type": "string"
+          },
+          "auth_key_password": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "become_method": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAeDomain": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "updated_by": {
+            "type": "string"
+          },
+          "updated_by_user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "priority": {
+            "type": "integer"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "commit_sha": {
+            "type": "string"
+          },
+          "commit_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "commit_message": {
+            "type": "string"
+          },
+          "git_repository_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "ref_type": {
+            "type": "string"
+          },
+          "last_import_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "source": {
+            "type": "string"
+          },
+          "top_level_namespace": {
+            "type": "string"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "domain_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "relative_path": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqAeClass": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "inherits": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "updated_by": {
+            "type": "string"
+          },
+          "updated_by_user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "domain_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "relative_path": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AutomateWorkspace": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "output": {
+            "type": "object"
+          },
+          "input": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AutomationRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "approval_state": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fulfilled_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requester_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "requester_name": {
+            "type": "string"
+          },
+          "request_type": {
+            "type": "string"
+          },
+          "request_state": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "destination_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "destination_type": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_order_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "process": {
+            "type": "boolean"
+          },
+          "cancelation_status": {
+            "type": "string"
+          },
+          "initiated_by": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AvailabilityZone": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "provider_services_supported": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "syntax": {
+            "type": "string"
+          },
+          "single_value": {
+            "type": "boolean"
+          },
+          "example_text": {
+            "type": "string"
+          },
+          "tag_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "show": {
+            "type": "boolean"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "perf_by_tag": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Disk": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "device_name": {
+            "type": "string"
+          },
+          "device_type": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "hardware_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "controller_type": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "free_space": {
+            "type": "integer"
+          },
+          "size_on_disk": {
+            "type": "integer"
+          },
+          "present": {
+            "type": "boolean"
+          },
+          "start_connected": {
+            "type": "boolean"
+          },
+          "auto_detect": {
+            "type": "boolean"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "disk_type": {
+            "type": "string"
+          },
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "backing_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "backing_type": {
+            "type": "string"
+          },
+          "storage_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "bootable": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "thin": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChargeableField": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "chargeback_rate_detail_measure_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "metric": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChargebackRate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "rate_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "default": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudDatabaseFlavor": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "cpus": {
+            "type": "integer"
+          },
+          "memory": {
+            "type": "integer"
+          },
+          "max_size": {
+            "type": "integer"
+          },
+          "max_connections": {
+            "type": "integer"
+          },
+          "performance": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudDatabase": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "db_engine": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "status_reason": {
+            "type": "string"
+          },
+          "used_storage": {
+            "type": "integer"
+          },
+          "max_storage": {
+            "type": "integer"
+          },
+          "extra_attributes": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_database_flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_database_server_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudNetwork": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cidr": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "external_facing": {
+            "type": "boolean"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "shared": {
+            "type": "boolean"
+          },
+          "provider_physical_network": {
+            "type": "string"
+          },
+          "provider_network_type": {
+            "type": "string"
+          },
+          "provider_segmentation_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vlan_transparent": {
+            "type": "boolean"
+          },
+          "extra_attributes": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudObjectStoreContainer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "object_count": {
+            "type": "integer"
+          },
+          "bytes": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudObjectStoreObject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "etag": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "content_length": {
+            "type": "integer"
+          },
+          "last_modified": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_object_store_container_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudSubnet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cidr": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "dhcp_enabled": {
+            "type": "boolean"
+          },
+          "gateway": {
+            "type": "string"
+          },
+          "network_protocol": {
+            "type": "string"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "dns_nameservers": {
+            "type": "string"
+          },
+          "ipv6_router_advertisement_mode": {
+            "type": "string"
+          },
+          "ipv6_address_mode": {
+            "type": "string"
+          },
+          "extra_attributes": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "network_router_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "network_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_cloud_subnet_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManageIQ::Providers::CloudManager::Template": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "config_xml": {
+            "type": "string"
+          },
+          "autostart": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_sync_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_scan_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_scan_attempt_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "boot_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tools_status": {
+            "type": "string"
+          },
+          "standby_action": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "state_changed_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "previous_state": {
+            "type": "string"
+          },
+          "connection_state": {
+            "type": "string"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "registered": {
+            "type": "boolean"
+          },
+          "busy": {
+            "type": "boolean"
+          },
+          "smart": {
+            "type": "boolean"
+          },
+          "memory_reserve": {
+            "type": "integer"
+          },
+          "memory_reserve_expand": {
+            "type": "boolean"
+          },
+          "memory_limit": {
+            "type": "integer"
+          },
+          "memory_shares": {
+            "type": "integer"
+          },
+          "memory_shares_level": {
+            "type": "string"
+          },
+          "cpu_reserve": {
+            "type": "integer"
+          },
+          "cpu_reserve_expand": {
+            "type": "boolean"
+          },
+          "cpu_limit": {
+            "type": "integer"
+          },
+          "cpu_shares": {
+            "type": "integer"
+          },
+          "cpu_shares_level": {
+            "type": "string"
+          },
+          "cpu_affinity": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "template": {
+            "type": "boolean"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "linked_clone": {
+            "type": "boolean"
+          },
+          "fault_tolerance": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "vnc_port": {
+            "type": "integer"
+          },
+          "flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud": {
+            "type": "boolean"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_subnet_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "raw_power_state": {
+            "type": "string"
+          },
+          "publicly_available": {
+            "type": "boolean"
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_requester": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "deprecated": {
+            "type": "boolean"
+          },
+          "storage_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cpu_hot_add_enabled": {
+            "type": "boolean"
+          },
+          "cpu_hot_remove_enabled": {
+            "type": "boolean"
+          },
+          "memory_hot_add_enabled": {
+            "type": "boolean"
+          },
+          "memory_hot_add_limit": {
+            "type": "integer"
+          },
+          "memory_hot_add_increment": {
+            "type": "integer"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "restart_needed": {
+            "type": "boolean"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "placement_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudTenant": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudVolumeSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_volume_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "creation_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "encrypted": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudVolumeType": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "backend_name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "public": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CloudVolume": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_volume_snapshot_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "volume_type": {
+            "type": "string"
+          },
+          "bootable": {
+            "type": "boolean"
+          },
+          "creation_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "iops": {
+            "type": "integer"
+          },
+          "encrypted": {
+            "type": "boolean"
+          },
+          "multi_attachment": {
+            "type": "boolean"
+          },
+          "storage_resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "storage_service_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "health_state": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmsCluster": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ha_enabled": {
+            "type": "boolean"
+          },
+          "ha_admit_control": {
+            "type": "boolean"
+          },
+          "ha_max_failures": {
+            "type": "integer"
+          },
+          "drs_enabled": {
+            "type": "boolean"
+          },
+          "drs_automation_level": {
+            "type": "string"
+          },
+          "drs_migration_threshold": {
+            "type": "integer"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "effective_cpu": {
+            "type": "integer"
+          },
+          "effective_memory": {
+            "type": "integer"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "hidden": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Compliance": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "compliant": {
+            "type": "boolean"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "event_type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Condition": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "expression": {
+            "type": "string"
+          },
+          "towhat": {
+            "type": "string"
+          },
+          "file_mtime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "applies_to_exp": {
+            "type": "string"
+          },
+          "miq_policy_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConfigurationProfile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "direct_operating_system_flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "direct_customization_script_ptable_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "direct_customization_script_medium_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_ref": {
+            "type": "string"
+          },
+          "operating_system_flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "customization_script_medium_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "customization_script_ptable_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "target_platform": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConfigurationScriptPayload": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "variables": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "survey_spec": {
+            "type": "string"
+          },
+          "inventory_root_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_script_source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "run_by_userid": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "string"
+          },
+          "payload_type": {
+            "type": "string"
+          },
+          "credentials": {
+            "type": "object"
+          },
+          "context": {
+            "type": "object"
+          },
+          "output": {
+            "type": "object"
+          },
+          "status": {
+            "type": "string"
+          },
+          "miq_task_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "payload_valid": {
+            "type": "boolean"
+          },
+          "payload_error": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConfigurationScriptSource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "scm_type": {
+            "type": "string"
+          },
+          "scm_url": {
+            "type": "string"
+          },
+          "scm_branch": {
+            "type": "string"
+          },
+          "scm_clean": {
+            "type": "boolean"
+          },
+          "scm_delete_on_update": {
+            "type": "boolean"
+          },
+          "scm_update_on_launch": {
+            "type": "boolean"
+          },
+          "authentication_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "last_updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_update_error": {
+            "type": "string"
+          },
+          "git_repository_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConfigurationScript": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "variables": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "survey_spec": {
+            "type": "string"
+          },
+          "inventory_root_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_script_source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "run_by_userid": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "string"
+          },
+          "payload_type": {
+            "type": "string"
+          },
+          "credentials": {
+            "type": "object"
+          },
+          "context": {
+            "type": "object"
+          },
+          "output": {
+            "type": "object"
+          },
+          "status": {
+            "type": "string"
+          },
+          "miq_task_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "payload_valid": {
+            "type": "boolean"
+          },
+          "payload_error": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConfiguredSystem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "direct_operating_system_flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_checkin": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "build_state": {
+            "type": "string"
+          },
+          "configuration_location_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_organization_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ipaddress": {
+            "type": "string"
+          },
+          "mac_address": {
+            "type": "string"
+          },
+          "ipmi_present": {
+            "type": "boolean"
+          },
+          "puppet_status": {
+            "type": "string"
+          },
+          "direct_customization_script_ptable_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "direct_customization_script_medium_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "operating_system_flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "customization_script_medium_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "customization_script_ptable_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "inventory_root_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "virtual_instance_ref": {
+            "type": "string"
+          },
+          "counterpart_type": {
+            "type": "string"
+          },
+          "counterpart_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContainerGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resource_version": {
+            "type": "string"
+          },
+          "restart_policy": {
+            "type": "string"
+          },
+          "dns_policy": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_node_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "container_replicator_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ipaddress": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "container_project_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "container_build_pod_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContainerImage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "image_ref": {
+            "type": "string"
+          },
+          "container_image_registry_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_sync_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_scan_attempt_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "digest": {
+            "type": "string"
+          },
+          "registered_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "architecture": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "entrypoint": {
+            "type": "string"
+          },
+          "docker_version": {
+            "type": "string"
+          },
+          "exposed_ports": {
+            "type": "string"
+          },
+          "environment_variables": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContainerNode": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resource_version": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "lives_on_type": {
+            "type": "string"
+          },
+          "lives_on_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "identity_infra": {
+            "type": "string"
+          },
+          "identity_machine": {
+            "type": "string"
+          },
+          "identity_system": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "kubernetes_kubelet_version": {
+            "type": "string"
+          },
+          "kubernetes_proxy_version": {
+            "type": "string"
+          },
+          "container_runtime_version": {
+            "type": "string"
+          },
+          "max_container_groups": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContainerProject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resource_version": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContainerTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resource_version": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_project_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "objects": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "object_labels": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContainerVolume": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "empty_dir_medium_type": {
+            "type": "string"
+          },
+          "gce_pd_name": {
+            "type": "string"
+          },
+          "git_repository": {
+            "type": "string"
+          },
+          "git_revision": {
+            "type": "string"
+          },
+          "nfs_server": {
+            "type": "string"
+          },
+          "iscsi_target_portal": {
+            "type": "string"
+          },
+          "iscsi_iqn": {
+            "type": "string"
+          },
+          "iscsi_lun": {
+            "type": "integer"
+          },
+          "glusterfs_endpoint_name": {
+            "type": "string"
+          },
+          "claim_name": {
+            "type": "string"
+          },
+          "rbd_ceph_monitors": {
+            "type": "string"
+          },
+          "rbd_image": {
+            "type": "string"
+          },
+          "rbd_pool": {
+            "type": "string"
+          },
+          "rbd_rados_user": {
+            "type": "string"
+          },
+          "rbd_keyring": {
+            "type": "string"
+          },
+          "common_path": {
+            "type": "string"
+          },
+          "common_fs_type": {
+            "type": "string"
+          },
+          "common_read_only": {
+            "type": "string"
+          },
+          "common_volume_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "common_partition": {
+            "type": "string"
+          },
+          "common_secret": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resource_version": {
+            "type": "string"
+          },
+          "capacity": {
+            "type": "string"
+          },
+          "access_modes": {
+            "type": "string"
+          },
+          "reclaim_policy": {
+            "type": "string"
+          },
+          "status_phase": {
+            "type": "string"
+          },
+          "status_message": {
+            "type": "string"
+          },
+          "status_reason": {
+            "type": "string"
+          },
+          "parent_type": {
+            "type": "string"
+          },
+          "persistent_volume_claim_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Container": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "restart_count": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "backing_ref": {
+            "type": "string"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "container_image_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "finished_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "exit_code": {
+            "type": "integer"
+          },
+          "signal": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "last_state": {
+            "type": "string"
+          },
+          "last_reason": {
+            "type": "string"
+          },
+          "last_started_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_finished_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_exit_code": {
+            "type": "integer"
+          },
+          "last_signal": {
+            "type": "integer"
+          },
+          "last_message": {
+            "type": "string"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "request_cpu_cores": {
+            "type": "number"
+          },
+          "request_memory_bytes": {
+            "type": "integer"
+          },
+          "limit_cpu_cores": {
+            "type": "number"
+          },
+          "limit_memory_bytes": {
+            "type": "integer"
+          },
+          "image": {
+            "type": "string"
+          },
+          "image_pull_policy": {
+            "type": "string"
+          },
+          "memory": {
+            "type": "string"
+          },
+          "cpu_cores": {
+            "type": "number"
+          },
+          "container_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "privileged": {
+            "type": "boolean"
+          },
+          "run_as_user": {
+            "type": "integer"
+          },
+          "run_as_non_root": {
+            "type": "boolean"
+          },
+          "capabilities_add": {
+            "type": "string"
+          },
+          "capabilities_drop": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Currency": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "unicode_hex": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomAttribute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "section": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "value_interpolated": {
+            "type": "string"
+          },
+          "unique_name": {
+            "type": "string"
+          },
+          "serialized_value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomButtonEvent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "host_name": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vm_name": {
+            "type": "string"
+          },
+          "vm_location": {
+            "type": "string"
+          },
+          "vm_or_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "dest_host_name": {
+            "type": "string"
+          },
+          "dest_host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "dest_vm_name": {
+            "type": "string"
+          },
+          "dest_vm_location": {
+            "type": "string"
+          },
+          "dest_vm_or_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source": {
+            "type": "string"
+          },
+          "chain_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "is_task": {
+            "type": "boolean"
+          },
+          "full_data": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "username": {
+            "type": "string"
+          },
+          "ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_cluster_name": {
+            "type": "string"
+          },
+          "ems_cluster_uid": {
+            "type": "string"
+          },
+          "dest_ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "dest_ems_cluster_name": {
+            "type": "string"
+          },
+          "dest_ems_cluster_uid": {
+            "type": "string"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_node_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_node_name": {
+            "type": "string"
+          },
+          "container_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_group_name": {
+            "type": "string"
+          },
+          "container_namespace": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "target_type": {
+            "type": "string"
+          },
+          "target_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_name": {
+            "type": "string"
+          },
+          "container_replicator_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_replicator_name": {
+            "type": "string"
+          },
+          "generating_ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vm_ems_ref": {
+            "type": "string"
+          },
+          "dest_vm_ems_ref": {
+            "type": "string"
+          },
+          "physical_chassis_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_switch_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_storage_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomButtonSet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "set_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "set_data": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "owner_type": {
+            "type": "string"
+          },
+          "owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomButton": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "applies_to_class": {
+            "type": "string"
+          },
+          "visibility_expression": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "wait_for_complete": {
+            "type": "boolean"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "applies_to_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "enablement_expression": {
+            "type": "string"
+          },
+          "disabled_text": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomizationScript": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "manager_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "manager_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "user_defined": {
+            "type": "boolean"
+          },
+          "in_use": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomizationTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pxe_image_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "system": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Storage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "store_type": {
+            "type": "string"
+          },
+          "total_space": {
+            "type": "integer"
+          },
+          "free_space": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "multiplehostaccess": {
+            "type": "integer"
+          },
+          "location": {
+            "type": "string"
+          },
+          "last_scan_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uncommitted": {
+            "type": "integer"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "directory_hierarchy_supported": {
+            "type": "boolean"
+          },
+          "thin_provisioning_supported": {
+            "type": "boolean"
+          },
+          "raw_disk_mappings_supported": {
+            "type": "boolean"
+          },
+          "master": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "storage_domain_type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "maintenance": {
+            "type": "boolean"
+          },
+          "maintenance_reason": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqEnterprise": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "settings": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqEventDefinitionSet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "set_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "set_data": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "owner_type": {
+            "type": "string"
+          },
+          "owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EventStream": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "host_name": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vm_name": {
+            "type": "string"
+          },
+          "vm_location": {
+            "type": "string"
+          },
+          "vm_or_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "dest_host_name": {
+            "type": "string"
+          },
+          "dest_host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "dest_vm_name": {
+            "type": "string"
+          },
+          "dest_vm_location": {
+            "type": "string"
+          },
+          "dest_vm_or_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source": {
+            "type": "string"
+          },
+          "chain_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "is_task": {
+            "type": "boolean"
+          },
+          "full_data": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "username": {
+            "type": "string"
+          },
+          "ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_cluster_name": {
+            "type": "string"
+          },
+          "ems_cluster_uid": {
+            "type": "string"
+          },
+          "dest_ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "dest_ems_cluster_name": {
+            "type": "string"
+          },
+          "dest_ems_cluster_uid": {
+            "type": "string"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_node_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_node_name": {
+            "type": "string"
+          },
+          "container_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_group_name": {
+            "type": "string"
+          },
+          "container_namespace": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "target_type": {
+            "type": "string"
+          },
+          "target_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_name": {
+            "type": "string"
+          },
+          "container_replicator_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "container_replicator_name": {
+            "type": "string"
+          },
+          "generating_ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vm_ems_ref": {
+            "type": "string"
+          },
+          "dest_vm_ems_ref": {
+            "type": "string"
+          },
+          "physical_chassis_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_switch_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_storage_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqEventDefinition": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "definition": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqProductFeature": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "feature_type": {
+            "type": "string"
+          },
+          "protected": {
+            "type": "boolean"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "hidden": {
+            "type": "boolean"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FirmwareBinary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "external_ref": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "firmware_registry_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FirmwareRegistry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "last_refresh_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_refresh_error": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Firmware": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "build": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "release_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guest_device_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Flavor": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "cpu_total_cores": {
+            "type": "integer"
+          },
+          "cpu_cores_per_socket": {
+            "type": "integer"
+          },
+          "memory": {
+            "type": "integer"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "supports_32_bit": {
+            "type": "boolean"
+          },
+          "supports_64_bit": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "supports_hvm": {
+            "type": "boolean"
+          },
+          "supports_paravirtual": {
+            "type": "boolean"
+          },
+          "block_storage_based_only": {
+            "type": "boolean"
+          },
+          "cloud_subnet_required": {
+            "type": "boolean"
+          },
+          "ephemeral_disk_size": {
+            "type": "integer"
+          },
+          "ephemeral_disk_count": {
+            "type": "integer"
+          },
+          "root_disk_size": {
+            "type": "integer"
+          },
+          "swap_disk_size": {
+            "type": "integer"
+          },
+          "publicly_available": {
+            "type": "boolean"
+          },
+          "cpu_sockets": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FloatingIp": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vm_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_network_only": {
+            "type": "boolean"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "network_port_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "fixed_ip_address": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "network_router_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmsFolder": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "hidden": {
+            "type": "boolean"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenericObjectDefinition": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenericObject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          },
+          "generic_object_definition_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "properties": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "group_type": {
+            "type": "string"
+          },
+          "sequence": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "settings": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "detailed_description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GuestDevice": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "device_name": {
+            "type": "string"
+          },
+          "device_type": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "hardware_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "controller_type": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "free_space": {
+            "type": "integer"
+          },
+          "size_on_disk": {
+            "type": "integer"
+          },
+          "address": {
+            "type": "string"
+          },
+          "switch_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "lan_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "model": {
+            "type": "string"
+          },
+          "iscsi_name": {
+            "type": "string"
+          },
+          "iscsi_alias": {
+            "type": "string"
+          },
+          "present": {
+            "type": "boolean"
+          },
+          "start_connected": {
+            "type": "boolean"
+          },
+          "auto_detect": {
+            "type": "boolean"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "chap_auth_enabled": {
+            "type": "boolean"
+          },
+          "manufacturer": {
+            "type": "string"
+          },
+          "field_replaceable_unit": {
+            "type": "string"
+          },
+          "parent_device_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vlan_key": {
+            "type": "string"
+          },
+          "vlan_enabled": {
+            "type": "boolean"
+          },
+          "peer_mac_address": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "speed": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HostAggregate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HostInitiatorGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HostInitiator": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "physical_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "host_cluster_name": {
+            "type": "string"
+          },
+          "host_initiator_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Host": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ipaddress": {
+            "type": "string"
+          },
+          "vmm_vendor": {
+            "type": "string"
+          },
+          "vmm_version": {
+            "type": "string"
+          },
+          "vmm_product": {
+            "type": "string"
+          },
+          "vmm_buildnumber": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "user_assigned_os": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "smart": {
+            "type": "integer"
+          },
+          "settings": {
+            "type": "string"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "connection_state": {
+            "type": "string"
+          },
+          "ssh_permit_root_login": {
+            "type": "string"
+          },
+          "admin_disabled": {
+            "type": "boolean"
+          },
+          "service_tag": {
+            "type": "string"
+          },
+          "asset_tag": {
+            "type": "string"
+          },
+          "ipmi_address": {
+            "type": "string"
+          },
+          "mac_address": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "failover": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "hyperthreading": {
+            "type": "boolean"
+          },
+          "ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "next_available_vnc_port": {
+            "type": "integer"
+          },
+          "hypervisor_hostname": {
+            "type": "string"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "maintenance": {
+            "type": "boolean"
+          },
+          "maintenance_reason": {
+            "type": "string"
+          },
+          "physical_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManageIQ::Providers::CloudManager::Vm": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "config_xml": {
+            "type": "string"
+          },
+          "autostart": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_sync_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_scan_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_scan_attempt_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "boot_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tools_status": {
+            "type": "string"
+          },
+          "standby_action": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "state_changed_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "previous_state": {
+            "type": "string"
+          },
+          "connection_state": {
+            "type": "string"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "registered": {
+            "type": "boolean"
+          },
+          "busy": {
+            "type": "boolean"
+          },
+          "smart": {
+            "type": "boolean"
+          },
+          "memory_reserve": {
+            "type": "integer"
+          },
+          "memory_reserve_expand": {
+            "type": "boolean"
+          },
+          "memory_limit": {
+            "type": "integer"
+          },
+          "memory_shares": {
+            "type": "integer"
+          },
+          "memory_shares_level": {
+            "type": "string"
+          },
+          "cpu_reserve": {
+            "type": "integer"
+          },
+          "cpu_reserve_expand": {
+            "type": "boolean"
+          },
+          "cpu_limit": {
+            "type": "integer"
+          },
+          "cpu_shares": {
+            "type": "integer"
+          },
+          "cpu_shares_level": {
+            "type": "string"
+          },
+          "cpu_affinity": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "template": {
+            "type": "boolean"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "linked_clone": {
+            "type": "boolean"
+          },
+          "fault_tolerance": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "vnc_port": {
+            "type": "integer"
+          },
+          "flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud": {
+            "type": "boolean"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_subnet_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "raw_power_state": {
+            "type": "string"
+          },
+          "publicly_available": {
+            "type": "boolean"
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_requester": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "deprecated": {
+            "type": "boolean"
+          },
+          "storage_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cpu_hot_add_enabled": {
+            "type": "boolean"
+          },
+          "cpu_hot_remove_enabled": {
+            "type": "boolean"
+          },
+          "memory_hot_add_enabled": {
+            "type": "boolean"
+          },
+          "memory_hot_add_limit": {
+            "type": "integer"
+          },
+          "memory_hot_add_increment": {
+            "type": "integer"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "restart_needed": {
+            "type": "boolean"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "placement_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IsoImage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pxe_image_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Lan": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "switch_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "allow_promiscuous": {
+            "type": "boolean"
+          },
+          "forged_transmits": {
+            "type": "boolean"
+          },
+          "mac_changes": {
+            "type": "boolean"
+          },
+          "computed_allow_promiscuous": {
+            "type": "boolean"
+          },
+          "computed_forged_transmits": {
+            "type": "boolean"
+          },
+          "computed_mac_changes": {
+            "type": "boolean"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LoadBalancer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "retirement_requester": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChargebackRateDetailMeasure": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "units": {
+            "type": "string"
+          },
+          "units_display": {
+            "type": "string"
+          },
+          "step": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MetricRollup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capture_interval": {
+            "type": "integer"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cpu_usage_rate_average": {
+            "type": "number"
+          },
+          "cpu_usagemhz_rate_average": {
+            "type": "number"
+          },
+          "mem_usage_absolute_average": {
+            "type": "number"
+          },
+          "disk_usage_rate_average": {
+            "type": "number"
+          },
+          "net_usage_rate_average": {
+            "type": "number"
+          },
+          "sys_uptime_absolute_latest": {
+            "type": "number"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "derived_cpu_available": {
+            "type": "number"
+          },
+          "derived_memory_available": {
+            "type": "number"
+          },
+          "derived_memory_used": {
+            "type": "number"
+          },
+          "derived_cpu_reserved": {
+            "type": "number"
+          },
+          "derived_memory_reserved": {
+            "type": "number"
+          },
+          "derived_vm_count_on": {
+            "type": "integer"
+          },
+          "derived_host_count_on": {
+            "type": "integer"
+          },
+          "derived_vm_count_off": {
+            "type": "integer"
+          },
+          "derived_host_count_off": {
+            "type": "integer"
+          },
+          "derived_storage_total": {
+            "type": "number"
+          },
+          "derived_storage_free": {
+            "type": "number"
+          },
+          "capture_interval_name": {
+            "type": "string"
+          },
+          "assoc_ids": {
+            "type": "string"
+          },
+          "cpu_ready_delta_summation": {
+            "type": "number"
+          },
+          "cpu_system_delta_summation": {
+            "type": "number"
+          },
+          "cpu_wait_delta_summation": {
+            "type": "number"
+          },
+          "resource_name": {
+            "type": "string"
+          },
+          "cpu_used_delta_summation": {
+            "type": "number"
+          },
+          "tag_names": {
+            "type": "string"
+          },
+          "parent_host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "derived_storage_vm_count_registered": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_used_registered": {
+            "type": "number"
+          },
+          "derived_storage_used_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_used_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_registered": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_mem_registered": {
+            "type": "number"
+          },
+          "derived_storage_mem_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_mem_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_disk_registered": {
+            "type": "number"
+          },
+          "derived_storage_disk_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_disk_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_managed": {
+            "type": "number"
+          },
+          "derived_storage_used_managed": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_managed": {
+            "type": "number"
+          },
+          "derived_storage_mem_managed": {
+            "type": "number"
+          },
+          "derived_storage_disk_managed": {
+            "type": "number"
+          },
+          "min_max": {
+            "type": "string"
+          },
+          "intervals_in_rollup": {
+            "type": "integer"
+          },
+          "mem_vmmemctl_absolute_average": {
+            "type": "number"
+          },
+          "mem_vmmemctltarget_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapin_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapout_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapped_absolute_average": {
+            "type": "number"
+          },
+          "mem_swaptarget_absolute_average": {
+            "type": "number"
+          },
+          "disk_devicelatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_kernellatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_queuelatency_absolute_average": {
+            "type": "number"
+          },
+          "derived_vm_used_disk_storage": {
+            "type": "number"
+          },
+          "derived_vm_allocated_disk_storage": {
+            "type": "number"
+          },
+          "derived_vm_numvcpus": {
+            "type": "number"
+          },
+          "time_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "derived_host_sockets": {
+            "type": "integer"
+          },
+          "derived_host_count_total": {
+            "type": "integer"
+          },
+          "derived_vm_count_total": {
+            "type": "integer"
+          },
+          "stat_container_group_create_rate": {
+            "type": "integer"
+          },
+          "stat_container_group_delete_rate": {
+            "type": "integer"
+          },
+          "stat_container_image_registration_rate": {
+            "type": "integer"
+          },
+          "disk_totalreadlatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_totalwritelatency_absolute_average": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Metric": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capture_interval": {
+            "type": "integer"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cpu_usage_rate_average": {
+            "type": "number"
+          },
+          "cpu_usagemhz_rate_average": {
+            "type": "number"
+          },
+          "mem_usage_absolute_average": {
+            "type": "number"
+          },
+          "disk_usage_rate_average": {
+            "type": "number"
+          },
+          "net_usage_rate_average": {
+            "type": "number"
+          },
+          "sys_uptime_absolute_latest": {
+            "type": "number"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "derived_cpu_available": {
+            "type": "number"
+          },
+          "derived_memory_available": {
+            "type": "number"
+          },
+          "derived_memory_used": {
+            "type": "number"
+          },
+          "derived_cpu_reserved": {
+            "type": "number"
+          },
+          "derived_memory_reserved": {
+            "type": "number"
+          },
+          "derived_vm_count_on": {
+            "type": "integer"
+          },
+          "derived_host_count_on": {
+            "type": "integer"
+          },
+          "derived_vm_count_off": {
+            "type": "integer"
+          },
+          "derived_host_count_off": {
+            "type": "integer"
+          },
+          "derived_storage_total": {
+            "type": "number"
+          },
+          "derived_storage_free": {
+            "type": "number"
+          },
+          "capture_interval_name": {
+            "type": "string"
+          },
+          "assoc_ids": {
+            "type": "string"
+          },
+          "cpu_ready_delta_summation": {
+            "type": "number"
+          },
+          "cpu_system_delta_summation": {
+            "type": "number"
+          },
+          "cpu_wait_delta_summation": {
+            "type": "number"
+          },
+          "resource_name": {
+            "type": "string"
+          },
+          "cpu_used_delta_summation": {
+            "type": "number"
+          },
+          "tag_names": {
+            "type": "string"
+          },
+          "parent_host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "parent_ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "derived_storage_vm_count_registered": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_used_registered": {
+            "type": "number"
+          },
+          "derived_storage_used_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_used_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_registered": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_mem_registered": {
+            "type": "number"
+          },
+          "derived_storage_mem_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_mem_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_disk_registered": {
+            "type": "number"
+          },
+          "derived_storage_disk_unregistered": {
+            "type": "number"
+          },
+          "derived_storage_disk_unmanaged": {
+            "type": "number"
+          },
+          "derived_storage_vm_count_managed": {
+            "type": "number"
+          },
+          "derived_storage_used_managed": {
+            "type": "number"
+          },
+          "derived_storage_snapshot_managed": {
+            "type": "number"
+          },
+          "derived_storage_mem_managed": {
+            "type": "number"
+          },
+          "derived_storage_disk_managed": {
+            "type": "number"
+          },
+          "min_max": {
+            "type": "string"
+          },
+          "intervals_in_rollup": {
+            "type": "integer"
+          },
+          "mem_vmmemctl_absolute_average": {
+            "type": "number"
+          },
+          "mem_vmmemctltarget_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapin_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapout_absolute_average": {
+            "type": "number"
+          },
+          "mem_swapped_absolute_average": {
+            "type": "number"
+          },
+          "mem_swaptarget_absolute_average": {
+            "type": "number"
+          },
+          "disk_devicelatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_kernellatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_queuelatency_absolute_average": {
+            "type": "number"
+          },
+          "derived_vm_used_disk_storage": {
+            "type": "number"
+          },
+          "derived_vm_allocated_disk_storage": {
+            "type": "number"
+          },
+          "derived_vm_numvcpus": {
+            "type": "number"
+          },
+          "time_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "derived_host_sockets": {
+            "type": "integer"
+          },
+          "derived_host_count_total": {
+            "type": "integer"
+          },
+          "derived_vm_count_total": {
+            "type": "integer"
+          },
+          "disk_totalreadlatency_absolute_average": {
+            "type": "number"
+          },
+          "disk_totalwritelatency_absolute_average": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NetworkRouter": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "admin_state_up": {
+            "type": "boolean"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "status": {
+            "type": "string"
+          },
+          "extra_attributes": {
+            "type": "string"
+          },
+          "network_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NetworkService": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "shared": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Network": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "hardware_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "device_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "dhcp_enabled": {
+            "type": "boolean"
+          },
+          "ipaddress": {
+            "type": "string"
+          },
+          "subnet_mask": {
+            "type": "string"
+          },
+          "lease_obtained": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lease_expires": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "default_gateway": {
+            "type": "string"
+          },
+          "dhcp_server": {
+            "type": "string"
+          },
+          "dns_server": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "ipv6address": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NotificationRecipient": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "notification_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "seen": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OrchestrationStack": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "orchestration_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "retirement_requester": {
+            "type": "string"
+          },
+          "status_reason": {
+            "type": "string"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group": {
+            "type": "string"
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "finish_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "configuration_script_base_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "verbosity": {
+            "type": "integer"
+          },
+          "hosts": {
+            "type": "string"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_script_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OrchestrationTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "md5": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "orderable": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalChassis": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "physical_rack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "overall_health_state": {
+            "type": "string"
+          },
+          "management_module_slot_count": {
+            "type": "integer"
+          },
+          "switch_slot_count": {
+            "type": "integer"
+          },
+          "fan_slot_count": {
+            "type": "integer"
+          },
+          "blade_slot_count": {
+            "type": "integer"
+          },
+          "powersupply_slot_count": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "parent_physical_chassis_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalRack": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ems_ref": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalServerProfile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "assigned_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "associated_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalServer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "product_name": {
+            "type": "string"
+          },
+          "manufacturer": {
+            "type": "string"
+          },
+          "machine_type": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "serial_number": {
+            "type": "string"
+          },
+          "field_replaceable_unit": {
+            "type": "string"
+          },
+          "raw_power_state": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "physical_rack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_compliance_name": {
+            "type": "string"
+          },
+          "ems_compliance_status": {
+            "type": "string"
+          },
+          "physical_chassis_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalStorageFamily": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capabilities": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalStorage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "access_state": {
+            "type": "string"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "overall_health_state": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "physical_rack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "drive_bays": {
+            "type": "integer"
+          },
+          "enclosures": {
+            "type": "integer"
+          },
+          "canister_slots": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "physical_chassis_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "total_space": {
+            "type": "integer"
+          },
+          "physical_storage_family_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "capabilities": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PhysicalSwitch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ports": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "allow_promiscuous": {
+            "type": "boolean"
+          },
+          "forged_transmits": {
+            "type": "boolean"
+          },
+          "mac_changes": {
+            "type": "boolean"
+          },
+          "switch_uuid": {
+            "type": "string"
+          },
+          "shared": {
+            "type": "boolean"
+          },
+          "mtu": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Picture": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "string"
+          },
+          "md5": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqPolicy": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expression": {
+            "type": "string"
+          },
+          "towhat": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "updated_by": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqPolicySet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "set_type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "set_data": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "owner_type": {
+            "type": "string"
+          },
+          "owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExtManagementSystem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "api_version": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "host_default_vnc_port_start": {
+            "type": "integer"
+          },
+          "host_default_vnc_port_end": {
+            "type": "integer"
+          },
+          "provider_region": {
+            "type": "string"
+          },
+          "last_refresh_error": {
+            "type": "string"
+          },
+          "last_refresh_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "provider_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "realm": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "project": {
+            "type": "string"
+          },
+          "parent_ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "subscription": {
+            "type": "string"
+          },
+          "last_metrics_error": {
+            "type": "string"
+          },
+          "last_metrics_update_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_metrics_success_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tenant_mapping_enabled": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "options": {
+            "type": "string"
+          },
+          "zone_before_pause_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_inventory_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capabilities": {
+            "type": "object"
+          },
+          "last_refresh_success_date": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqDialog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "dialog_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "file_mtime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqProvisionRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "approval_state": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fulfilled_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requester_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "requester_name": {
+            "type": "string"
+          },
+          "request_type": {
+            "type": "string"
+          },
+          "request_state": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "destination_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "destination_type": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_order_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "process": {
+            "type": "boolean"
+          },
+          "cancelation_status": {
+            "type": "string"
+          },
+          "initiated_by": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PxeImageType": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provision_type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PxeImage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "pxe_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pxe_menu_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "pxe_image_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "kernel": {
+            "type": "string"
+          },
+          "kernel_options": {
+            "type": "string"
+          },
+          "initrd": {
+            "type": "string"
+          },
+          "default_for_windows": {
+            "type": "boolean"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PxeMenu": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "file_name": {
+            "type": "string"
+          },
+          "contents": {
+            "type": "string"
+          },
+          "pxe_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PxeServer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uri_prefix": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_refresh_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "access_url": {
+            "type": "string"
+          },
+          "pxe_directory": {
+            "type": "string"
+          },
+          "customization_directory": {
+            "type": "string"
+          },
+          "windows_images_directory": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TenantQuota": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "warn_value": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChargebackRateDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "metric": {
+            "type": "string"
+          },
+          "per_time": {
+            "type": "string"
+          },
+          "per_unit": {
+            "type": "string"
+          },
+          "friendly_rate": {
+            "type": "string"
+          },
+          "chargeback_rate_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "chargeback_rate_detail_measure_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "chargeback_rate_detail_currency_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "chargeable_field_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "sub_metric": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqRegion": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "region": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "maintenance_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqReport": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "rpt_group": {
+            "type": "string"
+          },
+          "rpt_type": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer"
+          },
+          "db": {
+            "type": "string"
+          },
+          "cols": {
+            "type": "string"
+          },
+          "include": {
+            "type": "string"
+          },
+          "col_order": {
+            "type": "string"
+          },
+          "headers": {
+            "type": "string"
+          },
+          "conditions": {
+            "type": "string"
+          },
+          "order": {
+            "type": "string"
+          },
+          "sortby": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "graph": {
+            "type": "string"
+          },
+          "dims": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "file_mtime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "categories": {
+            "type": "string"
+          },
+          "timeline": {
+            "type": "string"
+          },
+          "template_type": {
+            "type": "string"
+          },
+          "where_clause": {
+            "type": "string"
+          },
+          "db_options": {
+            "type": "string"
+          },
+          "generate_cols": {
+            "type": "string"
+          },
+          "generate_rows": {
+            "type": "string"
+          },
+          "col_formats": {
+            "type": "string"
+          },
+          "tz": {
+            "type": "string"
+          },
+          "time_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "display_filter": {
+            "type": "string"
+          },
+          "col_options": {
+            "type": "string"
+          },
+          "rpt_options": {
+            "type": "string"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqRequestTask": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "request_type": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "miq_request_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "destination_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "destination_type": {
+            "type": "string"
+          },
+          "miq_request_task_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "phase_context": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cancelation_status": {
+            "type": "string"
+          },
+          "conversion_host_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "approval_state": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fulfilled_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requester_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "requester_name": {
+            "type": "string"
+          },
+          "request_type": {
+            "type": "string"
+          },
+          "request_state": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "destination_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "destination_type": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_order_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "process": {
+            "type": "boolean"
+          },
+          "cancelation_status": {
+            "type": "string"
+          },
+          "initiated_by": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ResourceAction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "action": {
+            "type": "string"
+          },
+          "dialog_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ae_namespace": {
+            "type": "string"
+          },
+          "ae_class": {
+            "type": "string"
+          },
+          "ae_instance": {
+            "type": "string"
+          },
+          "ae_message": {
+            "type": "string"
+          },
+          "ae_attributes": {
+            "type": "string"
+          },
+          "configuration_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "configuration_template_type": {
+            "type": "string"
+          },
+          "configuration_script_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ResourcePool": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "memory_reserve": {
+            "type": "integer"
+          },
+          "memory_reserve_expand": {
+            "type": "boolean"
+          },
+          "memory_limit": {
+            "type": "integer"
+          },
+          "memory_shares": {
+            "type": "integer"
+          },
+          "memory_shares_level": {
+            "type": "string"
+          },
+          "cpu_reserve": {
+            "type": "integer"
+          },
+          "cpu_reserve_expand": {
+            "type": "boolean"
+          },
+          "cpu_limit": {
+            "type": "integer"
+          },
+          "cpu_shares": {
+            "type": "integer"
+          },
+          "cpu_shares_level": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "vapp": {
+            "type": "boolean"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "cpu_cores_available": {
+            "type": "number"
+          },
+          "cpu_cores_reserve": {
+            "type": "number"
+          },
+          "cpu_cores_limit": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqReportResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "miq_report_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_task_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "report_source": {
+            "type": "string"
+          },
+          "db": {
+            "type": "string"
+          },
+          "report": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "scheduled_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_run_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_accessed_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "report_rows_per_detail_row": {
+            "type": "integer"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqUserRole": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "settings": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqSchedule": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "sched_action": {
+            "type": "string"
+          },
+          "filter": {
+            "type": "string"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "run_at": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "prod_default": {
+            "type": "string"
+          },
+          "last_run_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "miq_search_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "adhoc": {
+            "type": "boolean"
+          },
+          "file_depot_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqSearch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "filter": {
+            "type": "string"
+          },
+          "db": {
+            "type": "string"
+          },
+          "search_type": {
+            "type": "string"
+          },
+          "search_key": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SecurityGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "network_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "network_router_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_subnet_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SecurityPolicy": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SecurityPolicyRule": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "security_policy_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "sequence_number": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "direction": {
+            "type": "string"
+          },
+          "ip_protocol": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "sources_excluded": {
+            "type": "boolean"
+          },
+          "destinations_excluded": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqServer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "started_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "stopped_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pid": {
+            "type": "integer"
+          },
+          "build": {
+            "type": "string"
+          },
+          "percent_memory": {
+            "type": "number"
+          },
+          "percent_cpu": {
+            "type": "number"
+          },
+          "cpu_time": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "last_heartbeat": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "os_priority": {
+            "type": "integer"
+          },
+          "is_master": {
+            "type": "boolean"
+          },
+          "logo": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "memory_usage": {
+            "type": "string"
+          },
+          "memory_size": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ipaddress": {
+            "type": "string"
+          },
+          "drb_uri": {
+            "type": "string"
+          },
+          "mac_address": {
+            "type": "string"
+          },
+          "vm_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "has_active_userinterface": {
+            "type": "boolean"
+          },
+          "has_active_webservices": {
+            "type": "boolean"
+          },
+          "sql_spid": {
+            "type": "integer"
+          },
+          "log_file_depot_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "proportional_set_size": {
+            "type": "string"
+          },
+          "has_active_remote_console": {
+            "type": "boolean"
+          },
+          "system_memory_free": {
+            "type": "string"
+          },
+          "system_memory_used": {
+            "type": "string"
+          },
+          "system_swap_free": {
+            "type": "string"
+          },
+          "system_swap_used": {
+            "type": "string"
+          },
+          "has_active_cockpit_ws": {
+            "type": "boolean"
+          },
+          "unique_set_size": {
+            "type": "string"
+          },
+          "has_vix_disk_lib": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceTemplateCatalog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Dialog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "buttons": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "label": {
+            "type": "string"
+          },
+          "system": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceOffering": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "extra": {
+            "type": "object"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceOrder": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "user_name": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "placed_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceParametersSet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_offering_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "extra": {
+            "type": "object"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceTemplateProvisionRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "approval_state": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fulfilled_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requester_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "requester_name": {
+            "type": "string"
+          },
+          "request_type": {
+            "type": "string"
+          },
+          "request_state": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "destination_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "destination_type": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_order_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "process": {
+            "type": "boolean"
+          },
+          "cancelation_status": {
+            "type": "string"
+          },
+          "initiated_by": {
+            "type": "string"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "service_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "options": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "display": {
+            "type": "boolean"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "service_type": {
+            "type": "string"
+          },
+          "prov_type": {
+            "type": "string"
+          },
+          "provision_cost": {
+            "type": "number"
+          },
+          "service_template_catalog_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "long_description": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "generic_subtype": {
+            "type": "string"
+          },
+          "deleted_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "internal": {
+            "type": "boolean"
+          },
+          "zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "currency_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "price": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Service": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "service_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "options": {
+            "type": "string"
+          },
+          "visible": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "retirement_requester": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "initiator": {
+            "type": "string"
+          },
+          "lifecycle_state": {
+            "type": "string"
+          },
+          "currency_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "price": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqShortcut": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "rbac_feature_name": {
+            "type": "string"
+          },
+          "startup": {
+            "type": "boolean"
+          },
+          "sequence": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Snapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid": {
+            "type": "string"
+          },
+          "parent_uid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "current": {
+            "type": "integer"
+          },
+          "total_size": {
+            "type": "integer"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "create_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "disks": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "parent_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vm_or_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GuestApplication": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "product_icon": {
+            "type": "string"
+          },
+          "transform": {
+            "type": "string"
+          },
+          "language": {
+            "type": "integer"
+          },
+          "typename": {
+            "type": "string"
+          },
+          "vm_or_template_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "product_key": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "arch": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "release": {
+            "type": "string"
+          },
+          "install_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "container_image_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "build_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "StorageResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "logical_free": {
+            "type": "integer"
+          },
+          "logical_total": {
+            "type": "integer"
+          },
+          "physical_storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capabilities": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "StorageService": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "capabilities": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Switch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ports": {
+            "type": "integer"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "allow_promiscuous": {
+            "type": "boolean"
+          },
+          "forged_transmits": {
+            "type": "boolean"
+          },
+          "mac_changes": {
+            "type": "boolean"
+          },
+          "switch_uuid": {
+            "type": "string"
+          },
+          "shared": {
+            "type": "boolean"
+          },
+          "mtu": {
+            "type": "integer"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "type": {
+            "type": "string"
+          },
+          "health_state": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqTask": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pct_complete": {
+            "type": "integer"
+          },
+          "context_data": {
+            "type": "string"
+          },
+          "results": {
+            "type": "string"
+          },
+          "miq_server_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "started_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "zone": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "config_xml": {
+            "type": "string"
+          },
+          "autostart": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_sync_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_scan_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_scan_attempt_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "boot_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tools_status": {
+            "type": "string"
+          },
+          "standby_action": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "state_changed_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "previous_state": {
+            "type": "string"
+          },
+          "connection_state": {
+            "type": "string"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "registered": {
+            "type": "boolean"
+          },
+          "busy": {
+            "type": "boolean"
+          },
+          "smart": {
+            "type": "boolean"
+          },
+          "memory_reserve": {
+            "type": "integer"
+          },
+          "memory_reserve_expand": {
+            "type": "boolean"
+          },
+          "memory_limit": {
+            "type": "integer"
+          },
+          "memory_shares": {
+            "type": "integer"
+          },
+          "memory_shares_level": {
+            "type": "string"
+          },
+          "cpu_reserve": {
+            "type": "integer"
+          },
+          "cpu_reserve_expand": {
+            "type": "boolean"
+          },
+          "cpu_limit": {
+            "type": "integer"
+          },
+          "cpu_shares": {
+            "type": "integer"
+          },
+          "cpu_shares_level": {
+            "type": "string"
+          },
+          "cpu_affinity": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "template": {
+            "type": "boolean"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "linked_clone": {
+            "type": "boolean"
+          },
+          "fault_tolerance": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "vnc_port": {
+            "type": "integer"
+          },
+          "flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud": {
+            "type": "boolean"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_subnet_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "raw_power_state": {
+            "type": "string"
+          },
+          "publicly_available": {
+            "type": "boolean"
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_requester": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "deprecated": {
+            "type": "boolean"
+          },
+          "storage_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cpu_hot_add_enabled": {
+            "type": "boolean"
+          },
+          "cpu_hot_remove_enabled": {
+            "type": "boolean"
+          },
+          "memory_hot_add_enabled": {
+            "type": "boolean"
+          },
+          "memory_hot_add_limit": {
+            "type": "integer"
+          },
+          "memory_hot_add_increment": {
+            "type": "integer"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "restart_needed": {
+            "type": "boolean"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "placement_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Tenant": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "subdomain": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "login_text": {
+            "type": "string"
+          },
+          "logo_file_name": {
+            "type": "string"
+          },
+          "logo_content_type": {
+            "type": "string"
+          },
+          "logo_file_size": {
+            "type": "integer"
+          },
+          "logo_updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "login_logo_file_name": {
+            "type": "string"
+          },
+          "login_logo_content_type": {
+            "type": "string"
+          },
+          "login_logo_file_size": {
+            "type": "integer"
+          },
+          "login_logo_updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "divisible": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "use_config_for_attributes": {
+            "type": "boolean"
+          },
+          "default_miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TimeProfile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "description": {
+            "type": "string"
+          },
+          "profile_type": {
+            "type": "string"
+          },
+          "profile_key": {
+            "type": "string"
+          },
+          "profile": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "rollup_daily_metrics": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "userid": {
+            "type": "string"
+          },
+          "settings": {
+            "type": "string"
+          },
+          "lastlogon": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastlogoff": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "current_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "password_digest": {
+            "type": "string"
+          },
+          "failed_login_attempts": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Vm": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "config_xml": {
+            "type": "string"
+          },
+          "autostart": {
+            "type": "string"
+          },
+          "host_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_sync_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "storage_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_scan_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_scan_attempt_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "retires_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "boot_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tools_status": {
+            "type": "string"
+          },
+          "standby_action": {
+            "type": "string"
+          },
+          "power_state": {
+            "type": "string"
+          },
+          "state_changed_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "previous_state": {
+            "type": "string"
+          },
+          "connection_state": {
+            "type": "string"
+          },
+          "last_perf_capture_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "registered": {
+            "type": "boolean"
+          },
+          "busy": {
+            "type": "boolean"
+          },
+          "smart": {
+            "type": "boolean"
+          },
+          "memory_reserve": {
+            "type": "integer"
+          },
+          "memory_reserve_expand": {
+            "type": "boolean"
+          },
+          "memory_limit": {
+            "type": "integer"
+          },
+          "memory_shares": {
+            "type": "integer"
+          },
+          "memory_shares_level": {
+            "type": "string"
+          },
+          "cpu_reserve": {
+            "type": "integer"
+          },
+          "cpu_reserve_expand": {
+            "type": "boolean"
+          },
+          "cpu_limit": {
+            "type": "integer"
+          },
+          "cpu_shares": {
+            "type": "integer"
+          },
+          "cpu_shares_level": {
+            "type": "string"
+          },
+          "cpu_affinity": {
+            "type": "string"
+          },
+          "ems_created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "template": {
+            "type": "boolean"
+          },
+          "evm_owner_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "miq_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "linked_clone": {
+            "type": "boolean"
+          },
+          "fault_tolerance": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "ems_cluster_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_warn": {
+            "type": "integer"
+          },
+          "retirement_last_warn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "vnc_port": {
+            "type": "integer"
+          },
+          "flavor_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_zone_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud": {
+            "type": "boolean"
+          },
+          "retirement_state": {
+            "type": "string"
+          },
+          "cloud_network_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_subnet_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "raw_power_state": {
+            "type": "string"
+          },
+          "publicly_available": {
+            "type": "boolean"
+          },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "retirement_requester": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_group_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "deprecated": {
+            "type": "boolean"
+          },
+          "storage_profile_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cpu_hot_add_enabled": {
+            "type": "boolean"
+          },
+          "cpu_hot_remove_enabled": {
+            "type": "boolean"
+          },
+          "memory_hot_add_enabled": {
+            "type": "boolean"
+          },
+          "memory_hot_add_limit": {
+            "type": "integer"
+          },
+          "memory_hot_add_increment": {
+            "type": "integer"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ems_ref_type": {
+            "type": "string"
+          },
+          "restart_needed": {
+            "type": "boolean"
+          },
+          "ancestry": {
+            "type": "string"
+          },
+          "placement_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VolumeMapping": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "cloud_volume_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "host_initiator_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "ems_ref": {
+            "type": "string"
+          },
+          "uid_ems": {
+            "type": "string"
+          },
+          "lun": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "host_initiator_group_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MiqWidget": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "options": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "miq_schedule_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "read_only": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_generated_content_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "miq_task_id": {
+            "$ref": "#/components/schemas/ID"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Zone": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "settings": {
+            "type": "string"
+          },
+          "log_file_depot_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "visible": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/config/openapi.json
+++ b/config/openapi.json
@@ -11,6 +11,12 @@
     "parameters": {
     },
     "schemas": {
+      "ID": {
+        "type": "string",
+        "description": "ID of the resource",
+        "pattern": "^\\d+$",
+        "readOnly": true
+      },
       "Account": {
         "type": "object",
         "properties": {

--- a/config/openapi.json
+++ b/config/openapi.json
@@ -609,7 +609,7 @@
             "type": "string"
           },
           "provider_segmentation_id": {
-            "$ref": "#/components/schemas/ID"
+            "type": "string"
           },
           "vlan_transparent": {
             "type": "boolean"
@@ -1904,7 +1904,7 @@
             "type": "string"
           },
           "common_volume_id": {
-            "$ref": "#/components/schemas/ID"
+            "type": "string"
           },
           "common_partition": {
             "type": "string"
@@ -3741,7 +3741,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "The internal database ID."
+              }
+            ]
           },
           "vendor": {
             "type": "string",
@@ -3776,42 +3783,63 @@
             "description": "Indicates whether or not the VM is set to autostart."
           },
           "host_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the host that the VM/Template resides on."
+              }
+            ]
           },
           "last_sync_on": {
             "type": "string",
-            "description": "Timestamp for last SmartState analysis synchronization.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last SmartState analysis synchronization."
           },
           "created_on": {
             "type": "string",
-            "description": "The timestamp the VM was added to the app inventory.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the VM was added to the app inventory."
           },
           "updated_on": {
             "type": "string",
-            "description": "The last timestamp the VM was modified within the app.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The last timestamp the VM was modified within the app."
           },
           "storage_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the storage object associated with the VM."
+              }
+            ]
           },
           "guid": {
             "type": "string",
             "description": "A value used to uniquely identify the VM internally."
           },
           "ems_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the ExtManagementSystem associated with the VM."
+              }
+            ]
           },
           "last_scan_on": {
             "type": "string",
-            "description": "Timestamp for last SmartState analysis scan.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last SmartState analysis scan."
           },
           "last_scan_attempt_on": {
             "type": "string",
-            "description": "Timestamp for last attempt to perform SmartState Analysis.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last attempt to perform SmartState Analysis."
           },
           "uid_ems": {
             "type": "string",
@@ -3819,8 +3847,8 @@
           },
           "retires_on": {
             "type": "string",
-            "description": "Timestamp the VM is to be retired.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp the VM is to be retired."
           },
           "retired": {
             "type": "boolean",
@@ -3828,8 +3856,8 @@
           },
           "boot_time": {
             "type": "string",
-            "description": "The last time the VM was started.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The last time the VM was started."
           },
           "tools_status": {
             "type": "string",
@@ -3845,8 +3873,8 @@
           },
           "state_changed_on": {
             "type": "string",
-            "description": "The timestamp of the last power state change.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp of the last power state change."
           },
           "previous_state": {
             "type": "string",
@@ -3858,8 +3886,8 @@
           },
           "last_perf_capture_on": {
             "type": "string",
-            "description": "Timestamp for last performance metrics capture.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last performance metrics capture."
           },
           "registered": {
             "type": "boolean",
@@ -3919,18 +3947,32 @@
           },
           "ems_created_on": {
             "type": "string",
-            "description": "The timestamp the VM or Templated was created on the EMS itself.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the VM or Templated was created on the EMS itself."
           },
           "template": {
             "type": "boolean",
             "description": "Indicates whether this is a VM or template."
           },
           "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "Typically, the ID of the user that provisioned the VM (if provisioned through the app).Can also be set via inventory, the UI or Automate."
+              }
+            ]
           },
           "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the MIQ Group owner."
+              }
+            ]
           },
           "linked_clone": {
             "type": "boolean",
@@ -3949,7 +3991,14 @@
             "description": "A native unique reference for the VM within the EMS."
           },
           "ems_cluster_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of associated cluster."
+              }
+            ]
           },
           "retirement_warn": {
             "type": "integer",
@@ -3957,18 +4006,32 @@
           },
           "retirement_last_warn": {
             "type": "string",
-            "description": "Date of last retirement warning.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Date of last retirement warning."
           },
           "vnc_port": {
             "type": "integer",
             "description": "Port or port range used for VNC connections."
           },
           "flavor_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of associated flavor."
+              }
+            ]
           },
           "availability_zone_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the availability zone that the VM is part of."
+              }
+            ]
           },
           "cloud": {
             "type": "boolean",
@@ -3979,13 +4042,34 @@
             "description": "The current retirement state."
           },
           "cloud_network_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the cloud (virtual) network the VM/Template is associated with."
+              }
+            ]
           },
           "cloud_subnet_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "Subnet ID associated with the VM."
+              }
+            ]
           },
           "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the cloud tenant associated with the VM."
+              }
+            ]
           },
           "raw_power_state": {
             "type": "string",
@@ -3996,24 +4080,52 @@
             "description": "Indicates whether the VM is public or private."
           },
           "orchestration_stack_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the orchestration stack associated with the VM."
+              }
+            ]
           },
           "retirement_requester": {
             "type": "string",
             "description": "Userid of the user who requested retirement."
           },
           "tenant_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the tenant associated with the VM."
+              }
+            ]
           },
           "resource_group_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the resource group that the VM/Template belongs to."
+              }
+            ]
           },
           "deprecated": {
             "type": "boolean",
             "description": "Indicates whether or not a template is deprecated."
           },
           "storage_profile_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the storage profile associated with the VM."
+              }
+            ]
           },
           "cpu_hot_add_enabled": {
             "type": "boolean",
@@ -4057,7 +4169,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "The internal database ID."
+              }
+            ]
           },
           "vendor": {
             "type": "string",
@@ -4092,42 +4211,63 @@
             "description": "Indicates whether or not the VM is set to autostart."
           },
           "host_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the host that the VM/Template resides on."
+              }
+            ]
           },
           "last_sync_on": {
             "type": "string",
-            "description": "Timestamp for last SmartState analysis synchronization.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last SmartState analysis synchronization."
           },
           "created_on": {
             "type": "string",
-            "description": "The timestamp the VM was added to the app inventory.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the VM was added to the app inventory."
           },
           "updated_on": {
             "type": "string",
-            "description": "The last timestamp the VM was modified within the app.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The last timestamp the VM was modified within the app."
           },
           "storage_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the storage object associated with the VM."
+              }
+            ]
           },
           "guid": {
             "type": "string",
             "description": "A value used to uniquely identify the VM internally."
           },
           "ems_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the ExtManagementSystem associated with the VM."
+              }
+            ]
           },
           "last_scan_on": {
             "type": "string",
-            "description": "Timestamp for last SmartState analysis scan.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last SmartState analysis scan."
           },
           "last_scan_attempt_on": {
             "type": "string",
-            "description": "Timestamp for last attempt to perform SmartState Analysis.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last attempt to perform SmartState Analysis."
           },
           "uid_ems": {
             "type": "string",
@@ -4135,8 +4275,8 @@
           },
           "retires_on": {
             "type": "string",
-            "description": "Timestamp the VM is to be retired.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp the VM is to be retired."
           },
           "retired": {
             "type": "boolean",
@@ -4144,8 +4284,8 @@
           },
           "boot_time": {
             "type": "string",
-            "description": "The last time the VM was started.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The last time the VM was started."
           },
           "tools_status": {
             "type": "string",
@@ -4161,8 +4301,8 @@
           },
           "state_changed_on": {
             "type": "string",
-            "description": "The timestamp of the last power state change.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp of the last power state change."
           },
           "previous_state": {
             "type": "string",
@@ -4174,8 +4314,8 @@
           },
           "last_perf_capture_on": {
             "type": "string",
-            "description": "Timestamp for last performance metrics capture.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last performance metrics capture."
           },
           "registered": {
             "type": "boolean",
@@ -4235,18 +4375,32 @@
           },
           "ems_created_on": {
             "type": "string",
-            "description": "The timestamp the VM or Templated was created on the EMS itself.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the VM or Templated was created on the EMS itself."
           },
           "template": {
             "type": "boolean",
             "description": "Indicates whether this is a VM or template."
           },
           "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "Typically, the ID of the user that provisioned the VM (if provisioned through the app).Can also be set via inventory, the UI or Automate."
+              }
+            ]
           },
           "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the MIQ Group owner."
+              }
+            ]
           },
           "linked_clone": {
             "type": "boolean",
@@ -4265,7 +4419,14 @@
             "description": "A native unique reference for the VM within the EMS."
           },
           "ems_cluster_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of associated cluster."
+              }
+            ]
           },
           "retirement_warn": {
             "type": "integer",
@@ -4273,18 +4434,32 @@
           },
           "retirement_last_warn": {
             "type": "string",
-            "description": "Date of last retirement warning.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Date of last retirement warning."
           },
           "vnc_port": {
             "type": "integer",
             "description": "Port or port range used for VNC connections."
           },
           "flavor_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of associated flavor."
+              }
+            ]
           },
           "availability_zone_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the availability zone that the VM is part of."
+              }
+            ]
           },
           "cloud": {
             "type": "boolean",
@@ -4295,13 +4470,34 @@
             "description": "The current retirement state."
           },
           "cloud_network_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the cloud (virtual) network the VM/Template is associated with."
+              }
+            ]
           },
           "cloud_subnet_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "Subnet ID associated with the VM."
+              }
+            ]
           },
           "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the cloud tenant associated with the VM."
+              }
+            ]
           },
           "raw_power_state": {
             "type": "string",
@@ -4312,24 +4508,52 @@
             "description": "Indicates whether the VM is public or private."
           },
           "orchestration_stack_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the orchestration stack associated with the VM."
+              }
+            ]
           },
           "retirement_requester": {
             "type": "string",
             "description": "Userid of the user who requested retirement."
           },
           "tenant_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the tenant associated with the VM."
+              }
+            ]
           },
           "resource_group_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the resource group that the VM/Template belongs to."
+              }
+            ]
           },
           "deprecated": {
             "type": "boolean",
             "description": "Indicates whether or not a template is deprecated."
           },
           "storage_profile_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the storage profile associated with the VM."
+              }
+            ]
           },
           "cpu_hot_add_enabled": {
             "type": "boolean",
@@ -6199,7 +6423,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "[builtin] The internal record ID. This is the primary key."
+              }
+            ]
           },
           "name": {
             "type": "string",
@@ -6223,13 +6454,13 @@
           },
           "created_on": {
             "type": "string",
-            "description": "[builtin] The timestamp the record was created.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "[builtin] The timestamp the record was created."
           },
           "updated_on": {
             "type": "string",
-            "description": "[builtin] The timestamp the record was last updated.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "[builtin] The timestamp the record was last updated."
           },
           "pct_complete": {
             "type": "integer",
@@ -6244,7 +6475,14 @@
             "description": "Task execution result. Deprecated."
           },
           "miq_server_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "The ID of the ManageIQ server where the task was executed."
+              }
+            ]
           },
           "identifier": {
             "type": "string",
@@ -6252,8 +6490,8 @@
           },
           "started_on": {
             "type": "string",
-            "description": "The timestamp the task was actually started.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the task was actually started."
           },
           "zone": {
             "type": "string",
@@ -6266,7 +6504,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "The internal database ID."
+              }
+            ]
           },
           "vendor": {
             "type": "string",
@@ -6301,42 +6546,63 @@
             "description": "Indicates whether or not the VM is set to autostart."
           },
           "host_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the host that the VM/Template resides on."
+              }
+            ]
           },
           "last_sync_on": {
             "type": "string",
-            "description": "Timestamp for last SmartState analysis synchronization.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last SmartState analysis synchronization."
           },
           "created_on": {
             "type": "string",
-            "description": "The timestamp the VM was added to the app inventory.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the VM was added to the app inventory."
           },
           "updated_on": {
             "type": "string",
-            "description": "The last timestamp the VM was modified within the app.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The last timestamp the VM was modified within the app."
           },
           "storage_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the storage object associated with the VM."
+              }
+            ]
           },
           "guid": {
             "type": "string",
             "description": "A value used to uniquely identify the VM internally."
           },
           "ems_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the ExtManagementSystem associated with the VM."
+              }
+            ]
           },
           "last_scan_on": {
             "type": "string",
-            "description": "Timestamp for last SmartState analysis scan.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last SmartState analysis scan."
           },
           "last_scan_attempt_on": {
             "type": "string",
-            "description": "Timestamp for last attempt to perform SmartState Analysis.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last attempt to perform SmartState Analysis."
           },
           "uid_ems": {
             "type": "string",
@@ -6344,8 +6610,8 @@
           },
           "retires_on": {
             "type": "string",
-            "description": "Timestamp the VM is to be retired.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp the VM is to be retired."
           },
           "retired": {
             "type": "boolean",
@@ -6353,8 +6619,8 @@
           },
           "boot_time": {
             "type": "string",
-            "description": "The last time the VM was started.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The last time the VM was started."
           },
           "tools_status": {
             "type": "string",
@@ -6370,8 +6636,8 @@
           },
           "state_changed_on": {
             "type": "string",
-            "description": "The timestamp of the last power state change.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp of the last power state change."
           },
           "previous_state": {
             "type": "string",
@@ -6383,8 +6649,8 @@
           },
           "last_perf_capture_on": {
             "type": "string",
-            "description": "Timestamp for last performance metrics capture.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last performance metrics capture."
           },
           "registered": {
             "type": "boolean",
@@ -6444,18 +6710,32 @@
           },
           "ems_created_on": {
             "type": "string",
-            "description": "The timestamp the VM or Templated was created on the EMS itself.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the VM or Templated was created on the EMS itself."
           },
           "template": {
             "type": "boolean",
             "description": "Indicates whether this is a VM or template."
           },
           "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "Typically, the ID of the user that provisioned the VM (if provisioned through the app).Can also be set via inventory, the UI or Automate."
+              }
+            ]
           },
           "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the MIQ Group owner."
+              }
+            ]
           },
           "linked_clone": {
             "type": "boolean",
@@ -6474,7 +6754,14 @@
             "description": "A native unique reference for the VM within the EMS."
           },
           "ems_cluster_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of associated cluster."
+              }
+            ]
           },
           "retirement_warn": {
             "type": "integer",
@@ -6482,18 +6769,32 @@
           },
           "retirement_last_warn": {
             "type": "string",
-            "description": "Date of last retirement warning.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Date of last retirement warning."
           },
           "vnc_port": {
             "type": "integer",
             "description": "Port or port range used for VNC connections."
           },
           "flavor_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of associated flavor."
+              }
+            ]
           },
           "availability_zone_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the availability zone that the VM is part of."
+              }
+            ]
           },
           "cloud": {
             "type": "boolean",
@@ -6504,13 +6805,34 @@
             "description": "The current retirement state."
           },
           "cloud_network_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the cloud (virtual) network the VM/Template is associated with."
+              }
+            ]
           },
           "cloud_subnet_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "Subnet ID associated with the VM."
+              }
+            ]
           },
           "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the cloud tenant associated with the VM."
+              }
+            ]
           },
           "raw_power_state": {
             "type": "string",
@@ -6521,24 +6843,52 @@
             "description": "Indicates whether the VM is public or private."
           },
           "orchestration_stack_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the orchestration stack associated with the VM."
+              }
+            ]
           },
           "retirement_requester": {
             "type": "string",
             "description": "Userid of the user who requested retirement."
           },
           "tenant_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the tenant associated with the VM."
+              }
+            ]
           },
           "resource_group_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the resource group that the VM/Template belongs to."
+              }
+            ]
           },
           "deprecated": {
             "type": "boolean",
             "description": "Indicates whether or not a template is deprecated."
           },
           "storage_profile_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the storage profile associated with the VM."
+              }
+            ]
           },
           "cpu_hot_add_enabled": {
             "type": "boolean",
@@ -8633,7 +8983,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "The internal database ID."
+              }
+            ]
           },
           "vendor": {
             "type": "string",
@@ -8668,42 +9025,63 @@
             "description": "Indicates whether or not the VM is set to autostart."
           },
           "host_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the host that the VM/Template resides on."
+              }
+            ]
           },
           "last_sync_on": {
             "type": "string",
-            "description": "Timestamp for last SmartState analysis synchronization.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last SmartState analysis synchronization."
           },
           "created_on": {
             "type": "string",
-            "description": "The timestamp the VM was added to the app inventory.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the VM was added to the app inventory."
           },
           "updated_on": {
             "type": "string",
-            "description": "The last timestamp the VM was modified within the app.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The last timestamp the VM was modified within the app."
           },
           "storage_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the storage object associated with the VM."
+              }
+            ]
           },
           "guid": {
             "type": "string",
             "description": "A value used to uniquely identify the VM internally."
           },
           "ems_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the ExtManagementSystem associated with the VM."
+              }
+            ]
           },
           "last_scan_on": {
             "type": "string",
-            "description": "Timestamp for last SmartState analysis scan.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last SmartState analysis scan."
           },
           "last_scan_attempt_on": {
             "type": "string",
-            "description": "Timestamp for last attempt to perform SmartState Analysis.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last attempt to perform SmartState Analysis."
           },
           "uid_ems": {
             "type": "string",
@@ -8711,8 +9089,8 @@
           },
           "retires_on": {
             "type": "string",
-            "description": "Timestamp the VM is to be retired.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp the VM is to be retired."
           },
           "retired": {
             "type": "boolean",
@@ -8720,8 +9098,8 @@
           },
           "boot_time": {
             "type": "string",
-            "description": "The last time the VM was started.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The last time the VM was started."
           },
           "tools_status": {
             "type": "string",
@@ -8737,8 +9115,8 @@
           },
           "state_changed_on": {
             "type": "string",
-            "description": "The timestamp of the last power state change.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp of the last power state change."
           },
           "previous_state": {
             "type": "string",
@@ -8750,8 +9128,8 @@
           },
           "last_perf_capture_on": {
             "type": "string",
-            "description": "Timestamp for last performance metrics capture.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp for last performance metrics capture."
           },
           "registered": {
             "type": "boolean",
@@ -8811,18 +9189,32 @@
           },
           "ems_created_on": {
             "type": "string",
-            "description": "The timestamp the VM or Templated was created on the EMS itself.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "The timestamp the VM or Templated was created on the EMS itself."
           },
           "template": {
             "type": "boolean",
             "description": "Indicates whether this is a VM or template."
           },
           "evm_owner_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "Typically, the ID of the user that provisioned the VM (if provisioned through the app).Can also be set via inventory, the UI or Automate."
+              }
+            ]
           },
           "miq_group_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the MIQ Group owner."
+              }
+            ]
           },
           "linked_clone": {
             "type": "boolean",
@@ -8841,7 +9233,14 @@
             "description": "A native unique reference for the VM within the EMS."
           },
           "ems_cluster_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of associated cluster."
+              }
+            ]
           },
           "retirement_warn": {
             "type": "integer",
@@ -8849,18 +9248,32 @@
           },
           "retirement_last_warn": {
             "type": "string",
-            "description": "Date of last retirement warning.",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Date of last retirement warning."
           },
           "vnc_port": {
             "type": "integer",
             "description": "Port or port range used for VNC connections."
           },
           "flavor_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of associated flavor."
+              }
+            ]
           },
           "availability_zone_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the availability zone that the VM is part of."
+              }
+            ]
           },
           "cloud": {
             "type": "boolean",
@@ -8871,13 +9284,34 @@
             "description": "The current retirement state."
           },
           "cloud_network_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the cloud (virtual) network the VM/Template is associated with."
+              }
+            ]
           },
           "cloud_subnet_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "Subnet ID associated with the VM."
+              }
+            ]
           },
           "cloud_tenant_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the cloud tenant associated with the VM."
+              }
+            ]
           },
           "raw_power_state": {
             "type": "string",
@@ -8888,24 +9322,52 @@
             "description": "Indicates whether the VM is public or private."
           },
           "orchestration_stack_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the orchestration stack associated with the VM."
+              }
+            ]
           },
           "retirement_requester": {
             "type": "string",
             "description": "Userid of the user who requested retirement."
           },
           "tenant_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the tenant associated with the VM."
+              }
+            ]
           },
           "resource_group_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the resource group that the VM/Template belongs to."
+              }
+            ]
           },
           "deprecated": {
             "type": "boolean",
             "description": "Indicates whether or not a template is deprecated."
           },
           "storage_profile_id": {
-            "$ref": "#/components/schemas/ID"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "description": "ID of the storage profile associated with the VM."
+              }
+            ]
           },
           "cpu_hot_add_enabled": {
             "type": "boolean",

--- a/config/openapi.json
+++ b/config/openapi.json
@@ -276,7 +276,7 @@
         },
         "additionalProperties": false
       },
-      "ManageIQ::Providers::CloudManager::AuthKeyPair": {
+      "ManageIQ_Providers_CloudManager_AuthKeyPair": {
         "type": "object",
         "properties": {
           "id": {
@@ -1209,7 +1209,7 @@
         },
         "additionalProperties": false
       },
-      "ManageIQ::Providers::CloudManager::Template": {
+      "ManageIQ_Providers_CloudManager_Template": {
         "type": "object",
         "properties": {
           "id": {
@@ -4256,7 +4256,7 @@
         },
         "additionalProperties": false
       },
-      "ManageIQ::Providers::CloudManager::Vm": {
+      "ManageIQ_Providers_CloudManager_Vm": {
         "type": "object",
         "properties": {
           "id": {

--- a/config/openapi.json
+++ b/config/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
   },
-  "secuirty": [
+  "security": [
 
   ],
   "paths": {
@@ -1213,146 +1213,187 @@
             "$ref": "#/components/schemas/ID"
           },
           "vendor": {
-            "type": "string"
+            "type": "string",
+            "description": "The vendor for the VM, e.g. azure, amazon, etc."
           },
           "format": {
-            "type": "string"
+            "type": "string",
+            "description": "The format of the VM's disk, such as vmdk, qcow2, and tier1."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "The version of the VM definition."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the VM/Template."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "A description of the VM that is typically set by the provider, but may also be edited."
           },
           "location": {
-            "type": "string"
+            "type": "string",
+            "description": "The location of the VM, or its underlying storage."
           },
           "config_xml": {
-            "type": "string"
+            "type": "string",
+            "description": "The VM or Template configuration in XML format. Deprecated."
           },
           "autostart": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates whether or not the VM is set to autostart."
           },
           "host_id": {
             "$ref": "#/components/schemas/ID"
           },
           "last_sync_on": {
             "type": "string",
+            "description": "Timestamp for last SmartState analysis synchronization.",
             "format": "date-time"
           },
           "created_on": {
             "type": "string",
+            "description": "The timestamp the VM was added to the app inventory.",
             "format": "date-time"
           },
           "updated_on": {
             "type": "string",
+            "description": "The last timestamp the VM was modified within the app.",
             "format": "date-time"
           },
           "storage_id": {
             "$ref": "#/components/schemas/ID"
           },
           "guid": {
-            "type": "string"
+            "type": "string",
+            "description": "A value used to uniquely identify the VM internally."
           },
           "ems_id": {
             "$ref": "#/components/schemas/ID"
           },
           "last_scan_on": {
             "type": "string",
+            "description": "Timestamp for last SmartState analysis scan.",
             "format": "date-time"
           },
           "last_scan_attempt_on": {
             "type": "string",
+            "description": "Timestamp for last attempt to perform SmartState Analysis.",
             "format": "date-time"
           },
           "uid_ems": {
-            "type": "string"
+            "type": "string",
+            "description": "A globally unique reference for the VM across EMS."
           },
           "retires_on": {
             "type": "string",
+            "description": "Timestamp the VM is to be retired.",
             "format": "date-time"
           },
           "retired": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is retired."
           },
           "boot_time": {
             "type": "string",
+            "description": "The last time the VM was started.",
             "format": "date-time"
           },
           "tools_status": {
-            "type": "string"
+            "type": "string",
+            "description": "Status of guest tools."
           },
           "standby_action": {
-            "type": "string"
+            "type": "string",
+            "description": "Action taken when VM is put into standby mode."
           },
           "power_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current power state, typically 'on' or 'off'."
           },
           "state_changed_on": {
             "type": "string",
+            "description": "The timestamp of the last power state change.",
             "format": "date-time"
           },
           "previous_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The previous power state change."
           },
           "connection_state": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates the connection state of the VM, e.g. connected, disconnected, etc."
           },
           "last_perf_capture_on": {
             "type": "string",
+            "description": "Timestamp for last performance metrics capture.",
             "format": "date-time"
           },
           "registered": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM registered to a Provider. Deprecated."
           },
           "busy": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is being scanned for SmartState analysis. Deprecated."
           },
           "smart": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not smart proxy is enabled. Deprecated."
           },
           "memory_reserve": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Amount of memory that is guaranteed available for the VM."
           },
           "memory_reserve_expand": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Amount the memory can grow beyond its normal limits if there are unreserved resources available."
           },
           "memory_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The absolute memory limit for the VM."
           },
           "memory_shares": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of memory shares allocated. Used to determine resource allocation in case of resource contention."
           },
           "memory_shares_level": {
-            "type": "string"
+            "type": "string",
+            "description": "Memory shares allocation level."
           },
           "cpu_reserve": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Amount of CPU that is guaranteed available for the VM."
           },
           "cpu_reserve_expand": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Amount the CPU can grow beyond its normal limits if there are unreserved resources available."
           },
           "cpu_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The CPU utilization limit for the VM."
           },
           "cpu_shares": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of CPU shares allocated. Used to determine resource allocation in case of resource contention."
           },
           "cpu_shares_level": {
-            "type": "string"
+            "type": "string",
+            "description": "CPU shares allocation level."
           },
           "cpu_affinity": {
-            "type": "string"
+            "type": "string",
+            "description": "A comma separated list of host CPUs to schedule the VM on."
           },
           "ems_created_on": {
             "type": "string",
+            "description": "The timestamp the VM or Templated was created on the EMS itself.",
             "format": "date-time"
           },
           "template": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether this is a VM or template."
           },
           "evm_owner_id": {
             "$ref": "#/components/schemas/ID"
@@ -1361,29 +1402,36 @@
             "$ref": "#/components/schemas/ID"
           },
           "linked_clone": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM is a linked clone, i.e its disk is a referencing disk pointing to snapshot of another VM."
           },
           "fault_tolerance": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is fault tolerant, i.e. if one host crashes it will immediately pick up on another host in the cluster."
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "description": "An internal class name that includes the provider type."
           },
           "ems_ref": {
-            "type": "string"
+            "type": "string",
+            "description": "A native unique reference for the VM within the EMS."
           },
           "ems_cluster_id": {
             "$ref": "#/components/schemas/ID"
           },
           "retirement_warn": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Warning message when VM was put into retirement."
           },
           "retirement_last_warn": {
             "type": "string",
+            "description": "Date of last retirement warning.",
             "format": "date-time"
           },
           "vnc_port": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Port or port range used for VNC connections."
           },
           "flavor_id": {
             "$ref": "#/components/schemas/ID"
@@ -1392,10 +1440,12 @@
             "$ref": "#/components/schemas/ID"
           },
           "cloud": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM/Template is cloud or infra."
           },
           "retirement_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current retirement state."
           },
           "cloud_network_id": {
             "$ref": "#/components/schemas/ID"
@@ -1407,16 +1457,19 @@
             "$ref": "#/components/schemas/ID"
           },
           "raw_power_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The power state refreshed from the EMS."
           },
           "publicly_available": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM is public or private."
           },
           "orchestration_stack_id": {
             "$ref": "#/components/schemas/ID"
           },
           "retirement_requester": {
-            "type": "string"
+            "type": "string",
+            "description": "Userid of the user who requested retirement."
           },
           "tenant_id": {
             "$ref": "#/components/schemas/ID"
@@ -1425,25 +1478,31 @@
             "$ref": "#/components/schemas/ID"
           },
           "deprecated": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not a template is deprecated."
           },
           "storage_profile_id": {
             "$ref": "#/components/schemas/ID"
           },
           "cpu_hot_add_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates if CPUs can be added to the VM while it is powered on."
           },
           "cpu_hot_remove_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates if a CPU can be removed from a VM while powered on."
           },
           "memory_hot_add_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not memory can be hot added to the running VM."
           },
           "memory_hot_add_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The maximum amount of memory, in MB, that can be added to a running VM."
           },
           "memory_hot_add_increment": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Memory in MB that can be added to a running VM must be in increments of this value."
           },
           "hostname": {
             "type": "string"
@@ -4201,146 +4260,187 @@
             "$ref": "#/components/schemas/ID"
           },
           "vendor": {
-            "type": "string"
+            "type": "string",
+            "description": "The vendor for the VM, e.g. azure, amazon, etc."
           },
           "format": {
-            "type": "string"
+            "type": "string",
+            "description": "The format of the VM's disk, such as vmdk, qcow2, and tier1."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "The version of the VM definition."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the VM/Template."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "A description of the VM that is typically set by the provider, but may also be edited."
           },
           "location": {
-            "type": "string"
+            "type": "string",
+            "description": "The location of the VM, or its underlying storage."
           },
           "config_xml": {
-            "type": "string"
+            "type": "string",
+            "description": "The VM or Template configuration in XML format. Deprecated."
           },
           "autostart": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates whether or not the VM is set to autostart."
           },
           "host_id": {
             "$ref": "#/components/schemas/ID"
           },
           "last_sync_on": {
             "type": "string",
+            "description": "Timestamp for last SmartState analysis synchronization.",
             "format": "date-time"
           },
           "created_on": {
             "type": "string",
+            "description": "The timestamp the VM was added to the app inventory.",
             "format": "date-time"
           },
           "updated_on": {
             "type": "string",
+            "description": "The last timestamp the VM was modified within the app.",
             "format": "date-time"
           },
           "storage_id": {
             "$ref": "#/components/schemas/ID"
           },
           "guid": {
-            "type": "string"
+            "type": "string",
+            "description": "A value used to uniquely identify the VM internally."
           },
           "ems_id": {
             "$ref": "#/components/schemas/ID"
           },
           "last_scan_on": {
             "type": "string",
+            "description": "Timestamp for last SmartState analysis scan.",
             "format": "date-time"
           },
           "last_scan_attempt_on": {
             "type": "string",
+            "description": "Timestamp for last attempt to perform SmartState Analysis.",
             "format": "date-time"
           },
           "uid_ems": {
-            "type": "string"
+            "type": "string",
+            "description": "A globally unique reference for the VM across EMS."
           },
           "retires_on": {
             "type": "string",
+            "description": "Timestamp the VM is to be retired.",
             "format": "date-time"
           },
           "retired": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is retired."
           },
           "boot_time": {
             "type": "string",
+            "description": "The last time the VM was started.",
             "format": "date-time"
           },
           "tools_status": {
-            "type": "string"
+            "type": "string",
+            "description": "Status of guest tools."
           },
           "standby_action": {
-            "type": "string"
+            "type": "string",
+            "description": "Action taken when VM is put into standby mode."
           },
           "power_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current power state, typically 'on' or 'off'."
           },
           "state_changed_on": {
             "type": "string",
+            "description": "The timestamp of the last power state change.",
             "format": "date-time"
           },
           "previous_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The previous power state change."
           },
           "connection_state": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates the connection state of the VM, e.g. connected, disconnected, etc."
           },
           "last_perf_capture_on": {
             "type": "string",
+            "description": "Timestamp for last performance metrics capture.",
             "format": "date-time"
           },
           "registered": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM registered to a Provider. Deprecated."
           },
           "busy": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is being scanned for SmartState analysis. Deprecated."
           },
           "smart": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not smart proxy is enabled. Deprecated."
           },
           "memory_reserve": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Amount of memory that is guaranteed available for the VM."
           },
           "memory_reserve_expand": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Amount the memory can grow beyond its normal limits if there are unreserved resources available."
           },
           "memory_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The absolute memory limit for the VM."
           },
           "memory_shares": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of memory shares allocated. Used to determine resource allocation in case of resource contention."
           },
           "memory_shares_level": {
-            "type": "string"
+            "type": "string",
+            "description": "Memory shares allocation level."
           },
           "cpu_reserve": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Amount of CPU that is guaranteed available for the VM."
           },
           "cpu_reserve_expand": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Amount the CPU can grow beyond its normal limits if there are unreserved resources available."
           },
           "cpu_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The CPU utilization limit for the VM."
           },
           "cpu_shares": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of CPU shares allocated. Used to determine resource allocation in case of resource contention."
           },
           "cpu_shares_level": {
-            "type": "string"
+            "type": "string",
+            "description": "CPU shares allocation level."
           },
           "cpu_affinity": {
-            "type": "string"
+            "type": "string",
+            "description": "A comma separated list of host CPUs to schedule the VM on."
           },
           "ems_created_on": {
             "type": "string",
+            "description": "The timestamp the VM or Templated was created on the EMS itself.",
             "format": "date-time"
           },
           "template": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether this is a VM or template."
           },
           "evm_owner_id": {
             "$ref": "#/components/schemas/ID"
@@ -4349,29 +4449,36 @@
             "$ref": "#/components/schemas/ID"
           },
           "linked_clone": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM is a linked clone, i.e its disk is a referencing disk pointing to snapshot of another VM."
           },
           "fault_tolerance": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is fault tolerant, i.e. if one host crashes it will immediately pick up on another host in the cluster."
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "description": "An internal class name that includes the provider type."
           },
           "ems_ref": {
-            "type": "string"
+            "type": "string",
+            "description": "A native unique reference for the VM within the EMS."
           },
           "ems_cluster_id": {
             "$ref": "#/components/schemas/ID"
           },
           "retirement_warn": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Warning message when VM was put into retirement."
           },
           "retirement_last_warn": {
             "type": "string",
+            "description": "Date of last retirement warning.",
             "format": "date-time"
           },
           "vnc_port": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Port or port range used for VNC connections."
           },
           "flavor_id": {
             "$ref": "#/components/schemas/ID"
@@ -4380,10 +4487,12 @@
             "$ref": "#/components/schemas/ID"
           },
           "cloud": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM/Template is cloud or infra."
           },
           "retirement_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current retirement state."
           },
           "cloud_network_id": {
             "$ref": "#/components/schemas/ID"
@@ -4395,16 +4504,19 @@
             "$ref": "#/components/schemas/ID"
           },
           "raw_power_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The power state refreshed from the EMS."
           },
           "publicly_available": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM is public or private."
           },
           "orchestration_stack_id": {
             "$ref": "#/components/schemas/ID"
           },
           "retirement_requester": {
-            "type": "string"
+            "type": "string",
+            "description": "Userid of the user who requested retirement."
           },
           "tenant_id": {
             "$ref": "#/components/schemas/ID"
@@ -4413,25 +4525,31 @@
             "$ref": "#/components/schemas/ID"
           },
           "deprecated": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not a template is deprecated."
           },
           "storage_profile_id": {
             "$ref": "#/components/schemas/ID"
           },
           "cpu_hot_add_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates if CPUs can be added to the VM while it is powered on."
           },
           "cpu_hot_remove_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates if a CPU can be removed from a VM while powered on."
           },
           "memory_hot_add_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not memory can be hot added to the running VM."
           },
           "memory_hot_add_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The maximum amount of memory, in MB, that can be added to a running VM."
           },
           "memory_hot_add_increment": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Memory in MB that can be added to a running VM must be in increments of this value."
           },
           "hostname": {
             "type": "string"
@@ -7581,7 +7699,8 @@
             "type": "string"
           },
           "initiator": {
-            "type": "string"
+            "type": "string",
+            "description": "Entity that initiated the service creation"
           },
           "lifecycle_state": {
             "type": "string"
@@ -7916,49 +8035,62 @@
             "$ref": "#/components/schemas/ID"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the task. Typically doubles as a description."
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current state of the task - Initialized, Queued, Active, Finished, etc."
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "description": "The current status of the task - Ok, Warn, Error, Timeout, Expired, or Unknown."
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "Message associated with the task for logging or UI purposes."
           },
           "userid": {
-            "type": "string"
+            "type": "string",
+            "description": "The userid that created the task, or 'system' if created by the appliance."
           },
           "created_on": {
             "type": "string",
+            "description": "[builtin] The timestamp the record was created.",
             "format": "date-time"
           },
           "updated_on": {
             "type": "string",
+            "description": "[builtin] The timestamp the record was last updated.",
             "format": "date-time"
           },
           "pct_complete": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The current completion percentage of the task."
           },
           "context_data": {
-            "type": "string"
+            "type": "string",
+            "description": "Serialized metadata that may contain more detailed information about the task."
           },
           "results": {
-            "type": "string"
+            "type": "string",
+            "description": "Task execution result. Deprecated."
           },
           "miq_server_id": {
             "$ref": "#/components/schemas/ID"
           },
           "identifier": {
-            "type": "string"
+            "type": "string",
+            "description": "The resource this task is related to in 'class:id' format."
           },
           "started_on": {
             "type": "string",
+            "description": "The timestamp the task was actually started.",
             "format": "date-time"
           },
           "zone": {
-            "type": "string"
+            "type": "string",
+            "description": "The zone in which the task should be executed, or any zone if null."
           }
         },
         "additionalProperties": false
@@ -7970,146 +8102,187 @@
             "$ref": "#/components/schemas/ID"
           },
           "vendor": {
-            "type": "string"
+            "type": "string",
+            "description": "The vendor for the VM, e.g. azure, amazon, etc."
           },
           "format": {
-            "type": "string"
+            "type": "string",
+            "description": "The format of the VM's disk, such as vmdk, qcow2, and tier1."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "The version of the VM definition."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the VM/Template."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "A description of the VM that is typically set by the provider, but may also be edited."
           },
           "location": {
-            "type": "string"
+            "type": "string",
+            "description": "The location of the VM, or its underlying storage."
           },
           "config_xml": {
-            "type": "string"
+            "type": "string",
+            "description": "The VM or Template configuration in XML format. Deprecated."
           },
           "autostart": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates whether or not the VM is set to autostart."
           },
           "host_id": {
             "$ref": "#/components/schemas/ID"
           },
           "last_sync_on": {
             "type": "string",
+            "description": "Timestamp for last SmartState analysis synchronization.",
             "format": "date-time"
           },
           "created_on": {
             "type": "string",
+            "description": "The timestamp the VM was added to the app inventory.",
             "format": "date-time"
           },
           "updated_on": {
             "type": "string",
+            "description": "The last timestamp the VM was modified within the app.",
             "format": "date-time"
           },
           "storage_id": {
             "$ref": "#/components/schemas/ID"
           },
           "guid": {
-            "type": "string"
+            "type": "string",
+            "description": "A value used to uniquely identify the VM internally."
           },
           "ems_id": {
             "$ref": "#/components/schemas/ID"
           },
           "last_scan_on": {
             "type": "string",
+            "description": "Timestamp for last SmartState analysis scan.",
             "format": "date-time"
           },
           "last_scan_attempt_on": {
             "type": "string",
+            "description": "Timestamp for last attempt to perform SmartState Analysis.",
             "format": "date-time"
           },
           "uid_ems": {
-            "type": "string"
+            "type": "string",
+            "description": "A globally unique reference for the VM across EMS."
           },
           "retires_on": {
             "type": "string",
+            "description": "Timestamp the VM is to be retired.",
             "format": "date-time"
           },
           "retired": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is retired."
           },
           "boot_time": {
             "type": "string",
+            "description": "The last time the VM was started.",
             "format": "date-time"
           },
           "tools_status": {
-            "type": "string"
+            "type": "string",
+            "description": "Status of guest tools."
           },
           "standby_action": {
-            "type": "string"
+            "type": "string",
+            "description": "Action taken when VM is put into standby mode."
           },
           "power_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current power state, typically 'on' or 'off'."
           },
           "state_changed_on": {
             "type": "string",
+            "description": "The timestamp of the last power state change.",
             "format": "date-time"
           },
           "previous_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The previous power state change."
           },
           "connection_state": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates the connection state of the VM, e.g. connected, disconnected, etc."
           },
           "last_perf_capture_on": {
             "type": "string",
+            "description": "Timestamp for last performance metrics capture.",
             "format": "date-time"
           },
           "registered": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM registered to a Provider. Deprecated."
           },
           "busy": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is being scanned for SmartState analysis. Deprecated."
           },
           "smart": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not smart proxy is enabled. Deprecated."
           },
           "memory_reserve": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Amount of memory that is guaranteed available for the VM."
           },
           "memory_reserve_expand": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Amount the memory can grow beyond its normal limits if there are unreserved resources available."
           },
           "memory_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The absolute memory limit for the VM."
           },
           "memory_shares": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of memory shares allocated. Used to determine resource allocation in case of resource contention."
           },
           "memory_shares_level": {
-            "type": "string"
+            "type": "string",
+            "description": "Memory shares allocation level."
           },
           "cpu_reserve": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Amount of CPU that is guaranteed available for the VM."
           },
           "cpu_reserve_expand": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Amount the CPU can grow beyond its normal limits if there are unreserved resources available."
           },
           "cpu_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The CPU utilization limit for the VM."
           },
           "cpu_shares": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of CPU shares allocated. Used to determine resource allocation in case of resource contention."
           },
           "cpu_shares_level": {
-            "type": "string"
+            "type": "string",
+            "description": "CPU shares allocation level."
           },
           "cpu_affinity": {
-            "type": "string"
+            "type": "string",
+            "description": "A comma separated list of host CPUs to schedule the VM on."
           },
           "ems_created_on": {
             "type": "string",
+            "description": "The timestamp the VM or Templated was created on the EMS itself.",
             "format": "date-time"
           },
           "template": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether this is a VM or template."
           },
           "evm_owner_id": {
             "$ref": "#/components/schemas/ID"
@@ -8118,29 +8291,36 @@
             "$ref": "#/components/schemas/ID"
           },
           "linked_clone": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM is a linked clone, i.e its disk is a referencing disk pointing to snapshot of another VM."
           },
           "fault_tolerance": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is fault tolerant, i.e. if one host crashes it will immediately pick up on another host in the cluster."
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "description": "An internal class name that includes the provider type."
           },
           "ems_ref": {
-            "type": "string"
+            "type": "string",
+            "description": "A native unique reference for the VM within the EMS."
           },
           "ems_cluster_id": {
             "$ref": "#/components/schemas/ID"
           },
           "retirement_warn": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Warning message when VM was put into retirement."
           },
           "retirement_last_warn": {
             "type": "string",
+            "description": "Date of last retirement warning.",
             "format": "date-time"
           },
           "vnc_port": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Port or port range used for VNC connections."
           },
           "flavor_id": {
             "$ref": "#/components/schemas/ID"
@@ -8149,10 +8329,12 @@
             "$ref": "#/components/schemas/ID"
           },
           "cloud": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM/Template is cloud or infra."
           },
           "retirement_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current retirement state."
           },
           "cloud_network_id": {
             "$ref": "#/components/schemas/ID"
@@ -8164,16 +8346,19 @@
             "$ref": "#/components/schemas/ID"
           },
           "raw_power_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The power state refreshed from the EMS."
           },
           "publicly_available": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM is public or private."
           },
           "orchestration_stack_id": {
             "$ref": "#/components/schemas/ID"
           },
           "retirement_requester": {
-            "type": "string"
+            "type": "string",
+            "description": "Userid of the user who requested retirement."
           },
           "tenant_id": {
             "$ref": "#/components/schemas/ID"
@@ -8182,25 +8367,31 @@
             "$ref": "#/components/schemas/ID"
           },
           "deprecated": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not a template is deprecated."
           },
           "storage_profile_id": {
             "$ref": "#/components/schemas/ID"
           },
           "cpu_hot_add_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates if CPUs can be added to the VM while it is powered on."
           },
           "cpu_hot_remove_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates if a CPU can be removed from a VM while powered on."
           },
           "memory_hot_add_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not memory can be hot added to the running VM."
           },
           "memory_hot_add_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The maximum amount of memory, in MB, that can be added to a running VM."
           },
           "memory_hot_add_increment": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Memory in MB that can be added to a running VM must be in increments of this value."
           },
           "hostname": {
             "type": "string"
@@ -8382,146 +8573,187 @@
             "$ref": "#/components/schemas/ID"
           },
           "vendor": {
-            "type": "string"
+            "type": "string",
+            "description": "The vendor for the VM, e.g. azure, amazon, etc."
           },
           "format": {
-            "type": "string"
+            "type": "string",
+            "description": "The format of the VM's disk, such as vmdk, qcow2, and tier1."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "The version of the VM definition."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the VM/Template."
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "A description of the VM that is typically set by the provider, but may also be edited."
           },
           "location": {
-            "type": "string"
+            "type": "string",
+            "description": "The location of the VM, or its underlying storage."
           },
           "config_xml": {
-            "type": "string"
+            "type": "string",
+            "description": "The VM or Template configuration in XML format. Deprecated."
           },
           "autostart": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates whether or not the VM is set to autostart."
           },
           "host_id": {
             "$ref": "#/components/schemas/ID"
           },
           "last_sync_on": {
             "type": "string",
+            "description": "Timestamp for last SmartState analysis synchronization.",
             "format": "date-time"
           },
           "created_on": {
             "type": "string",
+            "description": "The timestamp the VM was added to the app inventory.",
             "format": "date-time"
           },
           "updated_on": {
             "type": "string",
+            "description": "The last timestamp the VM was modified within the app.",
             "format": "date-time"
           },
           "storage_id": {
             "$ref": "#/components/schemas/ID"
           },
           "guid": {
-            "type": "string"
+            "type": "string",
+            "description": "A value used to uniquely identify the VM internally."
           },
           "ems_id": {
             "$ref": "#/components/schemas/ID"
           },
           "last_scan_on": {
             "type": "string",
+            "description": "Timestamp for last SmartState analysis scan.",
             "format": "date-time"
           },
           "last_scan_attempt_on": {
             "type": "string",
+            "description": "Timestamp for last attempt to perform SmartState Analysis.",
             "format": "date-time"
           },
           "uid_ems": {
-            "type": "string"
+            "type": "string",
+            "description": "A globally unique reference for the VM across EMS."
           },
           "retires_on": {
             "type": "string",
+            "description": "Timestamp the VM is to be retired.",
             "format": "date-time"
           },
           "retired": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is retired."
           },
           "boot_time": {
             "type": "string",
+            "description": "The last time the VM was started.",
             "format": "date-time"
           },
           "tools_status": {
-            "type": "string"
+            "type": "string",
+            "description": "Status of guest tools."
           },
           "standby_action": {
-            "type": "string"
+            "type": "string",
+            "description": "Action taken when VM is put into standby mode."
           },
           "power_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current power state, typically 'on' or 'off'."
           },
           "state_changed_on": {
             "type": "string",
+            "description": "The timestamp of the last power state change.",
             "format": "date-time"
           },
           "previous_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The previous power state change."
           },
           "connection_state": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates the connection state of the VM, e.g. connected, disconnected, etc."
           },
           "last_perf_capture_on": {
             "type": "string",
+            "description": "Timestamp for last performance metrics capture.",
             "format": "date-time"
           },
           "registered": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM registered to a Provider. Deprecated."
           },
           "busy": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is being scanned for SmartState analysis. Deprecated."
           },
           "smart": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not smart proxy is enabled. Deprecated."
           },
           "memory_reserve": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Amount of memory that is guaranteed available for the VM."
           },
           "memory_reserve_expand": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Amount the memory can grow beyond its normal limits if there are unreserved resources available."
           },
           "memory_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The absolute memory limit for the VM."
           },
           "memory_shares": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of memory shares allocated. Used to determine resource allocation in case of resource contention."
           },
           "memory_shares_level": {
-            "type": "string"
+            "type": "string",
+            "description": "Memory shares allocation level."
           },
           "cpu_reserve": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Amount of CPU that is guaranteed available for the VM."
           },
           "cpu_reserve_expand": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Amount the CPU can grow beyond its normal limits if there are unreserved resources available."
           },
           "cpu_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The CPU utilization limit for the VM."
           },
           "cpu_shares": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of CPU shares allocated. Used to determine resource allocation in case of resource contention."
           },
           "cpu_shares_level": {
-            "type": "string"
+            "type": "string",
+            "description": "CPU shares allocation level."
           },
           "cpu_affinity": {
-            "type": "string"
+            "type": "string",
+            "description": "A comma separated list of host CPUs to schedule the VM on."
           },
           "ems_created_on": {
             "type": "string",
+            "description": "The timestamp the VM or Templated was created on the EMS itself.",
             "format": "date-time"
           },
           "template": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether this is a VM or template."
           },
           "evm_owner_id": {
             "$ref": "#/components/schemas/ID"
@@ -8530,29 +8762,36 @@
             "$ref": "#/components/schemas/ID"
           },
           "linked_clone": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM is a linked clone, i.e its disk is a referencing disk pointing to snapshot of another VM."
           },
           "fault_tolerance": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM is fault tolerant, i.e. if one host crashes it will immediately pick up on another host in the cluster."
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "description": "An internal class name that includes the provider type."
           },
           "ems_ref": {
-            "type": "string"
+            "type": "string",
+            "description": "A native unique reference for the VM within the EMS."
           },
           "ems_cluster_id": {
             "$ref": "#/components/schemas/ID"
           },
           "retirement_warn": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Warning message when VM was put into retirement."
           },
           "retirement_last_warn": {
             "type": "string",
+            "description": "Date of last retirement warning.",
             "format": "date-time"
           },
           "vnc_port": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Port or port range used for VNC connections."
           },
           "flavor_id": {
             "$ref": "#/components/schemas/ID"
@@ -8561,10 +8800,12 @@
             "$ref": "#/components/schemas/ID"
           },
           "cloud": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not the VM/Template is cloud or infra."
           },
           "retirement_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current retirement state."
           },
           "cloud_network_id": {
             "$ref": "#/components/schemas/ID"
@@ -8576,16 +8817,19 @@
             "$ref": "#/components/schemas/ID"
           },
           "raw_power_state": {
-            "type": "string"
+            "type": "string",
+            "description": "The power state refreshed from the EMS."
           },
           "publicly_available": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether the VM is public or private."
           },
           "orchestration_stack_id": {
             "$ref": "#/components/schemas/ID"
           },
           "retirement_requester": {
-            "type": "string"
+            "type": "string",
+            "description": "Userid of the user who requested retirement."
           },
           "tenant_id": {
             "$ref": "#/components/schemas/ID"
@@ -8594,25 +8838,31 @@
             "$ref": "#/components/schemas/ID"
           },
           "deprecated": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not a template is deprecated."
           },
           "storage_profile_id": {
             "$ref": "#/components/schemas/ID"
           },
           "cpu_hot_add_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates if CPUs can be added to the VM while it is powered on."
           },
           "cpu_hot_remove_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates if a CPU can be removed from a VM while powered on."
           },
           "memory_hot_add_enabled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether or not memory can be hot added to the running VM."
           },
           "memory_hot_add_limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The maximum amount of memory, in MB, that can be added to a running VM."
           },
           "memory_hot_add_increment": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Memory in MB that can be added to a running VM must be in increments of this value."
           },
           "hostname": {
             "type": "string"

--- a/lib/manageiq/api/open_api/generator.rb
+++ b/lib/manageiq/api/open_api/generator.rb
@@ -34,7 +34,16 @@ module ManageIQ
         end
 
         def build_schemas
-          ::Api::ApiConfig.collections.each_with_object({}) do |(_collection_name, collection), schemas|
+          schemas = {
+            "ID" => {
+              "type"        => "string",
+              "description" => "ID of the resource",
+              "pattern"     => "^\\d+$",
+              "readOnly"    => true,
+            }
+          }
+
+          ::Api::ApiConfig.collections.each do |_collection_name, collection|
             next unless collection.klass
 
             model = collection.klass.constantize
@@ -45,6 +54,8 @@ module ManageIQ
               "additionalProperties" => false
             }
           end
+
+          schemas
         end
 
         def build_schema_properties(model)
@@ -78,17 +89,6 @@ module ManageIQ
 
             properties_value
           end
-        end
-
-        def schemas
-          @schemas ||= {
-            "ID" => {
-              "type"        => "string",
-              "description" => "ID of the resource",
-              "pattern"     => "^\\d+$",
-              "readOnly"    => true,
-            }
-          }
         end
 
         def skeletal_openapi_spec

--- a/lib/manageiq/api/open_api/generator.rb
+++ b/lib/manageiq/api/open_api/generator.rb
@@ -46,9 +46,10 @@ module ManageIQ
           ::Api::ApiConfig.collections.each do |_collection_name, collection|
             next unless collection.klass
 
-            model = collection.klass.constantize
+            model       = collection.klass.constantize
+            schema_name = model.name.gsub("::", "_")
 
-            schemas[model.name] = {
+            schemas[schema_name] = {
               "type"                 => "object",
               "properties"           => build_schema_properties(model),
               "additionalProperties" => false

--- a/lib/manageiq/api/open_api/generator.rb
+++ b/lib/manageiq/api/open_api/generator.rb
@@ -94,10 +94,12 @@ module ManageIQ
         def skeletal_openapi_spec
           {
             "openapi"    => OPENAPI_VERSION,
-            "info"       => {},
-            "security"   => [],
+            "info"       => {
+              "version"     => api_version,
+              "title"       => ::Api::ApiConfig.base.name,
+              "description" => ::Api::ApiConfig.base.description
+            },
             "paths"      => {},
-            "servers"    => [],
             "components" => {
               "parameters" => {},
               "schemas"    => {}

--- a/lib/manageiq/api/open_api/generator.rb
+++ b/lib/manageiq/api/open_api/generator.rb
@@ -74,7 +74,7 @@ module ManageIQ
             properties_value["format"] = "date-time"
           when :integer
             if key == model.primary_key || key.ends_with?("_id")
-              properties_value = {"$ref" => "##{SCHEMAS_PATH}/ID"}
+              properties_value["$ref"] = "##{SCHEMAS_PATH}/ID"
             else
               properties_value["type"] = "integer"
             end

--- a/lib/manageiq/api/open_api/generator.rb
+++ b/lib/manageiq/api/open_api/generator.rb
@@ -20,7 +20,7 @@ module ManageIQ
 
         def generate!
           openapi_spec["components"]["schemas"] = build_schemas
-          File.write(openapi_path, "#{JSON.pretty_generate(openapi_spec)}\n")
+          openapi_path.write("#{JSON.pretty_generate(openapi_spec)}\n")
         end
 
         private

--- a/lib/manageiq/api/open_api/generator.rb
+++ b/lib/manageiq/api/open_api/generator.rb
@@ -43,20 +43,20 @@ module ManageIQ
             }
           }
 
-          ::Api::ApiConfig.collections.each do |_collection_name, collection|
+          models = ::Api::ApiConfig.collections.each_with_object({}) do |(_collection_name, collection), s|
             next unless collection.klass
 
             model       = collection.klass.constantize
             schema_name = model.name.gsub("::", "_")
 
-            schemas[schema_name] = {
+            s[schema_name] = {
               "type"                 => "object",
               "properties"           => build_schema_properties(model),
               "additionalProperties" => false
             }
           end
 
-          schemas
+          schemas.merge(models.sort.to_h)
         end
 
         def build_schema_properties(model)

--- a/lib/manageiq/api/open_api/generator.rb
+++ b/lib/manageiq/api/open_api/generator.rb
@@ -1,0 +1,108 @@
+module ManageIQ
+  module Api
+    module OpenApi
+      class Generator
+        require 'json'
+
+        OPENAPI_VERSION = "3.0.0".freeze
+        PARAMETERS_PATH = "/components/parameters".freeze
+        SCHEMAS_PATH    = "/components/schemas".freeze
+
+        attr_reader :manageiq_api_path, :openapi_path, :openapi_spec
+
+        def initialize
+          manageiq_api_engine = Vmdb::Plugins.all.detect { |e| e.name == "ManageIQ::Api::Engine" }
+
+          @manageiq_api_path = manageiq_api_engine.root
+          @openapi_path      = manageiq_api_path.join("config", "openapi.json")
+          @openapi_spec      = skeletal_openapi_spec
+        end
+
+        def generate!
+          openapi_spec["components"]["schemas"] = build_schemas
+          File.write(openapi_path, JSON.pretty_generate(openapi_spec) + "\n")
+        end
+
+        private
+
+        def api_version
+          ManageIQ::Api::VERSION
+        end
+
+        def server_base_path
+          "/api(/:version)"
+        end
+
+        def build_schemas
+          ::Api::ApiConfig.collections.each_with_object({}) do |(collection_name, collection), schemas|
+            next unless collection.klass
+
+            model = collection.klass.constantize
+
+            schemas[model.name] = {
+              "type"                 => "object",
+              "properties"           => build_schema_properties(model),
+              "additionalProperties" => false
+            }
+          end
+        end
+
+        def build_schema_properties(model)
+          model.columns_hash.each_with_object({}) do |(key, value), properties|
+            properties[key] = build_schema_properties_value(model, key, value)
+          end
+        end
+
+        def build_schema_properties_value(model, key, value)
+          if key == model.primary_key || key.ends_with?("_id")
+            {"$ref" => "##{SCHEMAS_PATH}/ID"}
+          else
+            properties_value = {
+              "type" => "string"
+            }
+
+            case value.sql_type_metadata.type
+            when :datetime
+              properties_value["format"] = "date-time"
+            when :integer
+              properties_value["type"] = "integer"
+            when :float
+              properties_value["type"] = "number"
+            when :boolean
+              properties_value["type"] = "boolean"
+            when :jsonb
+              properties_value["type"] = "object"
+            end
+
+            properties_value
+          end
+        end
+
+        def schemas
+          @schemas ||= {
+            "ID" => {
+              "type"        => "string",
+              "description" => "ID of the resource",
+              "pattern"     => "^\\d+$",
+              "readOnly"    => true,
+            }
+          }
+        end
+
+        def skeletal_openapi_spec
+          {
+            "openapi"    => OPENAPI_VERSION,
+            "info"       => {},
+            "secuirty"   => [],
+            "paths"      => {},
+            "servers"    => [],
+            "components" => {
+              "parameters" => {},
+              "schemas"    => {}
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/api/open_api/generator.rb
+++ b/lib/manageiq/api/open_api/generator.rb
@@ -20,7 +20,7 @@ module ManageIQ
 
         def generate!
           openapi_spec["components"]["schemas"] = build_schemas
-          File.write(openapi_path, JSON.pretty_generate(openapi_spec) + "\n")
+          File.write(openapi_path, "#{JSON.pretty_generate(openapi_spec)}\n")
         end
 
         private
@@ -34,7 +34,7 @@ module ManageIQ
         end
 
         def build_schemas
-          ::Api::ApiConfig.collections.each_with_object({}) do |(collection_name, collection), schemas|
+          ::Api::ApiConfig.collections.each_with_object({}) do |(_collection_name, collection), schemas|
             next unless collection.klass
 
             model = collection.klass.constantize
@@ -60,6 +60,8 @@ module ManageIQ
             properties_value = {
               "type" => "string"
             }
+
+            properties_value["description"] = value.comment if value.comment.present?
 
             case value.sql_type_metadata.type
             when :datetime
@@ -93,7 +95,7 @@ module ManageIQ
           {
             "openapi"    => OPENAPI_VERSION,
             "info"       => {},
-            "secuirty"   => [],
+            "security"   => [],
             "paths"      => {},
             "servers"    => [],
             "components" => {

--- a/lib/tasks/manageiq/api_tasks.rake
+++ b/lib/tasks/manageiq/api_tasks.rake
@@ -2,3 +2,11 @@
 # task :manageiq_api do
 #   # Task goes here
 # end
+
+namespace "manageiq:api" do
+  desc "Generate an OpenAPI specification"
+  task "openapi_generate" => :environment do
+    generator = ManageIQ::Api::OpenApi::Generator.new
+    generator.generate!
+  end
+end


### PR DESCRIPTION
Passes validation https://editor-next.swagger.io/

```
$ bundle exec rake app:manageiq:api:openapi_generate
```

TODO
- [x] Load models to build schema
- [x] Add descriptions if a column has a comment
- [ ] Detect and build parameters
- [ ] Handle multiple post actions

https://github.com/ManageIQ/manageiq-api/issues/717