### PR TITLE
Added options call for cloud networks

### DIFF
--- a/app/controllers/api/cloud_networks_controller.rb
+++ b/app/controllers/api/cloud_networks_controller.rb
@@ -15,12 +15,13 @@ module Api
 
       if params.key?("ems_id")
         ems = resource_search(params["ems_id"], :ext_management_systems, ExtManagementSystem)
+        klass = CloudNetwork.class_by_ems(ems)
+
         raise BadRequestError, "No Cloud Network support for - #{ems.class}" unless defined?(ems.class::CloudNetwork)
 
-        klass = ems.class::CloudNetwork
-        raise BadRequestError, "No DDF specified for - #{klass}" unless klass.respond_to?(:params_for_create)
+        raise BadRequestError, "No DDF specified for - #{klass}" unless klass.supports?(:create)
 
-        render_options(:cloud_networks, :form_schema => CloudNetwork.class_by_ems(ems).params_for_create(ems))
+        render_options(:cloud_networks, :form_schema => klass.params_for_create(ems))
       else
         cloud_network = resource_search(params["id"], :cloud_networks, CloudNetwork)
         render_options(:cloud_networks, :form_schema => cloud_network.params_for_edit)

--- a/app/controllers/api/cloud_networks_controller.rb
+++ b/app/controllers/api/cloud_networks_controller.rb
@@ -10,21 +10,29 @@ module Api
       action_result(true, "Deleting #{cloud_network.name}", :task_id => task_id)
     end
 
+    private def options_by_ems_id
+      ems = resource_search(params["ems_id"], :ext_management_systems, ExtManagementSystem)
+      klass = CloudNetwork.class_by_ems(ems)
+
+      raise BadRequestError, "No Cloud Network support for - #{ems.class}" unless defined?(ems.class::CloudNetwork)
+
+      raise BadRequestError, "No DDF specified for - #{klass}" unless klass.supports?(:create)
+
+      render_options(:cloud_networks, :form_schema => klass.params_for_create(ems))
+    end
+
+    private def options_by_id
+      cloud_network = resource_search(params["id"], :cloud_networks, CloudNetwork)
+      render_options(:cloud_networks, :form_schema => cloud_network.params_for_edit)
+    end
+
     def options
-      return super unless params.keys.include_any?(%w[id ems_id])
-
       if params.key?("ems_id")
-        ems = resource_search(params["ems_id"], :ext_management_systems, ExtManagementSystem)
-        klass = CloudNetwork.class_by_ems(ems)
-
-        raise BadRequestError, "No Cloud Network support for - #{ems.class}" unless defined?(ems.class::CloudNetwork)
-
-        raise BadRequestError, "No DDF specified for - #{klass}" unless klass.supports?(:create)
-
-        render_options(:cloud_networks, :form_schema => klass.params_for_create(ems))
+        options_by_ems_id
+      elsif params.key?("id")
+        options_by_id
       else
-        cloud_network = resource_search(params["id"], :cloud_networks, CloudNetwork)
-        render_options(:cloud_networks, :form_schema => cloud_network.params_for_edit)
+        super
       end
     end
   end

--- a/app/controllers/api/cloud_networks_controller.rb
+++ b/app/controllers/api/cloud_networks_controller.rb
@@ -9,5 +9,22 @@ module Api
       task_id = cloud_network.delete_cloud_network_queue(User.current_user.userid)
       action_result(true, "Deleting #{cloud_network.name}", :task_id => task_id)
     end
+
+    def options
+      return super unless params.keys.include_any?(%w[id ems_id])
+
+      if params.key?("ems_id")
+        ems = resource_search(params["ems_id"], :ext_management_systems, ExtManagementSystem)
+        raise BadRequestError, "No Cloud Network support for - #{ems.class}" unless defined?(ems.class::CloudNetwork)
+
+        klass = ems.class::CloudNetwork
+        raise BadRequestError, "No DDF specified for - #{klass}" unless klass.respond_to?(:params_for_create)
+
+        render_options(:cloud_networks, :form_schema => CloudNetwork.class_by_ems(ems).params_for_create(ems))
+      else
+        cloud_network = resource_search(params["id"], :cloud_networks, CloudNetwork)
+        render_options(:cloud_networks, :form_schema => cloud_network.params_for_edit)
+      end
+    end
   end
 end

