### PR TITLE
Fix retirement api for instances

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2075,6 +2075,10 @@
         :identifier: instance_reset
       - :name: set_ownership
         :identifier: vm_ownership
+      - :name: retire
+        :identifier: instance_retire_now
+      - :name: request_retire
+        :identifier: instance_retire
     :resource_actions:
       :get:
       - :name: read
@@ -2100,6 +2104,10 @@
         :identifier: instance_reset
       - :name: set_ownership
         :identifier: vm_ownership
+      - :name: retire
+        :identifier: instance_retire_now
+      - :name: request_retire
+        :identifier: instance_retire
     :snapshots_subcollection_actions:
       :get:
       - :name: read


### PR DESCRIPTION
Fixes the instances retirement form API.

Steps to reproduce bug:
1) Navigate to Compute -> Cloud -> Instances
<img width="1421" alt="Screen Shot 2021-09-14 at 10 19 27 AM" src="https://user-images.githubusercontent.com/32444791/133274968-30bc42c5-0f0c-45ed-970a-b1b4a083b071.png">

2) Select an instance then click Lifecycle and Set Retirement Dates
<img width="1429" alt="Screen Shot 2021-09-14 at 10 30 05 AM" src="https://user-images.githubusercontent.com/32444791/133276877-4e9d2b1a-d0a2-4d30-ad72-18ccf86b58d0.png">

3) Select Time Delay from Now from the first drop down menu.
<img width="1391" alt="Screen Shot 2021-09-14 at 10 30 54 AM" src="https://user-images.githubusercontent.com/32444791/133277342-d96ab255-3b85-45da-b487-c72f5154ffa0.png">

4) Enter any amount of hours, days, weeks or months and click submit.
<img width="1413" alt="Screen Shot 2021-09-14 at 10 31 13 AM" src="https://user-images.githubusercontent.com/32444791/133277111-1bebcc33-dd54-4855-8012-33288118a449.png">

@miq-bot add-label bug
@miq-bot add_reviewer @Fryguy
@miq-bot add_reviewer @bdunne