### PR TITLE
[requests/providers_spec.rb] Jansa approved spec

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1589,6 +1589,8 @@ describe "Providers API" do
 
   context 'GET /api/providers' do
     context "with multiple direct virtual attributes" do
+      let(:api_attributes) { "name,total_vms,total_vms_and_templates" }
+
       before do
         api_basic_authorize action_identifier(:providers, :read, :collection_actions, :get)
 
@@ -1609,7 +1611,7 @@ describe "Providers API" do
         expect {
           get api_providers_url, :params => {
             :expand     => "resources",
-            :attributes => "name,aggregate_vm_cpus,total_vms"
+            :attributes => api_attributes
           }
         }.to make_database_queries(:count => 0, :matching => query_match)
       end
@@ -1620,7 +1622,7 @@ describe "Providers API" do
         expect {
           get api_providers_url, :params => {
             :expand     => "resources",
-            :attributes => "name,aggregate_vm_cpus,total_vms"
+            :attributes => api_attributes
           }
         }.to make_database_queries(:count => 3, :matching => query_match)
       end


### PR DESCRIPTION
There has been a bit of a saga with these specs:

- https://github.com/ManageIQ/manageiq-api/pull/933#issuecomment-715313395
- https://github.com/ManageIQ/manageiq-api/pull/933#issuecomment-716787919

And it mostly ties in with some code that was updated for kasparov and up for `aggregate_vm_cpus`, but wasn't backported to `jansa` (which was probably the right choice).

- https://github.com/ManageIQ/manageiq/pull/20149

However, it caused the specs to behave differently on the two branches, and thus fail on `jansa`.  The nice part about these originally is that these specs very much replicated what we were seeing here:

https://github.com/ManageIQ/manageiq-api/issues/923#issuecomment-713160644

But since that isn't valid for both branches, it is better to use specs that are suited for both branches.

Links
-----

* `jansa` branch failure report:  https://github.com/ManageIQ/manageiq-api/pull/933#issuecomment-716787919
* Offending PRs:
  - https://github.com/ManageIQ/manageiq-api/pull/933
  - https://github.com/ManageIQ/manageiq-api/pull/940
* Related code not in `jansa`:  https://github.com/ManageIQ/manageiq/pull/20149

QA steps
--------

1. Pull down a local copy of this repo
   
2. Checkout the merge commit prior to my fix from #933 being added to `master`
   
   ```
   $ git checkout c2dc6c96
   ```
   
3. Override the `manageiq-api` gem in `bundler.d/`
   
   ```ruby
   override_gem 'manageiq-api', :path => '/Users/nicklamuro/code/redhat/manageiq-api'
   ```

From there, you should be able to repeat the testing you did for https://github.com/ManageIQ/manageiq-api/issues/923 but just change the attributes in the request to what is in the specs here:

```
/api/providers?expand=resources&attributes=name,total_vms,total_vms_and_templates
```