### PR TITLE
Add the list of available rails timezones to the base endpoint

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -6,14 +6,15 @@ module Api
 
     def index
       res = {
-        :name          => ApiConfig.base.name,
-        :description   => ApiConfig.base.description,
-        :version       => ManageIQ::Api::VERSION,
-        :versions      => entrypoint_versions,
-        :settings      => user_settings,
-        :identity      => auth_identity,
-        :server_info   => server_info,
-        :product_info  => product_info_data
+        :name         => ApiConfig.base.name,
+        :description  => ApiConfig.base.description,
+        :version      => ManageIQ::Api::VERSION,
+        :versions     => entrypoint_versions,
+        :settings     => user_settings,
+        :identity     => auth_identity,
+        :server_info  => server_info,
+        :timezones    => timezone_list,
+        :product_info => product_info_data
       }
       res[:authorization] = auth_authorization if attribute_selection.include?("authorization")
       res[:collections]   = entrypoint_collections
@@ -174,6 +175,15 @@ module Api
         "method" => method,
         "href"   => "#{@req.api_prefix}/#{collection}"
       }
+    end
+
+    def timezone_list
+      ActiveSupport::TimeZone.all.map do |tz|
+        {
+          :name        => tz.name,
+          :description => "(GMT#{tz.formatted_offset}) #{tz.name}",
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
There's no way to retrieve the list of available timezones from the frontend in a Rails-compatible way, so I'm adjusting the `/api` endpoint to provide a list of these. 

```js
# GET /api

{
  "name": "API",
  "description": "REST API",
  ...
  "timezones": [
    {
      "name": "International Date Line West",
      "description": "(GMT-12:00) International Date Line West"
    },
    {
      "name": "American Samoa",
      "description": "(GMT-11:00) American Samoa"
    },
    ...
  ],
  ...
}
```