### PR TITLE
Introduce error code for errors

### DIFF
--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -99,6 +99,13 @@ module Api
       json_body.fetch("resource", json_body.except("action"))
     end
 
+    # A bulk request is of the form:
+    # {:action => :create, resources => [{},{}]}
+    # @returns true if this is a bulk request
+    def bulk?
+      json_body.kind_of?(Hash) && json_body.key?("resources")
+    end
+
     private
 
     def expand_requested

--- a/spec/requests/alert_definitions_spec.rb
+++ b/spec/requests/alert_definitions_spec.rb
@@ -504,7 +504,7 @@ describe "Alerts Definition Profiles API" do
 
     post(api_alert_definition_profile_alert_definitions_url(nil, alert_definition_profile), :params => gen_request(:unassign, alert_definition))
 
-    expect(response).to have_http_status(:ok)
+    expect(response).to have_http_status(:bad_request)
     expect(response.parsed_body["results"].count).to eq(1)
     expect(response.parsed_body["results"]).to include(a_hash_including("success" => false,
                                                                         "message" => "Unassigning alert_definition #{alert_definition.id} from profile #{alert_definition_profile.id}"))

--- a/spec/requests/auth_key_pairs_spec.rb
+++ b/spec/requests/auth_key_pairs_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Auth Key Pairs API" do
 
         post(api_auth_key_pairs_url, :params => {'name' => 'foo', 'ems_id' => provider.id})
 
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
 
         expected = {
           "results" => [

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe 'Authentications API' do
           { 'success' => false, 'message' => 'must supply a manager resource' }
         ]
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
 
@@ -227,7 +227,7 @@ RSpec.describe 'Authentications API' do
           { 'success' => false, 'message' => 'type not currently supported' }
         ]
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
 
@@ -247,7 +247,7 @@ RSpec.describe 'Authentications API' do
       expect(response.parsed_body).to include(expected)
     end
 
-    it 'can create authentications in bulk' do
+    it 'creates and fails in a single request' do
       api_basic_authorize collection_action_identifier(:authentications, :create, :post)
 
       expected = {
@@ -258,13 +258,12 @@ RSpec.describe 'Authentications API' do
             'task_id' => a_kind_of(String)
           ),
           a_hash_including(
-            'success' => true,
-            'message' => 'Creating Authentication',
-            'task_id' => a_kind_of(String)
+            'success' => false,
+            'message' => 'must supply a manager resource'
           )
         ]
       }
-      post(api_authentications_url, :params => { :resources => [create_params, create_params] })
+      post(api_authentications_url, :params => {:resources => [create_params, create_params.except(:manager_resource)]})
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -425,7 +424,7 @@ RSpec.describe 'Authentications API' do
         'success' => false,
         'message' => "Update not supported for Authentication id:#{auth.id} name: '#{auth.name}'"
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
 

--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -298,13 +298,13 @@ describe "Automation Requests API" do
     context "SubResource#cancel" do
       let(:resource_1_response) { {"success" => false, "message" => "Cancel operation is not supported for AutomationTask"} }
       let(:resource_2_response) { {"success" => false, "message" => "Cancel operation is not supported for AutomationTask"} }
-      include_context "SubResource#cancel", [:automation_request, :request_task], :automation_request, :automation_task
+      include_context "SubResource#cancel", [:automation_request, :request_task], :automation_request, :automation_task, false
     end
   end
 
   context "Resource#cancel" do
     let(:resource_1_response) { {"success" => false, "message" => "Cancel operation is not supported for AutomationRequest"} }
     let(:resource_2_response) { {"success" => false, "message" => "Cancel operation is not supported for AutomationRequest"} }
-    include_context "Resource#cancel", "automation_request", :automation_request
+    include_context "Resource#cancel", "automation_request", :automation_request, false
   end
 end

--- a/spec/requests/configuration_script_payloads_spec.rb
+++ b/spec/requests/configuration_script_payloads_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Configuration Script Payloads API' do
           { 'success' => false, 'message' => 'type not currently supported' }
         ]
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
 

--- a/spec/requests/configuration_script_sources_spec.rb
+++ b/spec/requests/configuration_script_sources_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe 'Configuration Script Sources API' do
         'success' => false,
         'message' => "Update not supported for ConfigurationScriptSource id:#{config_script_src.id} name: '#{config_script_src.name}'"
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
 
@@ -294,7 +294,7 @@ RSpec.describe 'Configuration Script Sources API' do
         'success' => false,
         'message' => "Delete not supported for ConfigurationScriptSource id:#{config_script_src.id} name: '#{config_script_src.name}'"
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
 

--- a/spec/requests/instances_spec.rb
+++ b/spec/requests/instances_spec.rb
@@ -749,7 +749,7 @@ RSpec.describe "Instances API" do
       post(api_instance_security_groups_url(nil, instance_vmware),
            :params => gen_request(:add, "name" => "security_group_name"))
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expected = {
         "results" => [
           a_hash_including(
@@ -767,7 +767,7 @@ RSpec.describe "Instances API" do
       post(api_instance_security_groups_url(nil, instance_vmware),
            :params => gen_request(:remove, "name" => "security_group_name"))
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expected = {
         "results" => [
           a_hash_including(

--- a/spec/requests/lans_spec.rb
+++ b/spec/requests/lans_spec.rb
@@ -107,7 +107,8 @@ RSpec.describe 'Lans API' do
       post(api_lan_tags_url(nil, lan1), :params => gen_request(:assign, :name => "/managed/bad_category/bad_name"))
 
       expect_tagging_result(
-        [{:success => false, :href => api_lan_url(nil, lan1), :tag_category => "bad_category", :tag_name => "bad_name"}]
+        [{:success => false, :href => api_lan_url(nil, lan1), :tag_category => "bad_category", :tag_name => "bad_name"}],
+        :bad_request
       )
     end
 

--- a/spec/requests/network_routers_spec.rb
+++ b/spec/requests/network_routers_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'NetworkRouters API' do
         'success' => false,
         'message' => a_string_including('Delete not supported for Network Router')
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
   end

--- a/spec/requests/policies_assignment_spec.rb
+++ b/spec/requests/policies_assignment_spec.rb
@@ -65,7 +65,7 @@ describe "Policies Assignment API" do
 
     post(api_object_policies_url, :params => gen_request(:assign, :guid => "xyzzy"))
 
-    expect(response).to have_http_status(:ok)
+    expect(response).to have_http_status(:bad_request)
     results_hash = [{"success" => false, "href" => object_url, "message" => /must specify a valid/i}]
     expect_results_to_match_hash("results", results_hash)
   end
@@ -109,7 +109,7 @@ describe "Policies Assignment API" do
 
     post(api_object_policies_url, :params => gen_request(:unassign, :guid => "xyzzy"))
 
-    expect(response).to have_http_status(:ok)
+    expect(response).to have_http_status(:bad_request)
     results_hash = [{"success" => false, "href" => object_url, "message" => /must specify a valid/i}]
     expect_results_to_match_hash("results", results_hash)
   end

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -486,13 +486,13 @@ describe "Provision Requests API" do
     context "SubResource#cancel" do
       let(:resource_1_response) { {"success" => false, "message" => "Cancel operation is not supported for MiqRequestTask"} }
       let(:resource_2_response) { {"success" => false, "message" => "Cancel operation is not supported for MiqRequestTask"} }
-      include_context "SubResource#cancel", [:provision_request, :request_task], :miq_provision_request, :miq_request_task
+      include_context "SubResource#cancel", [:provision_request, :request_task], :miq_provision_request, :miq_request_task, false
     end
   end
 
   context "Resource#cancel" do
     let(:resource_1_response) { {"success" => false, "message" => "Cancel operation is not supported for MiqProvisionRequest"} }
     let(:resource_2_response) { {"success" => false, "message" => "Cancel operation is not supported for MiqProvisionRequest"} }
-    include_context "Resource#cancel", "provision_request", :miq_provision_request
+    include_context "Resource#cancel", "provision_request", :miq_provision_request, false
   end
 end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -540,13 +540,13 @@ RSpec.describe "Requests API" do
     context "SubResource#cancel" do
       let(:resource_1_response) { {"success" => false, "message" => "Cancel operation is not supported for MiqRequestTask"} }
       let(:resource_2_response) { {"success" => false, "message" => "Cancel operation is not supported for MiqRequestTask"} }
-      include_context "SubResource#cancel", [:request, :request_task], :service_template_provision_request, :miq_request_task
+      include_context "SubResource#cancel", [:request, :request_task], :service_template_provision_request, :miq_request_task, false
     end
   end
 
   context "Resource#cancel" do
     let(:resource_1_response) { {"success" => false, "message" => "Cancel operation is not supported for VmMigrateRequest"} }
     let(:resource_2_response) { {"success" => false, "message" => "Cancel operation is not supported for VmMigrateRequest"} }
-    include_context "Resource#cancel", "request", :vm_migrate_request
+    include_context "Resource#cancel", "request", :vm_migrate_request, false
   end
 end

--- a/spec/requests/service_catalogs_spec.rb
+++ b/spec/requests/service_catalogs_spec.rb
@@ -317,7 +317,7 @@ describe "Service Catalogs API" do
 
       post(sc_template_url(sc.id), :params => gen_request(:assign, "href" => api_service_template_url(nil, 999_999)))
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect_results_to_match_hash("results", [{"success" => false, "href" => api_service_catalog_url(nil, sc)}])
     end
 

--- a/spec/requests/service_orders_spec.rb
+++ b/spec/requests/service_orders_spec.rb
@@ -633,7 +633,7 @@ RSpec.describe "service orders API" do
     context "ServiceRequest#cancel" do
       let(:resource_1_response) { {"success" => false, "message" => "Cancel operation is not supported for ServiceTemplateProvisionRequest"} }
       let(:resource_2_response) { {"success" => false, "message" => "Cancel operation is not supported for ServiceTemplateProvisionRequest"} }
-      include_context "SubResource#cancel", [:service_order, :service_request], :shopping_cart, :service_template_provision_request
+      include_context "SubResource#cancel", [:service_order, :service_request], :shopping_cart, :service_template_provision_request, false
     end
   end
 

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -960,7 +960,7 @@ describe "Services API" do
 
       expected = { 'success' => false, 'message' => "Invalid resource href specified 1"}
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq(expected)
     end
 
@@ -977,7 +977,7 @@ describe "Services API" do
 
       expected = { 'success' => false, 'message' => "Cannot assign users to Service id:#{svc.id} name:'#{svc.name}'"}
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq(expected)
     end
 
@@ -992,7 +992,7 @@ describe "Services API" do
 
       expected = { 'success' => false, 'message' => "Must specify a resource reference"}
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to eq(expected)
     end
 
@@ -1278,7 +1278,7 @@ describe "Services API" do
         'success' => false,
         'message' => a_string_including('Must specify a valid provider href or id')
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
 
@@ -1293,7 +1293,7 @@ describe "Services API" do
         'success' => false,
         'message' => a_string_including('Must specify a valid provider href or id')
       }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
 

--- a/spec/requests/snapshots_spec.rb
+++ b/spec/requests/snapshots_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Snapshots API" do
           ]
         }
         expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "renders a failed action response if a name is not provided" do
@@ -120,7 +120,7 @@ RSpec.describe "Snapshots API" do
           ]
         }
         expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "doesn't render a failed action response if a name is not provided and optional" do
@@ -184,7 +184,7 @@ RSpec.describe "Snapshots API" do
           "message" => "The VM is not connected to a Host"
         }
         expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "will not revert to a snapshot unless authorized" do
