### PR TITLE
remove deprecated codeclimate test reporter gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,10 @@ rvm:
 addons:
   postgresql: '10'
 install: bin/setup
-after_script: bin/ci/after_script
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- bin/ci/after_script
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/manageiq-api.gemspec
+++ b/manageiq-api.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   # See: https://github.com/rails/jbuilder/issues/461
   spec.add_dependency "jbuilder", "~> 2.5", "!= 2.9.0"
 
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779 got added last week

@miq-bot add_label dependencies, test 
@miq-bot assign @Fryguy 