### PR TITLE
Expose CloudSubnet create/edit form via OPTIONS

### DIFF
--- a/app/controllers/api/cloud_subnets_controller.rb
+++ b/app/controllers/api/cloud_subnets_controller.rb
@@ -1,5 +1,19 @@
 module Api
   class CloudSubnetsController < BaseController
     include Subcollections::Tags
+
+    def options
+      return super unless params[:ems_id]
+
+      ems = ExtManagementSystem.find(params[:ems_id])
+
+      raise BadRequestError, "No CloudSubnet support for - #{ems.class}" unless defined?(ems.class::CloudSubnet)
+
+      klass = ems.class::CloudSubnet
+
+      raise BadRequestError, "No DDF specified for - #{klass}" unless klass.respond_to?(:params_for_create)
+
+      render_options(:cloud_subnets, :form_schema => klass.params_for_create(ems))
+    end
   end
 end

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -77,4 +77,19 @@ RSpec.describe 'CloudSubnets API' do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  describe 'OPTIONS /api/cloud_subnets?ems_id=:id' do
+    it 'returns a DDF schema when available via OPTIONS' do
+      zone = FactoryBot.create(:zone, :name => "api_zone")
+      provider = FactoryBot.create(:ems_network, :zone => zone)
+
+      allow(provider.class::CloudSubnet).to receive(:params_for_create).and_return('foo')
+
+      options(api_cloud_subnets_url, :params => {:ems_id => provider.id})
+      options("#{api_cloud_subnets_url}?ems_id=#{provider.id}")
+
+      expect(response.parsed_body['data']['form_schema']).to eq('foo')
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
So far this doesn't do much as there are no schemas defined in any provider, but it is totally analogous with what we do with cloud volumes.

@miq-bot add_label enhancement
@miq-bot assign @lpichler 