### PR TITLE
Added params for edit support to cloud subnets options

### DIFF
--- a/app/controllers/api/cloud_subnets_controller.rb
+++ b/app/controllers/api/cloud_subnets_controller.rb
@@ -3,7 +3,9 @@ module Api
     include Subcollections::Tags
 
     def options
-      if (ems_id = params["ems_id"])
+      if (id = params["id"])
+        render_update_resource_options(id)
+      elsif (ems_id = params["ems_id"])
         render_create_resource_options(ems_id)
       else
         super


### PR DESCRIPTION
Updated the cloud subnet options call to support params for edit when a cloud subnet id is provided in the api call.

@miq-bot add_reviewer @agrare
@miq-bot assign @agrare 
@miq-bot add-label enhancement