### PR TITLE
Expose tenant quota definitions via OPTIONS

### DIFF
--- a/app/controllers/api/tenants_controller.rb
+++ b/app/controllers/api/tenants_controller.rb
@@ -29,6 +29,10 @@ module Api
       super
     end
 
+    def options
+      render_options(:tenants, :quota_definitions => TenantQuota.quota_definitions)
+    end
+
     private
 
     def parse_set_parent(data)

--- a/spec/requests/tenant_quotas_spec.rb
+++ b/spec/requests/tenant_quotas_spec.rb
@@ -177,7 +177,6 @@ describe "tenant quotas API" do
     it "supports OPTIONS requests on a subcollection without authorization" do
       options api_tenant_quotas_url(nil, tenant)
       expect(response).to have_http_status(:ok)
-      expect(response.body).to be_empty
     end
 
     it "can delete multiple quotas from a tenant with POST" do

--- a/spec/requests/tenants_spec.rb
+++ b/spec/requests/tenants_spec.rb
@@ -317,4 +317,15 @@ RSpec.describe "tenants API" do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'OPTIONS /tenants' do
+    it 'includes tenant quota definitions' do
+      api_basic_authorize action_identifier(:tenants, :read, :collection_actions, :get)
+
+      options(api_tenants_url)
+
+      expect(response.parsed_body['data']).to have_key("quota_definitions")
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
```js
# OPTIONS http://admin:smartvm@localhost:3000/api/tenants

{
  //...
  "data": {
    "quota_definitions": {
      // ...
    }
  }
}
```

Resolves https://github.com/ManageIQ/manageiq-api/issues/982
Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6866

@miq-bot add_label enhancement, kasparov/no
@miq-bot add_reviewer @abellotti 
@miq-bot add_reviewer @lpichler 
@miq-bot assign @gtanzillo 