### PR TITLE
Include end date to queryable filter parameters for metric rollups end point

### DIFF
--- a/lib/services/api/metric_rollups_service.rb
+++ b/lib/services/api/metric_rollups_service.rb
@@ -1,32 +1,31 @@
 module Api
   class MetricRollupsService
-    REQUIRED_PARAMS = %w(resource_type capture_interval start_date).freeze
-    QUERY_PARAMS = %w(resource_ids).freeze
+    REQUIRED_FILTER_PARAMETERS = %w(resource_type capture_interval start_date).freeze
+    QUERY_FILTER_PARAMETERS = %w(resource_ids).freeze
 
-    attr_reader :params
+    attr_reader :filter_parameters
 
-    def initialize(params)
-      @params = params.slice(*(REQUIRED_PARAMS + QUERY_PARAMS))
-      validate_required_params
+    def initialize(parameters)
+      @filter_parameters = parameters.slice(*(REQUIRED_FILTER_PARAMETERS + QUERY_FILTER_PARAMETERS))
+      validate_required_filter_parameters
       validate_capture_interval
     end
 
     def query_metric_rollups
-      start_date = params[:start_date].to_date
-      end_date = params[:end_date].try(:to_date)
-
-      MetricRollup.rollups_in_range(params[:resource_type], params[:resource_ids], params[:capture_interval], start_date, end_date)
+      start_date = filter_parameters[:start_date].to_date
+      end_date = filter_parameters[:end_date].try(:to_date)
+      MetricRollup.rollups_in_range(filter_parameters[:resource_type], filter_parameters[:resource_ids], filter_parameters[:capture_interval], start_date, end_date)
     end
 
     private
 
-    def validate_required_params
-      not_specified = REQUIRED_PARAMS - params.keys
+    def validate_required_filter_parameters
+      not_specified = REQUIRED_FILTER_PARAMETERS - filter_parameters.keys
       raise BadRequestError, "Must specify #{not_specified.join(', ')}" unless not_specified.empty?
     end
 
     def validate_capture_interval
-      unless MetricRollup::CAPTURE_INTERVAL_NAMES.include?(params[:capture_interval])
+      unless MetricRollup::CAPTURE_INTERVAL_NAMES.include?(filter_parameters[:capture_interval])
         raise BadRequestError, "Capture interval must be one of #{MetricRollup::CAPTURE_INTERVAL_NAMES.join(', ')}"
       end
     end

--- a/lib/services/api/metric_rollups_service.rb
+++ b/lib/services/api/metric_rollups_service.rb
@@ -1,7 +1,7 @@
 module Api
   class MetricRollupsService
-    REQUIRED_FILTER_PARAMETERS = %w(resource_type capture_interval start_date).freeze
-    QUERY_FILTER_PARAMETERS = %w(resource_ids end_date).freeze
+    REQUIRED_FILTER_PARAMETERS = %w[resource_type capture_interval start_date].freeze
+    QUERY_FILTER_PARAMETERS = %w[resource_ids end_date].freeze
 
     attr_reader :filter_parameters
 

--- a/lib/services/api/metric_rollups_service.rb
+++ b/lib/services/api/metric_rollups_service.rb
@@ -1,7 +1,7 @@
 module Api
   class MetricRollupsService
     REQUIRED_FILTER_PARAMETERS = %w(resource_type capture_interval start_date).freeze
-    QUERY_FILTER_PARAMETERS = %w(resource_ids).freeze
+    QUERY_FILTER_PARAMETERS = %w(resource_ids end_date).freeze
 
     attr_reader :filter_parameters
 


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-api/issues/956.

```
GET /api/metric_rollups?expand=resources&resource_type=VmOrTemplate&capture_interval=daily&start_date='2011-10-21'&end_date='2019-10-22'
```

Before fix `end_date` have been ignored.  (When `end_date` is not specified then `end_date` is set to **'today'**.)

This fix adds ʻend_date` to queryable filter parameters and there is variable renaming in first commit -  'params' is known  as global variable on controller level.


