### PR TITLE
Resource search klass

### DIFF
--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class AuthenticationsController < BaseController
     def edit_resource(type, id, data)
-      auth = resource_search(id, type, collection_class(:authentications))
+      auth = resource_search(id, type)
       raise "Update not supported for #{authentication_ident(auth)}" unless auth.respond_to?(:update_in_provider_queue)
       task_id = auth.update_in_provider_queue(data.deep_symbolize_keys)
       action_result(true, "Updating #{authentication_ident(auth)}", :task_id => task_id)

--- a/app/controllers/api/automation_requests_controller.rb
+++ b/app/controllers/api/automation_requests_controller.rb
@@ -16,7 +16,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      request = resource_search(id, type, collection_class(:automation_requests))
+      request = resource_search(id, type)
       RequestEditor.edit(request, data)
       request
     end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -84,14 +84,13 @@ module Api
     end
 
     def show
-      klass = collection_class(@req.subject)
       opts  = {
         :name                  => @req.subject,
         :is_subcollection      => @req.subcollection?,
         :expand_actions        => true,
         :expand_custom_actions => true
       }
-      render_resource(@req.subject, resource_search(@req.subject_id, @req.subject, klass), opts)
+      render_resource(@req.subject, resource_search(@req.subject_id, @req.subject), opts)
     end
 
     def update

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -561,7 +561,7 @@ module Api
         type = @req.collection.to_sym
         base_klass = collection_class(type)
 
-        ems = resource_search(ems_id, :ext_management_systems, ExtManagementSystem)
+        ems = resource_search(ems_id, :providers)
         klass = ems.class_by_ems(base_klass.name)
         raise BadRequestError, "No #{type.to_s.titleize} support for - #{ems.name}" unless klass
         raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)

--- a/app/controllers/api/cloud_subnets_controller.rb
+++ b/app/controllers/api/cloud_subnets_controller.rb
@@ -22,7 +22,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      cloud_subnet = resource_search(id, type, collection_class(:cloud_subnets))
+      cloud_subnet = resource_search(id, type)
       raise BadRequestError, "Cannot update #{cloud_subnet_ident(cloud_subnet)}: #{cloud_subnet.unsupported_reason(:update)}" unless cloud_subnet.supports?(:update)
 
       task_id = cloud_subnet.update_cloud_subnet_queue(session[:userid], data.deep_symbolize_keys)

--- a/app/controllers/api/cloud_tenants_controller.rb
+++ b/app/controllers/api/cloud_tenants_controller.rb
@@ -15,7 +15,7 @@ module Api
 
     def edit_resource(type, id, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
-      cloud_tenant = resource_search(id, type, collection_class(:cloud_tenants))
+      cloud_tenant = resource_search(id, type)
 
       task_id = cloud_tenant.update_cloud_tenant_queue(current_user.userid, data)
       action_result(true, "Updating #{cloud_tenant_ident(cloud_tenant)}", :task_id => task_id)

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -17,7 +17,7 @@ module Api
     def edit_resource(type, id, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
 
-      cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))
+      cloud_volume = resource_search(id, type)
 
       raise BadRequestError, cloud_volume.unsupported_reason(:update) unless cloud_volume.supports?(:update)
 

--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -3,7 +3,7 @@ module Api
     include Subcollections::ConfigurationScriptPayloads
 
     def edit_resource(type, id, data)
-      config_script_src = resource_search(id, type, collection_class(:configuration_script_sources))
+      config_script_src = resource_search(id, type)
       raise "Update not supported for #{config_script_src_ident(config_script_src)}" unless config_script_src.respond_to?(:update_in_provider_queue)
       task_id = config_script_src.update_in_provider_queue(data.deep_symbolize_keys)
       action_result(true, "Updating #{config_script_src_ident(config_script_src)}", :task_id => task_id)

--- a/app/controllers/api/floating_ips_controller.rb
+++ b/app/controllers/api/floating_ips_controller.rb
@@ -12,7 +12,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      floating_ip = resource_search(id, type, collection_class(:floating_ips))
+      floating_ip = resource_search(id, type)
       raise BadRequestError, "Update for #{floating_ip_ident(floating_ip)}: #{floating_ip.unsupported_reason(:update)}" unless floating_ip.supports?(:update)
 
       task_id = floating_ip.update_floating_ip_queue(session[:userid], data.deep_symbolize_keys)

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -32,7 +32,7 @@ module Api
       validate_group_data(data)
       parse_set_role(data)
       parse_set_tenant(data)
-      group = resource_search(id, type, collection_class(:groups))
+      group = resource_search(id, type)
       parse_set_filters(data, :entitlement_id => group.entitlement.try(:id))
       raise ForbiddenError, "Cannot edit a read-only group" if group.read_only
       super

