### PR TITLE
Condense enqueue_ems_action

### DIFF
--- a/app/controllers/api/base_controller/action.rb
+++ b/app/controllers/api/base_controller/action.rb
@@ -46,6 +46,7 @@ module Api
       # @option options :method_name   - method name for the queue
       # @option options :args          - args for the queue method
       # @option options :role          - role for queue (defaults: ems_operations)
+      # @option options :supports      - check that this method_name is supported by the model
       def enqueue_action(type, id, action_phrase = nil, options = {})
         if action_phrase.kind_of?(Hash)
           options = action_phrase
@@ -53,7 +54,11 @@ module Api
         end
         action_phrase ||= "Performing #{options[:method_name]} for "
 
+        supports = options.delete(:supports)
+        supports = options[:method_name] if supports == true
+
         api_resource(type, id, action_phrase) do |model|
+          ensure_supports(type, model, options[:method_name], supports) if supports
           yield(model) if block_given?
           desc = "#{action_phrase} #{model_ident(model, type)}"
           {:task_id => queue_object_action(model, desc, options)}

--- a/app/controllers/api/base_controller/action.rb
+++ b/app/controllers/api/base_controller/action.rb
@@ -98,14 +98,6 @@ module Api
 
         MiqTask.generic_action_with_callback(task_options, queue_options)
       end
-
-      def queue_options(method, role = nil)
-        {
-          :method_name => method,
-          :role        => role,
-          :user        => true
-        }
-      end
     end
   end
 end

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -39,7 +39,11 @@ module Api
       end
 
       def ensure_supports(type, model, action, supports = action)
-        raise BadRequestError, "#{action.to_s.titleize} for #{type.to_s.titleize}: #{model.unsupported_reason(supports)}" unless model.supports?(supports)
+        unless model.supports?(supports)
+          # for class level methods (like create) we display the type, otherwise we display the instance information
+          instance_name = model.kind_of?(Class) ? type.to_s.titleize : model_ident(model, type)
+          raise BadRequestError, "#{action.to_s.titleize} for #{instance_name}: #{model.unsupported_reason(supports)}"
+        end
       end
 
       def ensure_respond_to(type, model, action, respond_to)

--- a/app/controllers/api/cloud_templates_controller.rb
+++ b/app/controllers/api/cloud_templates_controller.rb
@@ -1,11 +1,7 @@
 module Api
   class CloudTemplatesController < BaseController
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        cloud_template = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{cloud_template_ident(cloud_template)}")
-        request_compliance_check(cloud_template)
-      end
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
 
     def import_resource(_type, _id, data = {})
@@ -25,22 +21,6 @@ module Api
 
       action_result(true, msg, :task_id => task_id)
     rescue => err
-      action_result(false, err.to_s)
-    end
-
-    private
-
-    def cloud_template_ident(cloud_template)
-      "CloudTemplate id:#{cloud_template.id} name:'#{cloud_template.name}'"
-    end
-
-    def request_compliance_check(cloud_template)
-      desc = "#{cloud_template_ident(cloud_template)} check compliance requested"
-      raise "#{cloud_template_ident(cloud_template)} has no compliance policies assigned" unless cloud_template.has_compliance_policies?
-
-      task_id = queue_object_action(cloud_template, desc, :method_name => "check_compliance")
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
       action_result(false, err.to_s)
     end
   end

--- a/app/controllers/api/container_groups_controller.rb
+++ b/app/controllers/api/container_groups_controller.rb
@@ -1,27 +1,7 @@
 module Api
   class ContainerGroupsController < BaseController
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        container_group = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{container_group_ident(container_group)}")
-        request_compliance_check(container_group)
-      end
-    end
-
-    private
-
-    def container_group_ident(container_group)
-      "ContainerGroup id:#{container_group.id} name:'#{container_group.name}'"
-    end
-
-    def request_compliance_check(container_group)
-      desc = "#{container_group_ident(container_group)} check compliance requested"
-      raise "#{container_group_ident(container_group)} has no compliance policies assigned" if container_group.compliance_policies.blank?
-
-      task_id = queue_object_action(container_group, desc, :method_name => "check_compliance")
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
-      action_result(false, err.to_s)
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
   end
 end

--- a/app/controllers/api/container_images_controller.rb
+++ b/app/controllers/api/container_images_controller.rb
@@ -20,27 +20,13 @@ module Api
     end
 
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        container_image = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{container_image_ident(container_image)}")
-        request_compliance_check(container_image)
-      end
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
 
     private
 
     def container_image_ident(image)
       "ContainerImage id:#{image.id} name:'#{image.name}'"
-    end
-
-    def request_compliance_check(container_image)
-      desc = "#{container_image_ident(container_image)} check compliance requested"
-      raise "#{container_image_ident(container_image)} has no compliance policies assigned" if container_image.compliance_policies.blank?
-
-      task_id = queue_object_action(container_image, desc, :method_name => "check_compliance")
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
-      action_result(false, err.to_s)
     end
   end
 end

--- a/app/controllers/api/container_nodes_controller.rb
+++ b/app/controllers/api/container_nodes_controller.rb
@@ -1,27 +1,7 @@
 module Api
   class ContainerNodesController < BaseController
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        container_node = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{container_node_ident(container_node)}")
-        request_compliance_check(container_node)
-      end
-    end
-
-    private
-
-    def container_node_ident(container_node)
-      "ContainerNode id:#{container_node.id} name:'#{container_node.name}'"
-    end
-
-    def request_compliance_check(container_node)
-      desc = "#{container_node_ident(container_node)} check compliance requested"
-      raise "#{container_node_ident(container_node)} has no compliance policies assigned" if container_node.compliance_policies.blank?
-
-      task_id = queue_object_action(container_node, desc, :method_name => "check_compliance")
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
-      action_result(false, err.to_s)
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
   end
 end

--- a/app/controllers/api/data_stores_controller.rb
+++ b/app/controllers/api/data_stores_controller.rb
@@ -2,8 +2,8 @@ module Api
   class DataStoresController < BaseController
     include Subcollections::Tags
 
-    def delete_resource_main_action(type, data_store, _data)
-      {:task_id => queue_object_action(data_store, "Deleting #{model_ident(data_store, type)}", :method_name => "destroy")}
+    def delete_resource(type, id, _data = nil)
+      enqueue_ems_action(type, id, "Deleting", :method_name => "destroy")
     end
   end
 end

--- a/app/controllers/api/host_initiators_controller.rb
+++ b/app/controllers/api/host_initiators_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class HostInitiatorsController < BaseController
     def refresh_resource(type, id, _data = nil)
-      enqueue_action(type, id, "Refreshing", :method_name => :refresh_ems)
+      enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
     def create_resource(_type, _id = nil, data = {})

--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -25,27 +25,7 @@ module Api
     end
 
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        host = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{host_ident(host)}")
-        request_compliance_check(host)
-      end
-    end
-
-    private
-
-    def host_ident(host)
-      "Host id:#{host.id} name:'#{host.name}'"
-    end
-
-    def request_compliance_check(host)
-      desc = "#{host_ident(host)} check compliance requested"
-      raise "#{host_ident(host)} has no compliance policies assigned" if host.compliance_policies.blank?
-
-      task_id = queue_object_action(host, desc, :method_name => "check_compliance")
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
-      action_result(false, err.to_s)
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
   end
 end

--- a/app/controllers/api/instances_controller.rb
+++ b/app/controllers/api/instances_controller.rb
@@ -6,111 +6,40 @@ module Api
     include Subcollections::Snapshots
     extend Api::Mixins::CentralAdmin
 
-    DEFAULT_ROLE = 'ems_operations'.freeze
-
     def terminate_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for terminating a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Terminating #{instance_ident(instance)}")
-        terminate_instance(instance)
-      end
+      enqueue_ems_action(type, id, "Terminating", :method_name => "vm_destroy")
     end
 
     def stop_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for stopping a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Stopping #{instance_ident(instance)}")
