### PR TITLE
Add endpoint for cloud subnets

### DIFF
--- a/app/controllers/api/cloud_subnets_controller.rb
+++ b/app/controllers/api/cloud_subnets_controller.rb
@@ -15,5 +15,42 @@ module Api
 
       render_options(:cloud_subnets, :form_schema => klass.params_for_create(ems))
     end
+
+    def create_resource(_type, _id = nil, data = {})
+      ems = ExtManagementSystem.find(data['ems_id'])
+      klass = CloudSubnet.class_by_ems(ems)
+      raise BadRequestError, "Cannot create cloud subnet for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
+
+      task_id = ems.create_cloud_subnet_queue(session[:userid], data.deep_symbolize_keys)
+      action_result(true, "Creating Cloud Subnet #{data['name']} for Provider: #{ems.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def edit_resource(type, id, data)
+      cloud_subnet = resource_search(id, type, collection_class(:cloud_subnets))
+      raise BadRequestError, "Cannot update #{cloud_subnet_ident(cloud_subnet)}: #{cloud_subnet.unsupported_reason(:update)}" unless cloud_subnet.supports?(:update)
+
+      task_id = cloud_subnet.update_cloud_subnet_queue(session[:userid], data.deep_symbolize_keys)
+      action_result(true, "Updating #{cloud_subnet_ident(cloud_subnet)}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def delete_resource(type, id, _data = {})
+      delete_action_handler do
+        cloud_subnet = resource_search(id, type, collection_class(:cloud_subnets))
+        raise BadRequestError, "Cannot delete #{cloud_subnet_ident(cloud_subnet)}: #{cloud_subnet.unsupported_reason(:delete)}" unless cloud_subnet.supports?(:delete)
+
+        task_id = cloud_subnet.delete_cloud_subnet_queue(session[:userid])
+        action_result(true, "Deleting #{cloud_subnet_ident(cloud_subnet)}", :task_id => task_id)
+      end
+    end
+
+    private
+
+    def cloud_subnet_ident(cloud_subnet)
+      "Cloud Subnet id: #{cloud_subnet.id} name: '#{cloud_subnet.name}'"
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -628,7 +628,7 @@
     - :collection
     - :subcollection
     - :custom_actions
-    :verbs: *gp
+    :verbs: *gpppd
     :klass: CloudSubnet
     :subcollections:
     - :tags
@@ -637,12 +637,32 @@
       - :name: read
         :identifier: cloud_subnet_show_list
       :post:
+      - :name: create
+        :identifier: cloud_subnet_new
       - :name: query
         :identifier: cloud_subnet_show_list
+      - :name: edit
+        :identifier: cloud_subnet_edit
+      - :name: delete
+        :identifier: cloud_subnet_delete
     :resource_actions:
       :get:
       - :name: read
         :identifier: cloud_subnet_show
+      :post:
+      - :name: edit
+        :identifier: cloud_subnet_edit
+      - :name: delete
+        :identifier: cloud_subnet_delete
+      :patch:
+      - :name: edit
+        :identifier: cloud_subnet_edit
+      :put:
+      - :name: edit
+        :identifier: cloud_subnet_edit
+      :delete:
+      - :name: delete
+        :identifier: cloud_subnet_delete
     :subcollection_actions:
       :get:
       - :name: read

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -92,4 +92,153 @@ RSpec.describe 'CloudSubnets API' do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'POST /api/cloud_subnets' do
+    it 'forbids access to cloud subnets without an appropriate role' do
+      api_basic_authorize
+      post(api_cloud_subnets_url, :params => gen_request(:query, ""))
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "queues the creating of cloud subnet" do
+      api_basic_authorize collection_action_identifier(:cloud_subnets, :create)
+      request = {
+        "action"   => "create",
+        "resource" => {
+          "ems_id" => ems.id,
+          "name"   => "test_cloud_subnet"
+        }
+      }
+
+      post(api_cloud_subnets_url, :params => request)
+
+      expect_multiple_action_result(1, :success => true, :message => "Creating Cloud Subnet test_cloud_subnet for Provider: #{ems.name}", :task => true)
+    end
+
+    it "raises error when provider does not support creating of cloud subnets" do
+      api_basic_authorize collection_action_identifier(:cloud_subnets, :create)
+      provider = FactoryBot.create(:ems_amazon, :name => 'test_provider')
+      request = {
+        "action"   => "create",
+        "resource" => {
+          "ems_id" => provider.network_manager.id,
+          "name"   => "test_cloud_subnet"
+        }
+      }
+
+      post(api_cloud_subnets_url, :params => request)
+
+      expected = {"success" => false, "message" => a_string_including("Cannot create cloud subnet for Provider #{provider.name}")}
+      expect(response.parsed_body["results"].first).to include(expected)
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe "POST /api/cloud_subnets/:id" do
+    let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+    let(:cloud_subnet) { FactoryBot.create(:cloud_subnet_openstack, :ext_management_system => ems, :cloud_tenant => tenant) }
+
+    it "can queue the updating of a cloud subnet" do
+      api_basic_authorize(action_identifier(:cloud_subnets, :edit))
+
+      post(api_cloud_subnet_url(nil, cloud_subnet), :params => {:action => 'edit', :status => "inactive"})
+
+      expected = {
+        'success'   => true,
+        'message'   => a_string_including('Updating Cloud Subnet'),
+        'task_href' => a_string_matching(api_tasks_url),
+        'task_id'   => a_kind_of(String)
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can't queue the updating of a cloud subnet unless authorized" do
+      api_basic_authorize
+
+      post(api_cloud_subnet_url(nil, cloud_subnet), :params => {:action => 'edit', :status => "inactive"})
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "DELETE /api/cloud_subnets" do
+    let(:cloud_subnet) { FactoryBot.create(:cloud_subnet_openstack) }
+
+    it "can delete a cloud subnet" do
+      api_basic_authorize(action_identifier(:cloud_subnets, :delete))
+
+      delete(api_cloud_subnet_url(nil, cloud_subnet))
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "will not delete a cloud subnet unless authorized" do
+      api_basic_authorize
+
+      delete(api_cloud_subnet_url(nil, cloud_subnet))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "POST /api/cloud_subnets with delete action" do
+    it "can delete a cloud subnet" do
+      ems = FactoryBot.create(:ems_network)
+      cloud_subnet = FactoryBot.create(:cloud_subnet_openstack, :ext_management_system => ems)
+      api_basic_authorize(action_identifier(:cloud_subnets, :delete, :resource_actions))
+
+      post(api_cloud_subnet_url(nil, cloud_subnet), :params => gen_request(:delete))
+
+      expected = {
+        'success'   => true,
+        'message'   => a_string_including('Deleting Cloud Subnet'),
+        'task_href' => a_string_matching(api_tasks_url),
+        'task_id'   => a_kind_of(String)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it "will not delete a cloud subnet unless authorized" do
+      cloud_subnet = FactoryBot.create(:cloud_subnet)
+      api_basic_authorize
+
+      post(api_cloud_subnet_url(nil, cloud_subnet), :params => {:action => "delete"})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "can delete multiple cloud_subnets" do
+      ems = FactoryBot.create(:ems_network)
+      cloud_subnet1, cloud_subnet2 = FactoryBot.create_list(:cloud_subnet_openstack, 2, :ext_management_system => ems)
+      api_basic_authorize(action_identifier(:cloud_subnets, :delete, :resource_actions))
+
+      post(api_cloud_subnets_url, :params => {:action => "delete", :resources => [{:id => cloud_subnet1.id}, {:id => cloud_subnet2.id}]})
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "forbids multiple cloud subnet deletion without an appropriate role" do
+      cloud_subnet1, cloud_subnet2 = FactoryBot.create_list(:cloud_subnet, 2)
+      api_basic_authorize
+
+      post(api_cloud_subnets_url, :params => {:action => "delete", :resources => [{:id => cloud_subnet1.id}, {:id => cloud_subnet2.id}]})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "raises an error when delete not supported for cloud subnet" do
+      cloud_subnet = FactoryBot.create(:cloud_subnet)
+      api_basic_authorize(action_identifier(:cloud_subnets, :delete, :resource_actions))
+
+      post(api_cloud_subnet_url(nil, cloud_subnet), :params => gen_request(:delete))
+
+      expected = {
+        'success' => false,
+        'message' => a_string_including('Cannot delete Cloud Subnet')
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
Updated version of https://github.com/ManageIQ/manageiq-api/pull/1019

(just fixes some minor issues in the tests in the original, caused after [review changes](https://github.com/ManageIQ/manageiq-api/pull/1019#pullrequestreview-623246311))

Addresses https://github.com/ManageIQ/manageiq-api/issues/1013

@miq-bot add_label enhancement, kasparov/no, laskar/no


Sample Requests
----------------

### Create

**Request**

```
POST /api/cloud_subnets
```
```json
{
  "action": "create",
  "resource": {
    "ems_id": 10000000000013,
    "name":   "test_cloud_subnet"
  }
}
```

**Response**

```json
{
  "results": [
    {
      "success":   true,
      "message":   "Creating Cloud Subnet test_cloud_subnet for Provider: OpenStack Network Manager",
      "task_id":   "10000000053334",
      "task_href": "http://localhost:3000/api/tasks/10000000053334"
    }
  ]
}
```

### Edit

**Request**

```
POST /api/cloud_subnets/10000000000028
```
```json
{
  "action": "edit",
  "status": "available"
}
```

**Response**

```json
{
  "success":   true,
  "message":   "Updating Cloud Subnet id: 10000000000028 name: 'provider'",
  "task_id":   "10000000053335",
  "task_href": "http://localhost:3000/api/tasks/10000000053335"
}
```