### PR TITLE
[BaseController::Authentication] raise on missing AUTH_TOKEN

### DIFF
--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -240,7 +240,7 @@ describe "Authentication API" do
   end
 
   context "Token Based Authentication" do
-    %w(sql memory).each do |session_store|
+    %w(sql memory cache).each do |session_store|
       context "when using a #{session_store} session store" do
         before { stub_settings_merge(:server => {:session_store => session_store}) }
 
@@ -251,6 +251,15 @@ describe "Authentication API" do
 
           expect(response).to have_http_status(:ok)
           expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
+        end
+
+        it "authentication using a blank token" do
+          get api_entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => ""}
+
+          expected_msg = "Empty Authentication Token (HTTP_X_AUTH_TOKEN)"
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.parsed_body["error"]["message"]).to eq(expected_msg)
         end
 
         it "authentication using a bad token" do


### PR DESCRIPTION
`memcached` will raise an error when a key passed to it is either `nil` or has a length of zero:

```ruby
   # lib/dalli/client.rb:380

   def validate_key(key)
     raise ArgumentError, "key cannot be blank" if !key || key.length == 0

     # ...
   end
```

This isn't an issue for the other stores, but since `Dalli` is commonly used in production, you can get a unclear error of `"ArgumentError: key cannot be blank"` when a key isn't passed.

To avoid a unclear error, a guard statement has been introduced to prevent the Dalli error from bubbling up later, and will provide a more clear error message as to what is the problem in the future.  While this is only an issue with Dalli, this isn't bad functionality to have with the other Store types as well.

Notes:

- `.blank?` wasn't used here since it includes a Regexp check for non-empty strings that would be much slower for cases with a valid token.  Since this is a heavily hit method, just replicating what is done in Dalli is probably preferred.
- `cache` was added to the tests as a store type to test against, since it should now exist in CI.
- `nil` AUTH_TOKEN values are technically not reachable in practice because there is a guard for existence check for the value in a different method that prevents this method from getting called when the value is `nil`.  This is why there is no case checking for this in the specs, but figured it made sense to guard against `nil` anyway just to be safe.