### PR TITLE
[Subcollection::AlertDefinitions] Fix unassign success

### DIFF
--- a/app/controllers/api/subcollections/alert_definitions.rb
+++ b/app/controllers/api/subcollections/alert_definitions.rb
@@ -16,9 +16,9 @@ module Api
       end
 
       def alert_definitions_unassign_resource(object, type, id = nil, _data = nil)
-        alert = resource_search(id, type, collection_class(type))
-        success = object.remove_member(alert).present?
-        result = action_result(success, "Unassigning alert_definition #{id} from profile #{object.id}")
+        alert   = resource_search(id, type, collection_class(type))
+        success = object.remove_member(alert) > 0 rescue false
+        result  = action_result(success, "Unassigning alert_definition #{id} from profile #{object.id}")
         add_parent_href_to_result(result)
         add_subcollection_resource_to_result(result, type, alert)
       rescue => err


### PR DESCRIPTION
**Merge with** https://github.com/ManageIQ/manageiq/pull/21241

The change from using RelationshipMixin for MiqSet to using a dedicated join table caused the return value for `.remove_member` to change from returning an `ActiveRecord::AssociationRelation` (`Array` of results) to using a `.delete_all`, which returns just an `Integer` (which is the count of the affected records).

To also account for any `ActiveRecord` errors, a `rescue` was added to give a proper response for those as well.


Links
-----

- https://github.com/ManageIQ/manageiq/issues/21246
- https://github.com/ManageIQ/manageiq/pull/21241