### PR TITLE
Add endpoint for creating/editing/deleting floating IPs

### DIFF
--- a/app/controllers/api/floating_ips_controller.rb
+++ b/app/controllers/api/floating_ips_controller.rb
@@ -1,4 +1,40 @@
 module Api
   class FloatingIpsController < BaseController
+    def create_resource(_type, _id = nil, data = {})
+      ems = ExtManagementSystem.find(data['ems_id'])
+      klass = FloatingIp.class_by_ems(ems)
+      raise BadRequestError, "Create floating ip for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
+
+      task_id = ems.create_floating_ip_queue(session[:userid], data.deep_symbolize_keys)
+      action_result(true, "Creating Floating Ip #{data['name']} for Provider: #{ems.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def edit_resource(type, id, data)
+      floating_ip = resource_search(id, type, collection_class(:floating_ips))
+      raise BadRequestError, "Update for #{floating_ip_ident(floating_ip)}: #{floating_ip.unsupported_reason(:update)}" unless floating_ip.supports?(:update)
+
+      task_id = floating_ip.update_floating_ip_queue(session[:userid], data.deep_symbolize_keys)
+      action_result(true, "Updating #{floating_ip_ident(floating_ip)}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def delete_resource(type, id, _data = {})
+      delete_action_handler do
+        floating_ip = resource_search(id, type, collection_class(:floating_ips))
+        raise BadRequestError, "Delete for #{floating_ip_ident(floating_ip)}: #{floating_ip.unsupported_reason(:delete)}" unless floating_ip.supports?(:delete)
+
+        task_id = floating_ip.delete_floating_ip_queue(session[:userid])
+        action_result(true, "Deleting #{floating_ip_ident(floating_ip)}", :task_id => task_id)
+      end
+    end
+
+    private
+
+    def floating_ip_ident(floating_ip)
+      "Floating Ip id:#{floating_ip.id} name: '#{floating_ip.name}'"
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1586,19 +1586,39 @@
     :identifier: floating_ip
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpppd
     :klass: FloatingIp
     :collection_actions:
       :get:
       - :name: read
         :identifier: floating_ip_show_list
       :post:
+      - :name: create
+        :identifier: floating_ip_new
       - :name: query
         :identifier: floating_ip_show_list
+      - :name: edit
+        :identifier: floating_ip_edit
+      - :name: delete
+        :identifier: floating_ip_delete
     :resource_actions:
       :get:
       - :name: read
         :identifier: floating_ip_show
+      :post:
+      - :name: edit
+        :identifier: floating_ip_edit
+      - :name: delete
+        :identifier: floating_ip_delete
+      :patch:
+      - :name: edit
+        :identifier: floating_ip_edit
+      :put:
+      - :name: edit
+        :identifier: floating_ip_edit
+      :delete:
+      - :name: delete
+        :identifier: floating_ip_delete
   :folders:
     :description: Folders
     :options:

--- a/spec/requests/floating_ips_spec.rb
+++ b/spec/requests/floating_ips_spec.rb
@@ -53,5 +53,148 @@ RSpec.describe 'FloatingIp API' do
       post(api_floating_ips_url, :params => gen_request(:query, ""))
       expect(response).to have_http_status(:forbidden)
     end
+
+    it "queues the creating of floating ip" do
+      api_basic_authorize collection_action_identifier(:floating_ips, :create)
+      provider = FactoryBot.create(:ems_openstack, :name => 'test_provider')
+      request = {
+        "action"   => "create",
+        "resource" => {
+          "ems_id" => provider.network_manager.id,
+          "name"   => "test_floating_ip"
+        }
+      }
+
+      post(api_floating_ips_url, :params => request)
+
+      expect_multiple_action_result(1, :success => true, :message => "Creating Floating Ip test_floating_ip for Provider: #{provider.name}", :task => true)
+    end
+
+    it "raises error when provider does not support creating of floating ips" do
+      api_basic_authorize collection_action_identifier(:floating_ips, :create)
+      provider = FactoryBot.create(:ems_amazon, :name => 'test_provider')
+      request = {
+        "action"   => "create",
+        "resource" => {
+          "ems_id" => provider.network_manager.id,
+          "name"   => "test_floating_ip"
+        }
+      }
+
+      post(api_floating_ips_url, :params => request)
+
+      expected = {"success" => false, "message" => a_string_including("Create floating ip for Provider #{provider.name}")}
+      expect(response.parsed_body["results"].first).to include(expected)
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe "POST /api/floating_ips/:id" do
+    let(:ems) { FactoryBot.create(:ems_openstack) }
+    let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+    let(:floating_ip) { FactoryBot.create(:floating_ip_openstack, :ext_management_system => ems.network_manager, :cloud_tenant => tenant) }
+
+    it "can queue the updating of a floating ip" do
+      api_basic_authorize(action_identifier(:floating_ips, :edit))
+
+      post(api_floating_ip_url(nil, floating_ip), :params => {:action => 'edit', :status => "inactive"})
+
+      expected = {
+        'success'   => true,
+        'message'   => a_string_including('Updating Floating Ip'),
+        'task_href' => a_string_matching(api_tasks_url),
+        'task_id'   => a_kind_of(String)
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can't queue the updating of a floating ip unless authorized" do
+      api_basic_authorize
+
+      post(api_floating_ip_url(nil, floating_ip), :params => {:action => 'edit', :status => "inactive"})
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "DELETE /api/floating_ips" do
+    let(:floating_ip) { FactoryBot.create(:floating_ip_openstack) }
+
+    it "can delete a floating ip" do
+      api_basic_authorize(action_identifier(:floating_ips, :delete))
+
+      delete(api_floating_ip_url(nil, floating_ip))
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "will not delete a floating ip unless authorized" do
+      api_basic_authorize
+
+      delete(api_floating_ip_url(nil, floating_ip))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "POST /api/floating_ips with delete action" do
+    it "can delete a floating ip" do
+      ems = FactoryBot.create(:ems_network)
+      floating_ip = FactoryBot.create(:floating_ip_openstack, :ext_management_system => ems)
+      api_basic_authorize(action_identifier(:floating_ips, :delete, :resource_actions))
+
+      post(api_floating_ip_url(nil, floating_ip), :params => gen_request(:delete))
+
+      expected = {
+        'success'   => true,
+        'message'   => a_string_including('Deleting Floating Ip'),
+        'task_href' => a_string_matching(api_tasks_url),
+        'task_id'   => a_kind_of(String)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it "will not delete a floating ip unless authorized" do
+      floating_ip = FactoryBot.create(:floating_ip)
+      api_basic_authorize
+
+      post(api_floating_ip_url(nil, floating_ip), :params => {:action => "delete"})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "can delete multiple floating_ips" do
+      ems = FactoryBot.create(:ems_network)
+      floating_ip1, floating_ip2 = FactoryBot.create_list(:floating_ip_openstack, 2, :ext_management_system => ems)
+      api_basic_authorize(action_identifier(:floating_ips, :delete, :resource_actions))
+
+      post(api_floating_ips_url, :params => {:action => "delete", :resources => [{:id => floating_ip1.id}, {:id => floating_ip2.id}]})
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "forbids multiple floating ip deletion without an appropriate role" do
+      floating_ip1, floating_ip2 = FactoryBot.create_list(:floating_ip, 2)
+      api_basic_authorize
+
+      post(api_floating_ips_url, :params => {:action => "delete", :resources => [{:id => floating_ip1.id}, {:id => floating_ip2.id}]})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "raises an error when delete not supported for floating ip" do
+      floating_ip = FactoryBot.create(:floating_ip)
+      api_basic_authorize(action_identifier(:floating_ips, :delete, :resource_actions))
+
+      post(api_floating_ip_url(nil, floating_ip), :params => gen_request(:delete))
+
+      expected = {
+        'success' => false,
+        'message' => a_string_including('Delete for Floating Ip')
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 end


### PR DESCRIPTION

```
POST /api/floating_ips/10000000000054
{
    "action": "edit",
    "status": "test"
}
```
RESPONSE
```
{
    "success": true,
    "message": "Updating Floating Ip id:10000000000054 name: '10.9.60.154'",
    "task_id": "10000000053300",
    "task_href": "http://localhost:3000/api/tasks/10000000053300"
}
```

https://github.com/ManageIQ/manageiq-api/issues/901

@miq-bot add_label enhancement
