### PR TITLE
Remove send from chargeback api

### DIFF
--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -119,8 +119,16 @@ module Api
       end
 
       def target(parameter_record, assignment_type, rate_type)
-        target_assignment_method = "#{assignment_type}_target_assignment"
-        send(target_assignment_method, parameter_record[assignment_type.to_s], assignment_type, rate_type)
+        case assignment_type.to_sym
+        when :tag
+          tag_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+        when :label
+          label_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+        when :resource
+          resource_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+        else
+          raise BadRequestError, "Unknown assignment_type of #{assignment_type}"
+        end
       end
 
       def convert_assignment_key_from(parameter_key)

--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -118,19 +118,6 @@ module Api
         target_from(record['href'], assignment_type, rate_type)
       end
 
-      def target(parameter_record, assignment_type, rate_type)
-        case assignment_type.to_sym
-        when :tag
-          tag_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
-        when :label
-          label_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
-        when :resource
-          resource_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
-        else
-          raise BadRequestError, "Unknown assignment_type of #{assignment_type}"
-        end
-      end
-
       def convert_assignment_key_from(parameter_key)
         parameter_key == 'resource' ? :object : parameter_key.to_sym
       end
@@ -140,7 +127,19 @@ module Api
 
         rate = chargeback_rate(parameter_record)
 
-        {:cb_rate => rate, convert_assignment_key_from(assignment_type) => target(parameter_record, assignment_type, rate_type)}
+        case assignment_type.to_sym
+        when :tag
+          target = tag_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+          {:cb_rate => rate, convert_assignment_key_from(assignment_type) => target}
+        when :label
+          target = label_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+          {:cb_rate => rate, convert_assignment_key_from(assignment_type) => target}
+        when :resource
+          target = resource_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+          {:cb_rate => rate, convert_assignment_key_from(assignment_type) => target}
+        else
+          raise BadRequestError, "Unknown assignment_type of #{assignment_type}"
+        end
       end
 
       def determine_assignment_type(parameter_records)

--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -123,19 +123,20 @@ module Api
       end
 
       def rate_assignment(parameter_record, assignment_type, rate_type)
-        parameter_record['label'] = parameter_record.delete('resource') if assignment_type == :label
-
         rate = chargeback_rate(parameter_record)
 
         case assignment_type.to_sym
         when :tag
-          target = tag_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+          record = parameter_record["tag"]
+          target = tag_target_assignment(record, assignment_type, rate_type)
           {:cb_rate => rate, convert_assignment_key_from(assignment_type) => target}
         when :label
-          target = label_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+          record = parameter_record["label"] = parameter_record.delete("resource")
+          target = label_target_assignment(record, assignment_type, rate_type)
           {:cb_rate => rate, convert_assignment_key_from(assignment_type) => target}
         when :resource
-          target = resource_target_assignment(parameter_record[assignment_type.to_s], assignment_type, rate_type)
+          record = parameter_record["resource"]
+          target = resource_target_assignment(record, assignment_type, rate_type)
           {:cb_rate => rate, convert_assignment_key_from(assignment_type) => target}
         else
           raise BadRequestError, "Unknown assignment_type of #{assignment_type}"

--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -100,16 +100,20 @@ module Api
         @chargeback_rate[rate_id] ||= ChargebackRate.find(rate_id)
       end
 
-      def tag_target_assignment(record, _assignment_type, rate_type)
-        [tag_assigment(record, rate_type), rate_type == "Storage" ? 'storage' : record['assignment_prefix']]
+      def tag_target_assignment(parameter_record, rate, rate_type)
+        record = parameter_record["tag"]
+        rate_tag = rate_type == "Storage" ? 'storage' : record['assignment_prefix']
+        {:cb_rate => rate, :tag => [tag_assigment(record, rate_type), rate_tag]}
       end
 
-      def label_target_assignment(record, assignment_type, rate_type)
-        [target_from(record['href'], "label", rate_type), "container_image"]
+      def label_target_assignment(parameter_record, rate, rate_type)
+        record = parameter_record["label"] = parameter_record.delete("resource")
+        {:cb_rate => rate, :label => [target_from(record['href'], "label", rate_type), "container_image"]}
       end
 
-      def resource_target_assignment(record, assignment_type, rate_type)
-        target_from(record['href'], "resource", rate_type)
+      def resource_target_assignment(parameter_record, rate, rate_type)
+        record = parameter_record["resource"]
+        {:cb_rate => rate, :object => target_from(record['href'], "resource", rate_type)}
       end
 
       def convert_assignment_key_from(parameter_key)
@@ -121,17 +125,11 @@ module Api
 
         case assignment_type.to_sym
         when :tag
-          record = parameter_record["tag"]
-          target = tag_target_assignment(record, assignment_type, rate_type)
-          {:cb_rate => rate, :tag => target}
+          tag_target_assignment(parameter_record, rate, rate_type)
         when :label
-          record = parameter_record["label"] = parameter_record.delete("resource")
-          target = label_target_assignment(record, assignment_type, rate_type)
-          {:cb_rate => rate, :label => target}
+          label_target_assignment(parameter_record, rate, rate_type)
         when :resource
-          record = parameter_record["resource"]
-          target = resource_target_assignment(record, assignment_type, rate_type)
-          {:cb_rate => rate, :object => target}
+          resource_target_assignment(parameter_record, rate, rate_type)
         else
           raise BadRequestError, "Unknown assignment_type of #{assignment_type}"
         end


### PR DESCRIPTION
### Tangent from

I am reworking the api to make the flow of the actions more clear.
The `grep send` pointed here and it looked like this `send` was unnecessary and a tad bit confusing

### Goal

This is not a delete PR (sorry LJ). It is a simplification PR that will probably be more code.

The first commit is the one I care about. it replaces `send` with `case`.
The other commits are just trying to remove unnecessary dynamic keys in the hash.

Please view it commit by commit.

🚩 Half a dozen commits for 2 dozen lines of code, with a total delta of about 0 deserves a ref flag.