### PR TITLE
Added options call for security groups

### DIFF
--- a/app/controllers/api/security_groups_controller.rb
+++ b/app/controllers/api/security_groups_controller.rb
@@ -5,5 +5,15 @@ module Api
     def delete_resource_main_action(_type, security_group, _data = {})
       {:task_id => security_group.delete_security_group_queue(User.current_user.userid)}
     end
+
+    def options
+      if (id = params["id"])
+        render_update_resource_options(id)
+      elsif (ems_id = params["ems_id"])
+        render_create_resource_options(ems_id)
+      else
+        super
+      end
+    end
   end
 end

--- a/spec/requests/instances_spec.rb
+++ b/spec/requests/instances_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe "Instances API" do
+  include Spec::Support::SupportsHelper
   def update_raw_power_state(state, *instances)
     instances.each { |instance| instance.update!(:raw_power_state => state) }
   end
@@ -834,6 +835,27 @@ RSpec.describe "Instances API" do
         ]
       }
       expect(response.parsed_body).to include(expected)
+    end
+
+    it 'returns a DDF schema for add when available via OPTIONS' do
+      provider = FactoryBot.create(:ems_network, :zone => zone)
+      stub_supports(provider.class::SecurityGroup, :create)
+      stub_params_for(provider.class::SecurityGroup, :create, :fields => [])
+
+      options(api_security_groups_url(:ems_id => provider.id))
+
+      expect(response.parsed_body['data']).to match("form_schema" => {"fields" => []})
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns a DDF schema for edit when available via OPTIONS' do
+      stub_supports(@security_group.class, :update)
+      stub_params_for(@security_group.class, :update, :fields => [])
+
+      options(api_security_group_url(nil, @security_group))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['data']).to include("form_schema" => {"fields" => []})
     end
   end
 


### PR DESCRIPTION
Added options call for security groups to allow add and edit forms to receive the form fields from the provider repo.

Enables:
https://github.com/ManageIQ/manageiq-ui-classic/pull/7995
https://github.com/ManageIQ/manageiq-providers-openstack/pull/759