### PR TITLE
new POST API method allowing import of images from one provider into another

### DIFF
--- a/app/controllers/api/cloud_templates_controller.rb
+++ b/app/controllers/api/cloud_templates_controller.rb
@@ -8,12 +8,31 @@ module Api
       end
     end
 
+    def import_resource(_type, _id, data = {})
+      params = %w[dst_provider_id src_provider_id src_image_id]
+      raise BadRequestError, "Parameter 'data' has to contain non-empty values for the keys '#{params.join(", ")}', received: '#{data.to_json}'" if data.values_at(*params).any?(&:blank?)
+      raise BadRequestError, "Source and destination provider identifiers must differ" if data['dst_provider_id'] == data['src_provider_id']
+
+      ems_dst   = resource_search(data['dst_provider_id'], :providers, collection_class(:providers))
+      ems_src   = resource_search(data['src_provider_id'], :providers, collection_class(:providers))
+      src_image = resource_search(data['src_image_id'],    :providers, collection_class(:templates))
+
+      raise BadRequestError, "Source image specified by the id '#{data['src_image_id']}' does not belong to the source provider with id '#{ems_src.id}'" if src_image.ems_id != ems_src.id
+
+      task_id = ManageIQ::Providers::CloudManager::Template.import_image_queue(session[:userid], ems_dst, data)
+      msg = "Importing image '#{src_image.name}' from '#{ems_src.name}' into '#{ems_dst.name}'."
+      api_log_info(msg)
+
+      action_result(true, msg, :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     private
 
     def cloud_template_ident(cloud_template)
       "CloudTemplate id:#{cloud_template.id} name:'#{cloud_template.name}'"
     end
-
 
     def request_compliance_check(cloud_template)
       desc = "#{cloud_template_ident(cloud_template)} check compliance requested"

--- a/config/api.yml
+++ b/config/api.yml
@@ -699,6 +699,8 @@
         :identifier: image_show_list
       - :name: set_ownership
         :identifier: image_ownership
+      - :name: import
+        :identifier: image_import
     :resource_actions:
       :get:
       - :name: read


### PR DESCRIPTION
- this action is implemented in the context of a cloud template collection

- added import API endpoint for the image import operation in 'api.conf'

- added 'import_resource' implementation to the 'cloud_templates_controller.rb'

- calling static queueing method of the corresponding cloud template

- validation of input data is present and throws exceptions in case of malformed input

- minimal payload for a corresponding sample POST request
  '{"action": "import", "dst_provider_id": 10, "src_provider_id": 14, "src_image_id": 23 }'
  API path: /api/cloud_templates

- sibling PR in the base ManageIQ repository introducing static queuing method
  into base Template class is: https://github.com/ManageIQ/manageiq/pull/21106

- sibling PR in the base ManageIQ introducing a new feature is:
  https://github.com/ManageIQ/manageiq/pull/21112