--- a/spec/requests/cloud_networks_spec.rb
+++ b/spec/requests/cloud_networks_spec.rb
@@ -97,4 +97,35 @@ RSpec.describe 'Cloud Networks API' do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'OPTIONS /api/cloud_networks' do
+    it 'returns a DDF schema for add when available via OPTIONS' do
+      zone = FactoryBot.create(:zone, :name => "api_zone")
+      provider = FactoryBot.create(:ems_network, :zone => zone)
+
+      allow(provider.class::CloudNetwork).to receive(:params_for_create).and_return('foo')
+
+      options(api_cloud_networks_url, :params => {:ems_id => provider.id})
+      options("#{api_cloud_networks_url}?ems_id=#{provider.id}")
+
+      expect(response.parsed_body['data']['form_schema']).to eq('foo')
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'OPTIONS /api/cloud_networks/:id' do
+    it 'returns a DDF schema for edit when available via OPTIONS' do
+      provider = FactoryBot.create(:ems_amazon_with_cloud_networks)
+
+      cloud_network = provider.cloud_networks.first
+
+      allow(CloudNetwork).to receive(:find).with(cloud_network.id.to_s).and_return(cloud_network)
+      allow(Rbac).to receive(:filtered_object).and_return(cloud_network)
+      expect(cloud_network).to receive(:params_for_edit).and_return('foo')
+      options("#{api_cloud_networks_url}/#{cloud_network.id}")
+
+      expect(response.parsed_body['data']['form_schema']).to eq('foo')
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/cloud_networks_spec.rb
+++ b/spec/requests/cloud_networks_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe 'Cloud Networks API' do
 
       allow(provider.class::CloudNetwork).to receive(:params_for_create).and_return('foo')
 
-      options(api_cloud_networks_url, :params => {:ems_id => provider.id})
       options("#{api_cloud_networks_url}?ems_id=#{provider.id}")
 
       expect(response.parsed_body['data']['form_schema']).to eq('foo')


### PR DESCRIPTION
Depends on: #1060

Added an options call for cloud networks:

