### PR TITLE
[Api::Filter] Allow filtering '=' via arrays

### DIFF
--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -17,21 +17,20 @@ module Api
       "!~"  => {:default => "REGULAR EXPRESSION DOES NOT MATCH"},
     }.freeze
 
-    attr_reader :filters, :model
+    attr_reader :filters, :model, :and_expressions, :or_expressions
 
     def self.parse(filters, model)
       new(filters, model).parse
     end
 
     def initialize(filters, model)
-      @filters = filters
-      @model = model
+      @filters         = filters
+      @model           = model
+      @and_expressions = []
+      @or_expressions  = []
     end
 
     def parse
-      and_expressions = []
-      or_expressions = []
-
       filters.select(&:present?).each do |filter|
         parsed_filter = parse_filter(filter)
         *associations, attr = parsed_filter[:attr].split(".")

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -43,9 +43,15 @@ module Api
         end
 
         associations.map! { |assoc| ".#{assoc}" }
+
         field = "#{model.name}#{associations.join}-#{attr}"
-        target = parsed_filter[:logical_or] ? or_expressions : and_expressions
-        target << {parsed_filter[:operator] => {"field" => field, "value" => parsed_filter[:value]}}
+        expr  = {parsed_filter[:operator] => {"field" => field, "value" => parsed_filter[:value]}}
+
+        if parsed_filter[:logical_or]
+          or_expressions << expr
+        else
+          and_expressions << expr
+        end
       end
 
       and_part = and_expressions.one? ? and_expressions.first : {"AND" => and_expressions}

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -53,8 +53,6 @@ module Api
         end
       end
 
-      and_part = and_expressions.one? ? and_expressions.first : {"AND" => and_expressions}
-      composite_expression = or_expressions.empty? ? and_part : {"OR" => [and_part, *or_expressions]}
       MiqExpression.new(composite_expression).tap do |expression|
         raise BadRequestError, "Must filter on valid attributes for resource" unless expression.valid?
       end
@@ -117,6 +115,11 @@ module Api
       end
 
       {:logical_or => logical_or, :operator => method, :attr => filter_attr, :value => filter_value}
+    end
+
+    def composite_expression
+      and_part = and_expressions.one? ? and_expressions.first : {"AND" => and_expressions}
+      or_expressions.empty? ? and_part : {"OR" => [and_part, *or_expressions]}
     end
 
     def target_class(klass, reflections)

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe Api::Filter do
       expect(actual.exp).to eq(expected)
     end
 
+    it "supports multiple possible values using arrays with =" do
+      filters  = ["name=[foo,bar,baz]"]
+      actual   = described_class.parse(filters, Vm)
+      expected = {
+        "OR" => [
+          {"=" => {"field" => "Vm-name", "value" => "foo"}},
+          {"=" => {"field" => "Vm-name", "value" => "bar"}},
+          {"=" => {"field" => "Vm-name", "value" => "baz"}}
+        ]
+      }
+
+      expect(actual.exp).to eq(expected)
+    end
+
     it "supports NULL/nil equality test via =" do
       filters = ["retired=NULL"]
 


### PR DESCRIPTION
Adds functionality to the API to allow filtering a particular column by one of many types of values.  This could be particularly useful when filtering via a `type` column that is an STI column.

The SQL (functionally) that would be generated from the filter would be the following:

```sql
SELECT *
  FROM miq_requests
 WHERE (type = "MiqProvisionRequest" OR type = "VmMigrateRequest")
```

This avoids having to make changes to `MiqExpression` that would allow for something similar to how `where(:type => [a,b,c])` works already, and also ensures that we are using something that can be converted into SQL on the backend.


Links
-----

* Alternative proposal PR that doesn't quite work:  https://github.com/ManageIQ/manageiq-api/pull/1059


QA
--

I tested this using the following script:

```ruby
# Usage:  ruby fetch_requests.rb

require 'json'
require 'net/http'
require 'pp'

# Modify these vars if you want to change dates and such
days_ago = 7
states   = %w[pending_approval approved denied]
types    = %w[
               MiqProvisionConfiguredSystemRequest
               MiqProvisionRequest
               OrchestrationStackRetireRequest
               PhysicalServerProvisionRequest
               PhysicalServerFirmwareUpdateRequest
               ServiceRetireRequest
               ServiceReconfigureRequest
               ServiceTemplateProvisionRequest
               VmCloudReconfigureRequest
               VmMigrateRequest
               VmReconfigureRequest
               VmRetireRequest
           ]


miq_uri          = URI("http://localhost:3000")
http             = Net::HTTP.new(miq_uri.host, miq_uri.port)
headers          = { "accept" => "application/json" }

auth_hdr         = headers.merge("authorization" => "Basic " + ["admin:smartvm"].pack('m0'))
token            = JSON.parse(http.get("/api/auth", auth_hdr).body)["auth_token"]

req_hdrs         = headers.merge('X-Auth-Token' => token.to_s)
params           = URI.encode_www_form :attributes        => ["job_plays", "stdout"],
                                       :format_attributes => "stdout=html"

                   # equals:  'created_on>2000-01-01 00:00:00'

params           = "filter[]=created_on%3E#{(Time.now - days_ago * 24 * 60 * 60).to_s.gsub(/ /, '+')}"
                   # equals   'approval_state =~ /pending_approval|approved|denied/'
params          += "&filter[]=approval_state=[#{states.join(",")}]"
                   # equals   'approval_state =~ /MiqProvisionRequest|OrchestrationStackRetireRequest|.../'
params          += "&filter[]=type=[#{types.join(",")}]"
                   # equals:  'reason =~ Auto'
params          += "&filter[]=reason=~Auto"


services_url     = "/api/requests?expand=resources&#{params}"
response         = http.get(services_url, req_hdrs)

pp JSON.parse(response.body)
```

