### PR TITLE
Fix storing ae_attributes as uri_attributes for create/edit in CustomButtons

### DIFF
--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -7,7 +7,7 @@ module Api
         custom_button.userid = User.current_user.userid
         custom_button.options = data["options"].deep_symbolize_keys if data["options"]
         custom_button.save!
-        custom_button.create_resource_action!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
+        custom_button.get_resource_action.update!(data["resource_action"].deep_symbolize_keys) if data.key?("resource_action")
         custom_button
       end
     rescue => err

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -128,6 +128,21 @@ RSpec.describe 'CustomButtons API' do
       expect(response.parsed_body['results'].first).to include(custom_button_params.except('resource_action', 'uri_attributes'))
     end
 
+    let(:custom_button) { FactoryBot.create(:custom_button, :name => 'editable', :applies_to_class => 'GenericObjectDefinition', :applies_to_id => object_def.id) }
+
+    it 'can edit custom button' do
+      api_basic_authorize collection_action_identifier(:custom_buttons, :edit)
+      custom_button_params_for_edit = custom_button_params.merge('id' => custom_button.id)
+      post(api_custom_buttons_url, :params => {'action' => 'edit', 'resources' => [custom_button_params_for_edit]})
+      expect(response).to have_http_status(:ok)
+      custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
+      expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")
+      expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
+      expect(custom_button.uri_attributes).to eq(:request => 'automate_method')
+      expect(custom_button.resource_action.attributes).to include(custom_button_params['resource_action'])
+      expect(response.parsed_body['results'].first).to include(custom_button_params.except('resource_action', 'uri_attributes'))
+    end
+
     it 'can edit custom buttons by id' do
       api_basic_authorize collection_action_identifier(:custom_buttons, :edit)
 

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe 'CustomButtons API' do
   end
 
   describe 'POST /api/custom_buttons' do
-    let(:uri_attributes) { {'uri_attributes' => {'request' => 'automate_method'} } }
-    let(:resource_action) { { 'resource_action'=> {'ae_namespace' => 'SYSTEM', 'ae_class' => 'PROCESS'} } }
+    let(:uri_attributes) { {'uri_attributes' => {'request' => 'automate_method'}} }
+    let(:resource_action) { {'resource_action'=> {'ae_namespace' => 'SYSTEM', 'ae_class' => 'PROCESS'}} }
     let(:custom_button_params) do
       {
         'name'             => 'Generic Object Custom Button',
@@ -110,7 +110,7 @@ RSpec.describe 'CustomButtons API' do
           'button_color' => '#4727ff',
           'display'      => true,
         },
-        'visibility' => {'roles' => ['_ALL_']}
+        'visibility'       => {'roles' => ['_ALL_']}
       }.merge(uri_attributes).merge(resource_action)
     end
 

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'CustomButtons API' do
         'name'             => 'Generic Object Custom Button',
         'description'      => 'Generic Object Custom Button description',
         'applies_to_class' => 'GenericObjectDefinition',
