### PR TITLE
rails 6.1 support

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -90,7 +90,7 @@ module Api
       end
 
       def sort_directive(klass, attr, order, options)
-        arel = klass.arel_attribute(attr)
+        arel = klass.arel_table[attr]
         if order
           arel = arel.lower if options.map(&:downcase).include?("ignore_case")
           arel = %w[desc descending].include?(order.downcase) ? arel.desc : arel.asc


### PR DESCRIPTION
Merge with this pull request:

- [ ] https://github.com/ManageIQ/manageiq/pull/21652

Already merged dependencies:

- [x] https://github.com/ManageIQ/activerecord-virtual_attributes/pull/101

`arel_attribute` has gone away and `arel_table` is used instead.

This will work with the new version of virtual attributes, but will
have trouble with the old version.

So this change needs to be introduced along or after core changes to 6.1