### PR TITLE
[BaseController] Localize OPTIONS (allow optional user auth)

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -23,6 +23,7 @@ module Api
     before_action :log_request_initiated
     before_action :clear_cached_current_user
     before_action :require_api_user_or_token, :except => [:options, :product_info]
+    before_action :optional_api_user_or_token, :only => [:options]
     before_action :set_gettext_locale, :set_access_control_headers, :parse_api_request, :log_api_request
     before_action :validate_api_request, :except => [:product_info]
     before_action :validate_api_action, :except => [:options, :product_info]

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1561,6 +1561,15 @@ describe "Providers API" do
       expect(response.parsed_body["data"]["provider_settings"]["kubernetes"]["proxy_settings"]["settings"]["http_proxy"]["label"]).to eq('HTTP Proxy')
     end
 
+    it "translates options using user settings if auth passed" do
+      api_basic_authorize
+      @user.update(:settings => {:display => {:locale => "es"}})
+      options("#{api_providers_url}?type=ManageIQ::Providers::Openstack::CloudManager")
+
+      field = response.parsed_body["data"]["provider_form_schema"]["fields"].detect { |f| f["id"] == "provider_region" }
+      expect(field["label"]).to eq("Regi\u00f3n del proveedor")
+    end
+
     it "returns options for supported providers only" do
       allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).and_return(false)
       allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with("vmwarews").and_return(true)


### PR DESCRIPTION
This allows translating of OPTION data if a user is logged in.

To achieve this, the commit does a few things:

- Split up `.require_api_user_or_token` to pull out the "authentication" step into it's own method:  `.authenticate_user`
- Create a new method called `.optional_api_user_or_token` for only `OPTIONS` requests
  - Logs in a user in on `OPTIONS` calls, but no-op if it fails
  - in otherwords:  if you don't pass auth, still work as we did, but allow a user to log in and retrieve settings

By doing this, we can make sure that `:set_gettext_locale` can have a user if one is provided, and allow translations to be processed further down the line.


FYI
---

There are places where we are using `_N()` instead of `_()`, which will cause some of the translations to still result in English:

https://github.com/ManageIQ/manageiq-providers-kubernetes/blob/9b5b107dfcf702901683f02ac19263e2730d217a/app/models/manageiq/providers/kubernetes/container_manager/options.rb#L5-L13

This probably should be addressed, but can be handled on a case by case basis.


Links
-----

- Partially addresses: https://github.com/ManageIQ/manageiq-api/issues/1042


Testing/QA
----------

The spec in `spec/requests/providers_spec.rb` is a pretty good framework for seeing if this works:

- Update your user record to use a different locale ("es" for Spanish)
- Get an API auth token
- `curl` the OPTIONS endpoint:
  
  ```
  $ curl -X OPTIONS "localhost:3000?type=ManageIQ::Providers::Openstack::CloudManager"
  ```
  
(the `curl` above is missing some options for auth.  I use `miqperf` from `manageiq-performance` myself so I don't have to worry about these options)