### PR TITLE
Fix User AR object dumped to logs

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -121,7 +121,7 @@ module Api
       klass = fetch_provider_klass(collection_class(:providers), data)
       zone_name = data.delete('zone_name')
       data['id'] = id if id
-      task_id = klass.verify_credentials_task(current_user, zone_name, data)
+      task_id = klass.verify_credentials_task(current_user.userid, zone_name, data)
       action_result(true, 'Credentials sent for verification', :task_id => task_id)
     rescue => err
       action_result(false, err.to_s)


### PR DESCRIPTION
Before:
`MIQ(MiqTask.generic_action_with_callback) Task: [31] Queued the action: [Verify EMS Provider Credentials] being run for user: [#<User:0x00007fe73c569c28>]`
After:
`INFO -- : MIQ(MiqTask.generic_action_with_callback) Task: [32] Queued the action: [Verify EMS Provider Credentials] being run for user: [admin]`