### PR TITLE
[WIP] Added options call for network routers

### DIFF
--- a/app/controllers/api/network_routers_controller.rb
+++ b/app/controllers/api/network_routers_controller.rb
@@ -21,6 +21,32 @@ module Api
       end
     end
 
+    private def options_by_ems_id
+      ems = resource_search(params["ems_id"], :ext_management_systems, ExtManagementSystem)
+      klass = NetworkRouter.class_by_ems(ems)
+
+      raise BadRequestError, "No Cloud Network support for - #{ems.class}" unless defined?(ems.class::NetworkRouter)
+
+      raise BadRequestError, "No DDF specified for - #{klass}" unless klass.supports?(:create)
+
+      render_options(:cloud_networks, :form_schema => klass.params_for_create(ems, params["cn_id"]))
+    end
+
+    private def options_by_id
+      network_router = resource_search(params["id"], :network_routers, NetworkRouter)
+      render_options(:network_routers, :form_schema => network_router.params_for_edit)
+    end
+
+    def options
+      if params.key?("ems_id")
+        options_by_ems_id
+      elsif params.key?("id")
+        options_by_id
+      else
+        super
+      end
+    end
+
     private
 
     def network_router_ident(network_router)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2302,6 +2302,8 @@
       :post:
       - :name: query
         :identifier: network_router_show_list
+      - :name: create
+        :identifier: network_router_create
       - :name: edit
         :identifier: network_router_edit
       - :name: delete

--- a/spec/requests/network_routers_spec.rb
+++ b/spec/requests/network_routers_spec.rb
@@ -166,4 +166,31 @@ RSpec.describe 'NetworkRouters API' do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  describe 'OPTIONS /api/network_routers' do
+    it 'returns a DDF schema for add when available via OPTIONS' do
+      zone = FactoryBot.create(:zone, :name => "api_zone")
+      provider = FactoryBot.create(:ems_network, :zone => zone)
+
+      allow(provider.class::NetworkRouter).to receive(:params_for_create).and_return('foo')
+
+      options("#{api_network_routers_url}?ems_id=#{provider.id}")
+
+      expect(response.parsed_body['data']['form_schema']).to eq('foo')
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'OPTIONS /api/network_routers/:id' do
+    it 'returns a DDF schema for edit when available via OPTIONS' do
+      network_router = FactoryBot.create(:network_routers)
+
+      allow(NetworkRouter).to receive(:find).with(network_router.id.to_s).and_return(network_router)
+      allow(Rbac).to receive(:filtered_object).and_return(network_router)
+      expect(network_router).to receive(:params_for_edit).and_return('foo')
+      options("#{api_network_routers_url}/#{network_router.id}")
+      expect(response.parsed_body['data']['form_schema']).to eq('foo')
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
Depends on:  https://github.com/ManageIQ/manageiq-providers-openstack/pull/731

Added an options call for network routers.

Calling example with no cloud_network_id:
OPTIONS "http://admin:smartvm@localhost:3000/api/network_routers?ems_id=8"
`{"attributes":["cidr","cloud_tenant_id","description","ems_id","ems_ref","enabled","external_facing","extra_attributes","id","name","orchestration_stack_id","provider_network_type","provider_physical_network","provider_segmentation_id","resource_group_id","shared","status","type","vlan_transparent"],"virtual_attributes":["href_slug","maximum_transmission_unit","port_security_enabled","qos_policy_id","region_description","region_number","total_vms"],"relationships":["cloud_subnets","cloud_tenant","custom_action_buttons","custom_actions","custom_button_events","custom_button_sets","custom_buttons","ext_management_system","floating_ips","network_ports","network_routers","orchestration_stack","private_networks","public_network_routers","public_network_vms","public_networks","resource_group","security_groups","taggings","tags","vms"],"subcollections":["tags"],"data":{"form_schema":{"fields":[{"component":"select","id":"cloud_tenant_id","name":"cloud_tenant_id","key":"id-8","label":"Cloud Tenant Placement","placeholder":"\u003cChoose\u003e","validateOnMount":true,"validate":[{"type":"required","message":"Required"}],"isRequired":true,"options":[{"label":"cloud-user-demo","value":"1"},{"label":"admin","value":"2"},{"label":"openshift_demo","value":"3"},{"label":"testtel","value":"4"},{"label":"cloud-southeast","value":"5"},{"label":"Loic Tenant","value":"6"},{"label":"cloudwest","value":"7"},{"label":"Massachusetts","value":"8"},{"label":"testetot","value":"10"},{"label":"test-ivy","value":"13"},{"label":"test-ivr","value":"12"}],"includeEmpty":true,"clearOnUnmount":true},{"component":"sub-form","title":"Router Information","id":"routerInformation","name":"routerInformation","fields":[{"component":"text-field","id":"router_name","name":"name","label":"Router Name","validateOnMount":true,"validate":[{"type":"required","message":"Required"}],"isRequired":true,"clearOnUnmount":true},{"component":"switch","id":"admin_state_up","name":"admin_state_up","label":"Administrative State","onText":"Up","offText":"Down","initialValue":true}]},{"component":"sub-form","title":"External Gateway","id":"externalGateway","name":"externalGateway","fields":[{"component":"switch","id":"enable","name":"enable","label":"Enable","onText":"Yes","offText":"No"},{"component":"switch","id":"source_nat","name":"source_nat","label":"Source NAT","onText":"Yes","offText":"No","condition":{"when":"enable","is":true},"initialValue":true},{"component":"select","id":"network","name":"network","key":"id-8","label":"Network","placeholder":"\u003cChoose\u003e","includeEmpty":true,"clearOnUnmount":true,"condition":{"when":"enable","is":true},"options":[{"label":"ext","value":"6b3d0c3b-8b68-4c26-a493-5be44d160241,50"}]}]}]}}}%`

Can also call with a cloud_network_id in order to return only fields that are allowed to be edited while the rest are disabled.
OPTIONS "http://admin:smartvm@localhost:3000/api/network_routers/${cloud_network_id}

@miq-bot add-label enhancement
@miq-bot add-label dependencies