### PR TITLE
[Subcollection::Settings] Allow nested fetch

### DIFF
--- a/app/controllers/api/subcollections/settings.rb
+++ b/app/controllers/api/subcollections/settings.rb
@@ -35,8 +35,10 @@ module Api
 
       def resource_settings(resource)
         if super_admin? || current_user.role_allows?(:identifier => 'ops_settings')
-          settings = resource.settings_for_resource.to_hash.deep_stringify_keys
-          SettingsFilterer.filter_for(current_user, :settings => settings)
+          filter_opts           = {:settings => resource.settings_for_resource.to_hash.deep_stringify_keys}
+          filter_opts[:subtree] = @req.c_suffix if @req.method == :get
+
+          SettingsFilterer.filter_for(current_user, filter_opts)
         else
           raise ForbiddenError, "You are not authorized to view settings."
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
 
           if subcollection_name == :settings
             match(
-              "/:c_id/settings",
+              "/:c_id/settings(/*c_suffix)",
               :to  => "#{collection_name}#settings",
               :via => %w(get patch delete),
               :as  => "#{resource_name}_settings",

--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -161,6 +161,15 @@ RSpec.describe "Regions API", :regions do
         expect(response).to have_http_status(:ok)
       end
 
+      it "shows a subset of the settings when passing a nested route" do
+        api_basic_authorize(:ops_settings)
+
+        get(api_region_settings_url(nil, region, "product"))
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include("product" => a_hash_including("maindb" => "ExtManagementSystem"))
+      end
+
       it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
         expect_forbidden_request { get(api_region_settings_url(nil, region)) }
       end

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -181,6 +181,15 @@ RSpec.describe "Servers" do
       expect(response).to have_http_status(:ok)
     end
 
+    it "shows a subset of the settings when passing a nested route" do
+      api_basic_authorize(:ops_settings)
+
+      get(api_server_settings_url(nil, server, "product"))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("product" => a_hash_including("maindb" => "ExtManagementSystem"))
+    end
+
     it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
       api_basic_authorize
 

--- a/spec/requests/zones_spec.rb
+++ b/spec/requests/zones_spec.rb
@@ -172,6 +172,15 @@ RSpec.describe "Zones" do
       expect(response).to have_http_status(:ok)
     end
 
+    it "shows a subset of the settings when passing a nested route" do
+      api_basic_authorize(:ops_settings)
+
+      get(api_zone_settings_url(nil, zone, "product"))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("product" => a_hash_including("maindb" => "ExtManagementSystem"))
+    end
+
     it "does not allow an authenticated user who doesn't have the proper role to view the settings" do
       expect_forbidden_request { get(api_zone_settings_url(nil, zone)) }
     end


### PR DESCRIPTION
Allows the same `:arbitrary_resource_path` for `GET` that is done for the base `Api::SettingsController` collection to work with `Api::Subcollection::Settings`.

Links
-----

* Closes #1000