### PR TITLE
Add Subcollections::Settings

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -114,43 +114,7 @@ module Api
       end
     end
 
-    def settings
-      id       = @req.collection_id
-      type     = @req.collection
-      klass    = collection_class(@req.collection)
-      resource = resource_search(id, type, klass)
-
-      case @req.method
-      when :patch
-        raise ForbiddenError, "You are not authorized to edit settings." unless super_admin?
-        begin
-          resource.add_settings_for_resource(@req.json_body)
-        rescue Vmdb::Settings::ConfigurationInvalid => err
-          raise BadRequestError, "Settings validation failed - #{err}"
-        end
-      when :delete
-        raise ForbiddenError, "You are not authorized to remove settings." unless super_admin?
-        resource.remove_settings_path_for_resource(*@req.json_body)
-        head :no_content
-        return
-      end
-
-      render :json => resource_settings(resource)
-    end
-
-    def settings_query_resource(resource)
-      resource_settings(resource)
-    end
-
     private
-
-    def resource_settings(resource)
-      if super_admin? || current_user.role_allows?(:identifier => 'ops_settings')
-        whitelist_settings(resource.settings_for_resource.to_hash)
-      else
-        raise ForbiddenError, "You are not authorized to view settings."
-      end
-    end
 
     def current_user
       @current_user ||= User.current_user
@@ -158,13 +122,6 @@ module Api
 
     def super_admin?
       current_user.super_admin_user?
-    end
-
-    def whitelist_settings(settings)
-      return settings if super_admin?
-
-      whitelisted_categories = ApiConfig.collections[:settings][:categories]
-      settings.with_indifferent_access.slice(*whitelisted_categories)
     end
 
     def set_gettext_locale

--- a/app/controllers/api/regions_controller.rb
+++ b/app/controllers/api/regions_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class RegionsController < BaseController
+    include Subcollections::Settings
+
     INVALID_REGIONS_ATTRS = ID_ATTRS + %w[created_at updated_at region guid migrations_ran maintenance_zone_id].freeze
 
     # Edit an existing region (MiqRegion). Certain fields are meant for

--- a/app/controllers/api/servers_controller.rb
+++ b/app/controllers/api/servers_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ServersController < BaseController
+    include Subcollections::Settings
+
     VALID_SERVERS_ATTRS = %w[name zone].freeze
 
     # Edit an existing server (MiqServer). Certain fields are meant for

--- a/app/controllers/api/subcollections/settings.rb
+++ b/app/controllers/api/subcollections/settings.rb
@@ -24,7 +24,7 @@ module Api
           return
         end
 
-        render :json => resource_settings(resource)
+        render_resource :settings, resource_settings(resource)
       end
 
       def settings_query_resource(resource)

--- a/app/controllers/api/subcollections/settings.rb
+++ b/app/controllers/api/subcollections/settings.rb
@@ -1,0 +1,52 @@
+module Api
+  module Subcollections
+    module Settings
+      def settings
+        id       = @req.collection_id
+        type     = @req.collection
+        klass    = collection_class(@req.collection)
+        resource = resource_search(id, type, klass)
+
+        case @req.method
+        when :patch
+          raise ForbiddenError, "You are not authorized to edit settings." unless super_admin?
+
+          begin
+            resource.add_settings_for_resource(@req.json_body)
+          rescue Vmdb::Settings::ConfigurationInvalid => err
+            raise BadRequestError, "Settings validation failed - #{err}"
+          end
+        when :delete
+          raise ForbiddenError, "You are not authorized to remove settings." unless super_admin?
+
+          resource.remove_settings_path_for_resource(*@req.json_body)
+          head :no_content
+          return
+        end
+
+        render :json => resource_settings(resource)
+      end
+
+      def settings_query_resource(resource)
+        resource_settings(resource)
+      end
+
+      private
+
+      def resource_settings(resource)
+        if super_admin? || current_user.role_allows?(:identifier => 'ops_settings')
+          whitelist_settings(resource.settings_for_resource.to_hash)
+        else
+          raise ForbiddenError, "You are not authorized to view settings."
+        end
+      end
+
+      def whitelist_settings(settings)
+        return settings if super_admin?
+
+        whitelisted_categories = ApiConfig.collections[:settings][:categories]
+        settings.with_indifferent_access.slice(*whitelisted_categories)
+      end
+    end
+  end
+end

