### PR TITLE
[LASKER] ems_automation_add_provider was from a refactoring on master, not lasker

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2752,7 +2752,7 @@
       - :name: create
         :identifiers:
         - :klass: ManageIQ::Providers::AutomationManager
-          :identifier: ems_automation_add_provider
+          :identifier: automation_manager_add_provider
         - :klass: ManageIQ::Providers::InfraManager
           :identifier: ems_infra_new
         - :klass: ManageIQ::Providers::CloudManager


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-api/pull/1033 was fine on master but relied
on a refactoring/rewording of product features and models in https://github.com/ManageIQ/manageiq/pull/21108
and this refactoring did not get backported to lasker.

In other words, ems_automation_add_provider doesn't exist in lasker, but
automation_manager_add_provider does, so we'll use that.

cc @agrare 