### PR TITLE
Fixed endpoint feature mapping for policy-related endpoints

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -38,7 +38,7 @@
     :klass: Account
   :actions:
     :description: Actions
-    :identifier: action
+    :identifier: miq_action
     :options:
     - :collection
     :verbs: *gpppd
@@ -46,37 +46,37 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: action_show_list
+        :identifier: miq_action_show_list
       :post:
       - :name: query
-        :identifier: action_show_list
+        :identifier: miq_action_show_list
       - :name: create
-        :identifier: action_new
+        :identifier: miq_action_new
       - :name: edit
-        :identifier: action_edit
+        :identifier: miq_action_edit
       - :name: delete
-        :identifier: action_delete
+        :identifier: miq_action_delete
       :delete:
       - :name: delete
-        :identifier: action_delete
+        :identifier: miq_action_delete
     :resource_actions:
       :get:
       - :name: read
-        :identifier: action_show
+        :identifier: miq_action_show
       :post:
       - :name: edit
-        :identifier: action_edit
+        :identifier: miq_action_edit
       - :name: delete
-        :identifier: action_delete
+        :identifier: miq_action_delete
       :patch:
       - :name: edit
-        :identifier: action_edit
+        :identifier: miq_action_edit
       :put:
       - :name: edit
-        :identifier: action_edit
+        :identifier: miq_action_edit
       :delete:
       - :name: delete
-        :identifier: action_delete
+        :identifier: miq_action_delete
   :alert_actions:
     :description: Alert Actions
     :identifier: alert_action
@@ -176,8 +176,8 @@
       - :name: delete
         :identifier: alert_definition_delete
   :alerts:
-    :description: Alerts
-    :identifier: alert
+    :description: Alert Statuses
+    :identifier: alert_status
     :options:
     - :collection
     :verbs: *g
@@ -1441,7 +1441,7 @@
         :identifier: event_streams_show
   :events:
     :description: Events
-    :identifier: event
+    :identifier: miq_event
     :options:
     - :collection
     - :subcollection
@@ -1450,14 +1450,14 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: event
+        :identifier: miq_event
       :post:
       - :name: query
-        :identifier: event
+        :identifier: miq_event
     :resource_actions:
       :get:
       - :name: read
-        :identifier: event
+        :identifier: miq_event
   :features:
     :description: Product Features
     :options:
@@ -2387,7 +2387,7 @@
         :identifier: picture_new
   :policies:
     :description: Policies
-    :identifier: policy
+    :identifier: miq_policy
     :options:
     - :collection
     - :subcollection
@@ -2400,28 +2400,28 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: policy_view
+        :identifier: miq_policy_view
       :post:
       - :name: query
-        :identifier: policy_view
+        :identifier: miq_policy_view
       - :name: create
-        :identifier: policy_new
+        :identifier: miq_policy_new
       - :name: edit
-        :identifier: policy_edit
+        :identifier: miq_policy_edit
       - :name: delete
-        :identifier: policy_delete
+        :identifier: miq_policy_delete
     :resource_actions:
       :get:
       - :name: read
-        :identifier: policy_view
+        :identifier: miq_policy_view
       :post:
       - :name: edit
-        :identifier: policy_edit
+        :identifier: miq_policy_edit
       - :name: delete
-        :identifier: policy_delete
+        :identifier: miq_policy_delete
       :delete:
       - :name: delete
-        :identifier: policy_delete
+        :identifier: miq_policy_delete
     :subcollection_actions:
       :post:
       - :name: assign
@@ -2434,7 +2434,7 @@
       - :name: resolve
   :policy_actions:
     :description: Actions
-    :identifier: control_explorer
+    :identifier: control
     :options:
     - :collection
     - :subcollection
@@ -2443,17 +2443,17 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: control_explorer_view
+        :identifier: miq_action_show_list
       :post:
       - :name: query
-        :identifier: control_explorer_view
+        :identifier: miq_action_show_list
     :resource_actions:
       :get:
       - :name: read
-        :identifier: control_explorer_view
+        :identifier: miq_action_show
   :policy_profiles:
     :description: Policy Profiles
-    :identifier: policy_profile
+    :identifier: miq_policy_set
     :options:
     - :collection
     - :subcollection
@@ -2464,47 +2464,55 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: policy_profile_view
+        :identifier: miq_policy_set_view
       :post:
       - :name: query
-        :identifier: policy_profile_view
+        :identifier: miq_policy_set_view
       - :name: create
-        :identifier: profile_new
+        :identifier: miq_policy_set_new
       - :name: edit
-        :identifier: profile_edit
+        :identifier: miq_policy_set_edit
       - :name: delete
-        :identifier: profile_delete
+        :identifier: miq_policy_set_delete
     :resource_actions:
       :get:
       - :name: read
-        :identifier: policy_profile_view
+        :identifier: miq_policy_set_view
       :post:
       - :name: edit
-        :identifier: profile_edit
+        :identifier: miq_policy_set_edit
       - :name: delete
-        :identifier: profile_delete
+        :identifier: miq_policy_set_delete
       :delete:
       - :name: delete
-        :identifier: profile_delete
+        :identifier: miq_policy_set_delete
       :patch:
       - :name: edit
-        :identifier: profile_edit
+        :identifier: miq_policy_set_edit
       :put:
       - :name: edit
-        :identifier: profile_edit
+        :identifier: miq_policy_set_edit
     :policies_subcollection_actions:
       :post:
       - :name: assign
-        :identifier: policy_profile_assign
+        :identifier:
+        - miq_policy_conditions_assignment
+        - miq_policy_events_assignment
       - :name: unassign
-        :identifier: policy_profile_assign
+        :identifier:
+        - miq_policy_conditions_assignment
+        - miq_policy_events_assignment
       - :name: resolve
     :policies_subresource_actions:
       :post:
       - :name: assign
-        :identifier: policy_profile_assign
+        :identifier:
+        - miq_policy_conditions_assignment
+        - miq_policy_events_assignment
       - :name: unassign
-        :identifier: policy_profile_assign
+        :identifier:
+        - miq_policy_conditions_assignment
+        - miq_policy_events_assignment
       - :name: resolve
   :providers:
     :description: Providers


### PR DESCRIPTION
The policy de-explorerization had some [RBAC feature changes](https://github.com/ManageIQ/manageiq/pull/20438) and renaming which causes the CI fail on this repo as the feature mapping has not been updated. I went through these missing features and replaced them with the existing ones.

I'm not entirely sure about the `policy_profile_assign` as it seems like it maps to two new features `miq_policy_conditions_assignment` and `miq_policy_events_assignment`.

Another issue I found was that the `/alerts` endpoint is actually querying `MiqAlertStatus` entities. Here only the top-level feature identifier was wrongly set, so I adjusted it.


@lpichler @NickLaMuro @gtanzillo @abellotti please verify if I'm doing stuff the right way
@h-kataria can you please check if these features map properly and if the migrations were ran against the deleted ones to rename them to the new names

@miq-bot add_label bug, rbac, kasparov/no