### PR TITLE
Allow OPTIONS on /collection/:id for DDF resource params

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
     Api::ApiConfig.collections.each do |collection_name, collection|
       # OPTIONS action for each collection
-      match collection_name.to_s, :controller => collection_name, :action => :options, :via => :options, :as => nil
+      match "#{collection_name}(/:id)", :controller => collection_name, :action => :options, :via => :options, :as => nil
 
       collection_name_pluralized, resource_name = Api::Routing.inflections_for_named_route_helpers(collection_name.to_s)
 


### PR DESCRIPTION
Some cases require requesting options on an individual resource (e.g. DDF parameters for editing a specific resource).  These parameters might be different based on that particular record.

Currently DDF parameters for "create" are returned by calling `OPTIONS /collection`.

This enables DDF parameters for "update" by calling `OPTIONS /collection/:id`