### PR TITLE
put rbac around ems lookup

### DIFF
--- a/app/controllers/api/auth_key_pairs_controller.rb
+++ b/app/controllers/api/auth_key_pairs_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class AuthKeyPairsController < BaseController
     def create_resource(_type, _id = nil, data = {})
-      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+      ext_management_system = resource_search(data['ems_id'], :providers)
 
       klass = ManageIQ::Providers::CloudManager::AuthKeyPair.class_by_ems(ext_management_system)
       raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)

--- a/app/controllers/api/cloud_subnets_controller.rb
+++ b/app/controllers/api/cloud_subnets_controller.rb
@@ -11,7 +11,7 @@ module Api
     end
 
     def create_resource(_type, _id = nil, data = {})
-      ems = ExtManagementSystem.find(data['ems_id'])
+      ems = resource_search(data['ems_id'], :providers)
       klass = CloudSubnet.class_by_ems(ems)
       raise BadRequestError, "Cannot create cloud subnet for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
 

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -3,7 +3,7 @@ module Api
     include Subcollections::Tags
 
     def create_resource(_type, _id = nil, data = {})
-      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+      ext_management_system = resource_search(data['ems_id'], :providers)
 
       klass = CloudVolume.class_by_ems(ext_management_system)
       raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)

--- a/app/controllers/api/floating_ips_controller.rb
+++ b/app/controllers/api/floating_ips_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class FloatingIpsController < BaseController
     def create_resource(_type, _id = nil, data = {})
-      ems = ExtManagementSystem.find(data['ems_id'])
+      ems = resource_search(data['ems_id'], :providers)
       klass = FloatingIp.class_by_ems(ems)
       raise BadRequestError, "Create floating ip for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
 

--- a/app/controllers/api/host_initiator_groups_controller.rb
+++ b/app/controllers/api/host_initiator_groups_controller.rb
@@ -3,7 +3,7 @@ module Api
     def create_resource(type, _id = nil, data = {})
       raise BadRequestError, "ems_id not defined for #{type} resource" if data['ems_id'].blank?
 
-      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+      ext_management_system = resource_search(data['ems_id'], :providers)
 
       klass = HostInitiatorGroup.class_by_ems(ext_management_system)
       raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)

--- a/app/controllers/api/host_initiators_controller.rb
+++ b/app/controllers/api/host_initiators_controller.rb
@@ -7,7 +7,7 @@ module Api
     def create_resource(_type, _id = nil, data = {})
       raise BadRequestError, "ems_id not defined for #{_type} resource" if data['ems_id'].blank?
 
-      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+      ext_management_system = resource_search(data['ems_id'], :providers)
       task_id = HostInitiator.create_host_initiator_queue(session[:userid], ext_management_system, data)
       action_result(true, "Creating Host Initiator #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
     rescue => err

--- a/app/controllers/api/network_routers_controller.rb
+++ b/app/controllers/api/network_routers_controller.rb
@@ -3,7 +3,7 @@ module Api
     include Subcollections::Tags
 
     def create_resource(_type, _id = nil, data = {})
-      ems = ExtManagementSystem.find(data['ems_id'])
+      ems = resource_search(data['ems_id'], :providers)
       klass = NetworkRouter.class_by_ems(ems)
       raise BadRequestError, "Create network router for Provider #{ems.name}: #{klass.unsupported_reason(:create)}" unless klass.supports?(:create)
 

--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -5,7 +5,7 @@ module Api
     end
 
     def create_resource(_type, _id = nil, data = {})
-      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+      ext_management_system = resource_search(data['ems_id'], :providers)
       task_id = PhysicalStorage.create_physical_storage_queue(session[:userid], ext_management_system, data)
       action_result(true, "Creating Physical Storage #{data['name']} for Provider: #{ext_management_system.name}", :task_id => task_id)
     rescue => err

--- a/app/controllers/api/volume_mappings_controller.rb
+++ b/app/controllers/api/volume_mappings_controller.rb
@@ -5,7 +5,7 @@ module Api
     end
 
     def create_resource(_type, _id = nil, data = {})
-      ext_management_system = ExtManagementSystem.find(data['ems_id'])
+      ext_management_system = resource_search(data['ems_id'], :providers)
 
       klass = VolumeMapping.class_by_ems(ext_management_system)
       raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)


### PR DESCRIPTION
We need to run regular rbac around looking up resources for the user

Found a few lookups that didn't have rbac around them so added it
Don't think there is a way to exploit this other than learning that an ems exists given the `ems.id`.