### PR TITLE
[ZonesController] Allow "setting" settings

### DIFF
--- a/app/controllers/api/zones_controller.rb
+++ b/app/controllers/api/zones_controller.rb
@@ -30,5 +30,16 @@ module Api
 
       data.keys.select { |key| INVALID_ZONES_ATTRS.include?(key) }.compact.join(", ")
     end
+
+    # Since there is a `settings` attribute on Zone, and a subcollection for
+    # zones called `settings`, allow "setting" of the `:settings` column, and
+    # don't allow setting the "settings" subcollection data on this particular
+    # resource.
+    #
+    def extract_subcollection_data!(subcollections, data)
+      subcollection_keys = subcollections.reject { |subc| subc.to_s == "settings" }
+
+      super(subcollection_keys, data)
+    end
   end
 end

--- a/spec/requests/zones_spec.rb
+++ b/spec/requests/zones_spec.rb
@@ -24,6 +24,34 @@ RSpec.describe "Zones" do
     end
   end
 
+  context "create", :create do
+    it 'creates a new Zone' do
+      api_basic_authorize collection_action_identifier(:zones, :create)
+
+      expected = {'results' => [a_hash_including("name", "description", "settings")]}
+
+      expect do
+        post api_zones_url, :params => {:name => "sads", :description => ":sob:"}
+      end.to change(Zone, :count).by(1)
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'allows setting the "settings" hash on a Zone' do
+      api_basic_authorize collection_action_identifier(:zones, :create)
+
+      expected = {'results' => [a_hash_including("name", "description", "settings")]}
+      settings = {"proxy_server_ip" => "1.2.3.4"}
+
+      expect do
+        post api_zones_url, :params => {:name => "sads", :description => ":sob:", :settings => settings}
+      end.to change(Zone, :count).by(1)
+      expect(response.parsed_body).to include(expected)
+      expect(response.parsed_body["results"].first["settings"]).to eq({"proxy_server_ip" => "1.2.3.4"})
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   context "edit", :edit do
     it "will fail if you try to edit invalid fields" do
       api_basic_authorize action_identifier(:zones, :edit)


### PR DESCRIPTION
The Zone model/api-controller has two overriding features:

- A subcollection for "settings"
- A hash column called "settings"

The code in `Api::BaseController::Generic#add_resource` has a block in it that takes any key from the params hash that is part of a subcollection, and passes it to create those sub-resources.  This overrides the behavior of being able to write the `settings` hash directly on create (this is not a behavior that is replicated generically for `edit_resource`)

To allow for editing of `Zone#settings` on create, we override `add_resource` so that it will not include this sections of code for this particular controller.

Note:  The `alias` also needed to be re-applied, as `create_resource` is what is actually called by `Api::BaseController::Generic#create`