### PR TITLE
Add api options for instance snapshot creation

### DIFF
--- a/app/controllers/api/instances_controller.rb
+++ b/app/controllers/api/instances_controller.rb
@@ -122,6 +122,17 @@ module Api
       end
     end
 
+    def options
+      return super unless @req.subcollection?
+  
+      # Try to look for subcollection specific options
+      subcollection_options_method = "#{@req.subject}_subcollection_options"
+      return super unless respond_to?(subcollection_options_method)
+  
+      vm = resource_search(params[:c_id], @req.collection, collection_class(@req.collection))
+      render_options(@req.collection.to_sym, send(subcollection_options_method, vm))
+    end
+
     private
 
     def instance_ident(instance)


### PR DESCRIPTION
**Issue:**
snapshot an compute-->cloud--> Instance--> openstack or any of the instance for which snapshots are enabled-->click on Add new snapshot from Configuration, it open a blank page and there's nothing to entered such as name of the snapshot, etc.. There's no Finish button.

**Description**
Code is already present in vm snapshot , same code added it to instance controller.

**Before**
<img width="1449" alt="Screen Shot 2021-04-12 at 7 58 40 PM" src="https://user-images.githubusercontent.com/37085529/114477440-287e5880-9bca-11eb-931b-04bdfb4b36a2.png">
<img width="547" alt="Screen Shot 2021-04-12 at 7 59 07 PM" src="https://user-images.githubusercontent.com/37085529/114477442-2916ef00-9bca-11eb-9aad-8bb0293d6427.png">


**After**
<img width="1541" alt="Screen Shot 2021-04-12 at 7 55 56 PM" src="https://user-images.githubusercontent.com/37085529/114477462-33d18400-9bca-11eb-8b66-667bb260ca56.png">

@miq-bot assign @agrare 
@miq-bot add-reviewer @agrare 
@miq-bot add-label lasker/yes?
