### PR TITLE
Add API support for server decommission/recommission

### DIFF
--- a/app/controllers/api/physical_servers_controller.rb
+++ b/app/controllers/api/physical_servers_controller.rb
@@ -53,6 +53,14 @@ module Api
       end
     end
 
+    def decommission_server_resource(type, id, _data)
+      enqueue_ems_action(type, id, :method_name => :decommission_server)
+    end
+
+    def recommission_server_resource(type, id, _data)
+      enqueue_ems_action(type, id, :method_name => :recommission_server)
+    end
+
     private
 
     def ensure_resource_exists(type, id)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2430,6 +2430,10 @@
         :identifier: physical_server_turn_off_loc_led
       - :name: apply_config_pattern
         :identifier: physical_server_apply_config_pattern
+      - :name: decommission_server
+        :identifier: physical_server_decommission
+      - :name: recommission_server
+        :identifier: physical_server_recommission
     :resource_actions:
       :get:
       - :name: read
@@ -2459,6 +2463,10 @@
         :identifier: physical_server_turn_off_loc_led
       - :name: apply_config_pattern
         :identifier: physical_server_apply_config_pattern
+      - :name: decommission_server
+        :identifier: physical_server_decommission
+      - :name: recommission_server
+        :identifier: physical_server_recommission
   :physical_storages:
     :description: Physical Storages
     :identifier: physical_storage

--- a/spec/requests/physical_servers_spec.rb
+++ b/spec/requests/physical_servers_spec.rb
@@ -164,6 +164,26 @@ RSpec.describe "physical_servers API" do
         expect(response).to have_http_status(:success)
         expect(response.parsed_body).to include("success" => true)
       end
+
+      it "decommissions a server successfully" do
+        ps = FactoryBot.create(:physical_server)
+
+        api_basic_authorize action_identifier(:physical_servers, :decommission_server, :resource_actions, :post)
+        post(api_physical_server_url(nil, ps), :params => gen_request(:decommission_server))
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to include("success" => true)
+      end
+
+      it "recommissions a server successfully" do
+        ps = FactoryBot.create(:physical_server)
+
+        api_basic_authorize action_identifier(:physical_servers, :recommission_server, :resource_actions, :post)
+        post(api_physical_server_url(nil, ps), :params => gen_request(:recommission_server))
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to include("success" => true)
+      end
     end
 
     context "without an appropriate role" do
@@ -236,6 +256,26 @@ RSpec.describe "physical_servers API" do
         expect(response).to have_http_status(:forbidden)
         expect(response.parsed_body["error"]).to include("kind" => "forbidden")
       end
+
+      it "fails to decommission a physical server" do
+        ps = FactoryBot.create(:physical_server)
+
+        api_basic_authorize
+        post(api_physical_server_url(nil, ps), :params => gen_request(:decommission_server))
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body["error"]).to include("kind" => "forbidden")
+      end
+
+      it "fails to recommission a physical server" do
+        ps = FactoryBot.create(:physical_server)
+
+        api_basic_authorize
+        post(api_physical_server_url(nil, ps), :params => gen_request(:recommission_server))
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body["error"]).to include("kind" => "forbidden")
+      end
     end
 
     context "with a non existent physical server" do
@@ -246,7 +286,9 @@ RSpec.describe "physical_servers API" do
         :restart,
         :restart_now,
         :restart_to_sys_setup,
-        :restart_mgmt_controller
+        :restart_mgmt_controller,
+        :decommission_server,
+        :recommission_server
       ]
 
       actions.each do |action|
@@ -268,7 +310,9 @@ RSpec.describe "physical_servers API" do
         :restart,
         :restart_now,
         :restart_to_sys_setup,
-        :restart_mgmt_controller
+        :restart_mgmt_controller,
+        :decommission_server,
+        :recommission_server
       ]
 
       actions.each do |action|


### PR DESCRIPTION
Cisco Intersight provider allows to decommision and recommission a
server from and to a pool of available resources. This commit adds
support in the API for a particular operation to be exposed for the UI.