### PR TITLE
properly pass audit information for tasks

### DIFF
--- a/app/controllers/api/network_routers_controller.rb
+++ b/app/controllers/api/network_routers_controller.rb
@@ -7,7 +7,7 @@ module Api
       klass = NetworkRouter.class_by_ems(ems)
       raise BadRequestError, "Create network router for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
 
-      task_id = ems.create_network_router_queue(session[:userid], data.deep_symbolize_keys)
+      task_id = ems.create_network_router_queue(User.current_userid, data.deep_symbolize_keys)
       action_result(true, "Creating Network Router #{data['name']} for Provider: #{ems.name}", :task_id => task_id)
     rescue => err
       action_result(false, err.to_s)
@@ -17,7 +17,7 @@ module Api
       network_router = resource_search(id, type, collection_class(:network_routers))
       raise BadRequestError, "Update for #{network_router_ident(network_router)}: #{network_router.unsupported_reason(:update)}" unless network_router.supports?(:update)
 
-      task_id = network_router.update_network_router_queue(User.current_user.id, data.deep_symbolize_keys)
+      task_id = network_router.update_network_router_queue(User.current_userid, data.deep_symbolize_keys)
       action_result(true, "Updating #{network_router_ident(network_router)}", :task_id => task_id)
     rescue => err
       action_result(false, err.to_s)
@@ -27,7 +27,7 @@ module Api
       delete_action_handler do
         network_router = resource_search(id, type, collection_class(:network_routers))
         raise "Delete not supported for #{network_router_ident(network_router)}" unless network_router.respond_to?(:delete_network_router_queue)
-        task_id = network_router.delete_network_router_queue(User.current_user.id)
+        task_id = network_router.delete_network_router_queue(User.current_userid)
         action_result(true, "Deleting #{network_router_ident(network_router)}", :task_id => task_id)
       end
     end

--- a/app/controllers/api/subcollections/cloud_templates.rb
+++ b/app/controllers/api/subcollections/cloud_templates.rb
@@ -6,7 +6,7 @@ module Api
       end
 
       def cloud_templates_create_resource(parent, _type, _id, data)
-        task_id = ManageIQ::Providers::CloudManager::Template.create_image_queue(User.current_user.id, parent, data)
+        task_id = ManageIQ::Providers::CloudManager::Template.create_image_queue(User.current_userid, parent, data)
         action_result(true, 'Creating Image', :task_id => task_id)
       rescue => err
         action_result(false, err.to_s)
@@ -16,7 +16,7 @@ module Api
         raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
         image = resource_search(id, type, collection_class(:cloud_templates))
 
-        task_id = image.update_image_queue(User.current_user.id, data)
+        task_id = image.update_image_queue(User.current_userid, data)
         action_result(true, "Updating #{image_ident(image)}", :task_id => task_id)
       rescue => err
         action_result(false, err.to_s)
@@ -24,7 +24,7 @@ module Api
 
       def cloud_templates_delete_resource(_parent, type, id, _data)
         image = resource_search(id, type, collection_class(type))
-        task_id = image.delete_image_queue(User.current_user.id)
+        task_id = image.delete_image_queue(User.current_userid)
         action_result(true, "Deleting #{image_ident(image)}", :task_id => task_id)
       rescue => err
         action_result(false, err.to_s)

--- a/app/controllers/api/subcollections/flavors.rb
+++ b/app/controllers/api/subcollections/flavors.rb
@@ -6,7 +6,7 @@ module Api
       end
 
       def flavors_create_resource(parent, _type, _id, data)
-        task_id = Flavor.create_flavor_queue(User.current_user.id, parent, data)
+        task_id = Flavor.create_flavor_queue(User.current_userid, parent, data)
         action_result(true, 'Creating Flavor', :task_id => task_id)
       rescue => err
         action_result(false, err.to_s)
@@ -14,7 +14,7 @@ module Api
 
       def delete_resource_flavors(_parent, type, id, _data)
         flavor = resource_search(id, type, collection_class(type))
-        task_id = flavor.delete_flavor_queue(User.current_user.id)
+        task_id = flavor.delete_flavor_queue(User.current_userid)
         action_result(true, "Deleting #{flavor_ident(flavor)}", :task_id => task_id)
       rescue => err
         action_result(false, err.to_s)


### PR DESCRIPTION
these now properly pass the `userid` instead of the `user.id`

they were not showing up in the tasks view because the tasks were not assigned to the correct user