--- a/app/controllers/api/host_aggregates_controller.rb
+++ b/app/controllers/api/host_aggregates_controller.rb
@@ -16,7 +16,7 @@ module Api
     def edit_resource(type, id, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
 
-      host_aggregate = resource_search(id, type, collection_class(:host_aggregates))
+      host_aggregate = resource_search(id, type)
       raise "Edit not supported for #{host_aggregate.name}" unless host_aggregate.supports?(:update)
 
       task_id = host_aggregate.update_aggregate_queue(current_user.userid, data.symbolize_keys)

--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -13,7 +13,7 @@ module Api
     def edit_resource(type, id, data = {})
       credentials = data.delete(CREDENTIALS_ATTR)
       raise BadRequestError, "Cannot update non-credentials attributes of host resource" if data.any?
-      resource_search(id, type, collection_class(:hosts)).tap do |host|
+      resource_search(id, type).tap do |host|
         all_credentials = Array.wrap(credentials).each_with_object({}) do |creds, hash|
           auth_type = creds.delete(AUTH_TYPE_ATTR) || DEFAULT_AUTH_TYPE
           creds.symbolize_keys!

--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -295,7 +295,7 @@ module Api
       end
 
       def assign_resource(_type, rate_id, data)
-        rate = resource_search(rate_id, :chargebacks, ChargebackRate)
+        rate = resource_search(rate_id, :chargebacks)
 
         parsed_assignments = parse_resource_assignments(data['assignments'], rate)
 

--- a/app/controllers/api/mixins/service_templates.rb
+++ b/app/controllers/api/mixins/service_templates.rb
@@ -2,7 +2,7 @@ module Api
   module Mixins
     module ServiceTemplates
       def order_service_template(id, data, scheduled_time = nil)
-        service_template = resource_search(id, :service_templates, ServiceTemplate)
+        service_template = resource_search(id, :service_templates)
         raise BadRequestError, "Service ordering via API is not allowed" unless api_request_allowed?
         raise BadRequestError, "#{service_template_ident(service_template)} cannot be ordered - #{service_template.unsupported_reason(:order)}" unless service_template.supports?(:order)
 

--- a/app/controllers/api/network_routers_controller.rb
+++ b/app/controllers/api/network_routers_controller.rb
@@ -14,7 +14,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      network_router = resource_search(id, type, collection_class(:network_routers))
+      network_router = resource_search(id, type)
       raise BadRequestError, "Update for #{network_router_ident(network_router)}: #{network_router.unsupported_reason(:update)}" unless network_router.supports?(:update)
 
       task_id = network_router.update_network_router_queue(User.current_userid, data.deep_symbolize_keys)

--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -15,7 +15,7 @@ module Api
     def edit_resource(type, id, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
 
-      physical_storage = resource_search(id, type, collection_class(:physical_storages))
+      physical_storage = resource_search(id, type)
 
       raise BadRequestError, physical_storage.unsupported_reason(:update) unless physical_storage.supports?(:update)
 

--- a/app/controllers/api/policies_controller.rb
+++ b/app/controllers/api/policies_controller.rb
@@ -13,7 +13,7 @@ module Api
 
     def edit_resource(type, id = nil, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
-      policy = resource_search(id, type, collection_class(:policies))
+      policy = resource_search(id, type)
       begin
         add_policies_content(data, policy) if data["policy_contents"]
         policy.conditions = Condition.where(:id => data.delete("conditions_ids")) if data["conditions_ids"]

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -52,7 +52,7 @@ module Api
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
       raise BadRequestError, "Provider type cannot be updated" if data.key?(TYPE_ATTR)
 
-      provider = resource_search(id, type, collection_class(:providers))
+      provider = resource_search(id, type)
 
       if data.delete(DDF_ATTR)
         edit_provider_ddf(provider, data)
@@ -101,6 +101,7 @@ module Api
       end
     end
 
+    # NOTE: _type == :providers
     def verify_credentials_resource(_type, id = nil, data = {})
       klass = fetch_provider_klass(collection_class(:providers), data)
       zone_name = data.delete('zone_name')

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -338,7 +338,7 @@ module Api
 
       zone_id = parse_id(data[ZONE_ATTR], :zone)
       raise BadRequestError, "Missing zone href or id" if zone_id.nil?
-      resource_search(zone_id, :zone, Zone) # Only support Rbac allowed zone
+      resource_search(zone_id, :zones) # Only support Rbac allowed zone
     end
 
     def validate_provider_class

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -82,7 +82,7 @@ module Api
 
       enqueue_ems_action(type, id, "Importing Vm to", :method_name => 'import_vm', :args => [vm_id, target_params]) do
         # check if user can access the VM
-        resource_search(vm_id, :vms, Vm)
+        resource_search(vm_id, :vms)
       end
     end
 

--- a/app/controllers/api/provision_requests_controller.rb
+++ b/app/controllers/api/provision_requests_controller.rb
@@ -21,7 +21,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      req = resource_search(id, type, collection_class(:provision_requests))
+      req = resource_search(id, type)
       RequestEditor.edit(req, data)
       req
     end

--- a/app/controllers/api/pxe_servers_controller.rb
+++ b/app/controllers/api/pxe_servers_controller.rb
@@ -38,7 +38,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      server = resource_search(id, type, collection_class(:pxe_servers))
+      server = resource_search(id, type)
       menus = data.delete('pxe_menus')
       authentication = data.delete('authentication')
       PxeServer.transaction do

--- a/app/controllers/api/rates_controller.rb
+++ b/app/controllers/api/rates_controller.rb
@@ -26,7 +26,7 @@ module Api
         resource_id = parse_id(resource_relation, collection)
         raise BadRequestError, "Missing #{type} identifier href or id" unless resource_id
 
-        resource = resource_search(resource_id, type, collection_class(collection))
+        resource = resource_search(resource_id, collection)
         data[parameter_key] = resource if resource
       end
     end

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -15,7 +15,7 @@ module Api
     end
 
     def run_resource(type, id, _data)
-      report = resource_search(id, type, MiqReport)
+      report = resource_search(id, type)
       report_result = MiqReportResult.find(report.queue_generate_table(:userid => User.current_user.userid))
       run_report_result(true,
                         "running report #{report.id}",

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -30,7 +30,7 @@ module Api
 
     def edit_resource(type, id = nil, data = {})
       raise BadRequestError, "Must specify a id for editing a #{type} resource" unless id
-      request = resource_search(id, type, collection_class(:requests))
+      request = resource_search(id, type)
       RequestEditor.edit(request, data)
       request
     end

--- a/app/controllers/api/roles_controller.rb
+++ b/app/controllers/api/roles_controller.rb
@@ -32,7 +32,7 @@ module Api
         raise BadRequestError, "Cannot set a non-system role to read-only."
       end
 
-      role = resource_search(id, type, collection_class(:roles))
+      role = resource_search(id, type)
 
       # Can't edit a read-only role
       if role.read_only

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -70,7 +70,7 @@ module Api
       raise BadRequestError, "Invalid target_type #{params['target_type']}" unless type
 
       target = resource_search(params['target_id'], type)
-      resource_action = resource_search(params['resource_action_id'], :resource_actions, ResourceAction)
+      resource_action = resource_search(params['resource_action_id'], :resource_actions)
       [target, resource_action]
     end
 

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -32,7 +32,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      service_dialog = resource_search(id, type, Dialog)
+      service_dialog = resource_search(id, type)
       begin
         $api_log.warn("Both 'dialog_tabs':[...] and 'content':{'dialog_tabs':[...]} were specified. 'content':{'dialog_tabs':[...]} will be ignored.") if data.key?('dialog_tabs') && data['content'].try(:key?, 'dialog_tabs')
         service_dialog.update_tabs(data['dialog_tabs'] || data['content']['dialog_tabs']) if data['dialog_tabs'] || data['content']
@@ -44,7 +44,7 @@ module Api
     end
 
     def copy_resource(type, id, data)
-      service_dialog = resource_search(id, type, Dialog)
+      service_dialog = resource_search(id, type)
       attributes = data.dup
       attributes['label'] = "Copy of #{service_dialog.label}" unless attributes.key?('label')
       service_dialog.deep_copy(attributes).tap(&:save!)

--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -89,7 +89,7 @@ module Api
       if service_template_id.blank?
         raise BadRequestError, "Must specify a service_template_href for adding a service_request"
       end
-      service_template = resource_search(service_template_id, :service_templates, ServiceTemplate)
+      service_template = resource_search(service_template_id, :service_templates)
       service_template.provision_workflow(User.current_user, service_request, :submit_workflow => true)
     end
 

--- a/app/controllers/api/service_requests_controller.rb
+++ b/app/controllers/api/service_requests_controller.rb
@@ -8,7 +8,7 @@ module Api
     alias fetch_service_requests_picture fetch_picture
 
     def edit_resource(type, id, data)
-      request = resource_search(id, type, collection_class(:service_requests))
+      request = resource_search(id, type)
       RequestEditor.edit(request, data)
       request
     end
@@ -33,7 +33,7 @@ module Api
     def add_approver_resource(type, id, data)
       user = get_user(data)
       miq_approval = MiqApproval.create(:approver => user)
-      resource_search(id, type, collection_class(:service_requests)).tap do |service_request|
+      resource_search(id, type).tap do |service_request|
         service_request.miq_approvals << miq_approval
       end
     rescue => err
@@ -42,7 +42,7 @@ module Api
 
     def remove_approver_resource(type, id, data)
       user = get_user(data)
-      resource_search(id, type, collection_class(:service_requests)).tap do |service_request|
+      resource_search(id, type).tap do |service_request|
         miq_approval = service_request.miq_approvals.find_by(:approver_name => user.name)
         miq_approval.destroy if miq_approval
       end

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -21,7 +21,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      catalog_item = resource_search(id, type, collection_class(:service_templates))
+      catalog_item = resource_search(id, type)
       decode_picture(data) if data["picture"]
       catalog_item.update_catalog_item(data.deep_symbolize_keys, User.current_user.userid)
     rescue => err

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -156,19 +156,19 @@ module Api
     def fetch_service(data)
       service_id = parse_id(data, :services)
       raise BadRequestError, 'Missing Service identifier id' if service_id.nil?
-      resource_search(service_id, :services, Service)
+      resource_search(service_id, :services)
     end
 
     def fetch_orchestration_template(data)
       orchestration_template_id = parse_id(data, :orchestration_templates)
       raise BadRequestError, 'Missing OrchestrationTemplate identifier id' if orchestration_template_id.nil?
-      resource_search(orchestration_template_id, :orchestration_templates, OrchestrationTemplate)
+      resource_search(orchestration_template_id, :orchestration_templates)
     end
 
     def fetch_configuration_script(data)
       configuration_script_id = parse_id(data, :configuration_script)
       raise BadRequestError, 'Missing ConfigurationScript identifier id' if configuration_script_id.nil?
-      resource_search(configuration_script_id, :configuration_scripts, ConfigurationScript)
+      resource_search(configuration_script_id, :configuration_scripts)
     end
 
     def service_ident(svc)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -150,7 +150,7 @@ module Api
     def fetch_ext_management_system(data)
       orchestration_manager_id = parse_id(data, :providers)
       raise BadRequestError, 'Missing ExtManagementSystem identifier id' if orchestration_manager_id.nil?
-      resource_search(orchestration_manager_id, :ext_management_systems, ExtManagementSystem)
+      resource_search(orchestration_manager_id, :providers)
     end
 
     def fetch_service(data)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -96,8 +96,8 @@ module Api
       action_result(false, err.to_s)
     end
 
-    def queue_chargeback_report_resource(_type, id, _data)
-      service = resource_search(id, :services, Service)
+    def queue_chargeback_report_resource(type, id, _data)
+      service = resource_search(id, type)
       task = service.queue_chargeback_report_generation(:userid => current_user.userid)
       action_result(true, "Queued chargeback report generation for #{service_ident(service)}", :task_id => task.id)
     rescue StandardError => err

--- a/app/controllers/api/subcollections/features.rb
+++ b/app/controllers/api/subcollections/features.rb
@@ -68,7 +68,7 @@ module Api
           if feature.key?('identifier') && !feature['identifier'].nil?
             resource_search_by_criteria('identifier', feature['identifier'], feature_klass)
           else # Fallback to a feature id or href field.
-            resource_search(parse_id(feature, 'features'), 'features', feature_klass)
+            resource_search(parse_id(feature, 'features'), :features)
           end
         end
         new_features.compact


### PR DESCRIPTION
### Summary

No longer passing the `klass` into `resource_search` where it is unnecessary.
(and at a latter time probably don't ever pass `klass` into `resource_search`)

### Details

Reminder, `resource_search` looks up the `klass` from the type if it is not passed in:

```ruby
def resource_search(id, type, klass = nil)
  klass ||= collection_class(type)
```

This PR no longer looks up the `klass` before calling `resource_search`:

```diff
     def edit_resource(type, id, data)
-      auth = resource_search(id, type, collection_class(type))
+      auth = resource_search(id, type)
```

### Permutations

This has one commit per permutation type:

1. Don't lookup a `klass` by the same `type` that is passed it into `resource_search`
2. Don't specify the `klass` when it correlates to a controller's `type`.
3. Use `type=:providers` when looking up an ems.
    `resource_search(id, :ext_management-systems) ==> Unknown type`
4. Use plural `type` when looking up resources.
     NOTE: `resource_search` uses `type` in the following ways:
    - lookup the `klass`: before: passing in a bad type, required passing in a `klass`. after: Passing in right `type` now finds the `klass`.
    - looking up the `id`: before: passing in a bad type failed the lookup, but defaulted to `"id"` so it mostly works. after: passing in the right `type` finds the id (yes, typically `"id"`).
    - look for a `find_#{type}`. This is rare and does not exist for `features`, `providers`, and `providers`. But the only ones that do exist use a plural `type`.
5. Don't pass a hard coded class when the `type` resolves to that same class.

### Testing

I added print statements for every line changed:
- verified that the `type` was the expected value
- verified each change had a test on it
- verified class returned from the lookup was the expected value.

I had only found 2 areas of the code that were not tested (and not changed).
The sub-collections had a strange nuance, so I did not changing that as well