-
-        result = validate_instance_for_action(instance, "stop")
-        result = stop_instance(instance) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Stopping", :method_name => "stop", :supports => true)
     end
     central_admin :stop_resource, :stop
 
     def start_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Starting #{instance_ident(instance)}")
-
-        result = validate_instance_for_action(instance, "start")
-        result = start_instance(instance) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Starting", :method_name => "start", :supports => true)
     end
     central_admin :start_resource, :start
 
     def pause_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for pausing a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Pausing #{instance_ident(instance)}")
-
-        result = validate_instance_for_action(instance, "pause")
-        result = pause_instance(instance) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Pausing", :method_name => "pause", :supports => true)
     end
 
     def suspend_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for suspending a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Suspending #{instance_ident(instance)}")
-
-        result = validate_instance_for_action(instance, "suspend")
-        result = suspend_instance(instance) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Suspending", :method_name => "suspend", :supports => true)
     end
     central_admin :suspend_resource, :suspend
 
     def shelve_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for shelving a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Shelving #{instance_ident(instance)}")
-
-        result = validate_instance_for_action(instance, "shelve")
-        result = shelve_instance(instance) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Shelving", :method_name => "shelve", :supports => true)
     end
 
     def reboot_guest_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for rebooting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Rebooting #{instance_ident(instance)}")
-
-        result = validate_instance_for_action(instance, "reboot_guest")
-        result = reboot_guest_instance(instance) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Rebooting", :method_name => "reboot_guest", :supports => true)
     end
     central_admin :reboot_guest_resource, :reboot_guest
 
     def reset_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for resetting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Resetting #{instance_ident(instance)}")
-
-        result = validate_instance_for_action(instance, "reset")
-        result = reset_instance(instance) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Resetting", :method_name => "reset", :supports => true)
     end
     central_admin :reset_resource, :reset
 
@@ -127,80 +56,6 @@ module Api
   
       vm = resource_search(params[:c_id], @req.collection)
       render_options(@req.collection.to_sym, send(subcollection_options_method, vm))
