### PR TITLE
[Subcollections::Results] Add DELETE actions

### DIFF
--- a/app/controllers/api/subcollections/results.rb
+++ b/app/controllers/api/subcollections/results.rb
@@ -16,6 +16,11 @@ module Api
       def results_query_resource(object)
         object.miq_report_results.for_user(User.current_user)
       end
+
+      def results_delete_resource(_parent, type, miq_result_id, data)
+        delete_resource(type, miq_result_id, data)
+      end
+      alias delete_resource_results results_delete_resource
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -3014,6 +3014,13 @@
       :post:
       - :name: import
         :identifier: miq_report_export
+    :results_subresource_actions:
+      :post:
+      - :name: delete
+        :identifier: saved_report_delete
+      :delete:
+      - :name: delete
+        :identifier: saved_report_delete
   :request_tasks:
     :description: Request Tasks
     :options:
@@ -3166,7 +3173,7 @@
     :options:
     - :collection
     - :subcollection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: MiqReportResult
     :collection_actions:
       :get:
@@ -3184,6 +3191,10 @@
       :post:
       - :name: request_download
         :identifier: miq_report_view
+    :subcollection_actions:
+      :post:
+      - :name: delete
+        :identifier: saved_report_delete
   :roles:
     :description: Roles
     :identifier: rbac_role


### PR DESCRIPTION
Adds delete actions on collection and subcollection actions for MiqReportResults.

```
- DELETE `/api/results/:id`
- DELETE `/api/report/:r_id/results/:rr_id`
- POST   `/api/report/:r_id/results/:rr_id` (`{"action" => "delete"}`)
```

Links
-----

- Fixes https://github.com/ManageIQ/manageiq-api/issues/972