### PR TITLE
Custom button set reorder API

### DIFF
--- a/app/controllers/api/custom_button_sets_controller.rb
+++ b/app/controllers/api/custom_button_sets_controller.rb
@@ -7,5 +7,12 @@ module Api
     def edit_resource(type, id, data)
       super(type, id, data.deep_symbolize_keys)
     end
+
+    def reorder_resource(type, id, data)
+      api_action(type, id) do
+        CustomButtonSet.reorder_group_index(data["ids"])
+        action_result(true, "Button Group Reorder saved")
+      end
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1247,6 +1247,8 @@
         :identifier: ab_group_edit
       - :name: delete
         :identifier: ab_group_delete
+      - :name: reorder
+        :identifier: ab_group_reorder
     :resource_actions:
       :get:
       - :name: read

--- a/spec/requests/custom_button_sets_spec.rb
+++ b/spec/requests/custom_button_sets_spec.rb
@@ -108,6 +108,25 @@ RSpec.describe 'CustomButtonSets API' do
       expect(response.parsed_body).to include(expected)
       expect(cb_set.reload.set_data[:button_icon]).to eq("ff ff-closed")
     end
+
+    it 'can reorder custom button set by ids' do
+      api_basic_authorize collection_action_identifier(:custom_button_sets, :reorder)
+
+      request = {
+        'action'   => 'reorder',
+        'resource' => {
+          'ids' => [cb_set.id, cb_set2.id]
+        }
+      }
+
+      post(api_custom_button_sets_url, :params => request)
+
+      expected = {
+        'results' => [{"href" => "#{api_custom_button_sets_url}/", "message" => 'Button Group Reorder saved', "success" => true}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   describe 'POST /api/custom_button_sets/:id' do


### PR DESCRIPTION
Adding Api for [task](https://github.com/ManageIQ/manageiq-ui-classic/issues/7901)

Dependent PR:
- [x] https://github.com/ManageIQ/manageiq/pull/21814

## Successful API call

<img width="647" alt="Screenshot 2022-04-06 at 10 36 18 AM" src="https://user-images.githubusercontent.com/16753936/162378556-8e0eaa8a-5a08-48e7-b592-1f86955bcde9.png">

## Call returns error

<img width="650" alt="Screenshot 2022-04-06 at 10 36 02 AM" src="https://user-images.githubusercontent.com/16753936/162378469-5f46f416-f29d-4703-ab65-6aad150a90a4.png">