-    end
-
-    private
-
-    def instance_ident(instance)
-      "Instance id:#{instance.id} name:'#{instance.name}'"
-    end
-
-    def terminate_instance(instance)
-      desc = "#{instance_ident(instance)} terminating"
-      task_id = queue_object_action(instance, desc, queue_options("vm_destroy", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def stop_instance(instance)
-      desc = "#{instance_ident(instance)} stopping"
-      task_id = queue_object_action(instance, desc, queue_options("stop", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def start_instance(instance)
-      desc = "#{instance_ident(instance)} starting"
-      task_id = queue_object_action(instance, desc, queue_options("start", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def pause_instance(instance)
-      desc = "#{instance_ident(instance)} pausing"
-      task_id = queue_object_action(instance, desc, queue_options("pause", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def validate_instance_for_action(instance, action)
-      action_result(instance.supports?(action), instance.unsupported_reason(action.to_sym))
-    end
-
-    def suspend_instance(instance)
-      desc = "#{instance_ident(instance)} suspending"
-      task_id = queue_object_action(instance, desc, queue_options("suspend", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def shelve_instance(instance)
-      desc = "#{instance_ident(instance)} shelving"
-      task_id = queue_object_action(instance, desc, queue_options("shelve", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def reboot_guest_instance(instance)
-      desc = "#{instance_ident(instance)} rebooting"
-      task_id = queue_object_action(instance, desc, queue_options("reboot_guest", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def reset_instance(instance)
-      desc = "#{instance_ident(instance)} resetting"
-      task_id = queue_object_action(instance, desc, queue_options("reset", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
     end
   end
 end

--- a/app/controllers/api/instances_controller.rb
+++ b/app/controllers/api/instances_controller.rb
@@ -115,11 +115,7 @@ module Api
     central_admin :reset_resource, :reset
 
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        instance = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{instance_ident(instance)}")
-        request_compliance_check(instance)
-      end
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
 
     def options
@@ -204,16 +200,6 @@ module Api
       task_id = queue_object_action(instance, desc, queue_options("reset", DEFAULT_ROLE))
       action_result(true, desc, :task_id => task_id)
     rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def request_compliance_check(instance)
-      desc = "#{instance_ident(instance)} check compliance requested"
-      raise "#{instance_ident(instance)} has no compliance policies assigned" if instance.compliance_policies.blank?
-
-      task_id = queue_object_action(instance, desc, :method_name => "check_compliance")
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
       action_result(false, err.to_s)
     end
   end

--- a/app/controllers/api/physical_chassis_controller.rb
+++ b/app/controllers/api/physical_chassis_controller.rb
@@ -3,19 +3,19 @@ module Api
     include Subcollections::EventStreams
 
     def blink_loc_led_resource(type, id, _data)
-      enqueue_action(type, id, :method_name => :blink_loc_led)
+      enqueue_ems_action(type, id, :method_name => :blink_loc_led)
     end
 
     def turn_on_loc_led_resource(type, id, _data)
-      enqueue_action(type, id, :method_name => :turn_on_loc_led)
+      enqueue_ems_action(type, id, :method_name => :turn_on_loc_led)
     end
 
     def turn_off_loc_led_resource(type, id, _data)
-      enqueue_action(type, id, :method_name => :turn_off_loc_led)
+      enqueue_ems_action(type, id, :method_name => :turn_off_loc_led)
     end
 
     def refresh_resource(type, id, _data = nil)
-      enqueue_action(type, id, "Refreshing", :method_name => :refresh_ems)
+      enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
   end
 end

--- a/app/controllers/api/physical_racks_controller.rb
+++ b/app/controllers/api/physical_racks_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class PhysicalRacksController < BaseController
     def refresh_resource(type, id, _data = nil)
-      enqueue_action(type, id, "Refreshing", :method_name => :refresh_ems)
+      enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
   end
 end

--- a/app/controllers/api/physical_servers_controller.rb
+++ b/app/controllers/api/physical_servers_controller.rb
@@ -4,86 +4,59 @@ module Api
     include Subcollections::FirmwareBinaries
 
     def blink_loc_led_resource(type, id, _data)
-      change_resource_state(:blink_loc_led, type, id)
+      enqueue_ems_action(type, id, :method_name => :blink_loc_led)
     end
 
     def turn_on_loc_led_resource(type, id, _data)
-      change_resource_state(:turn_on_loc_led, type, id)
+      enqueue_ems_action(type, id, :method_name => :turn_on_loc_led)
     end
 
     def turn_off_loc_led_resource(type, id, _data)
-      change_resource_state(:turn_off_loc_led, type, id)
+      enqueue_ems_action(type, id, :method_name => :turn_off_loc_led)
     end
 
     def power_on_resource(type, id, _data)
-      change_resource_state(:power_on, type, id)
+      enqueue_ems_action(type, id, :method_name => :power_on)
     end
 
     def power_off_resource(type, id, _data)
-      change_resource_state(:power_off, type, id)
+      enqueue_ems_action(type, id, :method_name => :power_off)
     end
 
     def power_off_now_resource(type, id, _data)
-      change_resource_state(:power_off_now, type, id)
+      enqueue_ems_action(type, id, :method_name => :power_off_now)
     end
 
     def restart_resource(type, id, _data)
-      change_resource_state(:restart, type, id)
+      enqueue_ems_action(type, id, "Restarting", :method_name => :restart)
     end
 
     def restart_now_resource(type, id, _data)
-      change_resource_state(:restart_now, type, id)
+      enqueue_ems_action(type, id, :method_name => :restart_now)
     end
 
     def restart_to_sys_setup_resource(type, id, _data)
-      change_resource_state(:restart_to_sys_setup, type, id)
+      enqueue_ems_action(type, id, :method_name => :restart_to_sys_setup)
     end
 
     def restart_mgmt_controller_resource(type, id, _data)
-      change_resource_state(:restart_mgmt_controller, type, id)
+      enqueue_ems_action(type, id, :method_name => :restart_mgmt_controller)
     end
 
     def refresh_resource(type, id, _data = nil)
       enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
-    # Process apply config pattern operation for single and multi-resources
-    #
-    # Even the request for multi-resources isn't completed successfully, return a HTTP Status 200
     def apply_config_pattern_resource(type, id, data)
-      ensure_resource_exists(:customization_scripts, data["pattern_id"])
-      change_resource_state(:apply_config_pattern, type, id, [data["pattern_id"]])
-    rescue => err
-      raise err if single_resource?
-      action_result(false, err.to_s)
+      enqueue_ems_action(type, id, :method_name => :apply_config_pattern, :args => [data["pattern_id"]]) do
+        ensure_resource_exists(:customization_scripts, data["pattern_id"])
+      end
     end
 
     private
 
-    def change_resource_state(state, type, id, data = [])
-      raise BadRequestError, "Must specify an id for changing a #{type} resource" unless id
-
-      ensure_resource_exists(type, id) if single_resource?
-
-      api_action(type, id) do |klass|
-        begin
-          server = resource_search(id, type, klass)
-          desc = "Requested server state #{state} for #{server_ident(server)}"
-          api_log_info(desc)
-          task_id = queue_object_action(server, desc, :method_name => state, :role => :ems_operations, :args => data)
-          action_result(true, desc, :task_id => task_id)
-        rescue => err
-          action_result(false, err.to_s)
-        end
-      end
-    end
-
     def ensure_resource_exists(type, id)
       raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
-    end
-
-    def server_ident(server)
-      "Server instance: #{server.id} name:'#{server.name}'"
     end
   end
 end

--- a/app/controllers/api/physical_servers_controller.rb
+++ b/app/controllers/api/physical_servers_controller.rb
@@ -44,7 +44,7 @@ module Api
     end
 
     def refresh_resource(type, id, _data = nil)
-      enqueue_action(type, id, "Refreshing", :method_name => :refresh_ems)
+      enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
     # Process apply config pattern operation for single and multi-resources

--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class PhysicalStoragesController < BaseController
     def refresh_resource(type, id, _data = nil)
-      enqueue_action(type, id, "Refreshing", :method_name => :refresh_ems)
+      enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
     def create_resource(_type, _id = nil, data = {})

--- a/app/controllers/api/physical_switches_controller.rb
+++ b/app/controllers/api/physical_switches_controller.rb
@@ -3,11 +3,11 @@ module Api
     include Subcollections::EventStreams
 
     def refresh_resource(type, id, _data = nil)
-      enqueue_action(type, id, "Refreshing", :method_name => :refresh_ems)
+      enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
     def restart_resource(type, id, _data = nil)
-      enqueue_action(type, id, "Restarting", :method_name => :restart)
+      enqueue_ems_action(type, id, "Restarting", :method_name => :restart)
     end
   end
 end

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -72,23 +72,17 @@ module Api
     end
 
     def import_vm_resource(type, id = nil, data = {})
-      raise BadRequestError, "Must specify an id for import of VM to a #{type} resource" unless id
+      target_params = {
+        :name       => data.fetch_path('target', 'name'),
+        :cluster_id => parse_id(data.fetch_path('target', 'cluster'), :clusters),
+        :storage_id => parse_id(data.fetch_path('target', 'data_store'), :data_stores),
+        :sparse     => data.fetch_path('target', 'sparse')
+      }
+      vm_id = parse_id(data['source'], :vms)
 
-      api_action(type, id) do |klass|
-        provider = resource_search(id, type, klass)
-
-        vm_id = parse_id(data['source'], :vms)
+      enqueue_ems_action(type, id, "Importing Vm to", :method_name => 'import_vm', :args => [vm_id, target_params]) do
         # check if user can access the VM
         resource_search(vm_id, :vms, Vm)
-
-        api_log_info("Importing VM to #{provider_ident(provider)}")
-        target_params = {
-          :name       => data.fetch_path('target', 'name'),
-          :cluster_id => parse_id(data.fetch_path('target', 'cluster'), :clusters),
-          :storage_id => parse_id(data.fetch_path('target', 'data_store'), :data_stores),
-          :sparse     => data.fetch_path('target', 'sparse')
-        }
-        import_vm_to_provider(provider, vm_id, target_params)
       end
     end
 
@@ -291,16 +285,6 @@ module Api
       provider
     rescue => err
       raise BadRequestError, "Could not update the provider - #{err}"
-    end
-
-    def import_vm_to_provider(provider, source_vm_id, target_params)
-      desc = "#{provider_ident(provider)} importing vm"
-      task_id = queue_object_action(provider, desc,
-                                    :method_name => 'import_vm',
-                                    :args        => [source_vm_id, target_params])
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
     end
 
     def update_provider_authentication(provider, data)

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -118,11 +118,7 @@ module Api
     end
 
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        provider = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{provider_ident(provider)}")
-        request_compliance_check(provider)
-      end
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
 
     private
@@ -372,16 +368,6 @@ module Api
         end
       end
       @collection_klasses[:providers] = Provider
-    end
-
-    def request_compliance_check(provider)
-      desc = "#{provider_ident(provider)} check compliance requested"
-      raise "#{provider_ident(provider)} has no compliance policies assigned" if provider.compliance_policies.blank?
-
-      task_id = queue_object_action(provider, desc, :method_name => "check_compliance")
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
-      action_result(false, err.to_s)
     end
 
     def fetch_deep_keys(hash, prefix = nil)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -72,54 +72,15 @@ module Api
     end
 
     def start_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        service = resource_search(id, type, klass)
-        api_log_info("Starting #{service_ident(service)}")
-
-        begin
-          description = "#{service_ident(service)} starting"
-          task_id = queue_object_action(service, description, :method_name => "start", :role => "ems_operations")
-          action_result(true, description, :task_id => task_id)
-        rescue => e
-          action_result(false, e.to_s)
-        end
-      end
+      enqueue_ems_action(type, id, "Starting", :method_name => "start")
     end
 
     def stop_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        service = resource_search(id, type, klass)
-        api_log_info("Stopping #{service_ident(service)}")
-
-        begin
-          description = "#{service_ident(service)} stopping"
-          task_id = queue_object_action(service, description, :method_name => "stop", :role => "ems_operations")
-          action_result(true, description, :task_id => task_id)
-        rescue => e
-          action_result(false, e.to_s)
-        end
-      end
+      enqueue_ems_action(type, id, "Stopping", :method_name => "stop")
     end
 
     def suspend_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        service = resource_search(id, type, klass)
-        api_log_info("Suspending #{service_ident(service)}")
-
-        begin
-          description = "#{service_ident(service)} suspending"
-          task_id = queue_object_action(service, description, :method_name => "suspend", :role => "ems_operations")
-          action_result(true, description, :task_id => task_id)
-        rescue => e
-          action_result(false, e.to_s)
-        end
-      end
+      enqueue_ems_action(type, id, "Suspending", :method_name => "suspend")
     end
 
     def add_provider_vms_resource(type, id, data)

--- a/app/controllers/api/templates_controller.rb
+++ b/app/controllers/api/templates_controller.rb
@@ -9,27 +9,7 @@ module Api
     end
 
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        template = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{template_ident(template)}")
-        request_compliance_check(template)
-      end
-    end
-
-    private
-
-    def template_ident(template)
-      "Template id:#{template.id} name:'#{template.name}'"
-    end
-
-    def request_compliance_check(template)
-      desc = "#{template_ident(template)} check compliance requested"
-      raise "#{template_ident(template)} has no compliance policies assigned" unless template.has_compliance_policies?
-
-      task_id = queue_object_action(template, desc, :method_name => "check_compliance")
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
-      action_result(false, err.to_s)
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
   end
 end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -113,9 +113,8 @@ module Api
       raise BadRequestError, "Cannot edit VM - #{err}"
     end
 
-    def delete_resource_main_action(type, vm_model, _data = nil)
-      # TODO: ensure_supports(type, vm, :delete)
-      {:task_id => queue_object_action(vm_model, "Deleting #{model_ident(vm_model, type)}", queue_options("destroy"))}
+    def delete_resource(type, id, _data = nil)
+      enqueue_ems_action(type, id, "Deleting", :method_name => "destroy")
     end
 
     def set_owner_resource(type, id = nil, data = nil)

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -16,89 +16,34 @@ module Api
     include Subcollections::Software
     include Subcollections::Tags
 
-    DEFAULT_ROLE = 'ems_operations'.freeze
     RELATIONSHIP_COLLECTIONS = %w[vms templates].freeze
     VALID_EDIT_ATTRS = %w[description name child_resources parent_resource].freeze
 
     def start_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Starting #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "start")
-        result = start_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Starting", :method_name => "start", :supports => true)
     end
     central_admin :start_resource, :start
 
     def stop_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for stopping a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Stopping #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "stop")
-        result = stop_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Stopping", :method_name => "stop", :supports => true)
     end
     central_admin :stop_resource, :stop
 
     def suspend_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for suspending a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Suspending #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "suspend")
-        result = suspend_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Suspending", :method_name => "suspend", :supports => true)
     end
     central_admin :suspend_resource, :suspend
 
     def pause_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for pausing a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Pausing #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "pause")
-        result = pause_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Pausing", :method_name => "pause", :supports => true)
     end
 
     def shelve_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for shelving a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Shelving #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "shelve")
-        result = shelve_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Shelving", :method_name => "shelve", :supports => true)
     end
 
     def shelve_offload_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for shelve-offloading a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Shelve-offloading #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "shelve_offload")
-        result = shelve_offload_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Shelve-Offloading", :method_name => "shelve_offload", :supports => true)
     end
 
     def edit_resource(type, id, data)
@@ -143,16 +88,7 @@ module Api
     end
 
     def scan_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for scanning a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Scanning #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "smartstate_analysis")
-        result = scan_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Scanning", :method_name => "scan", :supports => :smartstate_analysis, :role => "smartstate")
     end
 
     def add_event_resource(type, id = nil, data = nil)
@@ -169,30 +105,12 @@ module Api
     end
 
     def reset_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for resetting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Resetting #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "reset")
-        result = reset_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Resetting", :method_name => "reset", :supports => true)
     end
     central_admin :reset_resource, :reset
 
     def reboot_guest_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for rebooting a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Rebooting #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "reboot_guest")
-        result = reboot_guest_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Rebooting", :method_name => "reboot_guest", :supports => true)
     end
     central_admin :reboot_guest_resource, :reboot_guest
 
@@ -214,16 +132,7 @@ module Api
     central_admin :rename_resource, :rename
 
     def shutdown_guest_resource(type, id = nil, _data = nil)
-      raise BadRequestError, "Must specify an id for shutting down a #{type} resource" unless id
-
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Shutting down #{vm_ident(vm)}")
-
-        result = validate_vm_for_action(vm, "shutdown_guest")
-        result = shutdown_guest_vm(vm) if result[:success]
-        result
-      end
+      enqueue_ems_action(type, id, "Shutting Down", :method_name => "shutdown_guest", :supports => true)
     end
     central_admin :shutdown_guest_resource, :shutdown_guest
 
@@ -243,13 +152,12 @@ module Api
       # protocol = "mks"
       protocol = data["protocol"] || "vnc"
 
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Requesting Console #{vm_ident(vm)}")
-
-        result = validate_vm_for_remote_console(vm, protocol)
-        result = request_console_vm(vm, protocol) if result[:success]
-        result
+      args = [User.current_user.userid, MiqServer.my_server.id, protocol]
+      enqueue_ems_action(type, id, "Requesting Console", :method_name => "remote_console_acquire_ticket", :args => args) do |vm|
+        # NOTE: we are queuing the :remote_console_acquire_ticket and returning the task id and href.
+        #
+        # The remote console ticket/info can be stashed in the task's context_data by the *_acquire_ticket method
+        vm.validate_remote_console_acquire_ticket(protocol)
       end
     end
 
@@ -273,21 +181,12 @@ module Api
     def request_retire_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for retiring a #{type} resource" unless id
 
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        msg = "Retiring request of vm #{vm_ident(vm)}"
-        if data && data["date"]
-          opts = {}
-          opts[:date] = data["date"]
-          opts[:warn] = data["warn"] if data["warn"]
-          msg << " on: #{opts}"
-          api_log_info(msg)
-          request_retire(vm, opts)
-        else
-          msg << " immediately."
-          api_log_info(msg)
-          request_retire(vm)
-        end
+      if data && data["date"]
+        opts = {:date => data["date"]}
+        opts[:warn] = data["warn"] if data["warn"]
+        enqueue_action(type, id, "Retiring on #{data["date"]}", :method_name => "retire", :role => "automate", :args => [opts])
+      else
+        enqueue_action(type, id, "Retiring immediately", :method_name => "make_retire_request", :role => "automate", :args => [User.current_user.id])
       end
     end
     alias retire_resource request_retire_resource
@@ -359,54 +258,6 @@ module Api
       action_result(false, err.message)
     end
 
-    def start_vm(vm)
-      desc = "#{vm_ident(vm)} starting"
-      task_id = queue_object_action(vm, desc, queue_options("start", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def stop_vm(vm)
-      desc = "#{vm_ident(vm)} stopping"
-      task_id = queue_object_action(vm, desc, queue_options("stop", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def suspend_vm(vm)
-      desc = "#{vm_ident(vm)} suspending"
-      task_id = queue_object_action(vm, desc, queue_options("suspend", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def pause_vm(vm)
-      desc = "#{vm_ident(vm)} pausing"
-      task_id = queue_object_action(vm, desc, queue_options("pause", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def shelve_vm(vm)
-      desc = "#{vm_ident(vm)} shelving"
-      task_id = queue_object_action(vm, desc, queue_options("shelve", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def shelve_offload_vm(vm)
-      desc = "#{vm_ident(vm)} shelve-offloading"
-      task_id = queue_object_action(vm, desc, queue_options("shelve_offload", DEFAULT_ROLE))
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
     def set_owner_vm(vm, owner)
       desc = "#{vm_ident(vm)} setting owner to '#{owner}'"
       user = User.lookup_by_identity(owner)
@@ -434,14 +285,6 @@ module Api
       data
     end
 
-    def scan_vm(vm)
-      desc = "#{vm_ident(vm)} scanning"
-      task_id = queue_object_action(vm, desc, :method_name => "scan", :role => "smartstate")
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
     def vm_event(vm, event_type, event_message, event_time)
       desc = "Adding Event type=#{event_type} message=#{event_message}"
       event_timestamp = event_time.blank? ? Time.now.utc : event_time.to_time(:utc)
@@ -452,63 +295,11 @@ module Api
       action_result(false, err.to_s)
     end
 
-    def reset_vm(vm)
-      desc = "#{vm_ident(vm)} resetting"
-      task_id = queue_object_action(vm, desc, :method_name => "reset", :role => "ems_operations")
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def shutdown_guest_vm(vm)
-      desc = "#{vm_ident(vm)} shutting down"
-      task_id = queue_object_action(vm, desc, :method_name => "shutdown_guest", :role => "ems_operations")
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def reboot_guest_vm(vm)
-      desc = "#{vm_ident(vm)} rebooting"
-      task_id = queue_object_action(vm, desc, :method_name => "reboot_guest", :role => "ems_operations")
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
     def rename_vm(vm, new_name)
       desc = "#{vm_ident(vm)} renaming to #{new_name}"
       task_id = vm.rename_queue(User.current_user.userid, new_name)
       action_result(true, desc, :task_id => task_id)
     rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def request_console_vm(vm, protocol)
-      desc = "#{vm_ident(vm)} requesting console"
-      task_id = queue_object_action(vm, desc,
-                                    :method_name => "remote_console_acquire_ticket",
-                                    :role        => "ems_operations",
-                                    :args        => [User.current_user.userid, MiqServer.my_server.id, protocol])
-      # NOTE:
-      # we are queuing the :remote_console_acquire_ticket and returning the task id and href.
-      #
-      # The remote console ticket/info can be stashed in the task's context_data by the *_acquire_ticket method
-      # context_data is returned as part of the task i.e. GET /api/tasks/:id
-      action_result(true, desc, :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
-    end
-
-    def request_retire(virtual_machine, opts = nil)
-      desc = "#{vm_ident(virtual_machine)} request retire"
-      task_id = if opts
-                  queue_object_action(virtual_machine, desc, :method_name => "retire", :role => "automate", :args => [opts])
-                else
-                  queue_object_action(virtual_machine, desc, :method_name => "make_retire_request", :role => "automate", :args => [User.current_user.id])
-                end
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
       action_result(false, err.to_s)
     end
   end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -294,11 +294,7 @@ module Api
     alias retire_resource request_retire_resource
 
     def check_compliance_resource(type, id, _data = nil)
-      api_action(type, id) do |klass|
-        vm = resource_search(id, type, klass)
-        api_log_info("Checking compliance of #{vm_ident(vm)}")
-        request_compliance_check(vm)
-      end
+      enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end
 
     def options
@@ -512,16 +508,6 @@ module Api
                 else
                   queue_object_action(virtual_machine, desc, :method_name => "make_retire_request", :role => "automate", :args => [User.current_user.id])
                 end
-      action_result(true, desc, :task_id => task_id)
-    rescue StandardError => err
-      action_result(false, err.to_s)
-    end
-
-    def request_compliance_check(vm)
-      desc = "#{vm_ident(vm)} check compliance requested"
-      raise "#{vm_ident(vm)} has no compliance policies assigned" unless vm.has_compliance_policies?
-
-      task_id = queue_object_action(vm, desc, :method_name => "check_compliance")
       action_result(true, desc, :task_id => task_id)
     rescue StandardError => err
       action_result(false, err.to_s)

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -229,7 +229,7 @@ module Api
     central_admin :shutdown_guest_resource, :shutdown_guest
 
     def refresh_resource(type, id = nil, _data = nil)
-      enqueue_action(type, id, "Refreshing", :method_name => :refresh_ems)
+      enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
     def request_console_resource(type, id = nil, data = nil)

--- a/app/controllers/api/volume_mappings_controller.rb
+++ b/app/controllers/api/volume_mappings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class VolumeMappingsController < BaseController
     def refresh_resource(type, id, _data = nil)
-      enqueue_action(type, id, "Refreshing", :method_name => :refresh_ems)
+      enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
     def create_resource(_type, _id = nil, data = {})

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe 'CloudSubnets API' do
 
       post(api_cloud_subnet_url(nil, cloud_subnet), :params => gen_request(:delete))
 
-      expect_bad_request(/Delete for Cloud Subnets.*not.*supported/)
+      expect_bad_request(/Delete for Cloud Subnet.*not.*supported/)
     end
   end
 end

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -146,7 +146,7 @@ describe "Cloud Volumes API" do
       api_basic_authorize(action_identifier(:cloud_volumes, :safe_delete, :resource_actions, :post))
 
       post(api_cloud_volume_url(nil, volume), :params => {"action" => "safe_delete"})
-      expect_bad_request("Safe Delete for Cloud Volumes: Feature not available/supported")
+      expect_bad_request(/Safe Delete for Cloud Volume.*not available/)
     end
 
     it "can safe delete a cloud volume as a resource action" do

--- a/spec/requests/instances_spec.rb
+++ b/spec/requests/instances_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Instances API" do
 
       expect_single_action_result(
         :success => true,
-        :message => /#{instance.id}.* terminating/i,
+        :message => /Terminating.*#{instance.id}/i,
         :href    => api_instance_url(nil, instance)
       )
       expect(MiqQueue.where(:method_name => "vm_destroy",
@@ -75,12 +75,12 @@ RSpec.describe "Instances API" do
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
-            "message" => a_string_matching(/#{instance1.id}.* terminating/i),
+            "message" => a_string_matching(/Terminating.*#{instance1.id}/i),
             "success" => true,
             "href"    => api_instance_url(nil, instance1)
           ),
           a_hash_including(
-            "message" => a_string_matching(/#{instance2.id}.* terminating/i),
+            "message" => a_string_matching(/Terminating.*#{instance2.id}/i),
             "success" => true,
             "href"    => api_instance_url(nil, instance2)
           )
@@ -114,7 +114,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:stop))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
+      expect_bad_request(/is not powered on/)
     end
 
     it "stops a valid instance" do
@@ -122,7 +122,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:stop))
 
-      expect_single_action_result(:success => true, :message => "stopping", :href => api_instance_url(nil, instance), :task => true)
+      expect_single_action_result(:success => true, :message => "Stopping", :href => api_instance_url(nil, instance), :task => true)
       expect(MiqQueue.where(:method_name => "stop",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -161,7 +161,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => false, :message => "is powered on", :href => api_instance_url(nil, instance))
+      expect_bad_request(/is powered on/)
     end
 
     it "starts an instance" do
@@ -170,7 +170,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => api_instance_url(nil, instance), :task => true)
+      expect_single_action_result(:success => true, :message => "Starting", :href => api_instance_url(nil, instance), :task => true)
       expect(MiqQueue.where(:method_name => "start",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -211,7 +211,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
+      expect_bad_request(/is not powered on/)
     end
 
     it "fails to pause a paused instance" do
@@ -220,7 +220,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
+      expect_bad_request(/is not powered on/)
     end
 
     it "pauses an instance" do
@@ -228,7 +228,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => true, :message => "pausing", :href => api_instance_url(nil, instance), :task => true)
+      expect_single_action_result(:success => true, :message => "Pausing", :href => api_instance_url(nil, instance), :task => true)
       expect(MiqQueue.where(:method_name => "pause",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -268,7 +268,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
+      expect_bad_request(/is not powered on/)
     end
 
     it "cannot suspend a suspended instance" do
@@ -277,7 +277,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
+      expect_bad_request(/is not powered on/)
     end
 
     it "suspends an instance" do
@@ -285,7 +285,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => true, :message => "suspending", :href => api_instance_url(nil, instance), :task => true)
+      expect_single_action_result(:success => true, :message => "Suspending", :href => api_instance_url(nil, instance), :task => true)
       expect(MiqQueue.where(:method_name => "suspend",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -325,7 +325,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance))
+      expect_single_action_result(:success => true, :message => 'Shelving', :href => api_instance_url(nil, instance))
     end
 
     it "shelves a suspended instance" do
@@ -334,7 +334,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance))
+      expect_single_action_result(:success => true, :message => 'Shelving', :href => api_instance_url(nil, instance))
     end
 
     it "shelves a paused instance" do
@@ -343,7 +343,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_instance_url(nil, instance))
+      expect_single_action_result(:success => true, :message => 'Shelving', :href => api_instance_url(nil, instance))
       expect(MiqQueue.where(:method_name => "shelve",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -356,11 +356,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(
-        :success => false,
-        :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused",
-        :href    => api_instance_url(nil, instance)
-      )
+      expect_bad_request(/has to be powered on, off, suspended or paused/)
     end
 
     it "shelves an instance" do
@@ -368,10 +364,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true,
-                                  :message => "shelving",
-                                  :href    => api_instance_url(nil, instance),
-                                  :task    => true)
+      expect_single_action_result(:success => true, :message => "Shelving", :href => api_instance_url(nil, instance), :task => true)
     end
 
     it "shelves multiple instances" do
@@ -407,7 +400,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
+      expect_bad_request(/is not powered on/)
     end
 
     it "reboots a valid instance" do
@@ -415,7 +408,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => true, :message => "rebooting", :href => api_instance_url(nil, instance), :task => true)
+      expect_single_action_result(:success => true, :message => "Rebooting", :href => api_instance_url(nil, instance), :task => true)
       expect(MiqQueue.where(:method_name => "reboot_guest",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -455,7 +448,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:reset))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_instance_url(nil, instance))
+      expect_bad_request(/is not powered on/)
     end
 
     it "resets a valid instance" do
@@ -463,7 +456,7 @@ RSpec.describe "Instances API" do
 
       post(instance_url, :params => gen_request(:reset))
 
-      expect_single_action_result(:success => true, :message => "resetting", :href => api_instance_url(nil, instance), :task => true)
+      expect_single_action_result(:success => true, :message => "Resetting", :href => api_instance_url(nil, instance), :task => true)
       expect(MiqQueue.where(:method_name => "reset",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -680,13 +680,7 @@ describe "Services API" do
 
         post(api_service_url(nil, service), :params => { :action => "start" })
 
-        expected = {
-          "href"    => api_service_url(nil, service),
-          "success" => true,
-          "message" => a_string_matching("starting")
-        }
-        expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect_single_action_result(:success => true, :message => /Starting/, :task => true, :href => api_service_url(nil, service))
       end
 
       it "can start multiple services for a user with appropriate role" do
@@ -695,22 +689,8 @@ describe "Services API" do
 
         post(api_services_url, :params => { :action => "start", :resources => [{:id => service_1.id}, {:id => service_2.id}] })
 
-        expected = {
-          "results" => a_collection_containing_exactly(
-            a_hash_including("success"   => true,
-                             "message"   => a_string_matching("starting"),
-                             "task_id"   => anything,
-                             "task_href" => anything,
-                             "href"      => api_service_url(nil, service_1)),
-            a_hash_including("success"   => true,
-                             "message"   => a_string_matching("starting"),
-                             "task_id"   => anything,
-                             "task_href" => anything,
-                             "href"      => api_service_url(nil, service_2)),
-          )
-        }
-        expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect_multiple_action_result(2, :success => true, :message => /Starting/, :task => true)
+        expect_result_resources_to_include_hrefs("results", [api_service_url(nil, service_1), api_service_url(nil, service_2)])
       end
 
       it "will not start a service for a user without an appropriate role" do
@@ -730,13 +710,7 @@ describe "Services API" do
 
         post(api_service_url(nil, service), :params => { :action => "stop" })
 
-        expected = {
-          "href"    => api_service_url(nil, service),
-          "success" => true,
-          "message" => a_string_matching("stopping")
-        }
-        expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect_single_action_result(:success => true, :message => /Stopping/, :href => api_service_url(nil, service))
       end
 
       it "can stop multiple services for a user with appropriate role" do
@@ -745,22 +719,8 @@ describe "Services API" do
 
         post(api_services_url, :params => { :action => "stop", :resources => [{:id => service_1.id}, {:id => service_2.id}] })
 
-        expected = {
-          "results" => a_collection_containing_exactly(
-            a_hash_including("success"   => true,
-                             "message"   => a_string_matching("stopping"),
-                             "task_id"   => anything,
-                             "task_href" => anything,
-                             "href"      => api_service_url(nil, service_1)),
-            a_hash_including("success"   => true,
-                             "message"   => a_string_matching("stopping"),
-                             "task_id"   => anything,
-                             "task_href" => anything,
-                             "href"      => api_service_url(nil, service_2)),
-          )
-        }
-        expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect_multiple_action_result(2, :success => true, :message => /Stopping/, :task => true)
+        expect_result_resources_to_include_hrefs("results", [api_service_url(nil, service_1), api_service_url(nil, service_2)])
       end
 
       it "will not stop a service for a user without an appropriate role" do
@@ -780,13 +740,7 @@ describe "Services API" do
 
         post(api_service_url(nil, service), :params => { :action => "suspend" })
 
-        expected = {
-          "href"    => api_service_url(nil, service),
-          "success" => true,
-          "message" => a_string_matching("suspending")
-        }
-        expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect_single_action_result(:success => true, :message => /Suspending/, :task => true, :href => api_service_url(nil, service))
       end
 
       it "can suspend multiple services for a user with appropriate role" do
@@ -795,22 +749,8 @@ describe "Services API" do
 
         post(api_services_url, :params => { :action => "suspend", :resources => [{:id => service_1.id}, {:id => service_2.id}] })
 
-        expected = {
-          "results" => a_collection_containing_exactly(
-            a_hash_including("success"   => true,
-                             "message"   => a_string_matching("suspending"),
-                             "task_id"   => anything,
-                             "task_href" => anything,
-                             "href"      => api_service_url(nil, service_1)),
-            a_hash_including("success"   => true,
-                             "message"   => a_string_matching("suspending"),
-                             "task_id"   => anything,
-                             "task_href" => anything,
-                             "href"      => api_service_url(nil, service_2)),
-          )
-        }
-        expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect_multiple_action_result(2, :success => true, :message => /Suspending/, :task => true)
+        expect_result_resources_to_include_hrefs("results", [api_service_url(nil, service_1), api_service_url(nil, service_2)])
       end
 
       it "will not suspend a service for a user without an appropriate role" do

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -578,7 +578,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => false, :message => "is powered on", :href => api_vm_url(nil, vm))
+      expect_bad_request(/is powered on/)
     end
 
     it "starts a vm" do
@@ -587,7 +587,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => api_vm_url(nil, vm), :task => true)
+      expect_single_action_result(:success => true, :message => /Starting/i, :href => api_vm_url(nil, vm), :task => true)
     end
 
     it "starting a vm queues it properly" do
@@ -596,7 +596,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => api_vm_url(nil, vm), :task => true)
+      expect_single_action_result(:success => true, :message => /Starting/i, :href => api_vm_url(nil, vm), :task => true)
       expect(MiqQueue.where(:class_name  => vm.class.name,
                             :instance_id => vm.id,
                             :method_name => "start",
@@ -640,7 +640,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:stop))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm))
+      expect_bad_request(/is not powered on/)
     end
 
     it "stops a vm" do
@@ -648,7 +648,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:stop))
 
-      expect_single_action_result(:success => true, :message => "stopping", :href => api_vm_url(nil, vm), :task => true)
+      expect_single_action_result(:success => true, :message => /Stopping/i, :href => api_vm_url(nil, vm), :task => true)
       expect(MiqQueue.where(:method_name => "stop",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -688,7 +688,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm))
+      expect_bad_request(/is not powered on/)
     end
 
     it "suspends a suspended vm" do
@@ -697,7 +697,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => api_vm_url(nil, vm))
+      expect_bad_request(/is not powered on/)
     end
 
     it "suspends a vm" do
@@ -705,7 +705,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:suspend))
 
-      expect_single_action_result(:success => true, :message => "suspending", :href => api_vm_url(nil, vm), :task => true)
+      expect_single_action_result(:success => true, :message => /Suspending/i, :href => api_vm_url(nil, vm), :task => true)
       expect(MiqQueue.where(:method_name => "suspend",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -745,7 +745,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "Feature not available/supported", :href => api_vm_url(nil, vm))
+      expect_bad_request(/Feature not available/)
     end
 
     it "pauses a pauseed vm" do
@@ -754,7 +754,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "Feature not available/supported", :href => api_vm_url(nil, vm))
+      expect_bad_request(/Feature not available/)
     end
 
     it "pauses a vm" do
@@ -762,7 +762,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:pause))
 
-      expect_single_action_result(:success => true, :message => "pausing", :href => api_vm_url(nil, vm_openstack), :task => true)
+      expect_single_action_result(:success => true, :message => /Pausing/i, :href => api_vm_url(nil, vm_openstack), :task => true)
       expect(MiqQueue.where(:class_name  => vm_openstack.class.name,
                             :instance_id => vm_openstack.id,
                             :method_name => "pause",
@@ -805,7 +805,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack))
+      expect_single_action_result(:success => true, :message => /Shelving/i, :href => api_vm_url(nil, vm_openstack))
     end
 
     it "shelves a suspended vm" do
@@ -814,7 +814,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack))
+      expect_single_action_result(:success => true, :message => /Shelving/i, :href => api_vm_url(nil, vm_openstack))
     end
 
     it "shelves a paused off vm" do
@@ -823,7 +823,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => api_vm_url(nil, vm_openstack))
+      expect_single_action_result(:success => true, :message => /Shelving/i, :href => api_vm_url(nil, vm_openstack))
     end
 
     it "shelves a shelved vm" do
@@ -832,9 +832,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => false,
-                                  :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused",
-                                  :href    => api_vm_url(nil, vm_openstack))
+      expect_bad_request(/current state has to be powered/)
     end
 
     it "shelves a vm" do
@@ -842,7 +840,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => "shelving", :href => api_vm_url(nil, vm_openstack), :task => true)
+      expect_single_action_result(:success => true, :message => /Shelving/i, :href => api_vm_url(nil, vm_openstack), :task => true)
       expect(MiqQueue.where(:method_name => "shelve",
                             :user_id     => @user.id,
                             :group_id    => @user.current_group.id,
@@ -854,10 +852,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:shelve))
 
-      expect_single_action_result(:success => false,
-                                  :message => "Feature not available/supported",
-                                  :href    => api_vm_url(nil, vm),
-                                  :task    => false)
+      expect_bad_request(/Feature not available/)
     end
 
     it "shelves multiple vms" do
@@ -892,9 +887,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve_offload))
 
-      expect_single_action_result(:success => false,
-                                  :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack))
+      expect_bad_request(/current state has to be shelved/)
     end
 
     it "shelve_offloads a powered off vm" do
@@ -903,9 +896,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve_offload))
 
-      expect_single_action_result(:success => false,
-                                  :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack))
+      expect_bad_request(/current state has to be shelved/)
     end
 
     it "shelve_offloads a suspended vm" do
@@ -914,9 +905,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve_offload))
 
-      expect_single_action_result(:success => false,
-                                  :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack))
+      expect_bad_request(/current state has to be shelved/)
     end
 
     it "shelve_offloads a paused off vm" do
@@ -925,9 +914,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve_offload))
 
-      expect_single_action_result(:success => false,
-                                  :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack))
+      expect_bad_request(/current state has to be shelved/)
     end
 
     it "shelve_offloads a shelve_offloaded vm" do
@@ -936,9 +923,7 @@ describe "Vms API" do
 
       post(vm_openstack_url, :params => gen_request(:shelve_offload))
 
-      expect_single_action_result(:success => false,
-                                  :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => api_vm_url(nil, vm_openstack))
+      expect_bad_request(/current state has to be shelved/)
     end
 
     it "shelve_offloads a shelved vm" do
@@ -948,7 +933,7 @@ describe "Vms API" do
       post(vm_openstack_url, :params => gen_request(:shelve_offload))
 
       expect_single_action_result(:success => true,
-                                  :message => "shelve-offloading",
+                                  :message => /Shelve-offloading/i,
                                   :href    => api_vm_url(nil, vm_openstack))
       expect(MiqQueue.where(:method_name => "shelve_offload",
                             :user_id     => @user.id,
@@ -961,10 +946,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:shelve_offload))
 
-      expect_single_action_result(:success => false,
-                                  :message => "Feature not available/supported",
-                                  :href    => api_vm_url(nil, vm),
-                                  :task    => false)
+      expect_bad_request(/Feature not available/)
     end
 
     it "shelve_offloads multiple vms" do
