### PR TITLE
Fix cloud object store container spec file

### DIFF
--- a/spec/requests/cloud_object_store_containers_spec.rb
+++ b/spec/requests/cloud_object_store_containers_spec.rb
@@ -58,7 +58,6 @@ describe "Cloud Object Store Containers API" do
       submit_data = {
         :ems_id          => provider.id,
         :name            => 'foo',
-        :emsType         => provider.type,
         :cloud_tenant_id => cloud_tenant.id,
       }
       post(api_cloud_object_store_containers_url, :params => submit_data)


### PR DESCRIPTION
Fixed incorrect value in the cloud object store container spec file. The emsType value is not used in the provider or api code so it is removed from the spec tests.