### PR TITLE
Compare user id with current user id with the right type

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -36,7 +36,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      id == User.current_user.id ? validate_self_user_data(data) : validate_user_data(data)
+      id.to_i == User.current_user.id ? validate_self_user_data(data) : validate_user_data(data)
       parse_set_group(data)
       parse_set_settings(data, resource_search(id, type, collection_class(type)))
       super


### PR DESCRIPTION
The `User.current_user.id` is an integer, meanwhile the `id` coming from the client is a string, so the ternary operator always resolves to `validate_user_data` which is wrong...fixing.

@miq-bot assign @lpichler 
@miq-bot add_label bug