### PR TITLE
Handle DDF type API_ATTRIBUTES in AuthenticationsSpec

### DIFF
--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe 'Authentications API' do
         next unless defined? subklass::API_OPTIONS
         subklass::API_OPTIONS.tap do |options|
           options[:attributes].each do |_k, val|
-            val[:type] = val[:type].to_s if val[:type]
+            val[:type] = val[:type].to_s if val && val[:type]
           end
           fields[subklass.name] = options
         end


### PR DESCRIPTION
If an Ansible credential has DDF type attributes then we don't get a val in the loop.  Still trying to work out if this is the right fix or a band aid, this doesn't seem to be an issue for all credentials just some

https://github.com/ManageIQ/manageiq/pull/20568