### PR TITLE
Attach detach cloud volume form (simplified)

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -55,5 +55,27 @@ module Api
         {:task_id => cloud_volume.backup_restore_queue(User.current_userid, backup['ems_ref'])}
       end
     end
+
+    def attach_resource(type, id, data = {})
+      api_resource(type, id, "Attaching Resource to", :supports => :attach_volume) do |cloud_volume|
+        raise BadRequestError, "Must specify a vm_id" if data["vm_id"].blank?
+
+        vm = resource_search(data["vm_id"], :vms)
+        {:task_id => cloud_volume.attach_volume_queue(User.current_userid, vm.ems_ref, data["device"].presence)}
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def detach_resource(type, id, data = {})
+      api_resource(type, id, "Detaching Resource from", :supports => :detach_volume) do |cloud_volume|
+        raise BadRequestError, "Must specify a vm_id" if data["vm_id"].blank?
+
+        vm = resource_search(data["vm_id"], :vms)
+        {:task_id => cloud_volume.detach_volume_queue(User.current_userid, vm.ems_ref)}
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -808,6 +808,10 @@
         :identifier: cloud_volume_backup_create
       - :name: restore_backup
         :identifier: cloud_volume_backup_restore
+      - :name: attach_volume
+        :identifier: cloud_volume_edit
+      - :name: detach_volume
+        :identifier: cloud_volume_edit
     :tags_subcollection_actions:
       :post:
       - :name: assign

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -208,6 +208,68 @@ describe "Cloud Volumes API" do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it 'attaches Cloud Volume to an instance' do
+      zone = FactoryBot.create(:zone)
+      ems = FactoryBot.create(:ems_autosde, :zone => zone)
+      vm = FactoryBot.create(:vm_vmware)
+      cloud_volume = FactoryBot.create(:cloud_volume_autosde, :ext_management_system => ems)
+
+      api_basic_authorize(action_identifier(:cloud_volumes, :attach_volume, :resource_actions, :post))
+      stub_supports(cloud_volume.class, :attach_volume)
+
+      payload = {:action => "attach", :resources => {:vm_id => vm.id.to_s}}
+      post(api_cloud_volume_url(nil, cloud_volume), :params => payload)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'detaches Cloud Volume from an instance' do
+      zone = FactoryBot.create(:zone)
+      ems = FactoryBot.create(:ems_autosde, :zone => zone)
+      hw = FactoryBot.create(:hardware)
+      vm = FactoryBot.create(:vm_vmware, :hardware => hw)
+      cloud_volume = FactoryBot.create(:cloud_volume_autosde, :ext_management_system => ems)
+      FactoryBot.create(:disk, :hardware => hw, :backing => cloud_volume)
+
+      api_basic_authorize(action_identifier(:cloud_volumes, :detach_volume, :resource_actions, :post))
+      stub_supports(cloud_volume.class, :detach_volume)
+
+      payload = {:action => "detach", :resources => {:vm_id => vm.id.to_s}}
+      post(api_cloud_volume_url(nil, cloud_volume), :params => payload)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'attach raise an error if the cloud volume does not support attach_volume' do
+      cloud_volume = FactoryBot.create(:cloud_volume_autosde)
+      stub_supports_not(:cloud_volumes, :attach_volume)
+
+      api_basic_authorize(action_identifier(:cloud_volumes, :attach_volume, :resource_actions, :post))
+
+      post(api_cloud_volume_url(nil, cloud_volume), :params => {:action => "attach"})
+      expected = {
+        "success" => false,
+        "message" => a_string_including("Attach Volume for Cloud Volume id: #{cloud_volume.id} name: '': Feature not available\/supported")
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'detach raise an error if the cloud volume does not support detach_volume' do
+      cloud_volume = FactoryBot.create(:cloud_volume_autosde)
+      stub_supports_not(:cloud_volumes, :detach_volume)
+
+      api_basic_authorize(action_identifier(:cloud_volumes, :detach_volume, :resource_actions, :post))
+
+      post(api_cloud_volume_url(nil, cloud_volume), :params => {:action => "detach"})
+      expected = {
+        "success" => false,
+        "message" => a_string_including("Detach Volume for Cloud Volume id: #{cloud_volume.id} name: '': Feature not available\/supported")
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
   describe 'restore backup' do


### PR DESCRIPTION
Required for upgrading [_attach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_attach.html.haml#L33) and [_detach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_detach.html.haml#L25) to react as per [7603](https://github.com/ManageIQ/manageiq-ui-classic/issues/7603).

Introduces the attach_resource and detach_resource endpoints for cloud volumes. 

This PR is a more simplified version of work done on [1141](https://github.com/ManageIQ/manageiq-api/pull/1141). Here we have not yet introduced the work done to make `options` more generic. That logic needs further testing and for the purposes of this PR falls slightly out of scope. 

@miq-bot add-reviewer @kbrock 
@miq-bot add-reviewer @agrare 
@miq-bot add-reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu