### PR TITLE
Add VM set_description action

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -114,6 +114,16 @@ module Api
     end
     central_admin :rename_resource, :rename
 
+    def set_description_resource(type, id, data = {})
+      new_description = data&.dig("new_description")&.strip
+      api_resource(type, id, "Setting description for", :supports => :set_description) do |vm|
+        raise BadRequestError, "Must specify a new_description" if new_description.blank?
+
+        task_id = vm.set_description_queue(User.current_userid, new_description)
+        action_result(true, "Setting description for #{model_ident(vm, type)} to #{new_description}", :task_id => task_id)
+      end
+    end
+
     def shutdown_guest_resource(type, id = nil, _data = nil)
       enqueue_ems_action(type, id, "Shutting Down", :method_name => "shutdown_guest", :supports => true)
     end

--- a/config/api.yml
+++ b/config/api.yml
@@ -4569,6 +4569,8 @@
         :identifier:
         - vm_retire_now
         - sui_vm_retire
+      - :name: set_description
+        :identifier: vm_edit
       - :name: set_owner
         :identifier: vm_edit
       - :name: set_ownership
@@ -4650,6 +4652,8 @@
       - :name: delete
         :identifier: vm_delete
       - :name: set_owner
+        :identifier: vm_edit
+      - :name: set_description
         :identifier: vm_edit
       - :name: set_ownership
         :identifier: vm_ownership

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1607,6 +1607,49 @@ describe "Vms API" do
     end
   end
 
+  context "Vm set_description action" do
+    it "to an invalid vm" do
+      api_basic_authorize action_identifier(:vms, :set_description)
+
+      post(invalid_vm_url, :params => gen_request(:set_description, "new_description" => "test"))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "to a valid vm without appropriate role" do
+      api_basic_authorize
+
+      post(invalid_vm_url, :params => gen_request(:set_description, "new_description" => "test"))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "to a vm with missing new_description" do
+      api_basic_authorize action_identifier(:vms, :set_description)
+
+      post(vm_url, :params => gen_request(:set_description))
+
+      expect_bad_request("Must specify a new_description")
+    end
+
+    it "to a single vm" do
+      api_basic_authorize action_identifier(:vms, :set_description)
+
+      post(vm_url, :params => gen_request(:set_description, "new_description" => "test"))
+
+      expect_single_action_result(:success => true, :message => /Setting description for Vm id: #{vm.id}.* to test/i, :href => api_vm_url(nil, vm))
+    end
+
+    it "to multiple vms" do
+      api_basic_authorize collection_action_identifier(:vms, :set_description)
+
+      post(api_vms_url, :params => gen_request(:set_description, [{"href" => vm1_url, "new_description" => "test1"}, {"href" => vm2_url, "new_description" => "test2"}]))
+
+      expect_multiple_action_result(2, :success => true, :task => true, :message => /Setting description for Vm.* to test[12]/i)
+      expect_result_resources_to_include_hrefs("results", [api_vm_url(nil, vm1), api_vm_url(nil, vm2)])
+    end
+  end
+
   context "Vm request console action" do
     it "to an invalid vm" do
       api_basic_authorize action_identifier(:vms, :request_console)


### PR DESCRIPTION
Alternative to #1112

ManageIQ/manageiq#21561

```
POST /api/vms/:id -d {"action": "set_description", "new_description": "test"}
{
  "success": true,
  "message": "VM id:2 name:'VM_NAME' setting description to test",
  "task_id": "82",
  "task_href": "http://localhost:3000/api/tasks/82",
  "href": "http://localhost:3000/api/vms/2"
}
```

@agrare sorry. Just had to tweak the way you wrote `set_resource_description`