### PR TITLE
Created *gpppd endpoint for host aggregates

### DIFF
--- a/app/controllers/api/host_aggregates_controller.rb
+++ b/app/controllers/api/host_aggregates_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  class HostAggregatesController < BaseController
+    include Subcollections::Tags
+
+    def create_resource(_type, _id, data = {})
+      ext_management_system = resource_search(data['ems_id'], :providers, collection_class(:providers))
+      data.delete('ems_id')
+
+      raise "Creation of Host Aggregates is not supported for this provider" unless ext_management_system.supports_create_host_aggregate?
+
+      task_id = ext_management_system.create_host_aggregate_queue(session[:userid], data)
+      action_result(true, "Creating Host Aggregate #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def edit_resource(type, id, data = {})
+      raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
+
+      host_aggregate = resource_search(id, type, collection_class(:host_aggregates))
+      raise "Edit not supported for #{host_aggregate.name}" unless host_aggregate.supports_update_aggregate?
+
+      task_id = host_aggregate.update_aggregate_queue(current_user.userid, data)
+      action_result(true, "Updating #{host_aggregate_ident(host_aggregate)}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def delete_resource(type, id, _data = {})
+      delete_action_handler do
+        host_aggregate = resource_search(id, type, collection_class(type))
+        raise "Delete not supported for #{host_aggregate.name}" unless host_aggregate.supports_delete_aggregate?
+
+        task_id = host_aggregate.delete_aggregate_queue(current_user.userid)
+        action_result(true, "Deleting #{host_aggregate.name}", :task_id => task_id)
+      end
+    end
+
+    private
+
+    def host_aggregate_ident(host_aggregate)
+      "Host Aggregate id:#{host_aggregate.id} name: '#{host_aggregate.name}'"
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1770,6 +1770,51 @@
       :get:
       - :name: read
         :identifier: guest_device_show
+  :host_aggregates:
+    :description: Host Aggregates
+    :identifier: host_aggregate
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *gpppd
+    :klass: HostAggregate
+    :subcollections:
+    - :tags
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: host_aggregate_show_list
+      :post:
+      - :name: query
+        :identifier: host_aggregate_show_list
+      - :name: create
+        :identifier: host_aggregate_new
+      - :name: delete
+        :identifier: host_aggregate_delete
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: host_aggregate_show
+      :post:
+      - :name: edit
+        :identifier: host_aggregate_edit
+      - :name: delete
+        :identifier: host_aggregate_delete
+      :patch:
+      - :name: edit
+        :identifier: host_aggregate_edit
+      :put:
+      - :name: edit
+        :identifier: host_aggregate_edit
+      :delete:
+      - :name: delete
+        :identifier: host_aggregate_delete
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: host_aggregate_tag
+      - :name: unassign
+        :identifier: host_aggregate_tag
   :hosts:
     :description: Hosts
     :identifier: host

--- a/spec/requests/host_aggregates_spec.rb
+++ b/spec/requests/host_aggregates_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe 'HostAggregates API' do
+  describe 'GET /api/host_aggregates' do
+    it 'lists all cloud tenants with an appropriate role' do
+      host_aggregate = FactoryBot.create(:host_aggregate)
+      api_basic_authorize collection_action_identifier(:host_aggregates, :read, :get)
+      get(api_host_aggregates_url)
+
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'host_aggregates',
+        'resources' => [
+          hash_including('href' => api_host_aggregate_url(nil, host_aggregate))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids access to cloud tenants without an appropriate role' do
+      api_basic_authorize
+
+      get(api_host_aggregates_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/host_aggregates/:id' do
+    it 'will show a host aggregate with an appropriate role' do
+      host_aggregate = FactoryBot.create(:host_aggregate)
+      api_basic_authorize action_identifier(:host_aggregates, :read, :resource_actions, :get)
+
+      get(api_host_aggregate_url(nil, host_aggregate))
+
+      expect(response.parsed_body).to include('href' => api_host_aggregate_url(nil, host_aggregate))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access to a host aggregate without an appropriate role' do
+      host_aggregate = FactoryBot.create(:host_aggregate)
+      api_basic_authorize
+
+      get(api_host_aggregate_url(nil, host_aggregate))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'POST /api/host_aggregates' do
+    it 'creates a host aggregate' do
+      ems = FactoryBot.create(:ems_openstack)
+      api_basic_authorize collection_action_identifier(:host_aggregates, :create, :post)
+
+      post(api_host_aggregates_url, :params => {:name => 'foo', :ems_id => ems.id})
+
+      expected = {
+        'results' => [a_hash_including(
+          'success' => true,
+          'message' => a_string_including('Creating Host Aggregate'),
+          'task_id' => a_kind_of(String)
+        )]
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  [:patch, :put].each do |request|
+    describe "#{request.to_s.upcase} /api/host_aggregates/:id" do
+      it 'updates a cloud tenant' do
+        host_aggregate = FactoryBot.create(:host_aggregate_openstack, :ext_management_system => FactoryBot.create(:ems_openstack))
+        api_basic_authorize action_identifier(:host_aggregates, :edit)
+
+        send(request, api_host_aggregate_url(nil, host_aggregate), :params => [:name => 'foo'])
+
+        expected = {
+          'success' => true,
+          'message' => a_string_including('Updating Host Aggregate'),
+          'task_id' => a_kind_of(String)
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(expected)
+      end
+    end
+  end
+
+  describe 'DELETE /api/host_aggregates/:id' do
+    it 'deletes a cloud tenant' do
+      host_aggregate = FactoryBot.create(:host_aggregate, :ext_management_system => FactoryBot.create(:ems_openstack))
+
+      api_basic_authorize action_identifier(:host_aggregates, :delete, :resource_actions, :delete)
+
+      delete(api_host_aggregate_url(nil, host_aggregate))
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end


### PR DESCRIPTION
Partially addresses https://github.com/ManageIQ/manageiq-api/issues/911

@agrare can you please take a look at it, if this is good enough from the providers' perspective?

@miq-bot add_label enhancement, kasparov/no

```js
# GET /api/host_aggregates

{
  "name": "host_aggregates",
  "count": 4,
  "subcount": 4,
  "pages": 1,
  "resources": [
    {
      "href": "http://localhost:3000/api/host_aggregates/1"
    },
    {
      "href": "http://localhost:3000/api/host_aggregates/2"
    },
    {
      "href": "http://localhost:3000/api/host_aggregates/3"
    },
    {
      "href": "http://localhost:3000/api/host_aggregates/4"
    }
  ],
  "actions": [
    {
      "name": "query",
      "method": "post",
      "href": "http://localhost:3000/api/host_aggregates"
    },
    {
      "name": "create",
      "method": "post",
      "href": "http://localhost:3000/api/host_aggregates"
    },
    {
      "name": "delete",
      "method": "post",
      "href": "http://localhost:3000/api/host_aggregates"
    }
  ],
  "links": {
    "self": "http://localhost:3000/api/host_aggregates?offset=0",
    "first": "http://localhost:3000/api/host_aggregates?offset=0",
    "last": "http://localhost:3000/api/host_aggregates?offset=0"
  }
}
```

```js
# GET /api/host_aggregates/1

{
  "href": "http://localhost:3000/api/host_aggregates/1",
  "id": "1",
  "ems_id": "7",
  "name": "novaHostAggregate",
  "ems_ref": "3",
  "type": "ManageIQ::Providers::Openstack::CloudManager::HostAggregate",
  "metadata": {
    "availability_zone": "nova"
  },
  "actions": [
    {
      "name": "edit",
      "method": "post",
      "href": "http://localhost:3000/api/host_aggregates/1"
    },
    {
      "name": "edit",
      "method": "patch",
      "href": "http://localhost:3000/api/host_aggregates/1"
    },
    {
      "name": "edit",
      "method": "put",
      "href": "http://localhost:3000/api/host_aggregates/1"
    },
    {
      "name": "delete",
      "method": "post",
      "href": "http://localhost:3000/api/host_aggregates/1"
    },
    {
      "name": "delete",
      "method": "delete",
      "href": "http://localhost:3000/api/host_aggregates/1"
    }
  ]
}
```

```js
# POST '{ "ems_id": 7, "name": "foo"  }' http://admin:smartvm@localhost:3000/api/host_aggregates

{
  "results": [
    {
      "success": true,
      "message": "Creating Host Aggregate foo for Provider: OpenStack",
      "task_id": "366184",
      "task_href": "http://localhost:3000/api/tasks/366184"
    }
  ]
}
```

```js
# PUT/PATCH  '{ "name": "foo"  }' http://admin:smartvm@localhost:3000/api/host_aggregates/1

{
  "success": true,
  "message": "Updating Host Aggregate id:1 name: 'novaHostAggregate'",
  "task_id": "366185",
  "task_href": "http://localhost:3000/api/tasks/366185"
}
```

```js
# DELETE http://admin:smartvm@localhost:3000/api/host_aggregates/1

( empty response, I think it's a bug because I copy-pasted from other working ones which provide the same no output)
```