### PR TITLE
[WIP] [POC][Api::Filter] Add AND filter priority

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -24,7 +24,7 @@ module Api
       #
       def filter_param(klass)
         return nil if params['filter'].blank?
-        Filter.parse(params["filter"], klass)
+        Filter.parse(params["filter"], klass, params["filter_options"])
       end
 
       def by_tag_param

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -17,15 +17,16 @@ module Api
       "!~"  => {:default => "REGULAR EXPRESSION DOES NOT MATCH"},
     }.freeze
 
-    attr_reader :filters, :model, :and_expressions, :or_expressions
+    attr_reader :filters, :model, :options, :and_expressions, :or_expressions
 
-    def self.parse(filters, model)
-      new(filters, model).parse
+    def self.parse(filters, model, options=nil)
+      new(filters, model, options).parse
     end
 
-    def initialize(filters, model)
+    def initialize(filters, model, options=nil)
       @filters         = filters
       @model           = model
+      @options         = parse_options(options)
       @and_expressions = []
       @or_expressions  = []
     end
@@ -59,6 +60,12 @@ module Api
     end
 
     private
+
+    def parse_options(options)
+      return [] if options.nil?
+
+      Array(options.split(","))
+    end
 
     def parse_filter(filter)
       logical_or = filter.gsub!(/^or /i, '').present?

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -17,21 +17,20 @@ module Api
       "!~"  => {:default => "REGULAR EXPRESSION DOES NOT MATCH"},
     }.freeze
 
-    attr_reader :filters, :model
+    attr_reader :filters, :model, :and_expressions, :or_expressions
 
     def self.parse(filters, model)
       new(filters, model).parse
     end
 
     def initialize(filters, model)
-      @filters = filters
-      @model = model
+      @filters         = filters
+      @model           = model
+      @and_expressions = []
+      @or_expressions  = []
     end
 
     def parse
-      and_expressions = []
-      or_expressions = []
-
       filters.select(&:present?).each do |filter|
         parsed_filter = parse_filter(filter)
         *associations, attr = parsed_filter[:attr].split(".")

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -43,9 +43,15 @@ module Api
         end
 
         associations.map! { |assoc| ".#{assoc}" }
+
         field = "#{model.name}#{associations.join}-#{attr}"
-        target = parsed_filter[:logical_or] ? or_expressions : and_expressions
-        target << {parsed_filter[:operator] => {"field" => field, "value" => parsed_filter[:value]}}
+        expr  = {parsed_filter[:operator] => {"field" => field, "value" => parsed_filter[:value]}}
+
+        if parsed_filter[:logical_or]
+          or_expressions << expr
+        else
+          and_expressions << expr
+        end
       end
 
       and_part = and_expressions.one? ? and_expressions.first : {"AND" => and_expressions}

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -53,8 +53,6 @@ module Api
         end
       end
 
-      and_part = and_expressions.one? ? and_expressions.first : {"AND" => and_expressions}
-      composite_expression = or_expressions.empty? ? and_part : {"OR" => [and_part, *or_expressions]}
       MiqExpression.new(composite_expression).tap do |expression|
         raise BadRequestError, "Must filter on valid attributes for resource" unless expression.valid?
       end
@@ -117,6 +115,11 @@ module Api
       end
 
       {:logical_or => logical_or, :operator => method, :attr => filter_attr, :value => filter_value}
+    end
+
+    def composite_expression
+      and_part = and_expressions.one? ? and_expressions.first : {"AND" => and_expressions}
+      or_expressions.empty? ? and_part : {"OR" => [and_part, *or_expressions]}
     end
 
     def target_class(klass, reflections)

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -146,6 +146,25 @@ RSpec.describe Api::Filter do
       expect(actual.exp).to eq(expected)
     end
 
+    it "supports favoring AND with multiple comparisons of both AND and OR" do
+      filters = ["id = 1000000000123", "name = foo", "or id > 1000000000456"]
+
+      actual = described_class.parse(filters, Vm, "and_priority")
+
+      expected = {
+        "AND" => [
+          {
+            "OR" => [
+              {"=" => {"field" => "Vm-name", "value" => "foo"}},
+              {">" => {"field" => "Vm-id", "value" => "1000000000456"}}
+            ]
+          },
+          {"=" => {"field" => "Vm-id", "value" => "1000000000123"}}
+        ]
+      }
+      expect(actual.exp).to eq(expected)
+    end
+
     it "supports filtering by attributes of associations" do
       filters = ["host.name='foo'"]
 


### PR DESCRIPTION
This is a proof of concept trying to fix the current implementation of `AND`/`OR` filtering in the API.

Probably going to abandon this PR, as probably implementing a `IN` operator is a simpler solution for the use case here.  But pushing it up as something to consider refining in the future if something like this seems necessary and can't be solved in another way.


Before
------

For example:

```
filter[]=col1=foo
&filter[]=col2=bar
&filter[]=or+col2=baz
&filter[]=col3=bar
&filter[]=or+col3=baz
```

Currently evaluates to:

```sql
WHERE (col1 = 'foo' AND col2 = 'baz' AND col3 = 'baz')
   OR col2 = 'baz'
   OR col3 = 'baz'
```

Which is confusing and I don't think obvious to any user.



After
-----

Currently this implementation isn't much more useful as you only can combine all `OR` statements together.  The previous implementation still exists, but favoring `AND` instead of `OR` on the top level can be triggered by passing `filtering_options=and_priority` in the query params.

Effectively the above evaluates to:

```sql
WHERE col1 = 'foo'
  AND (col2 = 'bar' OR col2 = 'baz' OR col3 = 'bar' OR col3 = 'baz')
```

Instead of what is probably more useful is some sort of grouping by column:

```sql
WHERE col1 = 'foo'
  AND (col2 = 'bar' OR col2 = 'baz')
  AND (col3 = 'bar' OR col3 = 'baz')
```