### PR TITLE
throw error for single resources DELETE

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -191,7 +191,7 @@ module Api
         add_href_to_result(result, type, id)
         log_result(result)
         result
-      rescue ActiveRecord::RecordNotFound, ForbiddenError => err
+      rescue ActiveRecord::RecordNotFound, ForbiddenError, BadRequestError, NotFoundError => err
         single_resource? ? raise(err) : action_result(false, err.to_s)
       rescue => err
         action_result(false, err.to_s)

--- a/spec/requests/auth_key_pairs_spec.rb
+++ b/spec/requests/auth_key_pairs_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe "Auth Key Pairs API" do
   end
 
   describe 'DELETE /api/auth_key_pairs/:id' do
+    let(:akp) { FactoryBot.create(:auth_key_pair_openstack, :resource => FactoryBot.create(:ems_cloud)) }
     it 'can delete an auth key pair by id' do
       api_basic_authorize action_identifier(:auth_key_pairs, :delete, :resource_actions, :delete)
 

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe 'Authentications API' do
 
   describe 'DELETE /api/authentications/:id' do
     it 'will delete an authentication' do
-      auth = FactoryBot.create(:authentication)
+      auth = FactoryBot.create(:embedded_ansible_openstack_credential)
       api_basic_authorize action_identifier(:authentications, :delete, :resource_actions, :delete)
 
       delete(api_authentication_url(nil, auth))

--- a/spec/requests/automate_domains_spec.rb
+++ b/spec/requests/automate_domains_spec.rb
@@ -36,20 +36,16 @@ describe "Automate Domains API" do
       api_basic_authorize action_identifier(:automate_domains, :delete)
 
       post(api_automate_domain_url(nil, automate_domain_locked), :params => gen_request(:delete))
-      expect_single_action_result(
-        :success => false,
-        :message => a_string_matching(/Not deleting.*locked/)
-      )
+
+      expect_bad_request(/Not deleting.*locked/)
     end
 
     it 'does not delete system domains' do
       api_basic_authorize action_identifier(:automate_domains, :delete)
 
       post(api_automate_domain_url(nil, automate_domain_system), :params => gen_request(:delete))
-      expect_single_action_result(
-        :success => false,
-        :message => a_string_matching(/Not deleting.*locked/)
-      )
+
+      expect_bad_request(/Not deleting.*locked/)
     end
 
     it 'deletes domains' do

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'CloudSubnets API' do
   end
 
   describe "DELETE /api/cloud_subnets" do
-    let(:cloud_subnet) { FactoryBot.create(:cloud_subnet_openstack) }
+    let(:cloud_subnet) { FactoryBot.create(:cloud_subnet_openstack, :ext_management_system => ems) }
 
     it "can delete a cloud subnet" do
       api_basic_authorize(action_identifier(:cloud_subnets, :delete))
@@ -227,7 +227,7 @@ RSpec.describe 'CloudSubnets API' do
 
       post(api_cloud_subnet_url(nil, cloud_subnet), :params => gen_request(:delete))
 
-      expect_single_action_result(:success => false, :message => /Delete for Cloud Subnets.*not.*supported/)
+      expect_bad_request(/Delete for Cloud Subnets.*not.*supported/)
     end
   end
 end

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -146,7 +146,7 @@ describe "Cloud Volumes API" do
       api_basic_authorize(action_identifier(:cloud_volumes, :safe_delete, :resource_actions, :post))
 
       post(api_cloud_volume_url(nil, volume), :params => {"action" => "safe_delete"})
-      expect_single_action_result(:success => false, :message => "Safe Delete for Cloud Volumes: Feature not available/supported")
+      expect_bad_request("Safe Delete for Cloud Volumes: Feature not available/supported")
     end
 
     it "can safe delete a cloud volume as a resource action" do

--- a/spec/requests/configuration_script_sources_spec.rb
+++ b/spec/requests/configuration_script_sources_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe 'Configuration Script Sources API' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :delete, :post)
 
       post(api_configuration_script_source_url(nil, config_script_src), :params => { :action => 'delete', :resource => params })
-      expect_single_action_result(:success => false, :message => /Delete not supported for Configuration Script Source/)
+      expect_bad_request(/Delete not supported for Configuration Script Source/)
     end
 
     it 'forbids configuration script source delete without an appropriate role' do

--- a/spec/requests/floating_ips_spec.rb
+++ b/spec/requests/floating_ips_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'FloatingIp API' do
       api_basic_authorize(action_identifier(:floating_ips, :delete, :resource_actions))
 
       post(api_floating_ip_url(nil, floating_ip), :params => gen_request(:delete))
-      expect_single_action_result(:success => false, :messge => /Delete for Floating Ip/)
+      expect_bad_request(/Delete for Floating Ip/)
     end
   end
 end

--- a/spec/requests/network_routers_spec.rb
+++ b/spec/requests/network_routers_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'NetworkRouters API' do
 
   describe "DELETE /api/network_routers" do
     it "can delete a router" do
-      network_router = FactoryBot.create(:network_router)
+      network_router = FactoryBot.create(:network_router_openstack)
       api_basic_authorize(action_identifier(:network_routers, :delete))
 
       delete(api_network_router_url(nil, network_router))
@@ -190,7 +190,7 @@ RSpec.describe 'NetworkRouters API' do
       api_basic_authorize(action_identifier(:network_routers, :delete, :resource_actions))
 
       post(api_network_router_url(nil, network_router), :params => gen_request(:delete))
-      expect_single_action_result(:success => false, :message => /Delete not supported for Network Router/)
+      expect_bad_request(/Delete not supported for Network Router/)
     end
   end
 

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -36,7 +36,7 @@ describe "Physical Storages API" do
 
       post(api_physical_storage_url(nil, physical_storage), :params => gen_request(:delete))
 
-      expect_single_action_result(:success => false, :message => /Feature not available/i)
+      expect_bad_request(/Feature not available/i)
     end
 
     it "Deletion of a single Physical Storage" do

--- a/spec/requests/volume_mappings_spec.rb
+++ b/spec/requests/volume_mappings_spec.rb
@@ -83,8 +83,7 @@ describe "Volume Mappings API" do
       api_basic_authorize(action_identifier(:volume_mappings, :delete, :resource_actions, :post))
 
       post(api_volume_mapping_url(nil, volume_mapping), :params => gen_request(:delete))
-
-      expect_single_action_result(:success => false, :message => /Feature not available/i)
+      expect_bad_request(/Feature not available/i)
     end
 
     it "Deletion of a single Volume Mapping" do


### PR DESCRIPTION
### Before

When we post DELETE for a single resource, we used to simply return no_content

### After

Now we are returning bad request
Note: other delete for a single resource return a bad request.
It is inconsistent. This is aiming to be more consistent.

### Unchanged

requests with bulk requests will still return the same codes as before

### Precedent

We have been changing our api to return error codes for single resources to make coding the front end easier.

### Why

For a number of our actions, we return a bad request. But for these, we are returning no_content. The inconsistency is making it hard to simplify our api actions.

### Feedback

This found a number of spec errors that were throwing an error but we didn't detect them.
You can see changes in spec factory calls that fixed these cases.

```
# old response:
200
{success:false, message:"Delete for Volume Mappings: Feature not available/supported"}

# new response
400
{error: { kind: "bad_request", message:"Delete for Volume Mappings: Feature not available/supported"}}
```

## Hidden agenda

In a few other areas of code, we have a bad request exception instead of the action response.
So changing this code makes those other areas work the same and we can merge/✂️ 