### PR TITLE
Correctly update CustomButton data

### DIFF
--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -8,6 +8,8 @@ module Api
         custom_button.options = data["options"].deep_symbolize_keys if data["options"]
         custom_button.save!
         custom_button.create_resource_action!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
+        data.except!('resource_action')
+        custom_button.update!(data.deep_symbolize_keys) if data.present?
         custom_button
       end
     rescue => err


### PR DESCRIPTION
1. Create a new generic object definition
2. Click on that newly created generic object in UI
3. Click on add a new custom button (for the above GO): fill in name, description, icon and Request
4. See what the newly created custom button looks like.

Before: the custom button would lack the data from `Request` field:
```
irb(main):004:0> pp CustomButton.find_by(:name => 'custom-button-01').resource_action.ae_attributes
{}
=> {}
```

After:
```
irb(main):005:0> pp CustomButton.find_by(:name => 'custom-button-01').resource_action.ae_attributes
{:request=>"InspectMe", :service_template=>nil, :hosts=>nil}
=> {:request=>"InspectMe", :service_template=>nil, :hosts=>nil}
irb(main):006:0>
```

This was working before https://github.com/ManageIQ/manageiq-api/pull/814, but since we replaced `custom_button.resource_action.update!()` with `custom_button.create_resource_action!()`, we're now losing some of the submitted data.

https://bugzilla.redhat.com/show_bug.cgi?id=1892811