And confirmed in the log that I was getting a proper query in the database using these filters:

```
[----] D, [2021-07-26T11:54:18.342990 #97861:3fd074e1a29c] DEBUG -- :    (0.3ms)  SELECT "miq_product_features"."identifier" FROM "miq_product_features" INNER JOIN "miq_roles_features" ON "miq_product_features"."id" = "miq_roles_features"."miq_product_feature_id" WHERE "miq_roles_features"."miq_user_role_id" = $1  [["miq_user_role_id", 1]]
[----] D, [2021-07-26T11:54:18.348058 #97861:3fd074e1a29c] DEBUG -- :   MiqRequest Load (0.3ms)  SELECT "miq_requests".* FROM "miq_requests" WHERE (("miq_requests"."created_on" > '2021-07-19 16:54:18' AND (("miq_requests"."approval_state" = 'pending_approval' OR "miq_requests"."approval_state" = 'approved') OR "miq_requests"."approval_state" = 'denied') AND ((((((((((("miq_requests"."type" = 'MiqProvisionConfiguredSystemRequest' OR "miq_requests"."type" = 'MiqProvisionRequest') OR "miq_requests"."type" = 'OrchestrationStackRetireRequest') OR "miq_requests"."type" = 'PhysicalServerProvisionRequest') OR "miq_requests"."type" = 'PhysicalServerFirmwareUpdateRequest') OR "miq_requests"."type" = 'ServiceRetireRequest') OR "miq_requests"."type" = 'ServiceReconfigureRequest') OR "miq_requests"."type" = 'ServiceTemplateProvisionRequest') OR "miq_requests"."type" = 'VmCloudReconfigureRequest') OR "miq_requests"."type" = 'VmMigrateRequest') OR "miq_requests"."type" = 'VmReconfigureRequest') OR "miq_requests"."type" = 'VmRetireRequest')))
[----] D, [2021-07-26T11:54:18.352262 #97861:3fd074e1a29c] DEBUG -- :   MiqRequest Inst Including Associations (0.1ms - 1rows)
[----] D, [2021-07-26T11:54:18.354745 #97861:3fd074e1a29c] DEBUG -- :   MiqApproval Load (0.2ms)  SELECT "miq_approvals".* FROM "miq_approvals" WHERE "miq_approvals"."miq_request_id" = $1 ORDER BY "miq_approvals"."id" ASC LIMIT $2  [["miq_request_id", 3], ["LIMIT", 1]]
[----] D, [2021-07-26T11:54:18.354951 #97861:3fd074e1a29c] DEBUG -- :   MiqApproval Inst Including Associations (0.1ms - 1rows)
[----] D, [2021-07-26T11:54:18.356607 #97861:3fd074e1a29c] DEBUG -- :   CACHE MiqRequest Load (0.0ms)  SELECT "miq_requests".* FROM "miq_requests" WHERE (("miq_requests"."created_on" > '2021-07-19 16:54:18' AND (("miq_requests"."approval_state" = 'pending_approval' OR "miq_requests"."approval_state" = 'approved') OR "miq_requests"."approval_state" = 'denied') AND ((((((((((("miq_requests"."type" = 'MiqProvisionConfiguredSystemRequest' OR "miq_requests"."type" = 'MiqProvisionRequest') OR "miq_requests"."type" = 'OrchestrationStackRetireRequest') OR "miq_requests"."type" = 'PhysicalServerProvisionRequest') OR "miq_requests"."type" = 'PhysicalServerFirmwareUpdateRequest') OR "miq_requests"."type" = 'ServiceRetireRequest') OR "miq_requests"."type" = 'ServiceReconfigureRequest') OR "miq_requests"."type" = 'ServiceTemplateProvisionRequest') OR "miq_requests"."type" = 'VmCloudReconfigureRequest') OR "miq_requests"."type" = 'VmMigrateRequest') OR "miq_requests"."type" = 'VmReconfigureRequest') OR "miq_requests"."type" = 'VmRetireRequest')))
[----] D, [2021-07-26T11:54:18.360629 #97861:3fd074e1a29c] DEBUG -- :   MiqRequest Inst Including Associations (0.1ms - 1rows)
```