@@ -1275,7 +1257,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:scan))
 
-      expect_single_action_result(:success => true, :message => "scanning", :href => api_vm_url(nil, vm), :task => true)
+      expect_single_action_result(:success => true, :message => /Scanning/i, :href => api_vm_url(nil, vm), :task => true)
     end
 
     it "scan multiple Vms" do
@@ -1367,7 +1349,7 @@ describe "Vms API" do
 
         post(vm_url, :params => gen_request(:retire))
 
-        expect_single_action_result(:success => true, :message => /#{vm.id}.* request retire/i, :href => api_vm_url(nil, vm))
+        expect_single_action_result(:success => true, :message => /Retiring.*#{vm.id}/i, :href => api_vm_url(nil, vm))
       end
 
       it "to multiple Vms" do
@@ -1375,29 +1357,8 @@ describe "Vms API" do
 
         post(api_vms_url, :params => gen_request(:retire, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-        vm1_task = MiqTask.find_by(:name => "VM id:#{vm1.id} name:'#{vm1.name}' request retire")
-        vm2_task = MiqTask.find_by(:name => "VM id:#{vm2.id} name:'#{vm2.name}' request retire")
-
-        expected = {
-          "results" => a_collection_containing_exactly(
-            {
-              "message"   => a_string_matching(/#{vm1.id}.* request retire/i),
-              "task_id"   => vm1_task.id.to_s,
-              "task_href" => api_task_url(nil, vm1_task),
-              "success"   => true,
-              "href"      => api_vm_url(nil, vm1)
-            },
-            {
-              "message"   => a_string_matching(/#{vm2.id}.* request retire/ii),
-              "task_id"   => vm2_task.id.to_s,
-              "task_href" => api_task_url(nil, vm2_task),
-              "success"   => true,
-              "href"      => api_vm_url(nil, vm2)
-            }
-          )
-        }
-        expect(response.parsed_body).to include(expected)
-        expect(response).to have_http_status(:ok)
+        expect_multiple_action_result(2, :success => true, :message => /Retiring/, :task_id => true)
+        expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
       end
 
       it "in the future" do
@@ -1405,7 +1366,7 @@ describe "Vms API" do
         date = 2.weeks.from_now
         post(vm_url, :params => gen_request(:retire, :date => date.iso8601))
 
-        expect_single_action_result(:success => true, :message => /#{vm.id}.* request retire/i, :href => api_vm_url(nil, vm))
+        expect_single_action_result(:success => true, :message => /Retiring.*#{vm.id}/i, :href => api_vm_url(nil, vm))
       end
     end
 
@@ -1413,23 +1374,15 @@ describe "Vms API" do
       context "valid" do
         it "to a single Vm" do
           api_basic_authorize(action_identifier(:vms, :request_retire))
-          message = "VM id:#{vm.id} name:'#{vm.name}' request retire"
-          task_id = MiqTask.find_by(:name => message)&.id
+          message = "name like 'Retiring%#{vm.id}%#{vm.name}%'"
+          task_id = MiqTask.find_by(message)&.id
           expect(task_id).to be_nil
 
           post(vm_url, :params => gen_request(:request_retire))
 
-          task = MiqTask.find_by(:name => message)
-          expected = {
-            "success"   => true,
-            "message"   => "VM id:#{vm.id} name:'#{vm.name}' request retire",
-            "task_id"   => task.id.to_s,
-            "task_href" => api_task_url(nil, task),
-            "href"      => api_vm_url(nil, vm)
-          }
-
-          expect(response).to have_http_status(:ok)
-          expect(response.parsed_body).to include(expected)
+          task = MiqTask.find_by(message)
+          expect_single_action_result(:success => true, :message => /Retiring/, :href => api_vm_url(nil, vm), :task_id => task&.id)
+          expect(task).not_to be_nil
         end
 
         it "in the future" do
@@ -1437,20 +1390,19 @@ describe "Vms API" do
           date = 2.weeks.from_now
           post(vm_url, :params => gen_request(:request_retire, :date => date.iso8601))
 
-          expect_single_action_result(:success => true, :message => /#{vm.id}.* request retire/i, :href => api_vm_url(nil, vm))
+          expect_single_action_result(:success => true, :message => /Retiring.*#{vm.id}/i, :href => api_vm_url(nil, vm))
         end
 
         it "queues retirement task" do
           api_basic_authorize(action_identifier(:vms, :request_retire))
-          message = "VM id:#{vm.id} name:'#{vm.name}' request retire"
-          task_id = MiqTask.find_by(:name => message)&.id
+          message = "name like 'Retiring%#{vm.id}%#{vm.name}%'"
+          task_id = MiqTask.find_by(message)&.id
           expect(task_id).to be_nil
           expect(MiqRequest.count).to eq(0)
 
           post(vm_url, :params => gen_request(:request_retire))
 
-          task = MiqTask.find_by(:name => message)
-
+          task = MiqTask.find_by(message)
           MiqTask.find(task.id).miq_queue.deliver
 
           expect(MiqQueue.count).to eq(1)
@@ -1458,39 +1410,11 @@ describe "Vms API" do
 
         it "to multiple Vms" do
           api_basic_authorize(collection_action_identifier(:vms, :request_retire))
-          message_vm1 = "VM id:#{vm1.id} name:'#{vm1.name}' request retire"
-          task_id_vm1 = MiqTask.find_by(:name => message_vm1)&.id
-          expect(task_id_vm1).to be_nil
-
-          message_vm2 = "VM id:#{vm2.id} name:'#{vm2.name}' request retire"
-          task_id_vm2 = MiqTask.find_by(:name => message_vm2)&.id
-          expect(task_id_vm2).to be_nil
 
           post(api_vms_url, :params => gen_request(:request_retire, [{"href" => vm1_url}, {"href" => vm2_url}]))
-          task_vm1 = MiqTask.find_by(:name => message_vm1)
-          task_vm2 = MiqTask.find_by(:name => message_vm2)
 
-          expected = {
-            "results" => [
-              {
-                "success"   => true,
-                "message"   => a_string_matching(/#{vm1.id}.* request retire/i),
-                "task_id"   => task_vm1.id.to_s,
-                "task_href" => api_task_url(nil, task_vm1),
-                "href"      => api_vm_url(nil, vm1)
-              },
-              {
-                "success"   => true,
-                "message"   => message_vm2,
-                "task_id"   => task_vm2.id.to_s,
-                "task_href" => api_task_url(nil, task_vm2),
-                "href"      => api_vm_url(nil, vm2)
-              }
-            ]
-          }
-
-          expect(response).to have_http_status(:ok)
-          expect(response.parsed_body).to include(expected)
+          expect_multiple_action_result(2, :success => true, :message => /Retiring/, :task_id => true)
+          expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
         end
       end
 
@@ -1536,7 +1460,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:reset))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* resetting/i, :href => api_vm_url(nil, vm))
+      expect_single_action_result(:success => true, :message => /Resetting.*#{vm.id}/i, :href => api_vm_url(nil, vm), :task_id => true)
     end
 
     it "to multiple Vms" do
@@ -1544,22 +1468,8 @@ describe "Vms API" do
 
       post(api_vms_url, :params => gen_request(:reset, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expected = {
-        "results" => a_collection_containing_exactly(
-          a_hash_including(
-            "message" => a_string_matching(/#{vm1.id}.* resetting/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm1)
-          ),
-          a_hash_including(
-            "message" => a_string_matching(/#{vm2.id}.* resetting/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm2)
-          )
-        )
-      }
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(2, :success => true, :message => /Resetting/)
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -1585,7 +1495,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:shutdown_guest))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* shutting down/i, :href => api_vm_url(nil, vm))
+      expect_single_action_result(:success => true, :message => /Shutting Down/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple Vms" do
@@ -1593,22 +1503,8 @@ describe "Vms API" do
 
       post(api_vms_url, :params => gen_request(:shutdown_guest, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expected = {
-        "results" => a_collection_containing_exactly(
-          a_hash_including(
-            "message" => a_string_matching(/#{vm1.id}.* shutting down/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm1)
-          ),
-          a_hash_including(
-            "message" => a_string_matching(/#{vm2.id}.* shutting down/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm2)
-          )
-        )
-      }
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(2, :success => true, :message => /Shutting Down/)
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -1642,22 +1538,8 @@ describe "Vms API" do
 
       post(api_vms_url, :params => gen_request(:refresh, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expected = {
-        "results" => a_collection_containing_exactly(
-          a_hash_including(
-            "message" => a_string_matching(/Refreshing Vm.*#{vm1.id}/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm1)
-          ),
-          a_hash_including(
-            "message" => a_string_matching(/Refreshing Vm.*#{vm2.id}/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm2)
-          )
-        )
-      }
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(2, :success => true, :message => /Refreshing/)
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -1683,7 +1565,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* rebooting/i, :href => api_vm_url(nil, vm))
+      expect_single_action_result(:success => true, :message => /Rebooting.*#{vm.id}/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple Vms" do
@@ -1691,22 +1573,8 @@ describe "Vms API" do
 
       post(api_vms_url, :params => gen_request(:reboot_guest, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expected = {
-        "results" => a_collection_containing_exactly(
-          a_hash_including(
-            "message" => a_string_matching(/#{vm1.id}.* rebooting/i,),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm1)
-          ),
-          a_hash_including(
-            "message" => a_string_matching(/#{vm2.id}.* rebooting/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm2)
-          )
-        )
-      }
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(2, :success => true, :message => /Rebooting/)
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -1740,7 +1608,7 @@ describe "Vms API" do
 
       post(vm_url, :params => gen_request(:rename, "new_name" => "new_vm"))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* renaming to new_vm/i, :href => api_vm_url(nil, vm))
+      expect_single_action_result(:success => true, :message => /Renaming/i, :href => api_vm_url(nil, vm))
     end
 
     it "to multiple vms" do
@@ -1748,23 +1616,8 @@ describe "Vms API" do
 
       post(api_vms_url, :params => gen_request(:rename, [{"href" => vm1_url, "new_name" => "new_1"}, {"href" => vm2_url, "new_name" => "new_2"}]))
 
-      expected = {
-        "results" => a_collection_containing_exactly(
-          a_hash_including(
-            "message" => a_string_matching(/#{vm1.id}.* renaming to new_1/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm1)
-          ),
-          a_hash_including(
-            "message" => a_string_matching(/#{vm2.id}.* renaming to new_2/i),
-            "success" => true,
-            "href"    => api_vm_url(nil, vm2)
-          )
-        )
-      }
-
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(2, :success => true, :message => /Renaming/i)
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
     end
   end
 
@@ -1793,7 +1646,7 @@ describe "Vms API" do
 
       post(api_vm_url(nil, vm), :params => gen_request(:request_console))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* requesting console/i, :href => api_vm_url(nil, vm))
+      expect_single_action_result(:success => true, :message => /Requesting Console.*#{vm.id}/i, :href => api_vm_url(nil, vm))
     end
   end
 


### PR DESCRIPTION
Blocked by / built on top of:
- [x] https://github.com/ManageIQ/manageiq-api/pull/1103 (first 2 commits)

### Overview

We have a pattern for actions that request the ems to perform an operation.
So I converted all `queue_object_action` calls over to `enqueue_ems_action`

Suggest reviewing by commit (unsure if commits will show in proper order but they are contained)

### Before
- `enqueue_action` mostly works for ems operations
- some ems operations get a user and others do not

### After
- fixed queue messaging when auto deriving a description.
- `enqueue_action` is generic and `enqueue_ems_action` is ems specific.
- user is now sent to all ems operations.
- introduced `:supports` parameter to easily enforce `supports?`.
- everything has been converted across except for subcollections and generic objects.
 

### Review

Only the first 2 commits do anything, and are minor changes at that.
The subsequent commits just leverage `enqueue_ems_action` (and delete code)

---

### Code effect

```diff
 class CloudTemplatesController < BaseController
   def check_compliance_resource(type, id, _data = nil)
-    api_action(type, id) do |klass|
-      container_image = resource_search(id, type, klass)
-      api_log_info("Checking compliance of #{container_image_ident(container_image)}")
-      request_compliance_check(container_image)
-   end
+   enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
  end
-
-  private
-
-  def cloud_template_ident(cloud_template)
-    "CloudTemplate id:#{cloud_template.id} name:'#{cloud_template.name}'"
-  end
-
-  def request_compliance_check(cloud_template)
-    desc = "#{cloud_template_ident(cloud_template)} check compliance requested"
-    raise BadRequestError, "Checking Compliance for #{cloud_template_ident(cloud_template)}: #{model.unsupported_reason(:check_compliance)}" unless model.supports?(:check_compliance)
-
-    task_id = queue_object_action(cloud_template, desc, :method_name => "check_compliance")
-    action_result(true, desc, :task_id => task_id)
-  rescue StandardError => err
-    action_result(false, err.to_s)
-  end
 end
```

Of course, not all are as compact as this, but this is a common and best case scenario.

