### PR TITLE
resource_search derive klass

### DIFF
--- a/app/controllers/api/alert_definition_profiles_controller.rb
+++ b/app/controllers/api/alert_definition_profiles_controller.rb
@@ -24,14 +24,14 @@ module Api
     end
 
     def assign_resource(type, id, data)
-      profile = resource_search(id, type, collection_class(type))
+      profile = resource_search(id, type)
       data['resources'].each do |resource|
         raise 'Must specify resource href' unless resource.key?('href')
         href = Href.new(resource['href'])
         if resource.key?('tag')
           profile.assign_to_tags([fetch_tag_classification_resource(resource['tag'])], href.subject)
         else
-          assignable_resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
+          assignable_resource = resource_search(href.subject_id, href.subject)
           profile.assign_to_objects([assignable_resource])
         end
       end
@@ -41,14 +41,14 @@ module Api
     end
 
     def unassign_resource(type, id, data)
-      profile = resource_search(id, type, collection_class(type))
+      profile = resource_search(id, type)
       data['resources'].each do |resource|
         raise 'Must specify resource href' unless resource.key?('href')
         href = Href.new(resource['href'])
         if resource.key?('tag')
           profile.unassign_tags([fetch_tag_classification_resource(resource['tag'])], href.subject)
         else
-          assignable_resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
+          assignable_resource = resource_search(href.subject_id, href.subject)
           profile.unassign_objects([assignable_resource])
         end
       end

--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -49,7 +49,7 @@ module Api
       attrs = data.dup.except('manager_resource')
       href = Href.new(data['manager_resource']['href'])
       raise 'invalid manager_resource href specified' unless href.subject && href.subject_id
-      manager_resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
+      manager_resource = resource_search(href.subject_id, href.subject)
       [manager_resource, attrs]
     end
   end

--- a/app/controllers/api/automate_domains_controller.rb
+++ b/app/controllers/api/automate_domains_controller.rb
@@ -67,7 +67,7 @@ module Api
       "Automate Domain id:#{domain.id} name:'#{domain.name}'"
     end
 
-    def resource_search(id, type, klass)
+    def resource_search(id, type, klass = nil)
       if id.to_s =~ /\A\d+\z/
         super
       else

--- a/app/controllers/api/automate_domains_controller.rb
+++ b/app/controllers/api/automate_domains_controller.rb
@@ -67,17 +67,9 @@ module Api
       "Automate Domain id:#{domain.id} name:'#{domain.name}'"
     end
 
-    def resource_search(id, type, klass = nil)
-      if id.to_s =~ /\A\d+\z/
-        super
-      else
-        begin
-          domain = collection_class(:automate_domains).find_by!(:name => id)
-        rescue
-          raise NotFoundError, "Couldn't find #{klass} with 'name'=#{id}"
-        end
-        super(domain.id, type, klass)
-      end
+    def resource_search(id, type, klass = nil, key_id = nil)
+      key_id = "name" if id && !id.integer?
+      super
     end
 
     def current_tenant

--- a/app/controllers/api/automate_workspaces_controller.rb
+++ b/app/controllers/api/automate_workspaces_controller.rb
@@ -2,17 +2,17 @@ module Api
   class AutomateWorkspacesController < BaseController
     def edit_resource(type, id, data = {})
       raise BadRequestError, "must contain at least one attribute to edit" if data.blank?
-      obj = resource_search(id, type, collection_class(type))
+      obj = resource_search(id, type)
       obj.merge_output!(data)
     end
 
     def decrypt_resource(type, id = nil, data = nil)
-      obj = resource_search(id, type, collection_class(type))
+      obj = resource_search(id, type)
       decrypt(obj, data)
     end
 
     def encrypt_resource(type, id = nil, data = nil)
-      obj = resource_search(id, type, collection_class(type))
+      obj = resource_search(id, type)
       obj.encrypt(data['object'], data['attribute'], data['value'])
     end
 

--- a/app/controllers/api/base_controller/action.rb
+++ b/app/controllers/api/base_controller/action.rb
@@ -4,10 +4,7 @@ module Api
       private
 
       def api_action(type, id)