--- a/app/controllers/api/subcollections/settings.rb
+++ b/app/controllers/api/subcollections/settings.rb
@@ -35,17 +35,11 @@ module Api
 
       def resource_settings(resource)
         if super_admin? || current_user.role_allows?(:identifier => 'ops_settings')
-          whitelist_settings(resource.settings_for_resource.to_hash)
+          settings = resource.settings_for_resource.to_hash.deep_stringify_keys
+          SettingsFilterer.filter_for(current_user, :settings => settings)
         else
           raise ForbiddenError, "You are not authorized to view settings."
         end
-      end
-
-      def whitelist_settings(settings)
-        return settings if super_admin?
-
-        whitelisted_categories = ApiConfig.collections[:settings][:categories]
-        settings.with_indifferent_access.slice(*whitelisted_categories)
       end
     end
   end

--- a/app/controllers/api/zones_controller.rb
+++ b/app/controllers/api/zones_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ZonesController < BaseController
+    include Subcollections::Settings
+
     INVALID_ZONES_ATTRS = ID_ATTRS + %w[created_on updated_on].freeze
 
     # Edit an existing zone. Certain fields are meant for internal use only

--- a/lib/services/api/settings_filterer.rb
+++ b/lib/services/api/settings_filterer.rb
@@ -2,7 +2,7 @@ module Api
   class SettingsFilterer
     def self.filter_for(user, opts = {})
       subtree = opts.fetch(:subtree, nil)
-      filterer = new(user)
+      filterer = new(user, opts[:settings], opts[:whitelist])
       if subtree
         filterer.fetch(:subtree => subtree)
       else
@@ -12,10 +12,10 @@ module Api
 
     attr_reader :user, :settings, :whitelist
 
-    def initialize(user, settings = Settings.to_hash.deep_stringify_keys, whitelist = ApiConfig.collections[:settings][:categories])
-      @user = user
-      @settings = settings
-      @whitelist = whitelist
+    def initialize(user, settings = nil, whitelist = nil)
+      @user      = user
+      @settings  = settings || Settings.to_hash.deep_stringify_keys
+      @whitelist = whitelist || ApiConfig.collections[:settings][:categories]
     end
 
     def fetch(opts = {})

--- a/spec/lib/services/api/settings_filterer_spec.rb
+++ b/spec/lib/services/api/settings_filterer_spec.rb
@@ -1,4 +1,26 @@
 RSpec.describe Api::SettingsFilterer do
+  describe ".filter_for" do
+    context "with opt[:settings]" do
+      it "filters on the custom settings that are passed" do
+        user     = instance_double("User", :super_admin_user? => true)
+        settings = { "api" => {"authentication" => "1337.minutes"} }
+        actual   = described_class.filter_for(user, :settings => settings)
+
+        expect(actual["api"]).to eq(settings["api"])
+      end
+    end
+
+    context "with opt[:whitelist]" do
+      it "uses the custom whitelist to filter settings" do
+        # whitelist only used on non-super-admin users
+        user   = instance_double("User", :super_admin_user? => false)
+        actual = described_class.filter_for(user, :whitelist => %w[api])
+
+        expect(actual.keys).to eq(%w[api])
+      end
+    end
+  end
+
   describe "#fetch" do
     context "given an admin user" do
       let(:user) { instance_double("User", :super_admin_user? => true) }


### PR DESCRIPTION
This code has been living in the base controller, when it really should just exist as a subcollection, so moving it there so it is matching conventions (easier to find), to better represent what it does, and only apply the method to controllers that actually use it.


Links
-----

Original PRs around this topic:

- https://github.com/ManageIQ/manageiq-api/pull/275
- https://github.com/ManageIQ/manageiq-api/pull/304