@@ -230,7 +230,7 @@ RSpec.describe "Snapshots API" do
           "message" => "The VM is not connected to a Host"
         }
         expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "will not delete a snapshot unless authorized" do
@@ -466,7 +466,7 @@ RSpec.describe "Snapshots API" do
           ]
         }
         expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "renders a failed action response if a name is not provided" do
@@ -486,7 +486,7 @@ RSpec.describe "Snapshots API" do
           ]
         }
         expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "will not create a snapshot unless authorized" do
@@ -532,7 +532,7 @@ RSpec.describe "Snapshots API" do
           "message" => "The VM is not connected to an active Provider"
         }
         expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it "will not delete a snapshot unless authorized" do

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1900,7 +1900,8 @@ describe "Vms API" do
       post(api_vm_tags_url(nil, vm1), :params => gen_request(:assign, :name => "/managed/bad_category/bad_name"))
 
       expect_tagging_result(
-        [{:success => false, :href => api_vm_url(nil, vm1), :tag_category => "bad_category", :tag_name => "bad_name"}]
+        [{:success => false, :href => api_vm_url(nil, vm1), :tag_category => "bad_category", :tag_name => "bad_name"}],
+        :bad_request
       )
     end
 
@@ -2109,11 +2110,11 @@ describe "Vms API" do
 
       expected = { 'success' => false, 'message' => 'Failed to set miq_server - Must specify a valid miq_server href or id' }
       expect(response.parsed_body).to eq(expected)
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
 
       post(api_vm_url(nil, vm), :params => { :action => 'set_miq_server', :miq_server => { :id => nil } })
       expect(response.parsed_body).to eq(expected)
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:bad_request)
     end
 
     it "can unassign a server if an empty hash is passed" do

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -200,7 +200,12 @@ module Spec
         end
 
         def expect_single_action_result(options = {})