-        klass = collection_class(type)
-
-        result = yield(klass)
-
+        result = yield(collection_class(type))
         add_href_to_result(result, type, id) unless result[:href]
         log_result(result)
         result
@@ -19,12 +16,12 @@ module Api
       # - constructs action_result for successes and failures
       # - throws errors for single resources and use results for multiple resoruces
       def api_resource(type, id, action_phrase)
-        api_action(type, id) do |klass|
+        api_action(type, id) do
           id ||= @req.collection_id
           raise BadRequestError, "#{action_phrase} #{type.to_s.titleize} requires an id" unless id
 
           api_log_info("#{action_phrase} #{type.to_s.titleize} id: #{id}")
-          resource = resource_search(id, type, klass)
+          resource = resource_search(id, type)
           result_options = yield(resource)
           if result_options.key?(:success) # full action hash (finer grained messaging)
             result_options

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -245,9 +245,10 @@ module Api
         end
       end
 
-      def validate_id(id, type, klass)
-        return if collection_config.resource_identifier(type) != "id"
-        raise NotFoundError, "Invalid #{klass} id #{id} specified" unless id.kind_of?(Integer) || id =~ /\A\d+\z/
+      def validate_id(id, key_id, klass)
+        if id.nil? || (key_id == "id" && !id.integer?)
+          raise BadRequestError, "Invalid #{klass} #{key_id} #{id || "nil"} specified"
+        end
       end
     end
   end

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -31,7 +31,7 @@ module Api
           data_spec = data.collect { |key, val| "#{key}=#{val}" }.join(", ")
           raise NotFoundError, "Invalid #{type} resource specified - #{data_spec}"
         end
