### PR TITLE
Move supports to api_resource

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -22,8 +22,7 @@ module Api
     end
 
     def safe_delete_resource(type, id, _data = {})
-      api_resource(type, id, "Deleting") do |cloud_volume|
-        ensure_supports(type, cloud_volume, :safe_delete)
+      api_resource(type, id, "Deleting", :supports => :safe_delete) do |cloud_volume|
         {:task_id => cloud_volume.safe_delete_volume_queue(User.current_userid)}
       end
     end

--- a/app/controllers/api/physical_storages_controller.rb
+++ b/app/controllers/api/physical_storages_controller.rb
@@ -24,16 +24,10 @@ module Api
       action_result(false, err.to_s)
     end
 
-    # really shouldn't override, but want the word Detaching in there
-    def delete_resource_action(type, id = nil, data = nil)
-      api_resource(type, id, "Detaching") do |resource|
-        delete_resource_main_action(type, resource, data)
+    def delete_resource_action(type, id = nil, _data = nil)
+      api_resource(type, id, "Detaching", :supports => :delete) do |physical_storage|
+        {:task_id => physical_storage.delete_physical_storage_queue(User.current_user)}
       end
-    end
-
-    def delete_resource_main_action(type, physical_storage, _data = nil)
-      ensure_supports(type, physical_storage, :delete)
-      {:task_id => physical_storage.delete_physical_storage_queue(User.current_user)}
     end
   end
 end


### PR DESCRIPTION
extracted from #1133

## Description

`api_resource` works for many of our actions.
Having it handle `supports` in an easy way can be a good win.
It also makes it easy to grep for code that does not implement supports.

For most of these `enqueue_action` and `api_resource` cases, we are going for having `supports` handled automatically. Putting this as part of the framework makes it easy to grep code for missing supports checks.

## Example

`PhysicalStoragesController` shows how to use `api_resource(..., :supports => :delete)`

The existing code base may not use that much but a number of examples will probably get updated in #1133

## Minor wrinkle

All of our cases have the `supports` value the same as the action except for one: the action is `scan` while `supports :smartstate_analysis`. This one case will have a potentially unclear error case for developers.

```ruby
enqueue_ems_action(type, id, "Scanning", :method_name => "scan", :supports => :smartstate_analysis, :role => "smartstate")
```

## Aside

I kinda wish I did not introduce the `delete_resource_main_action and just stuck with `delete_resource_action`. That has a half dozen cases where we could have leveraged `:supports => :delete`:

```ruby
    def delete_resource_main_action(type, key_pair, _data)
      ensure_supports(type, key_pair, :delete)
      {:task_id => key_pair.delete_key_pair_queue(User.current_userid)}
    end

    def delete_resource_action(type, key_pair, _data)
      api_resource(type, id, "Deleting", :supports => :delete) do |key_pair|
        {:task_id => key_pair.delete_key_pair_queue(User.current_userid)}
      end
    end
```