### PR TITLE
New feature - Editing physical storage

### DIFF
--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -20,6 +20,19 @@ module Api
       action_result(false, err.to_s)
     end
 
+    def edit_resource(type, id, data = {})
+      raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
+
+      physical_storage = resource_search(id, type, collection_class(:physical_storages))
+
+      raise BadRequestError, physical_storage.unsupported_reason(:update) unless physical_storage.supports?(:update)
+
+      task_id = physical_storage.update_physical_storage_queue(User.current_user, data)
+      action_result(true, "Updating #{physical_storage.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     def delete_resource(type, id, _data = nil)
       raise BadRequestError, "Must specify an id for deleting a #{type} resource" if id.blank?
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -2586,7 +2586,7 @@
     :identifier: physical_storage
     :options:
     - :collection
-    :verbs: *gpd
+    :verbs: *gpppd
     :klass: PhysicalStorage
     :subcollections:
     :collection_actions:
@@ -2596,6 +2596,8 @@
       :post:
       - :name: create
         :identifier: physical_storage_new
+      - :name: edit
+        :identifier: physical_storage_edit
       - :name: refresh
         :identifier: physical_storage_refresh
       - :name: delete
@@ -2604,6 +2606,9 @@
       :get:
       - :name: read
         :identifier: physical_storage_show
+      :patch:
+      - :name: edit
+        :identifier: physical_storage_edit
       :post:
       - :name: refresh
         :identifier: physical_storage_refresh

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -195,5 +195,4 @@ describe "Physical Storages API" do
       expect(response).to have_http_status(:ok)
     end
   end
-
 end

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -176,15 +176,6 @@ describe "Physical Storages API" do
   end
 
   context 'Physical Storages edit action' do
-    it 'OPTIONS /api/physical_storages/:id' do
-      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
-      physical_storage = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage", :ext_management_system => provider)
-
-      api_basic_authorize('physical_storage_edit')
-      options(api_physical_storage_url(nil, physical_storage))
-      expect(response).to have_http_status(:ok)
-    end
-
     it "PUT /api/physical_storages/:id'" do
       provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
       physical_storage = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage", :ext_management_system => provider)

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -174,4 +174,26 @@ describe "Physical Storages API" do
       end
     end
   end
+
+  context 'Physical Storages edit action' do
+    it 'OPTIONS /api/physical_storages/:id' do
+      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
+      physical_storage = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage", :ext_management_system => provider)
+
+      api_basic_authorize('physical_storage_edit')
+      options(api_physical_storage_url(nil, physical_storage))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "PUT /api/physical_storages/:id'" do
+      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
+      physical_storage = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage", :ext_management_system => provider)
+
+      api_basic_authorize('physical_storage_edit')
+      put(api_physical_storage_url(nil, physical_storage))
+      expect(response.parsed_body["message"]).to include("Updating")
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
 end


### PR DESCRIPTION
This PR add new feature for physical-storages, the ability to edit an existing physical-storage. We can change the storage name and/or the storage credentials (management-ip, user and password)

![image](https://user-images.githubusercontent.com/53213107/130013313-306aeba4-75cf-4c5b-8fff-24ac8444f62a.png)

![image](https://user-images.githubusercontent.com/53213107/130013379-5d4a7254-80b0-4921-bf0c-4a598847d3e9.png)

![image](https://user-images.githubusercontent.com/53213107/130013441-f79260a6-30b5-4bbe-affb-c70b81e8c76d.png)


links
-----
https://github.com/ManageIQ/manageiq-ui-classic/pull/7836
https://github.com/ManageIQ/manageiq-providers-autosde/pull/76