### PR TITLE
[WIP] [POC] [Performance] Add includes for direct relations

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -585,6 +585,10 @@ module Api
         attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
           if klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name) && attr_base.blank?
             attr_name
+          elsif klass.respond_to?(:reflect_on_association) && klass.reflect_on_association(attr_name)
+            next if attr_base_uses_rbac?(attr_base)
+
+            attr_name
           else
             next if attr_base.blank?
             next if virtual_attribute_accessor(type, attr_name)


### PR DESCRIPTION
This change adds includes for direct relationships that are passed in as attributes so they are loaded as part of the main query.

There is a quick RBac check just before allowing adding that attribute to determine if it participates in rbac, but otherwise it works just like an attribute.

The reason this didn't get included previously is relations like `tags` on `Vm` and others are lumped into the `virtual_attributes_for` grouping for the API, despite not being a virtual attribute (for "reasons"), and since it is not a `virtual_includes` nor is it an attribute with a `dot` notation, it doesn't get included with the rest.


Benchmarks
----------

Tested using:

```console
$ bundle exec miqperf benchmark -a -c 3 "/api/vms?offset=0&limit=1000&expand=resources&attributes=id,href,name,tags"
```

### Before

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2392 |     478 |      557.4 | 2036 |
| 1178 |     476 |      462.9 |  472 |
|  963 |     476 |      408.3 |  472 |


### After

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 1772 |      14 |         41 | 2037 |
|  452 |      11 |       48.9 |  472 |
|  245 |      11 |       24.5 |  472 |


Links
-----

* Partially addresses performance issues from:
  - https://github.com/ManageIQ/manageiq-api/issues/1074


QA
--

I think it makes sense to throw this patch in a running environment and determine if it will make a difference in idle performance as well as if it doesn't mess with general performance of the API.  I don't have an environment for this, so this is a call for help! :bow: