### PR TITLE
[config/api.yml] Fix for new miq_event identifiers

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1490,7 +1490,7 @@
         :identifier: event_streams_show
   :events:
     :description: Events
-    :identifier: miq_event
+    :identifier: miq_event_definition
     :options:
     - :collection
     - :subcollection
@@ -1499,14 +1499,14 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: miq_event
+        :identifier: miq_event_definition_show_list
       :post:
       - :name: query
-        :identifier: miq_event
+        :identifier: miq_event_definition
     :resource_actions:
       :get:
       - :name: read
-        :identifier: miq_event
+        :identifier: miq_event_definition_show
   :features:
     :description: Product Features
     :options:


### PR DESCRIPTION
This was changed in https://github.com/ManageIQ/manageiq/pull/21016 and due to https://github.com/ManageIQ/manageiq/pull/21016 it won't let the specs pass if there is a name mismatch.

Considerations
--------------

Currently in the UI, we have more granular filters for show/index, but in the API, we just use the single permission.

Perhaps it makes sense to make use of `miq_event_definition_show_list` and `miq_event_definition_show` instead of the broader permission?