### PR TITLE
Fix Provider create product feature

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2808,7 +2808,7 @@
         - :klass: ManageIQ::Providers::PhysicalInfraManager
           :identifier: ems_physical_infra_new
         - :klass: Provider
-          :identifier: provider_foreman_add_provider
+          :identifier: ems_configuration_add_provider
       - :name: edit
         :identifier: ems_infra_edit
       - :name: refresh


### PR DESCRIPTION
`provider_foreman_add_provider` was renamed to `ems_configuration_add_provider` in https://github.com/ManageIQ/manageiq/pull/19949