### PR TITLE
Only show OPTIONS for supported providers

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -156,9 +156,9 @@ module Api
       klass.params_for_create
     end
 
-    def leaf_subclasses
+    def supported_subclasses
       ActiveSupport::Dependencies.interlock.loading do
-        ManageIQ::Providers::BaseManager.leaf_subclasses
+        ManageIQ::Providers::BaseManager.supported_subclasses
       end
     end
 
@@ -169,7 +169,7 @@ module Api
     end
 
     def providers_options
-      providers_options = leaf_subclasses.inject({}) do |po, ems|
+      providers_options = supported_subclasses.inject({}) do |po, ems|
         po.merge(ems.ems_type => ems.options_description)
       end
 

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -150,7 +150,7 @@ module Api
     def provider_options(type)
       klass = type.safe_constantize
 
-      raise BadRequestError, "Invalid provider - #{type}" unless klass.try(:<, ExtManagementSystem)
+      raise BadRequestError, "Invalid provider - #{type}" unless klass.try(:<, ExtManagementSystem) && klass.permitted?
       raise BadRequestError, "No DDF specified for - #{type}" unless klass.respond_to?(:params_for_create)
 
       klass.params_for_create

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1553,12 +1553,21 @@ describe "Providers API" do
     it "returns options for all providers when no query" do
       options(api_providers_url)
       expect(response.parsed_body["data"]["provider_settings"].keys.count).to eq(
-        ManageIQ::Providers::BaseManager.leaf_subclasses.count
+        ManageIQ::Providers::BaseManager.supported_subclasses.count
       )
       expect(response.parsed_body["data"]["supported_providers"].count).to eq(
         ExtManagementSystem.supported_types_for_create.count
       )
       expect(response.parsed_body["data"]["provider_settings"]["kubernetes"]["proxy_settings"]["settings"]["http_proxy"]["label"]).to eq('HTTP Proxy')
+    end
+
+    it "returns options for supported providers only" do
+      allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).and_return(false)
+      allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with("vmwarews").and_return(true)
+
+      options(api_providers_url)
+      expect(response.parsed_body["data"]["provider_settings"].keys.count).to eq(1)
+      expect(response.parsed_body["data"]["supported_providers"].count).to eq(1)
     end
 
     context 'single provider queried' do

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1576,6 +1576,11 @@ describe "Providers API" do
         expect_bad_request("Invalid provider - foo")
       end
 
+      it 'raises an error if the provider is not an EMS' do
+        options("#{api_providers_url}?type=Vm")
+        expect_bad_request("Invalid provider - Vm")
+      end
+
       it 'raises an error if the provider is not supported' do
         allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).and_return(false)
         allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with("vmwarews").and_return(true)


### PR DESCRIPTION
@agrare Please review.

When I was working on the callers of leaf_subclasses, I noticed this.  If a provider type is blocked we should not be exposing it via the API.  Coincidentally, this actually helps me on the leaf_subclasses side, because it removes another caller...effectively I think leaf_subclasses should probably be a private method.