### PR TITLE
[BaseController::Render] Fix subquery_res.count

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -193,7 +193,7 @@ module Api
 
       def filter_results(miq_expression, res, options)
         if miq_expression.present? && options.key?(:limit) && options.key?(:offset)
-          subquery_res = Rbac.filtered(res, options.except(:offset, :limit))
+          subquery_res = Rbac.filtered(res, options.except(:offset, :limit, :extra_cols))
           [Rbac.filtered(res, options), subquery_res.count]
         else
           [Rbac.filtered(res, options)]

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1856,6 +1856,17 @@ describe "Vms API" do
       expect_result_resources_to_include_hrefs("resources", [api_vm_url(nil, vm2)])
     end
 
+    it "handles counts properly with virtual_attributes" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      get api_vms_url, :params => {
+        :expand     => "resources",
+        :filter     => ["ems_id!=null"],
+        :attributes => "name,provisioned_storage"
+      }
+
+      expect(response.parsed_body["subcount"]).to eq 1
+    end
+
     it "assigns a tag to a Vm without appropriate role" do
       api_basic_authorize
 


### PR DESCRIPTION
Very simply, the API can be provided with a filter + attribute params that can be reduced down to something like this:

```
https://localhost:3000/api/vms?expand=resources&filter[]=ems_id!=null&attributes=name,provisioned_storage
```

In the `bin/rails c`, it can be simplified to:

```ruby
irb> Vm.select(Vm.arel_table[Arel.star], :provisioned_storage).count
```

## Nitty Gritty Details

(that LJ is too lazy to read...)

This, in Rails 6, does not seem to work, as a `.join` is done to the `Vm.arel_table[Arel.star]` and the `:provisioned_storage` columns deep within the `ActiveRecord` library, and ultimately the `Vm.arel_table...` portion will be converted into a `struct` when passed as a SQL string, and not a column name or function, looking something like this:

```
SELECT COUNT(#<struct Arel::Attributes::Attribute relation=#...
```

This obviously isn't valid SQL, and while it might make sense to fix this in Rails (as it seems to be a regression), the solution isn't terribly obvious, and this is a simple fix on our end.

* * *

Side note:  The following also doesn't seem to be valid:

```
irb> Vm.select(:id, :provisioned_storage).count
(0.5ms)  SELECT COUNT(vendor, id) FROM "vms" WHERE ...
PG::UndefinedFunction: ERROR:  function count(character varying, bigint) does not exist
LINE 1: SELECT COUNT(vendor, id) FROM "vms" WHERE "vms"."type" IN ($...
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```

So it seems like the logic here is possibly flawed is Rails 6+, but what lead to this isn't clear.