### PR TITLE
Fix spec that verifies features to actually see all features

### DIFF
--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -22,60 +22,31 @@ describe 'API configuration (config/api.yml)' do
 
     describe 'identifiers' do
       let(:api_feature_identifiers) do
-        feature_identifiers { |set, id| set.add(id) }
-      end
+        collection_settings.each_with_object(Set.new) do |(_key, config), ids|
+          action_configs  = config.to_h.select { |k, v| k.to_s.end_with?("_actions") }.values
+          action_configs += Array(config.resource_entities).map { |e| Array(e.entity_actions) }
 
-      let(:sui_product_features) do
-        feature_identifiers { |set, id| set.add(id) if /^sui_/ =~ id }
+          action_configs.each do |action_config|
+            action_config.each do |_verb, actions|
+              actions.each do |action|
+                ids.merge(Array(action[:identifier]))
+                ids.merge(Array(action[:identifiers]).flat_map { |i| Array(i[:identifier]) })
+              end
+            end
+          end
+
+          ids.merge(Array(config[:identifier]))
+        end
       end
 
       it 'is not empty' do
         expect(api_feature_identifiers).not_to be_empty
       end
 
-      it 'contains only valid miq_feature identifiers' do
+      it 'contains only valid MiqProductFeature identifiers' do
         MiqProductFeature.seed_features
-        dangling = Array(api_feature_identifiers).reject { |feature| MiqProductFeature.feature_exists?(feature) }
-        expect(dangling).to be_empty
-      end
-
-      it 'contains valid sui specific miq_feature identifiers' do
-        expect(sui_product_features.subset?(api_feature_identifiers))
-      end
-
-      def feature_identifiers
-        collection_settings.each_with_object(Set.new) do |(_, cfg), set|
-          Array(cfg[:identifier]).each { |id| set.add(id) }
-          keys = %i(collection_actions resource_actions subcollection_actions subresource_actions)
-          Array(cfg[:subcollections]).each do |s|
-            keys << "#{s}_subcollection_actions" << "#{s}_subresource_actions"
-          end
-          keys.each do |action_type|
-            next unless cfg[action_type]
-            cfg[action_type].each do |_, method_cfg|
-              method_cfg.each do |action_cfg|
-                next unless action_cfg[:identifier]
-
-                Array(action_cfg[:identifier]).each { |id| yield(set, id) }
-              end
-            end
-          end
-          add_resource_entity_identifiers(cfg, set)
-        end
-      end
-
-      def add_resource_entity_identifiers(cfg, set)
-        return if cfg["resource_entities"].blank?
-
-        cfg["resource_entities"].each do |entity|
-          entity[:entity_actions].each do |_, method_cfg|
-            method_cfg.each do |action_cfg|
-              next unless action_cfg[:identifier]
-
-              Array(action_cfg[:identifier]).each { |id| set.add(id) }
-            end
-          end
-        end
+        invalid_features = api_feature_identifiers - MiqProductFeature.pluck(:identifier)
+        expect(invalid_features).to be_empty
       end
     end
   end

--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -18,12 +18,38 @@ describe 'API configuration (config/api.yml)' do
         end.map(&:first).sort
         expect(whitelisted).to eq(%i[automate_workspaces currencies features measures notifications pictures])
       end
+
+      it 'actions have associated options' do
+        noop_action_keys = %i[resource_actions subresource_actions subcollection_actions].freeze
+
+        collection_settings.each do |key, config|
+          action_keys = config.keys.select { |k| k.to_s.end_with?("_actions") }
+          action_keys.each do |action_key|
+            failure_id = "#{key.inspect}: #{action_key.inspect}"
+
+            if noop_action_keys.include?(action_key)
+              # NOOP - These are ok anywhere
+              #
+              # TODO: Verify that if something has subcollection_actions or subresource_actions
+              #   that it is actually defined as a subcollection in at least one other place.
+            elsif action_key == :collection_actions
+              option = action_key.to_s.chomp("_actions").to_sym
+              expect(config[:options]).to include(option), "#{failure_id} - expected config[:options] to include #{option.inspect}"
+            elsif action_key.to_s.end_with?("_subcollection_actions", "_subresource_actions")
+              option = action_key.to_s.chomp("_subcollection_actions").chomp("_subresource_actions").to_sym
+              expect(config[:subcollections]).to include(option), "ERROR: #{failure_id} - expected config[:subcollections] to include #{option.inspect}"
+            else
+              raise "Unexpected action key: #{failure_id}"
+            end
+          end
+        end
+      end
     end
 
     describe 'identifiers' do
       let(:api_feature_identifiers) do
         collection_settings.each_with_object(Set.new) do |(_key, config), ids|
-          action_configs  = config.to_h.select { |k, v| k.to_s.end_with?("_actions") }.values
+          action_configs  = config.to_h.select { |k, _v| k.to_s.end_with?("_actions") }.values
           action_configs += Array(config.resource_entities).map { |e| Array(e.entity_actions) }
 
           action_configs.each do |action_config|


### PR DESCRIPTION
@jrafanie Please review

Part of https://github.com/ManageIQ/manageiq/issues/21216

~~Built on #1037 so it will go green.~~ When this spec is run on master (prior to #1038), I get

```
  1) API configuration (config/api.yml) collections identifiers contains only valid miq_feature identifiers
     Failure/Error: expect(api_feature_identifiers - MiqProductFeature.pluck(:identifier)).to be_empty
       expected `#<Set: {"provider_foreman_add_provider", "vm_cloud_reconfigure"}>.empty?` to be truthy, got false
     # ./spec/lib/api/api_config_spec.rb:46:in `block (4 levels) in <top (required)>'
     # /Users/jfrey/.gem/ruby/2.7.2/gems/webmock-3.12.2/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

which is what I'd expect.

~~WIP because~~
- [x] ~~I want to add some more checks in this same spec file that ensures that collection actions are built properly~~
- [x] I'm not going to do this one...the test makes no sense. ~~I don't understand the SUI test and removed it for now, but I _think_ it really just wants to check that anytime an sui feature is added there is also a non-sui feature added.  However the spec as is written now doesn't do that and is just checking that Ruby .select is a subset, which is always is.~~ 