-        'uri_attributes'   => {:request => "automate_method"},
+        'uri_attributes'   => {'request' => 'automate_method'},
         'options'          => {
           'button_icon'  => 'ff ff-view-expanded',
           'button_color' => '#4727ff',
@@ -123,6 +123,7 @@ RSpec.describe 'CustomButtons API' do
       custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
       expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")
       expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
+      expect(custom_button.uri_attributes).to eq('request' => 'automate_method')
       expect(response.parsed_body['results'].first).to include(cb_rec.except('resource_action', 'uri_attributes'))
     end
 

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -98,33 +98,34 @@ RSpec.describe 'CustomButtons API' do
   end
 
   describe 'POST /api/custom_buttons' do
-    it 'can create a new custom button' do
-      api_basic_authorize collection_action_identifier(:custom_buttons, :create)
-
-      cb_rec = {
+    let(:uri_attributes) { {'uri_attributes' => {'request' => 'automate_method'} } }
+    let(:resource_action) { { 'resource_action'=> { 'ae_namespace' => 'SYSTEM', 'ae_class'     => 'PROCESS'} } }
+    let(:custom_button_params) do
+      {
         'name'             => 'Generic Object Custom Button',
         'description'      => 'Generic Object Custom Button description',
         'applies_to_class' => 'GenericObjectDefinition',
-        'uri_attributes'   => {'request' => 'automate_method'},
         'options'          => {
           'button_icon'  => 'ff ff-view-expanded',
           'button_color' => '#4727ff',
           'display'      => true,
         },
-        'resource_action'  => {
-          'ae_namespace' => 'SYSTEM',
-          'ae_class'     => 'PROCESS'
-        },
-        'visibility'       => {'roles' => ['_ALL_']}
-      }
-      post(api_custom_buttons_url, :params => cb_rec)
+        'visibility' => {'roles' => ['_ALL_']}
+      }.merge(uri_attributes).merge(resource_action)
+    end
+
+    it 'can create a new custom button' do
+      api_basic_authorize collection_action_identifier(:custom_buttons, :create)
+
+      post(api_custom_buttons_url, :params => custom_button_params)
 
       expect(response).to have_http_status(:ok)
       custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
       expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")
       expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
       expect(custom_button.uri_attributes).to eq('request' => 'automate_method')
-      expect(response.parsed_body['results'].first).to include(cb_rec.except('resource_action', 'uri_attributes'))
+      expect(custom_button.resource_action.attributes).to include(custom_button_params['resource_action'])
+      expect(response.parsed_body['results'].first).to include(custom_button_params.except('resource_action', 'uri_attributes'))
     end
 
     it 'can edit custom buttons by id' do

--- a/spec/requests/custom_buttons_spec.rb
+++ b/spec/requests/custom_buttons_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'CustomButtons API' do
 
   describe 'POST /api/custom_buttons' do
     let(:uri_attributes) { {'uri_attributes' => {'request' => 'automate_method'} } }
-    let(:resource_action) { { 'resource_action'=> { 'ae_namespace' => 'SYSTEM', 'ae_class'     => 'PROCESS'} } }
+    let(:resource_action) { { 'resource_action'=> {'ae_namespace' => 'SYSTEM', 'ae_class' => 'PROCESS'} } }
     let(:custom_button_params) do
       {
         'name'             => 'Generic Object Custom Button',
@@ -114,16 +114,139 @@ RSpec.describe 'CustomButtons API' do
       }.merge(uri_attributes).merge(resource_action)
     end
 
+    let(:edit_custom_button) { FactoryBot.create(:custom_button, :name => 'XXX', :applies_to_class => 'GenericObjectDefinition', :applies_to_id => object_def.id) }
+
+    let(:request_params)     { custom_button_params }
+    let(:edit_request_params) { {'action' => 'edit', 'resources' => [custom_button_params.merge('id' => edit_custom_button.id)]} }
+
+    subject do
+      post(api_custom_buttons_url, :params => request_params)
+    end
+
+    def expect_custom_button
+      expect(response).to have_http_status(:ok)
+      custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
+      expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")
+      expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
+      if uri_attributes['uri_attributes'].present?
+        expect(custom_button.uri_attributes.deep_symbolize_keys).to eq(uri_attributes['uri_attributes'].deep_symbolize_keys)
+        expect(custom_button.resource_action[:ae_attributes].deep_symbolize_keys).to eq(uri_attributes['uri_attributes'].deep_symbolize_keys)
+      end
+
+      if resource_action['resource_action'].present?
+        expect(custom_button.resource_action.attributes).to include(resource_action['resource_action'])
+      end
+      expect(response.parsed_body['results'].first).to include(custom_button_params.except('resource_action', 'uri_attributes'))
+    end
+
+    context "with resource_action in params" do
+      context "with uri_attributes in params" do
+        it "creates custom_button" do
+          api_basic_authorize collection_action_identifier(:custom_buttons, :create)
+
+          subject
+
+          expect_custom_button
+        end
+
+        context "update" do
+          let(:request_params) { edit_request_params }
+
+          it "update custom_button" do
+            api_basic_authorize collection_action_identifier(:custom_buttons, :edit)
+
+            subject
+
+            expect_custom_button
+          end
+        end
+      end
+
+      context "without uri_attributes in params" do
+        let(:uri_attributes) { {} }
+
+        it "creates custom_button" do
+          api_basic_authorize collection_action_identifier(:custom_buttons, :create)
+
+          subject
+
+          expect_custom_button
+        end
+
+        context "update" do
+          let(:request_params) { edit_request_params }
+
+          it "update custom_button" do
+            api_basic_authorize collection_action_identifier(:custom_buttons, :edit)
+
+            subject
+
+            expect_custom_button
+          end
+        end
+      end
+    end
+
+    context "without resource_action in params" do
+      let(:resource_action) { {} }
+
+      context "with uri_attributes in params" do
+        it "creates custom_button" do
+          api_basic_authorize collection_action_identifier(:custom_buttons, :create)
+
+          subject
+
+          expect_custom_button
+        end
+
+        context "update" do
+          let(:request_params) { edit_request_params }
+
+          it "update custom_button" do
+            api_basic_authorize collection_action_identifier(:custom_buttons, :edit)
+
+            subject
+
+            expect_custom_button
+          end
+        end
+      end
+
+      context "without uri_attributes in params" do
+        let(:uri_attributes) { {} }
+
+        it "creates custom_button" do
+          api_basic_authorize collection_action_identifier(:custom_buttons, :create)
+
+          subject
+
+          expect_custom_button
+        end
+
+        context "update" do
+          let(:request_params) { edit_request_params }
+
+          it "update custom_button" do
+            api_basic_authorize collection_action_identifier(:custom_buttons, :edit)
+
+            subject
+
+            expect_custom_button
+          end
+        end
+      end
+    end
+
     it 'can create a new custom button' do
       api_basic_authorize collection_action_identifier(:custom_buttons, :create)
 
-      post(api_custom_buttons_url, :params => custom_button_params)
+      post(api_custom_buttons_url, :params => request_params)
 
       expect(response).to have_http_status(:ok)
       custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
       expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")
       expect(custom_button.visibility[:roles]).to eq(['_ALL_'])
-      expect(custom_button.uri_attributes).to eq('request' => 'automate_method')
+      expect(custom_button.uri_attributes.deep_symbolize_keys).to eq(:request => 'automate_method')
       expect(custom_button.resource_action.attributes).to include(custom_button_params['resource_action'])
       expect(response.parsed_body['results'].first).to include(custom_button_params.except('resource_action', 'uri_attributes'))
     end
@@ -132,8 +255,8 @@ RSpec.describe 'CustomButtons API' do
 
     it 'can edit custom button' do
       api_basic_authorize collection_action_identifier(:custom_buttons, :edit)
-      custom_button_params_for_edit = custom_button_params.merge('id' => custom_button.id)
-      post(api_custom_buttons_url, :params => {'action' => 'edit', 'resources' => [custom_button_params_for_edit]})
+      custom_button_params_for_edit = {'action' => 'edit', 'resources' => [custom_button_params.merge('id' => custom_button.id)]}
+      post(api_custom_buttons_url, :params => custom_button_params_for_edit)
       expect(response).to have_http_status(:ok)
       custom_button = CustomButton.find(response.parsed_body['results'].first["id"])
       expect(custom_button.options[:button_icon]).to eq("ff ff-view-expanded")


### PR DESCRIPTION
Fixes:
- https://github.com/ManageIQ/manageiq/issues/20757



Method `uri_attributes=(data)` stores  `data` to `Custom_button#resource_action['ae_attributes']`. It builds `resource_action` object if did not exist before - it means that `Custom_button#uri_attributes` affects data in `resource_action` relation.

In api create, we build custom button first with basic attributes
but also `Custom_button#uri_attributes` populate data in `Custom_button#resource_action['ae_attributes']`
which builds`Custom_button#resource_action` relation.

Then there is code to handle `resource_action` when `resource_action` is passed from parameters but 
usage of  method`create_resource_action` replaces `resource_action` relation and data populated with  `Custom_button#uri_attributes` are lost.

So I used method `update` which only touches passed attributes.

```
POST /api/custom_buttons
{
  "name" : "test",
  "description" : "test",
  "applies_to_id"  : "1",
  "applies_to_class"  : "Vm",
  "uri_attributes" : {"request" : "test"}
}

=>

{
    "results": [
        {
            "href": "http://localhost:3090/api/custom_buttons/41",
            "id": "41",
            "guid": "5097bee6-d82e-4168-9b5b-0a8327f9bf87",
            "description": "test",
        ...
}
```

```
GET  /api/custom_buttons/41?attributes=uri_attributes

=>

{
    "href": "http://localhost:3090/api/custom_buttons/41",
    "id": "41",
    "guid": "5097bee6-d82e-4168-9b5b-0a8327f9bf87",
    "description": "tesAAt",
    "applies_to_class": "Vm",
    "visibility_expression": null,
    "options": {},
    "userid": "admin",
    "wait_for_complete": null,
    "created_on": "2020-11-22T18:03:41Z",
    "updated_on": "2020-11-22T18:03:41Z",
    "name": "tesAAt",
    "visibility": null,
    "applies_to_id": "1",
    "enablement_expression": null,
    "disabled_text": null,
   "uri_attributes": {
        "request": "test"
    },
   ...
}
```

@miq-bot add_label bug