### PR TITLE
Add errors hrefs back into responses

### DIFF
--- a/app/controllers/api/base_controller/action.rb
+++ b/app/controllers/api/base_controller/action.rb
@@ -26,7 +26,11 @@ module Api
           api_log_info("#{action_phrase} #{type.to_s.titleize} id: #{id}")
           resource = resource_search(id, type, klass)
           result_options = yield(resource)
-          action_result(true, "#{action_phrase} #{model_ident(resource, type)}", result_options)
+          if result_options.key?(:success) # full action hash (finer grained messaging)
+            result_options
+          else # result_options is action_hash (preferred)
+            action_result(true, "#{action_phrase} #{model_ident(resource, type)}", result_options)
+          end
         rescue ActiveRecord::RecordNotFound, ForbiddenError, BadRequestError, NotFoundError => err
           single_resource? ? raise : action_result(false, err.to_s)
         rescue => err

--- a/app/controllers/api/base_controller/action.rb
+++ b/app/controllers/api/base_controller/action.rb
@@ -3,12 +3,12 @@ module Api
     module Action
       private
 
-      def api_action(type, id, options = {})
+      def api_action(type, id)
         klass = collection_class(type)
 
-        result = yield(klass) if block_given?
+        result = yield(klass)
 
-        add_href_to_result(result, type, id) unless options[:skip_href]
+        add_href_to_result(result, type, id) unless result[:href]
         log_result(result)
         result
       end
@@ -19,21 +19,19 @@ module Api
       # - constructs action_result for successes and failures
       # - throws errors for single resources and use results for multiple resoruces
       def api_resource(type, id, action_phrase)
-        id ||= @req.collection_id
-        klass = collection_class(type)
-        raise BadRequestError, "#{action_phrase} #{type.to_s.titleize} requires an id" unless id
+        api_action(type, id) do |klass|
+          id ||= @req.collection_id
+          raise BadRequestError, "#{action_phrase} #{type.to_s.titleize} requires an id" unless id
 
-        api_log_info("#{action_phrase} #{type.to_s.titleize} id: #{id}")
-        resource = resource_search(id, type, klass)
-        result_options = yield(resource)
-        result = action_result(true, "#{action_phrase} #{model_ident(resource, type)}", result_options)
-        add_href_to_result(result, type, id)
-        log_result(result)
-        result
-      rescue ActiveRecord::RecordNotFound, ForbiddenError, BadRequestError, NotFoundError => err
-        single_resource? ? raise : action_result(false, err.to_s)
-      rescue => err
-        action_result(false, err.to_s)
+          api_log_info("#{action_phrase} #{type.to_s.titleize} id: #{id}")
+          resource = resource_search(id, type, klass)
+          result_options = yield(resource)
+          action_result(true, "#{action_phrase} #{model_ident(resource, type)}", result_options)
+        rescue ActiveRecord::RecordNotFound, ForbiddenError, BadRequestError, NotFoundError => err
+          single_resource? ? raise : action_result(false, err.to_s)
+        rescue => err
+          action_result(false, err.to_s)
+        end
       end
 
       # Enqueue an action to be performed.

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -195,30 +195,24 @@ module Api
           return invoke_custom_action_with_dialog(type, resource, action, data, custom_button)
         end
 
-        result = begin
-                   custom_button.invoke(resource)
-                   action_result(true, "Invoked custom action #{action} for #{type} id: #{resource.id}")
-                 rescue => err
-                   action_result(false, err.to_s)
-                 end
-        add_href_to_result(result, type, resource.id)
-        log_result(result)
-        result
+        api_action(type, resource.id) do
+          custom_button.invoke(resource)
+          action_result(true, "Invoked custom action #{action} for #{type} id: #{resource.id}")
+        rescue => err
+          action_result(false, err.to_s)
+        end
       end
 
       def invoke_custom_action_with_dialog(type, resource, action, data, custom_button)
-        result = begin
-                   custom_button.publish_event(nil, resource)
-                   wf_result = submit_custom_action_dialog(resource, custom_button, data)
-                   action_result(true,
-                                 "Invoked custom dialog action #{action} for #{type} id: #{resource.id}",
-                                 :result => wf_result[:request], :task_id => wf_result[:task_id])
-                 rescue => err
-                   action_result(false, err.to_s)
-                 end
-        add_href_to_result(result, type, resource.id)
-        log_result(result)
-        result
+        api_action(type, resource.id) do
+          custom_button.publish_event(nil, resource)
+          wf_result = submit_custom_action_dialog(resource, custom_button, data)
+          action_result(true,
+                        "Invoked custom dialog action #{action} for #{type} id: #{resource.id}",
+                        :result => wf_result[:request], :task_id => wf_result[:task_id])
+        rescue => err
+          action_result(false, err.to_s)
+        end
       end
 
       def submit_custom_action_dialog(resource, custom_button, data)

--- a/app/controllers/api/generic_objects_controller.rb
+++ b/app/controllers/api/generic_objects_controller.rb
@@ -29,17 +29,16 @@ module Api
 
     def invoke_custom_action(type, resource, action, data)
       return super(type, resource.reload, action, data) if resource_custom_action_button(resource, action)
-      result = begin
-                 description = method_description(resource, action)
-                 task_id = queue_object_action(resource, description, queue_args(action, data))
-                 action_result(true, description, :task_id => task_id)
-               rescue => err
-                 action_result(false, err.to_s)
-               end
-      add_href_to_result(result, type, resource.id)
-      log_result(result)
-      result
+
+      api_action(type, resource.id) do
+        description = method_description(resource, action)
+        task_id = queue_object_action(resource, description, queue_args(action, data))
+        action_result(true, description, :task_id => task_id)
+      rescue => err
+        action_result(false, err.to_s)
+      end
     end
+
     def method_description(resource, action)
       "Invoked method #{resource.generic_object_definition.name}##{action} for Generic Object id: #{resource.id} name: #{resource.name}"
     end

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -215,15 +215,12 @@ module Api
     end
 
     def invoke_reconfigure_dialog(type, svc, data = {})
-      result = begin
-                 wf_result = submit_reconfigure_dialog(svc, data)
-                 action_result(true, "#{service_ident(svc)} reconfiguring", :result => wf_result[:request])
-               rescue => err
-                 action_result(false, err.to_s)
-               end
-      add_href_to_result(result, type, svc.id)
-      log_result(result)
-      result
+      api_action(type, svc.id) do
+        wf_result = submit_reconfigure_dialog(svc, data)
+        action_result(true, "#{service_ident(svc)} reconfiguring", :result => wf_result[:request])
+      rescue => err
+        action_result(false, err.to_s)
+      end
     end
 
     def submit_reconfigure_dialog(svc, data)


### PR DESCRIPTION
  https://github.com/ManageIQ/manageiq-api/pull/1097

This feels separate enough that I wanted to pull out into its own PR.

### before before:

- many api errors had href in the responses. 

### before:

- more api errors had no href in the responses. (many that were transitioned to `api_resource` lost this).
- `api_resource` helper method forced the response message to be determined before looking up the resource. Turned out to not be flexible enough.

### after:

- api errors (all `api_resource` methods) have href in the responses.
- api messages can be customized with `api_resource` by optionally returning a result hash instead of just the result hash options.
-  converted a few other methods from awkward href code to use `api_result`.