### PR TITLE
[Api::SettingsFilterer] Remove excessive branching logic

### DIFF
--- a/lib/services/api/settings_filterer.rb
+++ b/lib/services/api/settings_filterer.rb
@@ -1,13 +1,7 @@
 module Api
   class SettingsFilterer
     def self.filter_for(user, opts = {})
-      subtree = opts.fetch(:subtree, nil)
-      filterer = new(user, opts[:settings], opts[:whitelist])
-      if subtree
-        filterer.fetch(:subtree => subtree)
-      else
-        filterer.fetch
-      end
+      new(user, opts[:settings], opts[:whitelist]).fetch(opts.slice(:subtree))
     end
 
     attr_reader :user, :settings, :whitelist


### PR DESCRIPTION
The check for `subtree` existence already exists in `#fetch`, so remove it from the `.filter_for` to make it cleaner.

Also simplifies the logic for passing opts to `#fetch`