### PR TITLE
Added creation of new VolumeMapping

### DIFF
--- a/app/controllers/api/volume_mappings_controller.rb
+++ b/app/controllers/api/volume_mappings_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  class VolumeMappingsController < BaseController
+    def refresh_resource(type, id, _data = nil)
+      raise BadRequestError, "Must specify an id for refreshing a #{type} resource" if id.blank?
+
+      ensure_resource_exists(type, id) if single_resource?
+
+      api_action(type, id) do |klass|
+        volume_mapping = resource_search(id, type, klass)
+        api_log_info("Refreshing #{volume_mapping_ident(volume_mapping)}")
+        refresh_volume_mapping(volume_mapping)
+      end
+    end
+
+    def create_resource(_type, _id = nil, data = {})
+      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+
+      klass = VolumeMapping.class_by_ems(ext_management_system)
+      raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
+
+      task_id = VolumeMapping.create_volume_mapping_queue(session[:userid], ext_management_system, data)
+      action_result(true, "Creating Volume Mapping for Provider: #{ext_management_system.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    private
+
+    def ensure_resource_exists(type, id)
+      raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
+    end
+
+    def refresh_volume_mapping(volume_mapping)
+      desc = "#{volume_mapping_ident(volume_mapping)} refreshing"
+      task_id = queue_object_action(volume_mapping, desc, :method_name => "refresh_ems", :role => "ems_operations")
+      action_result(true, "#{volume_mapping_ident(volume_mapping)} refreshing", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def volume_mapping_ident(volume_mapping)
+      "Volume Mapping id:#{volume_mapping.id}"
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -4859,6 +4859,30 @@
         :identifier:
         - vm_snapshot_delete
         - sui_vm_snapshot_delete
+  :volume_mappings:
+    :description: Volume Mappings
+    :identifier: volume_mapping
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: VolumeMapping
+    :subcollections:
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: volume_mapping_show_list
+      :post:
+      - :name: create
+        :identifier: volume_mapping_new
+      - :name: refresh
+        :identifier: volume_mapping_refresh
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: volume_mapping_show
+      :post:
+      - :name: refresh
+        :identifier: volume_mapping_refresh
   :widgets:
     :description: Miq Widgets
     :identifier: miq_report_widget_admin

--- a/spec/requests/volume_mappings_spec.rb
+++ b/spec/requests/volume_mappings_spec.rb
@@ -1,0 +1,138 @@
+describe "Volume Mappings API" do
+  context "POST /api/volume_mappings" do
+    it "with an invalid ems_id it responds with 404 Not Found" do
+      api_basic_authorize(collection_action_identifier(:volume_mappings, :create))
+
+      request = {
+        "action"   => "create",
+        "resource" => {
+          "ems_id"            => nil,
+          "cloud_volume_id"   => "1",
+          "host_initiator_id" => "1",
+        }
+      }
+
+      post(api_volume_mappings_url, :params => request)
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "creates new Volume Mapping" do
+      api_basic_authorize(collection_action_identifier(:volume_mappings, :create))
+      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
+      cloud_volume = FactoryBot.create(:cloud_volume)
+      host_initiator = FactoryBot.create(:host_initiator)
+
+      request = {
+        "action"   => "create",
+        "resource" => {
+          "ems_id"            => provider.id,
+          "cloud_volume_id"   => cloud_volume.id,
+          "host_initiator_id" => host_initiator.id,
+        }
+      }
+
+      post(api_volume_mappings_url, :params => request)
+
+      expect_multiple_action_result(1, :success => true, :message => "Creating Host Initiator test_host_initiator for Provider: #{provider.name}", :task => true)
+    end
+  end
+
+  context "GET /api/volume_mappings" do
+    it "returns all volume mappings" do
+      volume_mapping = FactoryBot.create(:volume_mapping)
+      api_basic_authorize('volume_mapping_show_list')
+
+      get(api_volume_mappings_url)
+
+      expected = {
+        "name"      => "volume_mappings",
+        "resources" => [{"href" => api_volume_mapping_url(nil, volume_mapping)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "GET /api/volume_mappings/:id" do
+    it "returns one volume_mapping" do
+      volume_mapping = FactoryBot.create(:volume_mapping)
+      api_basic_authorize('volume_mapping_show')
+
+      get(api_volume_mapping_url(nil, volume_mapping))
+
+      expected = {
+        "href" => api_volume_mapping_url(nil, volume_mapping)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe "Volume Mapping refresh action" do
+    context "with an invalid id" do
+      it "it responds with 404 Not Found" do
+        api_basic_authorize(action_identifier(:volume_mappings, :refresh, :resource_actions, :post))
+
+        post(api_volume_mapping_url(nil, 999_999), :params => gen_request(:refresh))
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "without an appropriate role" do
+      it "it responds with 403 Forbidden" do
+        volume_mapping = FactoryBot.create(:volume_mapping)
+        api_basic_authorize
+
+        post(api_volume_mapping_url(nil, volume_mapping), :params => gen_request(:refresh))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with an appropriate role" do
+      it "rejects refresh for unspecified volume mapping" do
+        api_basic_authorize(action_identifier(:volume_mappings, :refresh, :resource_actions, :post))
+
+        post(api_volume_mappings_url, :params => gen_request(:refresh, [{"href" => "/api/volume_mappings/"}, {"href" => "/api/volume_mappings/"}]))
+
+        expect_bad_request(/Must specify an id/i)
+      end
+
+      it "refresh of a single Volume Mapping" do
+        volume_mapping = FactoryBot.create(:volume_mapping)
+        api_basic_authorize('volume_mapping_refresh')
+
+        post(api_volume_mapping_url(nil, volume_mapping), :params => gen_request(:refresh))
+
+        expect_single_action_result(:success => true, :message => /#{volume_mapping.id}.* refreshing/i, :href => api_volume_mapping_url(nil, volume_mapping))
+      end
+
+      it "refresh of multiple Host Initiators" do
+        volume_mapping = FactoryBot.create(:volume_mapping)
+        volume_mapping_two = FactoryBot.create(:volume_mapping)
+        api_basic_authorize('volume_mapping_refresh')
+
+        post(api_volume_mappings_url, :params => gen_request(:refresh, [{"href" => api_volume_mapping_url(nil, volume_mapping)}, {"href" => api_volume_mapping_url(nil, volume_mapping_two)}]))
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including(
+              "message" => a_string_matching(/#{volume_mapping.id}.* refreshing/i),
+              "success" => true,
+              "href"    => api_volume_mapping_url(nil, volume_mapping)
+            ),
+            a_hash_including(
+              "message" => a_string_matching(/#{volume_mapping_two.id}.* refreshing/i),
+              "success" => true,
+              "href"    => api_volume_mapping_url(nil, volume_mapping_two)
+            )
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/21018 (or is it, @chessbyte ?)

This adds and API endpoint for creating volume-mappings. To create a volume mapping, one would send a `POST` request to `/api/volume_mappings` with the following fields:

- ems_id -- The ID of an EMS in MIQ that supports creating volume-mappings
- cloud_volume_id -- the ID of a cloud volume in the EMS
- host_initiator_id -- the ID of a host_initiator from the EMS that's in the same storage machine as the volume.


Needs to be done together with ManageIQ/manageiq-providers-autosde#57, ManageIQ/manageiq#21024