### PR TITLE
Replace the retire action with request_retire

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -174,16 +174,6 @@ module Api
       end
     end
 
-    def retire_resource(type, id = nil, data = nil)
-      raise BadRequestError, "Must specify an id for retiring a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Retiring #{vm_ident(vm)}")
-        retire_vm(vm, id, data)
-      end
-    end
-
     def reset_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for resetting a #{type} resource" unless id
 
@@ -292,7 +282,9 @@ module Api
       action_result(false, "Failed to set miq_server - #{err}")
     end
 
-    def request_retire_resource(type, id, data = nil)
+    def request_retire_resource(type, id = nil, data = nil)
+      raise BadRequestError, "Must specify an id for retiring a #{type} resource" unless id
+
       api_action(type, id) do |klass|
         vm = resource_search(id, type, klass)
         msg = "Retiring request of vm #{vm_ident(vm)}"
@@ -310,6 +302,7 @@ module Api
         end
       end
     end
+    alias retire_resource request_retire_resource
 
     def check_compliance_resource(type, id, _data = nil)
       api_action(type, id) do |klass|
@@ -483,15 +476,6 @@ module Api
       event_timestamp = event_time.blank? ? Time.now.utc : event_time.to_time(:utc)
 
       vm.add_ems_event(event_type, event_message, event_timestamp)
-      action_result(true, desc)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def retire_vm(vm, id, data)
-      desc = "#{vm_ident(vm)} retiring"
-      desc << " on #{data['date']}" if Hash(data)['date'].present?
-      generic_retire_resource(:vms, id, data)
       action_result(true, desc)
     rescue => err
       action_result(false, err.to_s)

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1367,7 +1367,7 @@ describe "Vms API" do
 
         post(vm_url, :params => gen_request(:retire))
 
-        expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => api_vm_url(nil, vm))
+        expect_single_action_result(:success => true, :message => /#{vm.id}.* request retire/i, :href => api_vm_url(nil, vm))
       end
 
       it "to multiple Vms" do
@@ -1375,17 +1375,24 @@ describe "Vms API" do
 
         post(api_vms_url, :params => gen_request(:retire, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
+        vm1_task = MiqTask.find_by(:name => "VM id:#{vm1.id} name:'#{vm1.name}' request retire")
+        vm2_task = MiqTask.find_by(:name => "VM id:#{vm2.id} name:'#{vm2.name}' request retire")
+
         expected = {
           "results" => a_collection_containing_exactly(
             {
-              "message" => a_string_matching(/#{vm1.id}.* retiring/i),
-              "success" => true,
-              "href"    => api_vm_url(nil, vm1)
+              "message"   => a_string_matching(/#{vm1.id}.* request retire/i),
+              "task_id"   => vm1_task.id.to_s,
+              "task_href" => api_task_url(nil, vm1_task),
+              "success"   => true,
+              "href"      => api_vm_url(nil, vm1)
             },
             {
-              "message" => a_string_matching(/#{vm2.id}.* retiring/ii),
-              "success" => true,
-              "href"    => api_vm_url(nil, vm2)
+              "message"   => a_string_matching(/#{vm2.id}.* request retire/ii),
+              "task_id"   => vm2_task.id.to_s,
+              "task_href" => api_task_url(nil, vm2_task),
+              "success"   => true,
+              "href"      => api_vm_url(nil, vm2)
             }
           )
         }
@@ -1398,7 +1405,7 @@ describe "Vms API" do
         date = 2.weeks.from_now
         post(vm_url, :params => gen_request(:retire, :date => date.iso8601))
 
-        expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => api_vm_url(nil, vm))
+        expect_single_action_result(:success => true, :message => /#{vm.id}.* request retire/i, :href => api_vm_url(nil, vm))
       end
     end
 


### PR DESCRIPTION
The `#retire_now` method has been superseded by request_retire.  Also
retire_now doesn't appear to actually work.

Alias the retire_vm action to the new request_retire_action.

https://github.com/ManageIQ/manageiq/issues/21124