### PR TITLE
Use standard create/update/delete for supports? checks

### DIFF
--- a/app/controllers/api/auth_key_pairs_controller.rb
+++ b/app/controllers/api/auth_key_pairs_controller.rb
@@ -4,8 +4,7 @@ module Api
       ext_management_system = ExtManagementSystem.find(data['ems_id'])
 
       klass = ManageIQ::Providers::CloudManager::AuthKeyPair.class_by_ems(ext_management_system)
-
-      raise ext_management_system.unsupported_reason(:auth_key_pair_create) unless ext_management_system.supports?(:auth_key_pair_create)
+      raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
 
       task_id = klass.create_key_pair_queue(session[:userid], ext_management_system, data)
       action_result(true, "Creating Cloud Key Pair #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -6,8 +6,7 @@ module Api
       ext_management_system = ExtManagementSystem.find(data['ems_id'])
 
       klass = CloudVolume.class_by_ems(ext_management_system)
-
-      raise BadRequestError, ext_management_system.unsupported_reason(:cloud_volume_create) unless ext_management_system.supports?(:cloud_volume_create)
+      raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
 
       task_id = klass.create_volume_queue(session[:userid], ext_management_system, data)
       action_result(true, "Creating Cloud Volume #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)


### PR DESCRIPTION
Rather than using "special" supports feature names we should prefer standard create/update/delete where possible

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/754
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/727
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/303
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/7954
- [ ] https://github.com/ManageIQ/manageiq/pull/21550