### PR TITLE
Fix klass.superclass not matching with acts_as_leaf_class

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -139,7 +139,7 @@ module Api
 
     def authorize_provider(typed_provider_klass)
       create_action = collection_config["providers"].collection_actions.post.detect { |a| a.name == "create" }
-      provider_spec = create_action.identifiers.detect { |i| i.klass.constantize.name == typed_provider_klass.superclass.name }
+      provider_spec = create_action.identifiers.detect { |i| typed_provider_klass < i.klass.constantize }
       raise BadRequestError, "Unsupported request class #{typed_provider_klass}" if provider_spec.blank?
 
       if provider_spec.identifier && !api_user_role_allows?(provider_spec.identifier)


### PR DESCRIPTION
When a manager class subclasses from another non-core manager-type class.  For example if `ManageIQ::Providers::Openshift::ContainerManager` inherits from `ManageIQ::Providers::Kubernetes::ContainerManager` instead of `ManageIQ::Providers::ContainerManager` then using superclass doesn't work.

Required for: https://github.com/ManageIQ/manageiq/pull/20756