### PR TITLE
Safe delete for cloud volume

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -16,6 +16,17 @@ module Api
       action_result(false, err.to_s)
     end
 
+    def safe_delete_resource(type, id, _data = {})
+      delete_action_handler do
+        cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))
+
+        raise BadRequestError, cloud_volume.unsupported_reason(:safe_delete) unless cloud_volume.supports?(:safe_delete)
+
+        task_id = cloud_volume.safe_delete_volume_queue(User.current_user)
+        action_result(true, "Deleting Cloud Volume #{cloud_volume.name}", :task_id => task_id)
+      end
+    end
+
     def delete_resource(type, id, _data = {})
       delete_action_handler do
         cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))

--- a/config/api.yml
+++ b/config/api.yml
@@ -807,6 +807,8 @@
         :identifier: cloud_volume_show_list
       - :name: delete
         :identifier: cloud_volume_delete
+      - :name: safe_delete
+        :identifier: cloud_volume_safe_delete
     :resource_actions:
       :get:
       - :name: read
@@ -814,6 +816,8 @@
       :post:
       - :name: delete
         :identifier: cloud_volume_delete
+      - :name: safe_delete
+        :identifier: cloud_volume_safe_delete
       :delete:
       - :name: delete
         :identifier: cloud_volume_delete


### PR DESCRIPTION
This PR adds a safe-delete operation to the API.
It's meant to shadow the regular delete operation but it performs checks to make sure deleting the item doesn't destabilize the system in some way. 
```
POST /api/cloud_volumes/1

{
    "action": "safe_delete"    
}

{
    "success": true,
    "message": "Deleting Cloud Volume my_volume",
    "task_id": "22",
    "task_href": "https://my_ems/api/tasks/22"
}

```

```
POST /api/cloud_volumes/

{
    "action": "safe_delete"  ,  
    "resources": [{"id": 1}, {"id": 2}]
}

{
    "results": [
        {
            "success": true,
            "message": "Deleting Cloud Volume smiling-aardwolf",
            "task_id": "6",
            "task_href": "https://my_provider/api/tasks/6"
        },
        {
            "success": true,
            "message": "Deleting Cloud Volume pistachio-agama",
            "task_id": "7",
            "task_href": "https://my_provider/api/tasks/7"
        }
    ]
}
```
Part of https://github.com/ManageIQ/manageiq/issues/21055