### PR TITLE
Fix user_spec.rb test order failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ rvm:
 - 2.7.2
 addons:
   postgresql: '10'
+services:
+- memcached
 install: bin/setup
 after_script: bin/ci/after_script

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -615,10 +615,14 @@ RSpec.describe "users API" do
   end
 
   context "Revoking Sessions" do
+    before do
+      # Keep this outside of the loop below with the `let` providing the value
+      # for the stub, otherwise it will not work as expected
+      stub_settings_merge(:server => {:session_store => session_store_value})
+    end
+
     %w[cache sql memory].each do |session_store|
-      before do
-        ::Settings.server.session_store = session_store
-      end
+      let(:session_store_value) { session_store }
 
       it "revokes all own sessions of authenticated user with #{session_store}" do
         api_basic_authorize

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -633,8 +633,6 @@ RSpec.describe "users API" do
         FactoryBot.create(:session, :user_id => @user.id)
         expect(Session.where(:user_id => @user.id).count).to eq(1)
 
-        TokenStore.token_caches
-
         ts = TokenStore.acquire("api", 100)
 
         ts.create_user_token("my_token", {:userid => @user.userid, :expires_on => Time.zone.now + 100.days}, {:expires_in => 100})

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -619,7 +619,10 @@ RSpec.describe "users API" do
       # Keep this outside of the loop below with the `let` providing the value
       # for the stub, otherwise it will not work as expected
       stub_settings_merge(:server => {:session_store => session_store_value})
+      TokenStore.token_caches.clear
     end
+
+    after { TokenStore.token_caches.clear }
 
     %w[cache sql memory].each do |session_store|
       let(:session_store_value) { session_store }


### PR DESCRIPTION
Fixes a few issues with the `spec/requests/user_spec.rb` tests:

- Fixes a settings stub issue where only `memory` store was tested
- Fixes issue where running after `rspec/requests/authentication_spec.rb` causes the `user_spec.rb` tests to fail due to cache of `TokenStore.token_caches`
- Removes pointless call to `TokenStore.token_caches` in the middle of the specs


Links
-----

- Example failed build:  https://travis-ci.com/github/ManageIQ/manageiq-api/builds/231533940