### PR TITLE
Add VM set_description action

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -4744,6 +4744,8 @@
         :identifier: vm_guest_shutdown
       - :name: reboot_guest
         :identifier: vm_guest_restart
+      - :name: set_description
+        :identifier: vm_rename
       - :name: start
         :identifier:
         - vm_start


### PR DESCRIPTION
```
POST /api/vms/:id -d {"action": "set_description", "new_description": "test"}
{
  "success": true,
  "message": "VM id:2 name:'VM_NAME' setting description to test",
  "task_id": "82",
  "task_href": "http://localhost:3000/api/tasks/82",
  "href": "http://localhost:3000/api/vms/2"
}
```

https://github.com/ManageIQ/manageiq/issues/21561