### PR TITLE
Allow `id` as a method parameter name

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,3 +1,6 @@
+Naming/MethodParameterName:
+  AllowedNames:
+  - id
 Style/GlobalVars:
   AllowedVariables:
   - $api_log


### PR DESCRIPTION
Most API method signatures look like `def api_action(type, id, data = {})` and rubocop warns that `id` is too short to be a helpful variable name.