### PR TITLE
Add support for editing autosde cloud volume

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -59,7 +59,11 @@ module Api
 
       raise BadRequestError, "No DDF specified for - #{klass}" unless klass.respond_to?(:params_for_create)
 
-      render_options(:cloud_volumes, :form_schema => klass.params_for_create(ems))
+      if params["record_id"]
+        render_options(:cloud_volumes, :form_schema => klass.params_for_update(ems, params))
+      else
+        render_options(:cloud_volumes, :form_schema => klass.params_for_create(ems))
+      end
     end
   end
 end

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -49,20 +49,19 @@ module Api
     end
 
     def options
-      return super unless params[:ems_id]
+      if params[:id]
+        cloud_volume = resource_search(params[:id], :cloud_volumes, CloudVolume)
+        render_options(:cloud_volumes, :form_schema => cloud_volume.params_for_update)
+      elsif params[:ems_id]
+        ems = resource_search(params[:ems_id], :ext_management_systems, ExtManagementSystem)
+        raise BadRequestError, "No CloudVolume support for - #{ems.class}" unless defined?(ems.class::CloudVolume)
 
-      ems = ExtManagementSystem.find(params[:ems_id])
+        klass = ems.class::CloudVolume
+        raise BadRequestError, "No DDF specified for - #{klass}" unless klass.respond_to?(:params_for_create)
 
-      raise BadRequestError, "No CloudVolume support for - #{ems.class}" unless defined?(ems.class::CloudVolume)
-
-      klass = ems.class::CloudVolume
-
-      raise BadRequestError, "No DDF specified for - #{klass}" unless klass.respond_to?(:params_for_create)
-
-      if params["record_id"]
-        render_options(:cloud_volumes, :form_schema => klass.params_for_update(ems, params))
-      else
         render_options(:cloud_volumes, :form_schema => klass.params_for_create(ems))
+      else
+        super
       end
     end
   end

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -57,7 +57,7 @@ module Api
         raise BadRequestError, "No CloudVolume support for - #{ems.class}" unless defined?(ems.class::CloudVolume)
 
         klass = ems.class::CloudVolume
-        raise BadRequestError, "No DDF specified for - #{klass}" unless klass.respond_to?(:params_for_create)
+        raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
 
         render_options(:cloud_volumes, :form_schema => klass.params_for_create(ems))
       else

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -222,7 +222,6 @@ describe "Cloud Volumes API" do
       provider = FactoryBot.create(:ems_autosde, :zone => zone)
       cloud_volume = FactoryBot.create(:cloud_volume_autosde, :ext_management_system => provider)
 
-      allow(CloudVolume).to receive(:find).with(cloud_volume.id.to_s).and_return(cloud_volume)
       allow(Rbac).to receive(:filtered_object).and_return(cloud_volume)
       expect(cloud_volume).to receive(:params_for_update).and_return('foo')
       options("#{api_cloud_volumes_url}/#{cloud_volume.id}")

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -8,7 +8,7 @@
 # GET /api/cloud_volumes/:id
 #
 
-fdescribe "Cloud Volumes API" do
+describe "Cloud Volumes API" do
   it "forbids access to cloud volumes without an appropriate role" do
     api_basic_authorize
 
@@ -203,7 +203,7 @@ fdescribe "Cloud Volumes API" do
 
   describe 'OPTIONS /api/cloud_volumes' do
     it 'returns a DDF schema for add when available via OPTIONS' do
-      zone = FactoryBot.create(:zone, :name => "api_zone")
+      zone = FactoryBot.create(:zone)
       provider = FactoryBot.create(:ems_autosde, :zone => zone)
 
       allow(provider.class::CloudVolume).to receive(:params_for_create).and_return('foo')
@@ -218,11 +218,9 @@ fdescribe "Cloud Volumes API" do
 
   describe 'OPTIONS /api/cloud_volumes/:id' do
     it 'returns a DDF schema for edit when available via OPTIONS' do
-      zone = FactoryBot.create(:zone, :name => "api_zone")
+      zone = FactoryBot.create(:zone)
       provider = FactoryBot.create(:ems_autosde, :zone => zone)
-      volume = FactoryBot.create(:cloud_volume_autosde, :ext_management_system => provider, :name => "my_volume")
-
-      cloud_volume = provider.cloud_volumes.first
+      cloud_volume = FactoryBot.create(:cloud_volume_autosde, :ext_management_system => provider)
 
       allow(CloudVolume).to receive(:find).with(cloud_volume.id.to_s).and_return(cloud_volume)
       allow(Rbac).to receive(:filtered_object).and_return(cloud_volume)


### PR DESCRIPTION
This PR is part of PRs that solve Autosde cloud volume editing

![image](https://user-images.githubusercontent.com/53213107/125775465-d40dc87e-29a7-4aac-a032-2554801875ed.png)

If specific info about a cloud volume is passed then we are under update mode (not creation) and the update field should be used.

Links
----------------
https://github.com/ManageIQ/manageiq-ui-classic/pull/7788
https://github.com/ManageIQ/manageiq-providers-autosde/pull/72