Calling example with no cloud_network_id:
OPTIONS "http://admin:smartvm@localhost:3000/api/cloud_networks?ems_id=8"  
`{
  "attributes": [
    "cidr",
    "cloud_tenant_id",
    "description",
    "ems_id",
    "ems_ref",
    "enabled",
    "external_facing",
    "extra_attributes",
    "id",
    "name",
    "orchestration_stack_id",
    "provider_network_type",
    "provider_physical_network",
    "provider_segmentation_id",
    "resource_group_id",
    "shared",
    "status",
    "type",
    "vlan_transparent"
  ],
  "virtual_attributes": [
    "href_slug",
    "maximum_transmission_unit",
    "port_security_enabled",
    "qos_policy_id",
    "region_description",
    "region_number",
    "total_vms"
  ],
  "relationships": [
    "cloud_subnets",
    "cloud_tenant",
    "custom_action_buttons",
    "custom_actions",
    "custom_button_events",
    "custom_button_sets",
    "custom_buttons",
    "ext_management_system",
    "floating_ips",
    "network_ports",
    "network_routers",
    "orchestration_stack",
    "private_networks",
    "public_network_routers",
    "public_network_vms",
    "public_networks",
    "resource_group",
    "security_groups",
    "taggings",
    "tags",
    "vms"
  ],
  "subcollections": [
    "tags"
  ],
  "data": {
    "form_schema": {
      "fields": [
        {
          "component": "sub-form",
          "title": "Placement",
          "id": "placement",
          "name": "placement",
          "fields": [
            {
              "component": "select",
              "id": "cloud_tenant",
              "name": "cloud_tenant",
              "key": "id-8",
              "label": "Cloud Tenant",
              "placeholder": "<Choose>",
              "validateOnMount": true,
              "validate": [
                {
                  "type": "required",
                  "message": "Required"
                }
              ],
              "isDisabled": false,
              "options": [
                {
                  "label": "cloud-user-demo",
                  "value": "1"
                },
                {
                  "label": "admin",
                  "value": "2"
                },
                {
                  "label": "openshift_demo",
                  "value": "3"
                },
                {
                  "label": "testtel",
                  "value": "4"
                },
                {
                  "label": "cloud-southeast",
                  "value": "5"
                },
                {
                  "label": "Loic Tenant",
                  "value": "6"
                },
                {
                  "label": "cloudwest",
                  "value": "7"
                },
                {
                  "label": "Massachusetts",
                  "value": "8"
                },
                {
                  "label": "testetot",
                  "value": "10"
                },
                {
                  "label": "test-ivy",
                  "value": "13"
                },
                {
                  "label": "test-ivr",
                  "value": "12"
                }
              ],
              "includeEmpty": true,
              "clearOnUnmount": true
            }
          ]
        },
        {
          "component": "sub-form",
          "title": "Network Provider Information",
          "id": "provider-information",
          "name": "provider-information",
          "condition": {
            "when": "cloud_tenant",
            "isNotEmpty": true
          },
          "fields": [
            {
              "component": "select",
              "id": "provider_network_type",
              "name": "provider_network_type",
              "label": "Provider Network Type",
              "placeholder": "Nothing selected",
              "options": [
                {
                  "label": "None"
                },
                {
                  "label": "Local",
                  "value": "local"
                },
                {
                  "label": "Flat",
                  "value": "flat"
                },
                {
                  "label": "GRE",
                  "value": "gre"
                },
                {
                  "label": "GENEVE",
                  "value": "geneve"
                },
                {
                  "label": "VLAN",
                  "value": "vlan"
                },
                {
                  "label": "VXLAN",
                  "value": "vxlan"
                }
              ],
              "isDisabled": false
            },
            {
              "component": "sub-form",
              "id": "subform-1",
              "name": "subform-1",
              "condition": {
                "when": "provider_network_type",
                "is": "flat"
              },
              "fields": [
                {
                  "component": "text-field",
                  "label": "Physical Network",
                  "maxLength": 128,
                  "id": "provider_physical_network",
                  "name": "provider_physical_network",
                  "isDisabled": false,
                  "validateOnMount": true,
                  "clearOnUnmount": true,
                  "validate": [
                    {
                      "type": "required",
                      "message": "Required"
                    }
                  ]
                }
              ]
            },
            {
              "component": "sub-form",
              "id": "subform-2",
              "name": "subform-2",
              "condition": {
                "when": "provider_network_type",
                "is": "gre"
              },
              "fields": [
                {
                  "component": "text-field",
                  "label": "Segmentation ID",
                  "maxLength": 128,
                  "id": "provider_segmentation_id",
                  "name": "provider_segmentation_id",
                  "isDisabled": false,
                  "validateOnMount": true,
                  "clearOnUnmount": true,
                  "validate": [
                    {
                      "type": "required",
                      "message": "Required"
                    }
                  ]
                }
              ]
            },
            {
              "component": "sub-form",
              "id": "subform-3",
              "name": "subform-3",
              "condition": {
                "when": "provider_network_type",
                "is": "vlan"
              },
              "fields": [
                {
                  "component": "text-field",
                  "label": "Physical Network",
                  "maxLength": 128,
                  "id": "provider_physical_network",
                  "name": "provider_physical_network",
                  "isDisabled": false,
                  "validateOnMount": true,
                  "clearOnUnmount": true,
                  "validate": [
                    {
                      "type": "required",
                      "message": "Required"
                    }
                  ]
                },
                {
                  "component": "text-field",
                  "label": "Segmentation ID",
                  "maxLength": 128,
                  "id": "provider_segmentation_id",
                  "name": "provider_segmentation_id",
                  "isDisabled": false,
                  "validateOnMount": true,
                  "clearOnUnmount": true,
                  "validate": [
                    {
                      "type": "required",
                      "message": "Required"
                    }
                  ]
                }
              ]
            },
            {
              "component": "sub-form",
              "id": "subform-4",
              "name": "subform-4",
              "condition": {
                "when": "provider_network_type",
                "is": "vxlan"
              },
              "fields": [
                {
                  "component": "text-field",
                  "label": "Segmentation ID",
                  "maxLength": 128,
                  "id": "provider_segmentation_id",
                  "name": "provider_segmentation_id",
                  "isDisabled": false,
                  "clearOnUnmount": true
                }
              ]
            }
          ]
        },
        {
          "component": "sub-form",
          "title": "Network Information",
          "id": "network-information",
          "name": "network-information",
          "fields": [
            {
              "component": "text-field",
              "id": "name",
              "name": "name",
              "validateOnMount": true,
              "label": "Network Name",
              "validate": [
                {
                  "type": "required",
                  "message": "Required"
                }
              ]
            }
          ]
        },
        {
          "component": "switch",
          "id": "cloud_network_external_facing",
          "name": "external_facing",
          "label": "External Router",
          "onText": "Yes",
          "offText": "No"
        },
        {
          "component": "switch",
          "id": "cloud_network_enabled",
          "name": "enabled",
          "label": "Adminstrative State",
          "onText": "Up",
          "offText": "Down"
        },
        {
          "component": "switch",
          "id": "cloud_network_shared",
          "name": "shared",
          "label": "Shared",
          "onText": "Yes",
          "offText": "No"
        }
      ]
    }
  }
}`

Can also call with a cloud_network_id in order to return only fields that are allowed to be edited while the rest are disabled.
OPTIONS "http://admin:smartvm@localhost:3000/api/cloud_networks/${cloud_network_id}

@miq-bot add_reviewer @Fryguy 
@miq-bot add-label enhancement
@miq-bot add-label dependencies