### PR TITLE
Added option to return no fields when no network manager is selected for cloud network form

### DIFF
--- a/app/controllers/api/cloud_networks_controller.rb
+++ b/app/controllers/api/cloud_networks_controller.rb
@@ -11,14 +11,18 @@ module Api
     end
 
     private def options_by_ems_id
-      ems = resource_search(params["ems_id"], :ext_management_systems, ExtManagementSystem)
-      klass = CloudNetwork.class_by_ems(ems)
+      if params["ems_id"] == "nil"
+        render_options(:cloud_networks, :form_schema => {:fields => []})
+      else
+        ems = resource_search(params["ems_id"], :ext_management_systems, ExtManagementSystem)
+        klass = CloudNetwork.class_by_ems(ems)
 
-      raise BadRequestError, "No Cloud Network support for - #{ems.class}" unless defined?(ems.class::CloudNetwork)
+        raise BadRequestError, "No Cloud Network support for - #{ems.class}" unless defined?(ems.class::CloudNetwork)
 
-      raise BadRequestError, "No DDF specified for - #{klass}" unless klass.supports?(:create)
+        raise BadRequestError, "No DDF specified for - #{klass}" unless klass.supports?(:create)
 
-      render_options(:cloud_networks, :form_schema => klass.params_for_create(ems))
+        render_options(:cloud_networks, :form_schema => klass.params_for_create(ems))
+      end
     end
 
     private def options_by_id

--- a/spec/requests/cloud_networks_spec.rb
+++ b/spec/requests/cloud_networks_spec.rb
@@ -127,4 +127,13 @@ RSpec.describe 'Cloud Networks API' do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'OPTIONS /api/cloud_networks?ems_id=nil' do
+    it 'returns an empty ddf schema with no fields' do
+      options("#{api_cloud_networks_url}?ems_id=nil")
+
+      expect(response.parsed_body['data']['form_schema']).to eq("fields" => [])
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-api/issues/1064

I tried to fix this issue on the UI code but after trying different methods it does not seem possible. It resulted in the UI updating faster than the api would return its data causing the cloud tenants field to have incorrect data. Another UI fix was possible but resulted in log errors. This was the only solution found that works and produces no errors.

Before:
<img width="1059" alt="Screen Shot 2021-08-05 at 4 20 20 PM" src="https://user-images.githubusercontent.com/32444791/128415909-ce02de2b-bd5a-4c53-a321-cd024f7706a9.png">

After:
<img width="1074" alt="Screen Shot 2021-08-05 at 4 21 13 PM" src="https://user-images.githubusercontent.com/32444791/128415918-aa367e60-686f-4324-b113-c8aae6f49c3f.png">

@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug