### PR TITLE
introduce expect_deleted

### DIFF
--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -3,15 +3,6 @@ describe 'TasksController' do
   let(:task2)   { FactoryBot.create(:miq_task, :state => MiqTask::STATE_FINISHED) }
   let(:my_task) { FactoryBot.create(:miq_task, :state => MiqTask::STATE_FINISHED, :userid => "api_user_id") }
 
-  def expect_deleted(*args)
-    args.each do |arg|
-      expect(MiqTask.find_by(:id => arg.id)).to be_nil
-    end
-  end
-
-  def expect_not_deleted(*args)
-    expect(MiqTask.where(:id => args.collect(&:id)).length).to eq(args.length)
-  end
 
   it 'will not delete other users tasks on DELETE when role is miq_task_my_ui' do
     api_basic_authorize 'miq_task_my_ui', resource_action_identifier(:tasks, :delete, :delete)

--- a/spec/support/api/helpers.rb
+++ b/spec/support/api/helpers.rb
@@ -267,6 +267,18 @@ module Spec
           expect(response).to have_http_status(:forbidden)
         end
 
+        def expect_deleted(*args)
+          args.flatten!
+          klass = args.first.class
+          expect(klass.where(:id => args.map(&:id)).exists?).to be false
+        end
+
+        def expect_not_deleted(*args)
+          args.flatten!
+          klass = args.first.class
+          expect(klass.where(:id => args.map(&:id)).count).to eq(args.length)
+        end
+
         def select_attributes(attrlist)
           attrlist.sort.select { |attr| !::Api.encrypted_attribute?(attr) }
         end


### PR DESCRIPTION
I noticed that in a lot of places, we are looking at the messages but not looking to see if the objects were actually deleted

extracted the task only helper to be usable by all api specs