### PR TITLE
Added cloud object store container endpoints

### DIFF
--- a/app/controllers/api/cloud_object_store_containers_controller.rb
+++ b/app/controllers/api/cloud_object_store_containers_controller.rb
@@ -1,4 +1,18 @@
 module Api
   class CloudObjectStoreContainersController < BaseController
+    def create_resource(type, _ems_id = nil, data = {})
+      create_ems_resource(type, data, :supports => true) do |ems, klass|
+        resource_search(data["cloud_tenant_id"], :cloud_tenants) if data["cloud_tenant_id"]
+        {:task_id => klass.cloud_object_store_container_create_queue(User.current_userid, ems, data.symbolize_keys)}
+      end
+    end
+
+    def options
+      if (ems_id = params["ems_id"])
+        render_create_resource_options(ems_id)
+      else
+        super
+      end
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -594,6 +594,8 @@
       :post:
       - :name: query
         :identifier: cloud_object_store_container_show_list
+      - :name: create
+        :identifier: cloud_object_store_container_new
     :resource_actions:
       :get:
       - :name: read

--- a/spec/requests/cloud_object_store_containers_spec.rb
+++ b/spec/requests/cloud_object_store_containers_spec.rb
@@ -1,4 +1,6 @@
 describe "Cloud Object Store Containers API" do
+  include Spec::Support::SupportsHelper
+
   context 'GET /api/cloud_object_store_containers' do
     it 'forbids access to cloud object store containers without an appropriate role' do
       api_basic_authorize
@@ -43,6 +45,49 @@ describe "Cloud Object Store Containers API" do
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context 'POST /api/cloud_object_store_containers/' do
+    it 'it can create cloud object store containers through POST' do
+      zone = FactoryBot.create(:zone)
+      provider = FactoryBot.create(:ems_storage, :zone => zone)
+      cloud_tenant = FactoryBot.create(:cloud_tenant, :ext_management_system => provider)
+
+      api_basic_authorize collection_action_identifier(:cloud_object_store_containers, :create, :post)
+      submit_data = {
+        :ems_id          => provider.id,
+        :name            => 'foo',
+        :emsType         => provider.type,
+        :cloud_tenant_id => cloud_tenant.id,
+      }
+      post(api_cloud_object_store_containers_url, :params => submit_data)
+
+      expected = {
+        'results' => a_collection_containing_exactly(
+          a_hash_including(
+            'success' => true,
+            'message' => a_string_including('Creating Cloud Object Store Container')
+          )
+        )
+      }
+
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'OPTIONS /api/cloud_object_store_containers' do
+    it 'returns a DDF schema for add when available via OPTIONS' do
+      zone = FactoryBot.create(:zone)
+      provider = FactoryBot.create(:ems_storage, :zone => zone)
+      stub_supports(provider.class::CloudObjectStoreContainer, :create)
+      stub_params_for(provider.class::CloudObjectStoreContainer, :create, :fields => [])
+
+      options(api_cloud_object_store_container_url(nil, provider.id, :ems_id => provider.id))
+
+      expect(response.parsed_body['data']).to match("form_schema" => {"fields" => []})
+      expect(response).to have_http_status(:ok)
     end
   end
 end


### PR DESCRIPTION
Depends On: 
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/754
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/753
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/785
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/786
- [x] https://github.com/ManageIQ/manageiq/pull/21791
- [x] https://github.com/ManageIQ/manageiq/pull/21794

Added endpoints to allow for creating cloud object store containers and for getting the provider fields for the create cloud object store container form.