### PR TITLE
[zones_spec.rb] Add tests for authentication

### DIFF
--- a/spec/requests/zones_spec.rb
+++ b/spec/requests/zones_spec.rb
@@ -25,6 +25,42 @@ RSpec.describe "Zones" do
   end
 
   context "edit", :edit do
+    it "can create zone authentication" do
+      api_basic_authorize action_identifier(:zones, :edit)
+
+      zone   = FactoryBot.create(:zone, :description => "Current Zone description")
+      params = gen_request(:edit,
+                           "description"               => "Updated Zone Description",
+                           "authentication_attributes" => {"userid" => "foo", "password" => "bar"})
+
+      expect(zone.authentication).to eq(nil) # sanity check
+
+      post api_zone_url(nil, zone), :params => params
+      zone.reload
+
+      expect(zone.description).to             eq("Updated Zone Description")
+      expect(zone.authentication.userid).to   eq("foo")
+      expect(zone.authentication.password).to eq("bar")
+    end
+
+    it "can delete an existing authentication" do
+      api_basic_authorize action_identifier(:zones, :edit)
+
+      zone   = FactoryBot.create(:zone, :description               => "Current Zone description",
+                                        :authentication_attributes => {:userid => "foo", :password => "bar"})
+      params = gen_request(:edit,
+                           "description"               => "Updated Zone Description",
+                           "authentication_attributes" => {"_destroy" => "true"})
+
+      expect(zone.authentication.userid).to eq("foo") # sanity check
+
+      post api_zone_url(nil, zone), :params => params
+      zone.reload
+
+      expect(zone.description).to    eq("Updated Zone Description")
+      expect(zone.authentication).to eq(nil)
+    end
+
     it "will fail if you try to edit invalid fields" do
       api_basic_authorize action_identifier(:zones, :edit)
 


### PR DESCRIPTION
**REQUIRES https://github.com/ManageIQ/manageiq/pull/21047 to be merged**

Adds some specs to cover creating and deleting authentications attached to zones using `accepts_nested_attributes_for :authentication`


Links
-----

* Core PR:  https://github.com/ManageIQ/manageiq/pull/21047
* Cross Repo tests:  https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/319
* Related to https://github.com/ManageIQ/manageiq-api/issues/898