### PR TITLE
Add support for cloud volume snapshot subcollection

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class CloudVolumesController < BaseController
     include Subcollections::Tags
+    include Subcollections::CloudVolumeSnapshots
 
     def create_resource(type, _id = nil, data = {})
       create_ems_resource(type, data, :supports => true) do |ems, klass|

--- a/app/controllers/api/subcollections/cloud_volume_snapshots.rb
+++ b/app/controllers/api/subcollections/cloud_volume_snapshots.rb
@@ -1,0 +1,40 @@
+module Api
+  module Subcollections
+    module CloudVolumeSnapshots
+      def cloud_volume_snapshots_query_resource(object)
+        object.cloud_volume_snapshots
+      end
+
+      def cloud_volume_snapshots_create_resource(parent, type, _id, data)
+        api_action(type, nil) do
+          klass = parent.ext_management_system.class_by_ems(:CloudVolumeSnapshot)
+          ensure_supports(type, klass, :create)
+          message = "Creating cloud volume snapshot #{data["name"]} for #{model_ident(parent, :cloud_volumes)}"
+          task_id = parent.create_volume_snapshot_queue(User.current_userid, data.symbolize_keys)
+
+          action_result(true, message, :task_id => task_id)
+        end
+      end
+
+      def update_resource_cloud_volume_snapshots(_parent, type, id, data)
+        api_resource(type, id, "Updating", :supports => :update) do |cloud_volume_snapshot|
+          {:task_id => cloud_volume_snapshot.update_cloud_volume_queue(User.current_userid, data.symbolize_keys)}
+        end
+      end
+      alias cloud_volume_snapshots_update_resource update_resource_cloud_volume_snapshots
+
+      def delete_resource_cloud_volume_snapshots(_parent, type, id, _data)
+        api_resource(type, id, "Deleting", :supports => :delete) do |cloud_volume_snapshot|
+          {:task_id => cloud_volume_snapshot.delete_cloud_volume_queue(User.current_userid)}
+        end
+      end
+      alias cloud_volume_snapshots_delete_resource delete_resource_cloud_volume_snapshots
+
+      def cloud_volume_snapshots_subcollection_options(parent)
+        raise BadRequestError, "No DDF specified for cloud volume snapshots in #{parent}" unless parent.respond_to?(:params_for_create_cloud_volume_snapshot)
+
+        {:cloud_volume_snapshot_form_schema => parent.params_for_create_cloud_volume_snapshot}
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -746,6 +746,12 @@
         :identifier: cloud_tenant_tag
       - :name: unassign
         :identifier: cloud_tenant_tag
+  :cloud_volume_snapshots:
+    :description: Cloud Volume Snapshots
+    :options:
+    - :subcollection
+    :verbs: *gpppd
+    :klass: CloudVolumeSnapshot
   :cloud_volume_types:
     :description: Cloud Volume Types
     :identifier: cloud_volume_type
@@ -770,6 +776,7 @@
     :verbs: *gpppd
     :subcollections:
     - :tags
+    - :cloud_volume_snapshots
     :klass: CloudVolume
     :collection_actions:
       :get:
@@ -805,6 +812,22 @@
         :identifier: cloud_volume_tag
       - :name: unassign
         :identifier: cloud_volume_tag
+    :cloud_volume_snapshots_subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: cloud_volume_snapshot_view
+      :post:
+      - :name: create
+        :identifier: cloud_volume_snapshot_create
+      - :name: delete
+        :identifier: cloud_volume_snapshot_delete
+    :cloud_volume_snapshots_subresource_actions:
+      :get:
+      - :name: read
+        :identifier: cloud_volume_snapshot_view
+      :post:
+      - :name: delete
+        :identifier: cloud_volume_snapshot_delete
   :clusters:
     :description: Clusters
     :identifier: ems_cluster

