### PR TITLE
add queue_name for ems_operations

### DIFF
--- a/app/controllers/api/base_controller/action.rb
+++ b/app/controllers/api/base_controller/action.rb
@@ -129,6 +129,9 @@ module Api
           queue_options[:tenant_id] = user.current_tenant.id
         end
         queue_options[:zone] = object.my_zone if %w(ems_operations smartstate).include?(options[:role])
+        if !queue_options.key?(:queue_name) && options[:role] == "ems_operations"
+          queue_options[:queue_name] = object.ext_management_system&.queue_name_for_ems_operations
+        end
 
         MiqTask.generic_action_with_callback(task_options, queue_options)
       end

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -72,15 +72,15 @@ module Api
     end
 
     def start_resource(type, id = nil, _data = nil)
-      enqueue_ems_action(type, id, "Starting", :method_name => "start")
+      enqueue_action(type, id, "Starting", :method_name => "start")
     end
 
     def stop_resource(type, id = nil, _data = nil)
-      enqueue_ems_action(type, id, "Stopping", :method_name => "stop")
+      enqueue_action(type, id, "Stopping", :method_name => "stop")
     end
 
     def suspend_resource(type, id = nil, _data = nil)
-      enqueue_ems_action(type, id, "Suspending", :method_name => "suspend")
+      enqueue_action(type, id, "Suspending", :method_name => "suspend")
     end
 
     def add_provider_vms_resource(type, id, data)


### PR DESCRIPTION
### Overview

In the API, we queue ems operations to go to the ems operations worker.

Most of the places in our code we use `Model.method_queue` and the method handles the details.
A few places in the api use `enqueue_ems_action` to directly put the message on the queue.

In most places, we are getting away from this code and creating an enqueue method for each action (i.e.: `def action_queue`)

### Problem

For ems operations, `enqueue_ems_action` was not setting the correct `queue_name`.

### Before

For 57 cases, we add partial queue items:

```ruby
{
  :role       => "ems_operations",
  :zone       => object.zone,
  :queue_name => nil
}
```

(`grep enqueue_ems_action` to find them)

### After

For these cases, we add the `queue_name`.

```ruby
{
  :role       => "ems_operations",
  :zone       => object.zone,
  :queue_name => object.ems.queue_name_for_ems_operations
}
```

### Before

Service start and stop requests were going to the ems operations worker. This new code blew up since the model did not have an ems defined.

### After

Service start and stop requests are going to the generic worker.

### Extra

Some of our `ContainerImage` specs has a nil ems and were blowing up. So I added the `&.`
