### PR TITLE
[WIP] Attach detach cloud volume api

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -565,7 +565,7 @@ module Api
         if resource.try(:params_for_attach) ## TODO can we make this one line?
           render_options(type, :form_schema => resource.params_for_attach)  
         else
-          render_options(type, :form_schema => {})  
+          render_options(type, :form_schema => {}) ## {:fields => []}
         end
       end
 

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -545,7 +545,14 @@ module Api
       end
 
       def render_options(resource, data = {})
+        p "mels pre render options 1" ## none of this is being hit
+        p "resource"
+        p resource
         klass = collection_class(resource)
+        p "klass"
+        p klass
+        p "mels collection class"
+        p klass
         render :json => OptionsSerializer.new(klass, data).serialize
       end
 
@@ -567,6 +574,35 @@ module Api
         raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
 
         render_options(type, :form_schema => klass.params_for_create(ems))
+      end
+
+      def render_attach_resource_options_mels(ems_id)
+        p "-------------------------- mels attach options "
+        type = @req.collection.to_sym
+        base_klass = collection_class(type)
+  
+        ## render_create_resource_options
+        ems = resource_search(ems_id, :providers) # TODO catch nil cases
+        klass = ems.class_by_ems(base_klass.name)
+        raise BadRequestError, "No #{type.to_s.titleize} support for - #{ems.name}" unless klass
+        raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
+  
+        ## render_update_resource_options
+        # type = @req.collection.to_sym # we do it above
+        resource = resource_search(ems_id, type)
+        raise BadRequestError, resource.unsupported_reason(:update) unless resource.supports?(:update)
+  
+        ## for hardcoding faster | storageManager: 5 | record id: 445 |
+        p "content"
+        p klass
+        p type
+        p ems
+        p "--------"
+        p type
+        p resource
+        p "---------------------- mels render options" ## this is the last thing that does get hit
+        render_options(type, :form_schema => klass.mels())
+        # render_options(type, :form_schema => resource.mels())
       end
 
       # This is a helper method used by both .determine_include_for_find and

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -549,19 +549,23 @@ module Api
         render :json => OptionsSerializer.new(klass, data).serialize
       end
 
-      def render_update_resource_options(id, action)
+      def render_update_resource_options(id)
         type = @req.collection.to_sym
         resource = resource_search(id, type)
         raise BadRequestError, resource.unsupported_reason(:update) unless resource.supports?(:update)
 
-        if action == "attach"
-          if resource.try(:params_for_attach) ## TODO can we make this one line?
-            render_options(type, :form_schema => resource.params_for_attach)  
-          else
-            render_options(type, :form_schema => {})  
-          end
+        render_options(type, :form_schema => resource.params_for_update)
+      end
+
+      def render_attach_resource_options(id)
+        type = @req.collection.to_sym
+        resource = resource_search(id, type)
+        raise BadRequestError, resource.unsupported_reason(:attach_volume) unless resource.supports?(:attach_volume)
+
+        if resource.try(:params_for_attach) ## TODO can we make this one line?
+          render_options(type, :form_schema => resource.params_for_attach)  
         else
-          render_options(type, :form_schema => resource.params_for_update)
+          render_options(type, :form_schema => {})  
         end
       end
 

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -34,13 +34,47 @@ module Api
 
     def options
       if (id = params["id"])
+        p "========================= mels id was called"
         render_update_resource_options(id)
       elsif (ems_id = params["ems_id"])
+        p "========================= mels ems_id"
         render_create_resource_options(ems_id)
+        ## we can have a check for another param to see how it is maybe? if ems_id then if is also attach
+      elsif (ems_id_attach = params["ems_id_attach"])
+        p "========================= mels ems_id_attach"
+        render_attach_resource_options_mels(ems_id_attach) ## this figures out the provider on its own
       else
         super
       end
     end
+
+    def render_attach_resource_options_mels(ems_id)
+      p "-------------------------- mels attach options "
+      type = @req.collection.to_sym
+      base_klass = collection_class(type)
+
+      ems = resource_search(ems_id, :providers)
+      klass = ems.class_by_ems(base_klass.name)
+      raise BadRequestError, "No #{type.to_s.titleize} support for - #{ems.name}" unless klass
+      raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
+
+      p "content"
+      p klass
+      p type
+      p ems
+      p "---------------------- mels render options"
+      render_options(type, :form_schema => params_for_attach(ems)) ## resource or class
+    end
+
+    # def render_update_resource_options_mels(id)
+    #   p "-------------------------- mels update attach options "
+    #   type = @req.collection.to_sym
+    #   resource = resource_search(id, type)
+    #   raise BadRequestError, resource.unsupported_reason(:update) unless resource.supports?(:update)
+
+    #   p "---------------------- mels render options"
+    #   render_options(type, :form_schema => resource.params_for_attach)
+    # end
 
     def create_backup_resource(type, id, data)
       api_resource(type, id, "Creating backup", :supports => :backup_create) do |cloud_volume|

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -34,15 +34,10 @@ module Api
 
     def options
       if (id = params["id"])
-        p "========================= mels id was called"
-        render_update_resource_options(id)
+        action = params["option_action"] || "update"
+        render_update_resource_options(id, action)
       elsif (ems_id = params["ems_id"])
-        p "========================= mels ems_id"
         render_create_resource_options(ems_id)
-        ## we can have a check for another param to see how it is maybe? if ems_id then if is also attach
-      elsif (ems_id_attach = params["ems_id_attach"])
-        p "========================= mels ems_id_attach"
-        render_attach_resource_options_mels(ems_id_attach) ## this figures out the provider on its own
       else
         super
       end

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -53,5 +53,27 @@ module Api
         {:task_id => cloud_volume.backup_restore_queue(User.current_userid, data.symbolize_keys)}
       end
     end
