### PR TITLE
Add create network_router to the api

### DIFF
--- a/app/controllers/api/network_routers_controller.rb
+++ b/app/controllers/api/network_routers_controller.rb
@@ -2,6 +2,17 @@ module Api
   class NetworkRoutersController < BaseController
     include Subcollections::Tags
 
+    def create_resource(_type, _id = nil, data = {})
+      ems = ExtManagementSystem.find(data['ems_id'])
+      klass = NetworkRouter.class_by_ems(ems)
+      raise BadRequestError, "Create network router for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
+
+      task_id = ems.create_network_router_queue(session[:userid], data.deep_symbolize_keys)
+      action_result(true, "Creating Network Router #{data['name']} for Provider: #{ems.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     def edit_resource(type, id, data)
       network_router = resource_search(id, type, collection_class(:network_routers))
       raise BadRequestError, "Update for #{network_router_ident(network_router)}: #{network_router.unsupported_reason(:update)}" unless network_router.supports?(:update)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2300,6 +2300,8 @@
       - :name: read
         :identifier: network_router_show_list
       :post:
+      - :name: create
+        :identifier: network_router_new
       - :name: query
         :identifier: network_router_show_list
       - :name: edit


### PR DESCRIPTION
Luckily the network_router_new already existed in ui-classic and in miq_features.yml
So the only needed updates was adding the create method to the controller and marking it as available

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6862

/cc @GilbertCherrie I think this should get you all set for create