### PR TITLE
Add PXE server credential validation endpoint

### DIFF
--- a/app/controllers/api/pxe_servers_controller.rb
+++ b/app/controllers/api/pxe_servers_controller.rb
@@ -55,6 +55,15 @@ module Api
       end
     end
 
+    def verify_credentials_resource(_type, id = nil, data = {})
+      zone_name = data.delete('zone_name')
+      data['id'] = id if id
+      task_id = PxeServer.verify_depot_settings_queue(User.current_user.userid, zone_name, data)
+      action_result(true, "Credentials sent for verification", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     private
 
     def validate_data_for(klass, data)

--- a/config/api.yml
+++ b/config/api.yml
@@ -3030,6 +3030,8 @@
         :identifier: pxe_server_edit
       - :name: delete
         :identifier: pxe_server_delete
+      - :name: verify_credentials
+        :identifier: pxe_server_new
     :resource_actions:
       :get:
       - :name: read

--- a/spec/requests/pxe_servers_spec.rb
+++ b/spec/requests/pxe_servers_spec.rb
@@ -267,4 +267,29 @@ RSpec.describe 'PxeServers API' do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  describe 'post /api/pxe_servers with verify_credentials action' do
+    it 'queues the request to verify the credentials' do
+      api_basic_authorize collection_action_identifier(:pxe_servers, :verify_credentials)
+      request = {
+        "action"    => "verify_credentials",
+        "zone_name" => "zone",
+        "resource"  => {:name => "test", :uri => "smb://tmp/foo", :username => "test", :password => "foo"}
+      }
+      post(api_pxe_servers_url, :params => request)
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including(
+            "message"   => a_string_matching(/Credentials sent for verification/),
+            "success"   => true,
+            "task_href" => a_string_matching(api_tasks_url),
+            "task_id"   => a_kind_of(String)
+          )
+        )
+      }
+
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/21013.

https://github.com/ManageIQ/manageiq-api/issues/926

@miq-bot add_label enhancement, kasparov/no

```
POST /api/pxe_servers
{"action" => "verify_credentials",
 "resource" =>
  {:name => "test", :uri => "smb://tmp/foo", :username => "test", :password => "foo"}
}
```

```
RESPONSE
{"results" =>
  [{"success" => true,
    "message" => "Credentials sent for verification",
    "task_id" => "13000000000006",
    "task_href" => "http://localhost:3000/api/tasks/13000000000006"}]
}
```