### PR TITLE
[GroupsController] Fix filter_expression save format

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -18,7 +18,7 @@ module Api
       parse_set_role(data)
       parse_set_tenant(data)
       parse_set_filters(data)
-      group = collection_class(:groups).create(data)
+      group = collection_class(:groups).create(data.to_h)
       if group.invalid?
         raise BadRequestError, "Failed to add a new group - #{group.errors.full_messages.join(', ')}"
       end
@@ -57,10 +57,11 @@ module Api
     def parse_set_filters(data, entitlement_id: nil)
       filters           = data.delete("filters")
       filter_expression = data.delete("filter_expression")
+      filter_expression = filter_expression["exp"] if filter_expression && filter_expression["exp"]
       if filters || filter_expression
         entitlements = {"id" => entitlement_id}
-        entitlements["filters"]           = filters           if filters
-        entitlements["filter_expression"] = filter_expression if filter_expression
+        entitlements["filters"]           = filters.stringify_keys.to_h          if filters
+        entitlements["filter_expression"] = MiqExpression.new(filter_expression) if filter_expression
         data["entitlement_attributes"] = entitlements
       end
     end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -174,7 +174,8 @@ describe "Groups API" do
       expect(expected_group.description).to eq(sample_group["description"])
       expect(expected_group.entitlement).to be_present
       expect(expected_group.entitlement.filters).to eq(sample_group["filters"])
-      expect(expected_group.entitlement.filter_expression).to eq(sample_group["filter_expression"])
+      expect(expected_group.entitlement.filter_expression.class).to be(MiqExpression)
+      expect(expected_group.entitlement.filter_expression.exp).to eq(sample_group["filter_expression"]["exp"])
     end
 
     it "fails to create group with invalid filter specified" do


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-api/issues/1053

When saving through the UI, the data passed from the browser are converted into a proper `MiqExpression` object:

https://github.com/ManageIQ/manageiq-ui-classic/blob/d0e9a1b319718f6a91d1a0c5ca3edb792bf1a8ee/app/controllers/ops_controller/ops_rbac.rb#L1267

However, in the API, this was just passed and saved as an `Hash` (`HashWithIndifferentAccess`), and this seems cause issues with being editable and usable when the unserialized hash data is used.

This fixes that by match the API with what we save it as in the UI.