### PR TITLE
Allow creation of AutomationManagers via API

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2795,6 +2795,8 @@
         - ems_block_storage_show_list
       - :name: create
         :identifiers:
+        - :klass: ManageIQ::Providers::AutomationManager
+          :identifier: ems_automation_add_provider
         - :klass: ManageIQ::Providers::InfraManager
           :identifier: ems_infra_new
         - :klass: ManageIQ::Providers::CloudManager


### PR DESCRIPTION
https://talk.manageiq.org/t/bad-request-when-trying-to-add-create-ansible-tower-providers-via-api/5394/3