-        resource = resource_search(id, type, collection_class(type))
+        resource = resource_search(id, type)
         opts = {
           :name                  => type.to_s,
           :is_subcollection      => false,
@@ -43,8 +43,7 @@ module Api
       end
 
       def edit_resource(type, id, data)
-        klass = collection_class(type)
-        resource = resource_search(id, type, klass)
+        resource = resource_search(id, type)
         resource.update!(data.except(*ID_ATTRS))
         resource
       end
@@ -76,10 +75,9 @@ module Api
       end
 
       def retire_resource(type, id, data = nil)
-        klass = collection_class(type)
         if id
           msg = "Retiring #{type} id #{id}"
-          resource = resource_search(id, type, klass)
+          resource = resource_search(id, type)
           if data && data["date"]
             opts = {}
             opts[:date] = data["date"]
@@ -107,7 +105,7 @@ module Api
         end
 
         api_log_info("Invoking #{action} on #{type} id #{id}")
-        resource = resource_search(id, type, collection_class(type))
+        resource = resource_search(id, type)
         unless resource_custom_action_names(resource).include?(action)
           raise BadRequestError, "Unsupported Custom Action #{action} for the #{type} resource specified"
         end

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -28,7 +28,7 @@ module Api
 
       def parent_resource_obj
         type = @req.collection.to_sym
-        resource_search(@req.collection_id, type, collection_class(type))
+        resource_search(@req.collection_id, type)
       end
 
       def collection_class(type)

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -106,7 +106,7 @@ module Api
         if data
           group_id = parse_group(data)
           raise BadRequestError, "Missing Group identifier href, id or description" if group_id.nil?
-          resource_search(group_id, :groups, collection_class(:groups))
+          resource_search(group_id, :groups)
         end
       end
 
@@ -114,7 +114,7 @@ module Api
         if data
           role_id = parse_role(data)
           raise BadRequestError, "Missing Role identifier href, id or name" if role_id.nil?
-          resource_search(role_id, :roles, collection_class(:roles))
+          resource_search(role_id, :roles)
         end
       end
 
@@ -122,7 +122,7 @@ module Api
         if data
           tenant_id = parse_tenant(data)
           raise BadRequestError, "Missing Tenant identifier href or id" if tenant_id.nil?
-          resource_search(tenant_id, :tenants, collection_class(:tenants))
+          resource_search(tenant_id, :tenants)
         end
       end
 

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -125,7 +125,8 @@ module Api
 
       private
 
-      def resource_search(id, type, klass)
+      def resource_search(id, type, klass = nil)
+        klass  ||= collection_class(type)
         validate_id(id, type, klass)
         key_id = collection_config.resource_identifier(type)
         target =
@@ -550,9 +551,7 @@ module Api
 
       def render_update_resource_options(id)
         type = @req.collection.to_sym
-        klass = collection_class(type)
-
-        resource = resource_search(id, type, klass)
+        resource = resource_search(id, type)
         raise BadRequestError, resource.unsupported_reason(:update) unless resource.supports?(:update)
 
         render_options(type, :form_schema => resource.params_for_update)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -125,10 +125,10 @@ module Api
 
       private
 
-      def resource_search(id, type, klass = nil)
+      def resource_search(id, type, klass = nil, key_id = nil)
         klass  ||= collection_class(type)
-        validate_id(id, type, klass)
-        key_id = collection_config.resource_identifier(type)
+        key_id ||= collection_config.resource_identifier(type)
+        validate_id(id, key_id, klass)
         target =
           if respond_to?("find_#{type}")
             public_send("find_#{type}", id)

--- a/app/controllers/api/cloud_templates_controller.rb
+++ b/app/controllers/api/cloud_templates_controller.rb
@@ -13,8 +13,8 @@ module Api
       raise BadRequestError, "Parameter 'data' has to contain non-empty values for the keys '#{params.join(", ")}', received: '#{data.to_json}'" if data.values_at(*params).any?(&:blank?)
       raise BadRequestError, "Source and destination provider identifiers must differ" if data['dst_provider_id'] == data['src_provider_id']
 
-      ems_dst   = resource_search(data['dst_provider_id'], :providers, collection_class(:providers))
-      ems_src   = resource_search(data['src_provider_id'], :providers, collection_class(:providers))
+      ems_dst   = resource_search(data['dst_provider_id'], :providers)
+      ems_src   = resource_search(data['src_provider_id'], :providers)
       src_image = resource_search(data['src_image_id'],    :providers, collection_class(:templates))
 
       raise BadRequestError, "Source image specified by the id '#{data['src_image_id']}' does not belong to the source provider with id '#{ems_src.id}'" if src_image.ems_id != ems_src.id

--- a/app/controllers/api/cloud_tenants_controller.rb
+++ b/app/controllers/api/cloud_tenants_controller.rb
@@ -4,7 +4,7 @@ module Api
     include Subcollections::Tags
 
     def create_resource(_type, _id, data = {})
-      ext_management_system = resource_search(data['ems_id'], :providers, collection_class(:providers))
+      ext_management_system = resource_search(data['ems_id'], :providers)
       data.delete('ems_id')
 
       task_id = CloudTenant.create_cloud_tenant_queue(session[:userid], ext_management_system, data)

--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -20,7 +20,7 @@ module Api
       validate_attrs(data)
       manager_id = parse_id(data['manager_resource'], :providers)
       raise 'Must specify a valid manager_resource href or id' unless manager_id
-      manager = resource_search(manager_id, :providers, collection_class(:providers))
+      manager = resource_search(manager_id, :providers)
 
       type = "#{manager.type}::ConfigurationScriptSource"
       klass = ConfigurationScriptSource.descendant_get(type)

--- a/app/controllers/api/custom_buttons_controller.rb
+++ b/app/controllers/api/custom_buttons_controller.rb
@@ -57,7 +57,7 @@ module Api
     end
 
     def fetch_custom_button(type, id)
-      resource_search(id, type, collection_class(type))
+      resource_search(id, type)
     end
   end
 end

--- a/app/controllers/api/firmware_registries_controller.rb
+++ b/app/controllers/api/firmware_registries_controller.rb
@@ -6,7 +6,7 @@ module Api
     end
 
     def sync_fw_binaries_resource(type, id, _data)
-      resource_search(id, type, collection_class(type)).sync_fw_binaries_queue
+      resource_search(id, type).sync_fw_binaries_queue
       action_result(true, "FirmwareBinary [id: #{id}] synced")
     rescue => err
       action_result(false, err.to_s)

--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -28,7 +28,7 @@ module Api
     # @returns model (not action result hash)
     def delete_resource(type, id, data = {})
       id ||= data['name']
-      model = resource_search(id, type, collection_class(type))
+      model = resource_search(id, type)
       delete_resource_main_action(type, model, data)
       model
     rescue => err
@@ -127,7 +127,8 @@ module Api
     def add_picture_resource(data)
       return nil if data.empty?
       id = parse_id(data, :pictures)
-      return resource_search(id, :pictures, collection_class(:pictures)) if id
+      return resource_search(id, :pictures) if id
+
       Picture.create_from_base64(data)
     end
 
@@ -140,7 +141,7 @@ module Api
       resource_search(id, type, collection_class(type))
     end
 
-    def resource_search(id, type, klass)
+    def resource_search(id, type, klass = nil)
       if id.to_s =~ /\A\d+\z/
         super
       else

--- a/app/controllers/api/generic_object_definitions_controller.rb
+++ b/app/controllers/api/generic_object_definitions_controller.rb
@@ -27,8 +27,7 @@ module Api
     # TODO: convert callers to accept an action hash
     # @returns model (not action result hash)
     def delete_resource(type, id, data = {})
-      id ||= data['name']
-      model = resource_search(id, type)
+      model = fetch_generic_object_definition(type, id, data)
       delete_resource_main_action(type, model, data)
       model
     rescue => err
@@ -137,17 +136,12 @@ module Api
     end
 
     def fetch_generic_object_definition(type, id, data)
-      id ||= data['name']
-      resource_search(id, type, collection_class(type))
+      resource_search(id || data['name'], type, nil, id ? nil : "name")
     end
 
-    def resource_search(id, type, klass = nil)
-      if id.to_s =~ /\A\d+\z/
-        super
-      else
-        go_def = klass.find_by!(:name => id)
-        filter_resource(go_def, type, klass)
-      end
+    def resource_search(id, type, klass = nil, key_id = nil)
+      key_id = "name" if id && !id.integer?
+      super
     end
   end
 end

--- a/app/controllers/api/generic_objects_controller.rb
+++ b/app/controllers/api/generic_objects_controller.rb
@@ -16,7 +16,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      resource_search(id, type, collection_class(type)).tap do |generic_object|
+      resource_search(id, type).tap do |generic_object|
         generic_object.update!(data.except(*ADDITIONAL_ATTRS))
         add_associations(generic_object, data, generic_object.generic_object_definition) if data.key?('associations')
         generic_object.save!
@@ -45,7 +45,7 @@ module Api
 
     def retrieve_generic_object_definition(data)
       definition_id = parse_id(data['generic_object_definition'], :generic_object_definitions)
-      resource_search(definition_id, :generic_object_definitions, collection_class(:generic_object_definitions))
+      resource_search(definition_id, :generic_object_definitions)
     end
 
     def queue_args(action, data)

--- a/app/controllers/api/host_aggregates_controller.rb
+++ b/app/controllers/api/host_aggregates_controller.rb
@@ -3,7 +3,7 @@ module Api
     include Subcollections::Tags
 
     def create_resource(_type, _id, data = {})
-      ext_management_system = resource_search(data.delete('ems_id'), :providers, collection_class(:providers))
+      ext_management_system = resource_search(data.delete('ems_id'), :providers)
       klass = ext_management_system.class_by_ems('HostAggregate')
       raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
 

--- a/app/controllers/api/instances_controller.rb
+++ b/app/controllers/api/instances_controller.rb
@@ -129,7 +129,7 @@ module Api
       subcollection_options_method = "#{@req.subject}_subcollection_options"
       return super unless respond_to?(subcollection_options_method)
   
-      vm = resource_search(params[:c_id], @req.collection, collection_class(@req.collection))
+      vm = resource_search(params[:c_id], @req.collection)
       render_options(@req.collection.to_sym, send(subcollection_options_method, vm))
     end
 

--- a/app/controllers/api/mixins/generic_objects.rb
+++ b/app/controllers/api/mixins/generic_objects.rb
@@ -28,7 +28,7 @@ module Api
         data['associations'].each do |association, resource_refs|
           resources = resource_refs.collect do |ref|
             href = Href.new(ref['href'])
-            resource_search(href.subject_id, href.subject, collection_class(href.subject))
+            resource_search(href.subject_id, href.subject)
           end
           generic_object.send("#{association}=", resources)
         end

--- a/app/controllers/api/mixins/policy_simulation.rb
+++ b/app/controllers/api/mixins/policy_simulation.rb
@@ -20,7 +20,7 @@ module Api
       def simulate_policy_resource(type, id, data = {})
         raise BadRequestError, "Must specify an event for policy simulation" if data["event"].blank?
 
-        resource = resource_search(id, type, collection_class(type))
+        resource = resource_search(id, type)
 
         api_action(type, id) do
           api_log_info("Simulating policy for #{resource_ident(resource)}")

--- a/app/controllers/api/orchestration_templates_controller.rb
+++ b/app/controllers/api/orchestration_templates_controller.rb
@@ -11,7 +11,7 @@ module Api
     end
 
     def copy_resource(type, id, data = {})
-      resource = resource_search(id, type, collection_class(type))
+      resource = resource_search(id, type)
       resource.dup.tap do |new_resource|
         new_resource.assign_attributes(data)
         new_resource.save!

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -69,7 +69,7 @@ module Api
       type = collection_config.name_for_subclass(params['target_type'].camelize)
       raise BadRequestError, "Invalid target_type #{params['target_type']}" unless type
 
-      target = resource_search(params['target_id'], type, collection_class(type))
+      target = resource_search(params['target_id'], type)
       resource_action = resource_search(params['resource_action_id'], :resource_actions, ResourceAction)
       [target, resource_action]
     end

--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -31,8 +31,8 @@ module Api
       service_order
     end
 
-    def validate_id(id, type, klass)
-      id == USER_CART_ID || super(id, type, klass)
+    def validate_id(id, key_id, klass)
+      id == USER_CART_ID || super
     end
 
     def find_service_orders(id)

--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -16,7 +16,7 @@ module Api
     end
 
     def clear_resource(type, id, _data)
-      service_order = resource_search(id, type, collection_class(type))
+      service_order = resource_search(id, type)
       begin
         service_order.clear
       rescue => e
@@ -26,7 +26,7 @@ module Api
     end
 
     def order_resource(type, id, _data)
-      service_order = resource_search(id, type, collection_class(type))
+      service_order = resource_search(id, type)
       service_order.checkout
       service_order
     end
@@ -48,7 +48,7 @@ module Api
     end
 
     def copy_resource(type, id, data)
-      service_order = resource_search(id, type, collection_class(type))
+      service_order = resource_search(id, type)
       service_order.deep_copy(data)
     rescue => err
       raise BadRequestError, "Could not copy service order - #{err}"

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -34,7 +34,7 @@ module Api
     end
 
     def archive_resource(type, id, _data)
-      service_template = resource_search(id, type, collection_class(type))
+      service_template = resource_search(id, type)
       service_template.archive!
       action_result(true, "Archived Service Template")
     rescue => err
@@ -42,7 +42,7 @@ module Api
     end
 
     def unarchive_resource(type, id, _data)
-      service_template = resource_search(id, type, collection_class(type))
+      service_template = resource_search(id, type)
       service_template.unarchive!
       action_result(true, "Unarchived Service Template")
     rescue => err

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -26,7 +26,7 @@ module Api
 
     def add_resource_resource(type, id, data)
       raise "Must specify a service href or id to add_resource to" unless id
-      svc = resource_search(id, type, collection_class(type))
+      svc = resource_search(id, type)
 
       resource_type, resource = validate_resource(data)
       raise "Cannot assign #{resource_type} to #{service_ident(svc)}" unless resource.respond_to? :add_to_service
@@ -39,7 +39,7 @@ module Api
 
     def remove_resource_resource(type, id, data)
       raise 'Must specify a resource to remove_resource from' unless id
-      svc = resource_search(id, type, collection_class(type))
+      svc = resource_search(id, type)
 
       resource_type, resource = validate_resource(data)
 
@@ -51,7 +51,7 @@ module Api
 
     def remove_all_resources_resource(type, id, _data)
       raise "Must specify a service href or id to remove resources from" unless id
-      svc = resource_search(id, type, collection_class(type))
+      svc = resource_search(id, type)
       svc.remove_all_resources
       action_result(true, "Removed all resources from #{service_ident(svc)}")
     rescue => err
@@ -123,11 +123,11 @@ module Api
     end
 
     def add_provider_vms_resource(type, id, data)
-      service = resource_search(id, type, collection_class(type))
+      service = resource_search(id, type)
 
       provider_id = parse_id(data['provider'], :providers)
       raise 'Must specify a valid provider href or id' unless provider_id
-      provider = resource_search(provider_id, :providers, collection_class(:providers))
+      provider = resource_search(provider_id, :providers)
 
       task_id = service.add_provider_vms(provider, data['uid_ems']).miq_task_id
       action_result(true, "Adding provider vms for #{service_ident(service)}", :task_id => task_id)
@@ -152,7 +152,7 @@ module Api
       href = Href.new(resource_href)
       raise "Invalid resource href specified #{resource_href}" unless href.subject && href.subject_id
 
-      resource = resource_search(href.subject_id, href.subject, collection_class(href.subject))
+      resource = resource_search(href.subject_id, href.subject)
       [href.subject, resource]
     end
 

--- a/app/controllers/api/subcollections/alert_definitions.rb
+++ b/app/controllers/api/subcollections/alert_definitions.rb
@@ -6,7 +6,7 @@ module Api
       end
 
       def alert_definitions_assign_resource(object, type, id = nil, _data = nil)
-        alert = resource_search(id, type, collection_class(type))
+        alert = resource_search(id, type)
         object.add_member(alert)
         result = action_result(true, "Assigning alert_definition #{id} to profile #{object.id}")
         add_parent_href_to_result(result)
@@ -16,7 +16,7 @@ module Api
       end
 
       def alert_definitions_unassign_resource(object, type, id = nil, _data = nil)
-        alert   = resource_search(id, type, collection_class(type))
+        alert   = resource_search(id, type)
         success = object.remove_member(alert) > 0 rescue false
         result  = action_result(success, "Unassigning alert_definition #{id} from profile #{object.id}")
         add_parent_href_to_result(result)

--- a/app/controllers/api/subcollections/cloud_networks.rb
+++ b/app/controllers/api/subcollections/cloud_networks.rb
@@ -20,7 +20,7 @@ module Api
         raise BadRequestError, "Must specify an id for updating a #{type} resource" unless resource_id
 
         data.deep_symbolize_keys!
-        cloud_network = resource_search(resource_id, type, collection_class(type))
+        cloud_network = resource_search(resource_id, type)
         task_id = cloud_network.update_cloud_network_queue(User.current_user.userid, data)
         action_result(true, "Updating #{cloud_network.name}", :task_id => task_id)
       end

--- a/app/controllers/api/subcollections/cloud_templates.rb
+++ b/app/controllers/api/subcollections/cloud_templates.rb
@@ -23,7 +23,7 @@ module Api
       end
 
       def cloud_templates_delete_resource(_parent, type, id, _data)
-        image = resource_search(id, type, collection_class(type))
+        image = resource_search(id, type)
         task_id = image.delete_image_queue(User.current_userid)
         action_result(true, "Deleting #{image_ident(image)}", :task_id => task_id)
       rescue => err

--- a/app/controllers/api/subcollections/flavors.rb
+++ b/app/controllers/api/subcollections/flavors.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def delete_resource_flavors(_parent, type, id, _data)
-        flavor = resource_search(id, type, collection_class(type))
+        flavor = resource_search(id, type)
         task_id = flavor.delete_flavor_queue(User.current_userid)
         action_result(true, "Deleting #{flavor_ident(flavor)}", :task_id => task_id)
       rescue => err

--- a/app/controllers/api/subcollections/security_groups.rb
+++ b/app/controllers/api/subcollections/security_groups.rb
@@ -42,7 +42,7 @@ module Api
         raise BadRequestError, "Must specify an id for updating a #{type} resource" unless resource_id
 
         data.deep_symbolize_keys!
-        security_group = resource_search(resource_id, type, collection_class(type))
+        security_group = resource_search(resource_id, type)
         task_id = security_group.update_security_group_queue(User.current_user.userid, data)
         action_result(true, "Updating #{security_group.name}", :task_id => task_id)
       end

--- a/app/controllers/api/subcollections/security_policies.rb
+++ b/app/controllers/api/subcollections/security_policies.rb
@@ -20,7 +20,7 @@ module Api
         raise BadRequestError, "Must specify an id for updating a #{type} resource" unless resource_id
 
         data.deep_symbolize_keys!
-        security_policy = resource_search(resource_id, type, collection_class(type))
+        security_policy = resource_search(resource_id, type)
         task_id = security_policy.update_security_policy_queue(User.current_user.userid, data)
         action_result(true, "Updating #{security_policy.name}", :task_id => task_id)
       end

--- a/app/controllers/api/subcollections/security_policy_rules.rb
+++ b/app/controllers/api/subcollections/security_policy_rules.rb
@@ -20,7 +20,7 @@ module Api
         raise BadRequestError, "Must specify an id for updating a #{type} resource" unless resource_id
 
         data.deep_symbolize_keys!
-        security_policy_rule = resource_search(resource_id, type, collection_class(type))
+        security_policy_rule = resource_search(resource_id, type)
         task_id = security_policy_rule.update_security_policy_rule_queue(User.current_user.userid, data)
         action_result(true, "Updating #{security_policy_rule.name}", :task_id => task_id)
       end

--- a/app/controllers/api/subcollections/settings.rb
+++ b/app/controllers/api/subcollections/settings.rb
@@ -2,10 +2,7 @@ module Api
   module Subcollections
     module Settings
       def settings
-        id       = @req.collection_id
-        type     = @req.collection
-        klass    = collection_class(@req.collection)
-        resource = resource_search(id, type, klass)
+        resource = resource_search(@req.collection_id, @req.collection)
 
         case @req.method
         when :patch

--- a/app/controllers/api/subcollections/snapshots.rb
+++ b/app/controllers/api/subcollections/snapshots.rb
@@ -23,7 +23,7 @@ module Api
       end
 
       def delete_resource_snapshots(parent, type, id, _data)
-        snapshot = resource_search(id, type, collection_class(type))
+        snapshot = resource_search(id, type)
         begin
           raise parent.unsupported_reason(:remove_snapshot) unless parent.supports?(:remove_snapshot)
 
@@ -38,7 +38,7 @@ module Api
 
       def snapshots_revert_resource(parent, type, id, _data)
         raise parent.unsupported_reason(:revert_to_snapshot) unless parent.supports?(:revert_to_snapshot)
-        snapshot = resource_search(id, type, collection_class(type))
+        snapshot = resource_search(id, type)
 
         message = "Reverting to snapshot #{snapshot.name} for #{snapshot_ident(parent)}"
         task_id = queue_object_action(parent, message, :method_name => "revert_to_snapshot", :args => [id])

--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -4,7 +4,7 @@ module Api
       include Api::Mixins::Tags
 
       def assign_tags_resource(type, id, data)
-        resource = resource_search(id, type, collection_class(type))
+        resource = resource_search(id, type)
         data['tags'].collect do |tag|
           tags_assign_resource(resource, type, tag['id'], tag)
         end
@@ -13,7 +13,7 @@ module Api
       end
 
       def unassign_tags_resource(type, id, data)
-        resource = resource_search(id, type, collection_class(type))
+        resource = resource_search(id, type)
         data['tags'].collect do |tag|
           tags_unassign_resource(resource, type, tag['id'], tag)
         end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -38,7 +38,7 @@ module Api
     def edit_resource(type, id, data)
       id.to_i == User.current_user.id ? validate_self_user_data(data) : validate_user_data(data)
       parse_set_group(data)
-      parse_set_settings(data, resource_search(id, type, collection_class(type)))
+      parse_set_settings(data, resource_search(id, type))
       super
     end
 
@@ -67,8 +67,8 @@ module Api
     end
 
     def revoke_sessions_resource(type, id, _data)
-      api_action(type, id) do |klass|
-        user = target_user(id, type, klass)
+      api_action(type, id) do
+        user = target_user(id, type)
         api_log_info("Revoking all sessions of user #{user.userid}")
 
         user.revoke_sessions
@@ -80,11 +80,11 @@ module Api
 
     private
 
-    def target_user(id, type, klass)
+    def target_user(id, type)
       if id == current_user.id
         current_user
       elsif current_user.role_allows?(:identifier => 'revoke_user_sessions')
-        resource_search(id, type, klass)
+        resource_search(id, type)
       else
         raise ForbiddenError, "The user is not authorized for this task or item."
       end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -104,7 +104,7 @@ module Api
     def edit_resource(type, id, data)
       attrs = validate_edit_data(data)
       parent, children = build_parent_children(data)
-      resource_search(id, type, collection_class(type)).tap do |vm|
+      resource_search(id, type).tap do |vm|
         vm.replace_children(children)
         vm.set_parent(parent)
         vm.update!(attrs)
@@ -255,14 +255,14 @@ module Api
     end
 
     def set_miq_server_resource(type, id, data)
-      vm = resource_search(id, type, collection_class(type))
+      vm = resource_search(id, type)
 
       miq_server = if data['miq_server'].empty?
                      nil
                    else
                      miq_server_id = parse_id(data['miq_server'], :servers)
                      raise 'Must specify a valid miq_server href or id' unless miq_server_id
-                     resource_search(miq_server_id, :servers, collection_class(:servers))
+                     resource_search(miq_server_id, :servers)
                    end
 
       vm.miq_server = miq_server
@@ -308,7 +308,7 @@ module Api
       subcollection_options_method = "#{@req.subject}_subcollection_options"
       return super unless respond_to?(subcollection_options_method)
 
-      vm = resource_search(params[:c_id], @req.collection, collection_class(@req.collection))
+      vm = resource_search(params[:c_id], @req.collection)
       render_options(@req.collection.to_sym, send(subcollection_options_method, vm))
     end
 
@@ -341,7 +341,7 @@ module Api
     def fetch_relationship(href)
       href = Href.new(href)
       raise "Invalid relationship type #{href.subject}" unless RELATIONSHIP_COLLECTIONS.include?(href.subject)
-      resource_search(href.subject_id, href.subject, collection_class(href.subject))
+      resource_search(href.subject_id, href.subject)
     end
 
     def valid_custom_attrs

--- a/spec/requests/queries_spec.rb
+++ b/spec/requests/queries_spec.rb
@@ -68,7 +68,7 @@ describe "Queries API" do
 
       get vm1_url + 'garbage'
 
-      expect(response).to have_http_status(:not_found)
+      expect_bad_request(/Invalid Vm.*garbage.* specified/i)
     end
   end
 
@@ -126,7 +126,7 @@ describe "Queries API" do
       api_basic_authorize
 
       get acct1_url + 'garbage'
-      expect(response).to have_http_status(:not_found)
+      expect_bad_request(/Invalid Account.*garbage.* specified/i)
     end
   end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -745,7 +745,7 @@ RSpec.describe "users API" do
         let(:expected_result_invalid_id) do
           {
             "success" => false,
-            "message" => "Invalid User id  specified",
+            "message" => "Invalid User id nil specified",
             "href"    => "http://www.example.com/api/users/"
           }
         end

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -71,7 +71,7 @@ describe "Widgets API" do
 
         post(api_widgets_url, :params => gen_request(:generate_content, [{"href" => api_widgets_url}, {"href" => api_widgets_url}]))
 
-        expect(response).to have_http_status(:not_found)
+        expect_bad_request(/Invalid MiqWidget id nil specified/i)
       end
 
       context "generate_content for group" do


### PR DESCRIPTION
update resource_search in 2 (commits) ways:

1. Optionally pass a search key so searching by `name` instead of `id` does not need to reimplement `resource_search`.
2. Make `klass` optional for `resource_search` since it is basically just `collection_class(type)` anyway.

There are a number of `resource_search` instances that explicitly pass a different value into `collection_class` than `type`. I held off of updating these. They changes seemed to work fine but I'm trying to keep this PR as straight forward as possible.