+
+    def attach_resource(type, id, data = {})
+      api_resource(type, id, "Attaching Resource to", :supports => :attach_volume) do |cloud_volume|
+        raise BadRequestError, "Must specify a vm_id" if data["vm_id"].blank?
+
+        vm = resource_search(data["vm_id"], :vms)
+        {:task_id => cloud_volume.attach_volume_queue(User.current_userid, vm.ems_ref, data["device"].presence)}
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def detach_resource(type, id, data = {})
+      api_resource(type, id, "Detaching Resource from", :supports => :detach_volume) do |cloud_volume|
+        raise BadRequestError, "Must specify a vm_id" if data["vm_id"].blank?
+
+        vm = resource_search(data["vm_id"], :vms)
+        {:task_id => cloud_volume.detach_volume_queue(User.current_userid, vm.ems_ref)}
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -35,7 +35,7 @@ module Api
     def options
       if (id = params["id"])
         action = params["option_action"] || "update"
-        render_update_resource_options(id, action)
+        send("render_#{action}_resource_options", id)
       elsif (ems_id = params["ems_id"])
         render_create_resource_options(ems_id)
       else

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -48,34 +48,6 @@ module Api
       end
     end
 
-    def render_attach_resource_options_mels(ems_id)
-      p "-------------------------- mels attach options "
-      type = @req.collection.to_sym
-      base_klass = collection_class(type)
-
-      ems = resource_search(ems_id, :providers)
-      klass = ems.class_by_ems(base_klass.name)
-      raise BadRequestError, "No #{type.to_s.titleize} support for - #{ems.name}" unless klass
-      raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
-
-      p "content"
-      p klass
-      p type
-      p ems
-      p "---------------------- mels render options"
-      render_options(type, :form_schema => params_for_attach(ems)) ## resource or class
-    end
-
-    # def render_update_resource_options_mels(id)
-    #   p "-------------------------- mels update attach options "
-    #   type = @req.collection.to_sym
-    #   resource = resource_search(id, type)
-    #   raise BadRequestError, resource.unsupported_reason(:update) unless resource.supports?(:update)
-
-    #   p "---------------------- mels render options"
-    #   render_options(type, :form_schema => resource.params_for_attach)
-    # end
-
     def create_backup_resource(type, id, data)
       api_resource(type, id, "Creating backup", :supports => :backup_create) do |cloud_volume|
         {:task_id => cloud_volume.backup_create_queue(User.current_userid, data)}

--- a/config/api.yml
+++ b/config/api.yml
@@ -799,6 +799,10 @@
         :identifier: cloud_volume_backup_create
       - :name: restore_backup
         :identifier: cloud_volume_backup_restore
+      - :name: attach
+        :identifier: cloud_volume_edit
+      - :name: detach
+        :identifier: cloud_volume_edit
     :tags_subcollection_actions:
       :post:
       - :name: assign

--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -15,6 +15,7 @@ module Api
     end
 
     def action
+      # for basic HTTP POST, default action is "create" with data being the POST body
       @action ||= case method
                   when :get         then 'read'
                   when :put, :patch then 'edit'

--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -15,12 +15,11 @@ module Api
     end
 
     def action
-      # for basic HTTP POST, default action is "create" with data being the POST body
       @action ||= case method
                   when :get         then 'read'
                   when :put, :patch then 'edit'
                   when :delete      then 'delete'
-                  when :options     then 'options'
+                  when :options     then @params['option_action'] || 'options'
                   else json_body['action'] || 'create'
                   end
     end

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -184,6 +184,7 @@ describe "Cloud Volumes API" do
       provider = FactoryBot.create(:ems_autosde, :zone => zone)
       cloud_volume = FactoryBot.create(:cloud_volume_autosde, :ext_management_system => provider)
 
+      api_basic_authorize(action_identifier(:cloud_volumes, :attach, :resource_actions, :post)) ## ?? this wasnt the fix
       stub_supports(cloud_volume.class, :attach_volume)
       stub_params_for(cloud_volume.class, :attach_volume, :fields => [])
       options(api_cloud_volume_url(nil, cloud_volume), :params => {"option_action" => "attach"})

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -177,6 +177,20 @@ describe "Cloud Volumes API" do
       expect(response.parsed_body['data']).to match("form_schema" => {"fields" => []})
       expect(response).to have_http_status(:ok)
     end
+
+    ## TODO: test case not passing
+    it 'returns a DDF schema for attach cloud volume when available via OPTIONS' do
+      zone = FactoryBot.create(:zone)
+      provider = FactoryBot.create(:ems_autosde, :zone => zone)
+      cloud_volume = FactoryBot.create(:cloud_volume_autosde, :ext_management_system => provider)
+
+      stub_supports(cloud_volume.class, :attach_volume)
+      stub_params_for(cloud_volume.class, :attach_volume, :fields => [])
+      options(api_cloud_volume_url(nil, cloud_volume), :params => {"option_action" => "attach"})
+
+      # expect(response.parsed_body['data']).to match("form_schema" => {"fields" => []})
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe 'OPTIONS /api/cloud_volumes/:id' do


### PR DESCRIPTION
Fixes:
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/issues/7603

dependent upon:
- [x] #1147 
- [x] #1149 

Required for upgrading [_attach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_attach.html.haml#L33) and [_detach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_detach.html.haml#L25)

Introduces the attach_resource and detach_resource endpoints for cloud volumes. 