### PR TITLE
Introducing a simple GET-only endpoint for shortcuts

### DIFF
--- a/app/controllers/api/shortcuts_controller.rb
+++ b/app/controllers/api/shortcuts_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ShortcutsController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -4003,6 +4003,21 @@
       :get:
       - :name: read
         :identifier: ops_settings
+  :shortcuts:
+    :description: Shortcuts
+    :options:
+    - :collection
+    :identifier: shortcuts
+    :klass: MiqShortcut
+    :verbs: *g
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: shortcuts
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: shortcuts
   :snapshots:
     :description: Snapshots
     :options:

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -402,6 +402,11 @@ describe "Rest API Collections" do
       FactoryBot.create(:miq_search)
       test_collection_query(:search_filters, api_search_filters_url, MiqSearch)
     end
+
+    it 'query shortcuts' do
+      FactoryBot.create(:miq_shortcut, :rbac_feature_name => 'shortcuts')
+      test_collection_query(:shortcuts, api_shortcuts_url, MiqShortcut)
+    end
   end
 
   context "Collections Bulk Queries" do


### PR DESCRIPTION
The list of shortcuts for startpages is being stored in the database, so we need to expose them through the API to access them from the UI. It is probably necessary to expose it to all users, but the feature still needs to be created. Also the collection entities should be displayed only if the user has access to them based on their `rbac_feature_name` attribute.

So I think I need some help here to filter the results based on this field @gtanzillo 

Depends on https://github.com/ManageIQ/manageiq/pull/20844