-          expect(response).to have_http_status(:ok)
+          if options.key?(:success) || options.key?("success")
+            status = options[:success] || options["success"] ? :ok : :bad_request
+            expect(response).to have_http_status(status)
+          else
+            expect(response).to have_http_status(:ok)
+          end
           expected = options.slice("href", "message", "success")
           expected["success"] = options[:success] if options.key?(:success)
           expected["message"] = a_string_matching(options[:message]) if options[:message]
@@ -222,8 +227,8 @@ module Spec
           {"task_id" => anything, "task_href" => anything}
         end
 
-        def expect_tagging_result(tag_results)
-          expect(response).to have_http_status(:ok)
+        def expect_tagging_result(tag_results, status = :ok)
+          expect(response).to have_http_status(status)
           expect(response.parsed_body).to have_key("results")
           results = response.parsed_body["results"]
           expect(results.size).to eq(tag_results.size)

--- a/spec/support/shared_examples/sub_resource_cancel.rb
+++ b/spec/support/shared_examples/sub_resource_cancel.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context "SubResource#cancel" do |ns, request_factory, factory|
+RSpec.shared_context "SubResource#cancel" do |ns, request_factory, factory, success = true|
   let(:base_namespace) { ns.first.to_s.pluralize.to_sym }
   let(:sub_namespace)  { ns[1].to_s.pluralize.to_sym }
   let(:namespace)      { ns.join("_") }
@@ -17,7 +17,7 @@ RSpec.shared_context "SubResource#cancel" do |ns, request_factory, factory|
       api_basic_authorize subcollection_action_identifier(base_namespace, sub_namespace, :cancel)
       post(send(instance_url, nil, request, resource_1.id), :params => gen_request(:cancel))
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(success ? :ok : :bad_request)
       expect(response.parsed_body).to eq(resource_1_response)
     end
   end


### PR DESCRIPTION
Fixes #919 

We are currently returning an ok (200) http status from all api requests, even the ones that fail.
This makes routing difficult in the ui.

It is not so cut and dry because some requests take multiple records and end up with multiple statuses, some failing and some succeeding.

### Before 

We returned an ok for all create and update requests, even when they failed.

### After

Now if there is one resource, including a collection of one resource, and it fails creating or updating, it will return a failed status code (4xx)

The status of `406` (not processable) is the best status available to us.
