### PR TITLE
Fix the error message at OPTIOS /api/cloud_volumes

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -29,7 +29,7 @@ module Api
 
       ems = ExtManagementSystem.find(params[:ems_id])
 
-      raise BadRequestError, "No CloudVolume support for - #{klass}" unless defined?(ems.class::CloudVolume)
+      raise BadRequestError, "No CloudVolume support for - #{ems.class}" unless defined?(ems.class::CloudVolume)
 
       klass = ems.class::CloudVolume
 


### PR DESCRIPTION
The `klass` is undefined there, so we need to use `ems.class` instead.

Parent issue https://github.com/ManageIQ/manageiq-ui-classic/issues/7334

@miq-bot assign @lpichler 
@miq-bot add_label bug, kasparov/no