### PR TITLE
save after setting parent on vm update

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -103,9 +103,9 @@ module Api
       attrs = validate_edit_data(data)
       parent, children = build_parent_children(data)
       resource_search(id, type, collection_class(type)).tap do |vm|
-        vm.update!(attrs)
         vm.replace_children(children)
         vm.set_parent(parent)
+        vm.update!(attrs)
       end
     rescue => err
       raise BadRequestError, "Cannot edit VM - #{err}"


### PR DESCRIPTION
when we call replace_children on vm edit, it should be the responsibility of the caller to save the parent, so the update should be _after_
see the related https://github.com/ManageIQ/manageiq/pull/20990

@miq-bot add_label bug 

broken in https://github.com/ManageIQ/manageiq/pull/20274
