### PR TITLE
[BaseController::Authentication] Rescue from token_valid?

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -107,26 +107,6 @@ module Api
       end
 
       def authenticate_with_user_token(auth_token)
-        # Using `.nil?` + `.empty?` to avoid a REGEXP on `.blank?` valid
-        # tokens, which can be expensive on every request:
-        #
-        #   http://tmm1.net/ruby21-profiling/
-        #
-        # We only care about empty? and not whitespace anyway since the reason
-        # for this check is because Dalli checks for `nil`, or specifically a
-        # zero length string to raise an error with:
-        #
-        #   # lib/dalli/client.rb:380
-        #
-        #   def validate_key(key)
-        #     raise ArgumentError, "key cannot be blank" if !key || key.length == 0
-        #
-        #     # ...
-        #   end
-        #
-        raise AuthenticationError, "Missing Authentication Token (#{HttpHeaders::AUTH_TOKEN})" if auth_token.nil?
-        raise AuthenticationError, "Empty Authentication Token (#{HttpHeaders::AUTH_TOKEN})"   if auth_token.length == 0
-
         if !api_token_mgr.token_valid?(auth_token)
           raise AuthenticationError, "Invalid Authentication Token #{auth_token} specified"
         else
@@ -139,6 +119,10 @@ module Api
 
           auth_user(userid)
         end
+      rescue TokenManager::MissingTokenError
+        raise AuthenticationError, "Missing Authentication Token (#{HttpHeaders::AUTH_TOKEN})"
+      rescue TokenManager::EmptyTokenError
+        raise AuthenticationError, "Empty Authentication Token (#{HttpHeaders::AUTH_TOKEN})"
       end
 
       def authenticate_with_system_token(x_miq_token)


### PR DESCRIPTION
**Requires https://github.com/ManageIQ/manageiq/pull/21518 to be merged first!!!**

Now that https://github.com/ManageIQ/manageiq/pull/21518 exists, use the errors that are raised to raise errors in the API instead of using custom logic in the API only.