### PR TITLE
consolidate api create

### DIFF
--- a/app/controllers/api/cloud_subnets_controller.rb
+++ b/app/controllers/api/cloud_subnets_controller.rb
@@ -10,15 +10,10 @@ module Api
       end
     end
 
-    def create_resource(_type, _id = nil, data = {})
-      ems = resource_search(data['ems_id'], :providers)
-      klass = CloudSubnet.class_by_ems(ems)
-      raise BadRequestError, "Cannot create cloud subnet for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
-
-      task_id = ems.create_cloud_subnet_queue(session[:userid], data.deep_symbolize_keys)
-      action_result(true, "Creating Cloud Subnet #{data['name']} for Provider: #{ems.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+    def create_resource(type, _id = nil, data = {})
+      create_ems_resource(type, data, :supports => true) do |ems, _klass|
+        {:task_id => ems.create_cloud_subnet_queue(User.current_userid, data.deep_symbolize_keys)}
+      end
     end
 
     def edit_resource(type, id, data)

--- a/app/controllers/api/cloud_tenants_controller.rb
+++ b/app/controllers/api/cloud_tenants_controller.rb
@@ -3,14 +3,11 @@ module Api
     include Subcollections::SecurityGroups
     include Subcollections::Tags
 
-    def create_resource(_type, _id, data = {})
-      ext_management_system = resource_search(data['ems_id'], :providers)
-      data.delete('ems_id')
-
-      task_id = CloudTenant.create_cloud_tenant_queue(session[:userid], ext_management_system, data)
-      action_result(true, "Creating Cloud Tenant #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+    def create_resource(type, _id, data = {})
+      # TODO: introduce supports for CloudTenant creation
+      create_ems_resource(type, data) do |ems, klass|
+        {:task_id => klass.create_cloud_tenant_queue(User.current_userid, ems, data)}
+      end
     end
 
     def edit_resource(type, id, data = {})

--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -22,10 +22,7 @@ module Api
       # Since we are passing a custom hash to create_ems_resource (instead of data variable)
       # we need to manually remove it from data.
       data.delete('id')
-      create_ems_resource(type, {'ems_id' => manager_id, 'name' => data['name']}) do |manager, klass|
-        # TODO: introduce supports for configuration scripts create
-        raise "ConfigurationScriptSource cannot be added to #{model_ident(manager, :provider)}" unless klass.respond_to?(:create_in_provider_queue)
-
+      create_ems_resource(type, {'ems_id' => manager_id, 'name' => data['name']}, :supports => true) do |_manager, klass|
         {:task_id => klass.create_in_provider_queue(manager_id, data.deep_symbolize_keys)}
       end
     end

--- a/app/controllers/api/floating_ips_controller.rb
+++ b/app/controllers/api/floating_ips_controller.rb
@@ -1,14 +1,9 @@
 module Api
   class FloatingIpsController < BaseController
-    def create_resource(_type, _id = nil, data = {})
-      ems = resource_search(data['ems_id'], :providers)
-      klass = FloatingIp.class_by_ems(ems)
-      raise BadRequestError, "Create floating ip for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
-
-      task_id = ems.create_floating_ip_queue(session[:userid], data.deep_symbolize_keys)
-      action_result(true, "Creating Floating Ip #{data['name']} for Provider: #{ems.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+    def create_resource(type, _id = nil, data = {})
+      create_ems_resource(type, data, :supports => true) do |ems, _klass|
+        {:task_id => ems.create_floating_ip_queue(User.current_userid, data.deep_symbolize_keys)}
+      end
     end
 
     def edit_resource(type, id, data)

--- a/app/controllers/api/host_initiator_groups_controller.rb
+++ b/app/controllers/api/host_initiator_groups_controller.rb
@@ -1,17 +1,9 @@
 module Api
   class HostInitiatorGroupsController < BaseController
     def create_resource(type, _id = nil, data = {})
-      raise BadRequestError, "ems_id not defined for #{type} resource" if data['ems_id'].blank?
-
-      ext_management_system = resource_search(data['ems_id'], :providers)
-
-      klass = HostInitiatorGroup.class_by_ems(ext_management_system)
-      raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
-
-      task_id = HostInitiatorGroup.create_host_initiator_group_queue(session[:userid], ext_management_system, data)
-      action_result(true, "Creating Host Initiator Group #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+      create_ems_resource(type, data, :supports => true) do |ems, klass|
+        {:task_id => klass.create_host_initiator_group_queue(User.current_userid, ems, data)}
+      end
     end
   end
 end

--- a/app/controllers/api/host_initiators_controller.rb
+++ b/app/controllers/api/host_initiators_controller.rb
@@ -4,14 +4,10 @@ module Api
       enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
-    def create_resource(_type, _id = nil, data = {})
-      raise BadRequestError, "ems_id not defined for #{_type} resource" if data['ems_id'].blank?
-
-      ext_management_system = resource_search(data['ems_id'], :providers)
-      task_id = HostInitiator.create_host_initiator_queue(session[:userid], ext_management_system, data)
-      action_result(true, "Creating Host Initiator #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+    def create_resource(type, _id = nil, data = {})
+      create_ems_resource(type, data, :supports => true) do |ems, klass|
+        {:task_id => klass.create_host_initiator_queue(User.current_userid, ems, data)}
+      end
     end
   end
 end

--- a/app/controllers/api/network_routers_controller.rb
+++ b/app/controllers/api/network_routers_controller.rb
@@ -2,15 +2,10 @@ module Api
   class NetworkRoutersController < BaseController
     include Subcollections::Tags
 
-    def create_resource(_type, _id = nil, data = {})
-      ems = resource_search(data['ems_id'], :providers)
-      klass = NetworkRouter.class_by_ems(ems)
-      raise BadRequestError, "Create network router for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
-
-      task_id = ems.create_network_router_queue(User.current_userid, data.deep_symbolize_keys)
-      action_result(true, "Creating Network Router #{data['name']} for Provider: #{ems.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+    def create_resource(type, _id = nil, data = {})
+      create_ems_resource(type, data, :supports => true) do |ems, _klass|
+        {:task_id => ems.create_network_router_queue(User.current_userid, data.deep_symbolize_keys)}
+      end
     end
 
     def edit_resource(type, id, data)

--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -4,12 +4,11 @@ module Api
       enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
-    def create_resource(_type, _id = nil, data = {})
-      ext_management_system = resource_search(data['ems_id'], :providers)
-      task_id = PhysicalStorage.create_physical_storage_queue(session[:userid], ext_management_system, data)
-      action_result(true, "Creating Physical Storage #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+    def create_resource(type, _id = nil, data = {})
+      # TODO: introduce supports for ems specific physical storage
+      create_ems_resource(type, data) do |ems, klass|
+        {:task_id => klass.create_physical_storage_queue(User.current_userid, ems, data)}
+      end
     end
 
     def edit_resource(type, id, data = {})

--- a/app/controllers/api/volume_mappings_controller.rb
+++ b/app/controllers/api/volume_mappings_controller.rb
@@ -4,16 +4,10 @@ module Api
       enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end
 
-    def create_resource(_type, _id = nil, data = {})
-      ext_management_system = resource_search(data['ems_id'], :providers)
-
-      klass = VolumeMapping.class_by_ems(ext_management_system)
-      raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
-
-      task_id = VolumeMapping.create_volume_mapping_queue(session[:userid], ext_management_system, data)
-      action_result(true, "Creating Volume Mapping for Provider: #{ext_management_system.name}", :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+    def create_resource(type, _id = nil, data = {})
+      create_ems_resource(type, data, :supports => true) do |ems, klass|
+        {:task_id => klass.create_volume_mapping_queue(User.current_user, ems, data)}
+      end
     end
 
     def delete_resource_main_action(type, volume_mapping, _data = nil)

--- a/spec/requests/auth_key_pairs_spec.rb
+++ b/spec/requests/auth_key_pairs_spec.rb
@@ -67,20 +67,7 @@ RSpec.describe "Auth Key Pairs API" do
 
         post(api_auth_key_pairs_url, :params => {'name' => 'foo', 'ems_id' => provider.id})
 
-        expect(response).to have_http_status(:ok)
-
-        expected = {
-          "results" => [
-            a_hash_including(
-              "success"   => true,
-              "message"   => a_string_matching(/Creating Cloud Key Pair/),
-              "task_id"   => anything,
-              "task_href" => a_string_matching(api_tasks_url)
-            )
-          ]
-        }
-
-        expect(response.parsed_body).to include(expected)
+        expect_multiple_action_result(1, :success => true, :task => true, :message => /Creating Auth Key Pair/)
       end
     end
 
@@ -91,18 +78,7 @@ RSpec.describe "Auth Key Pairs API" do
 
         post(api_auth_key_pairs_url, :params => {'name' => 'foo', 'ems_id' => provider.id})
 
-        expect(response).to have_http_status(:bad_request)
-
-        expected = {
-          "results" => [
-            a_hash_including(
-              "success" => false,
-              "message" => a_string_matching('not available')
-            )
-          ]
-        }
-
-        expect(response.parsed_body).to include(expected)
+        expect_bad_request(/not.*supported/)
       end
     end
 

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'CloudSubnets API' do
 
       post(api_cloud_subnets_url, :params => request)
 
-      expect_multiple_action_result(1, :success => true, :message => "Creating Cloud Subnet test_cloud_subnet for Provider: #{ems.name}", :task => true)
+      expect_multiple_action_result(1, :success => true, :task => true, :message => /Creating Cloud Subnet test_cloud_subnet for Provider #{ems.name}/)
     end
 
     it "raises error when provider does not support creating of cloud subnets" do
@@ -128,10 +128,7 @@ RSpec.describe 'CloudSubnets API' do
       }
 
       post(api_cloud_subnets_url, :params => request)
-
-      expected = {"success" => false, "message" => a_string_including("Cannot create cloud subnet for Provider #{provider.name}")}
-      expect(response.parsed_body["results"].first).to include(expected)
-      expect(response).to have_http_status(:bad_request)
+      expect_bad_request(/Create for Cloud Subnet.*not.*supported/)
     end
   end
 

--- a/spec/requests/configuration_script_sources_spec.rb
+++ b/spec/requests/configuration_script_sources_spec.rb
@@ -302,61 +302,24 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'creates a configuration script source with appropriate role' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :create, :post)
 
-      expected = {
-        'results' => [
-          a_hash_including(
-            'success' => true,
-            'message' => a_string_including('Creating ConfigurationScriptSource'),
-            'task_id' => a_kind_of(String)
-          )
-        ]
-      }
       post(api_configuration_script_sources_url, :params => create_params)
-
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(1, :success => true, :task => true, :message => /Creating Configuration Script Source/)
     end
 
     it 'create a new configuration script source with manager_resource id' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :create, :post)
       create_params[:manager_resource] = { :id => manager.id }
 
-      expected = {
-        'results' => [
-          a_hash_including(
-            'success' => true,
-            'message' => "Creating ConfigurationScriptSource for Manager id:#{manager.id} name: '#{manager.name}'",
-            'task_id' => a_kind_of(String)
-          )
-        ]
-      }
       post(api_configuration_script_sources_url, :params => create_params)
-
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(1, :success => true, :task => true, :message => /Creating Configuration Script Source/)
     end
 
     it 'can create new configuration script sources in bulk' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :create, :post)
 
-      expected = {
-        'results' => [
-          a_hash_including(
-            'success' => true,
-            'message' => a_string_including('Creating ConfigurationScriptSource'),
-            'task_id' => a_kind_of(String)
-          ),
-          a_hash_including(
-            'success' => true,
-            'message' => a_string_including('Creating ConfigurationScriptSource'),
-            'task_id' => a_kind_of(String)
-          )
-        ]
-      }
       post(api_configuration_script_sources_url, :params => { :resources => [create_params, create_params] })
 
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
+      expect_multiple_action_result(2, :success => true, :task => true, :message => /Creating Configuration Script Source/)
     end
 
     it 'requires a manager_resource to be specified' do
@@ -364,14 +327,8 @@ RSpec.describe 'Configuration Script Sources API' do
 
       post(api_configuration_script_sources_url, :params => { :resources => [create_params.except(:manager_resource)] })
 
-      expected = {
-        'results' => [{
-          'success' => false,
-          'message' => 'Must supply a manager resource'
-        }]
-      }
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include(expected)
+      expect_multiple_action_result(1, :success => false, :message => /Must specify a Provider/)
     end
 
     it 'requires a valid manager' do
@@ -380,14 +337,7 @@ RSpec.describe 'Configuration Script Sources API' do
 
       post(api_configuration_script_sources_url, :params => { :resources => [create_params] })
 
-      expected = {
-        'results' => [{
-          'success' => false,
-          'message' => 'Must specify a valid manager_resource href or id'
-        }]
-      }
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include(expected)
+      expect_multiple_action_result(1, :success => false, :message => /Must specify a Provider/)
     end
 
     it 'forbids creation of new configuration script source without an appropriate role' do

--- a/spec/requests/floating_ips_spec.rb
+++ b/spec/requests/floating_ips_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'FloatingIp API' do
 
       post(api_floating_ips_url, :params => request)
 
-      expect_multiple_action_result(1, :success => true, :message => "Creating Floating Ip test_floating_ip for Provider: #{provider.name}", :task => true)
+      expect_multiple_action_result(1, :success => true, :message => /Creating Floating Ip test_floating_ip for Provider #{provider.name}/, :task => true)
     end
 
     it "raises error when provider does not support creating of floating ips" do
@@ -83,10 +83,7 @@ RSpec.describe 'FloatingIp API' do
       }
 
       post(api_floating_ips_url, :params => request)
-
-      expected = {"success" => false, "message" => a_string_including("Create floating ip for Provider #{provider.name}")}
-      expect(response.parsed_body["results"].first).to include(expected)
-      expect(response).to have_http_status(:bad_request)
+      expect_bad_request(/Create.*not.*supported/)
     end
   end
 

--- a/spec/requests/host_initiator_groups_spec.rb
+++ b/spec/requests/host_initiator_groups_spec.rb
@@ -32,7 +32,7 @@ describe "Host Initiator Groups API" do
 
       post(api_host_initiator_groups_url, :params => request)
 
-      expect_multiple_action_result(1, :success => true, :message => "Creating Host Initiator Group test_host_initiator_group for Provider: #{provider.name}", :task => true)
+      expect_multiple_action_result(1, :success => true, :message => /Creating Host Initiator Group test_host_initiator_group for Provider #{provider.name}/, :task => true)
     end
 
     it "Refuses to create without appropriate role" do

--- a/spec/requests/host_initiators_spec.rb
+++ b/spec/requests/host_initiators_spec.rb
@@ -39,7 +39,7 @@ describe "Host Initiators API" do
 
       post(api_host_initiators_url, :params => request)
 
-      expect_multiple_action_result(1, :success => true, :message => "Creating Host Initiator test_host_initiator for Provider: #{provider.name}", :task => true)
+      expect_multiple_action_result(1, :success => true, :message => /Creating Host Initiator test_host_initiator for Provider #{provider.name}/, :task => true)
     end
   end
 

--- a/spec/requests/network_routers_spec.rb
+++ b/spec/requests/network_routers_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'NetworkRouters API' do
 
       post(api_network_routers_url, :params => request)
 
-      expect_multiple_action_result(1, :success => true, :message => "Creating Network Router test_network_router for Provider: #{ems.name}", :task => true)
+      expect_multiple_action_result(1, :success => true, :message => /Creating Network Router test_network_router for Provider #{ems.name}/, :task => true)
     end
 
     it "raises error when provider does not support creating of network routers" do
@@ -92,13 +92,7 @@ RSpec.describe 'NetworkRouters API' do
       }
 
       post(api_network_routers_url, :params => request)
-
-      expected = {
-        "success" => false,
-        "message" => a_string_including("Create network router for Provider #{ems.name}")
-      }
-      expect(response.parsed_body["results"].first).to include(expected)
-      expect(response).to have_http_status(:bad_request)
+      expect_bad_request(/Create.*not.*supported/)
     end
   end
 

--- a/spec/requests/physical_storages_spec.rb
+++ b/spec/requests/physical_storages_spec.rb
@@ -17,7 +17,7 @@ describe "Physical Storages API" do
 
       post(api_physical_storages_url, :params => request)
 
-      expect_multiple_action_result(1, :success => true, :message => "Creating Physical Storage test_storage for Provider: #{provider.name}", :task => true)
+      expect_multiple_action_result(1, :success => true, :message => /Creating Physical Storage test_storage for Provider #{provider.name}/, :task => true)
     end
   end
 

--- a/spec/requests/volume_mappings_spec.rb
+++ b/spec/requests/volume_mappings_spec.rb
@@ -35,7 +35,7 @@ describe "Volume Mappings API" do
 
       post(api_volume_mappings_url, :params => request)
 
-      expect_multiple_action_result(1, :success => true, :message => "Creating Volume Mapping for Provider: #{provider.name}", :task => true)
+      expect_multiple_action_result(1, :success => true, :message => /Creating Volume Mapping/, :task => true)
     end
   end
 

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -71,7 +71,7 @@ describe "Widgets API" do
 
         post(api_widgets_url, :params => gen_request(:generate_content, [{"href" => api_widgets_url}, {"href" => api_widgets_url}]))
 
-        expect_bad_request(/Invalid MiqWidget id nil specified/i)
+        expect_multiple_action_result(2, :success => false, :message => /Invalid MiqWidget id nil specified/i)
       end
 
       context "generate_content for group" do


### PR DESCRIPTION
depends:

- [x] https://github.com/ManageIQ/manageiq/pull/21674
- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/274
 
uses resource_search for looking up the ems/provider

extracted error catching and action_results out of api_resource
so it could be used for create
and so code climate would be happier