--- a/spec/requests/cloud_volume_snapshots_spec.rb
+++ b/spec/requests/cloud_volume_snapshots_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe "CloudVolumeSnapshots API" do
+  include Spec::Support::SupportsHelper
+
+  let(:ems) { FactoryBot.create(:ems_cinder) }
+  let(:cloud_volume) { FactoryBot.create(:cloud_volume_openstack, :ext_management_system => ems) }
+  let(:cloud_volume_snapshot) { FactoryBot.create(:cloud_volume_snapshot_openstack, :cloud_volume => cloud_volume, :ext_management_system => ems) }
+
+  describe "as a subcollection of cloud volumes" do
+    describe "GET /api/cloud_volumes/:c_id/cloud_volume_snapshots" do
+      it "can list the cloud volume snapshots of an cloud_volumes" do
+        api_basic_authorize(subcollection_action_identifier(:cloud_volumes, :cloud_volume_snapshots, :read, :get))
+
+        cloud_volume_snapshot
+        FactoryBot.create(:cloud_volume_snapshot)
+
+        get(api_cloud_volume_cloud_volume_snapshots_url(nil, cloud_volume))
+        expected = {
+          "count"     => 2,
+          "name"      => "cloud_volume_snapshots",
+          "subcount"  => 1,
+          "resources" => [
+            {"href" => api_cloud_volume_cloud_volume_snapshot_url(nil, cloud_volume, cloud_volume_snapshot)}
+          ]
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will not list cloud volume snapshots unless authorized" do
+        api_basic_authorize
+
+        cloud_volume_snapshot
+        get(api_cloud_volume_cloud_volume_snapshots_url(nil, cloud_volume))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "GET /api/cloud_volumes/:c_id/cloud_volume_snapshots" do
+      it "can show a cloud volume snapshot" do
+        api_basic_authorize(subcollection_action_identifier(:cloud_volumes, :cloud_volume_snapshots, :read, :get))
+
+        get(api_cloud_volume_cloud_volume_snapshot_url(nil, cloud_volume, cloud_volume_snapshot))
+        expected = {
+          "id"   => cloud_volume_snapshot.id.to_s,
+          "href" => api_cloud_volume_cloud_volume_snapshot_url(nil, cloud_volume, cloud_volume_snapshot)
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will not show a cloud volume snapshot unless authorized" do
+        api_basic_authorize
+
+        get(api_cloud_volume_cloud_volume_snapshot_url(nil, cloud_volume, cloud_volume_snapshot))
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "POST /api/cloud_volumes/:c_id/cloud_volume_snapshots" do
+      it "can queue the creation of a cloud volume snapshot" do
+        api_basic_authorize(subcollection_action_identifier(:cloud_volumes, :cloud_volume_snapshots, :create))
+        stub_supports(CloudVolumeSnapshot, :create)
+
+        post(api_cloud_volume_cloud_volume_snapshots_url(nil, cloud_volume), :params => {:name => "new snapshot"})
+
+        expect_multiple_action_result(1, :success => true, :message => "Creating cloud volume snapshot")
+      end
+
+      it "renders a failed action response if cloud volume snapshotting is not supported" do
+        api_basic_authorize(subcollection_action_identifier(:cloud_volumes, :cloud_volume_snapshots, :create))
+        stub_supports_not(ems.class_by_ems(:CloudVolumeSnapshot), :create)
+
+        post(api_cloud_volume_cloud_volume_snapshots_url(nil, cloud_volume), :params => {:name => "Alice's snapshot"})
+
+        expect_bad_request(/Feature not .*supported/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Cloud Volume Snapshots to the api:

- Moved the `_queue` calls to the core repo.
- Using `CloudVolumeSnapshot.supports :crud` (instead of `CloudVolume.supports :create_snapshot`)
- Changed methods to use the `raw_` naming convention

Related PRs:

- [x] https://github.com/ManageIQ/manageiq/pull/21801
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/787
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/755

Continuation of #1086
