### PR TITLE
Add API controller for physical server profiles

### DIFF
--- a/app/controllers/api/physical_server_profiles_controller.rb
+++ b/app/controllers/api/physical_server_profiles_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  class PhysicalServerProfilesController < BaseController
+    include Subcollections::EventStreams
+
+
+
+    private
+
+    def ensure_resource_exists(type, id)
+      raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
+    end
+  end
+end

--- a/app/controllers/api/physical_server_profiles_controller.rb
+++ b/app/controllers/api/physical_server_profiles_controller.rb
@@ -3,9 +3,9 @@ module Api
     include Subcollections::EventStreams
 
     def assign_server_resource(type, id, data)
-      enqueue_ems_action(type, id, :method_name => :assign_server, :args => [data["server_id"]]) do
-        ensure_resource_exists(:physical_servers, data["server_id"])
-      end
+      # Make sure the requested server exists
+      resource_search(data["server_id"], :physical_servers)
+      enqueue_ems_action(type, id, :method_name => :assign_server, :args => [data["server_id"]])
     end
 
     def deploy_server_resource(type, id, _data)
@@ -14,12 +14,6 @@ module Api
 
     def unassign_server_resource(type, id, _data)
       enqueue_ems_action(type, id, :method_name => :unassign_server)
-    end
-
-    private
-
-    def ensure_resource_exists(type, id)
-      raise NotFoundError, "#{type} with id:#{id} not found" unless collection_class(type).exists?(id)
     end
   end
 end

--- a/app/controllers/api/physical_server_profiles_controller.rb
+++ b/app/controllers/api/physical_server_profiles_controller.rb
@@ -2,7 +2,19 @@ module Api
   class PhysicalServerProfilesController < BaseController
     include Subcollections::EventStreams
 
+    def assign_server_resource(type, id, data)
+      enqueue_ems_action(type, id, :method_name => :assign_server, :args => [data["server_id"]]) do
+        ensure_resource_exists(:physical_servers, data["server_id"])
+      end
+    end
 
+    def deploy_server_resource(type, id, _data)
+      enqueue_ems_action(type, id, :method_name => :deploy_server)
+    end
+
+    def unassign_server_resource(type, id, _data)
+      enqueue_ems_action(type, id, :method_name => :unassign_server)
+    end
 
     private
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -2389,6 +2389,39 @@
       :post:
       - :name: refresh
         :identifier: physical_rack_refresh
+  :physical_server_profiles:
+    :description: Physical Server Profiles
+    :identifier: physical_server_profile
+    :options:
+      - :collection
+    :verbs: *gp
+    :klass: PhysicalServerProfile
+    :subcollections:
+      - :event_streams
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: physical_server_profile_show_list
+      :post:
+        - :name: query
+          :identifier: physical_server_profile_show_list
+        - :name: assign_server
+          :identifier: physical_server_profile_assign_server
+        - :name: deploy_server
+          :identifier: physical_server_profile_deploy_server
+        - :name: unassign_server
+          :identifier: physical_server_profile_unassign_server
+    :resource_actions:
+      :get:
+        - :name: read
+          :identifier: physical_server_profile_show
+      :post:
+        - :name: assign_server
+          :identifier: physical_server_profile_assign_server
+        - :name: deploy_server
+          :identifier: physical_server_profile_deploy_server
+        - :name: unassign_server
+          :identifier: physical_server_profile_unassign_server
   :physical_servers:
     :description: Physical Servers
     :identifier: physical_server
@@ -2518,39 +2551,6 @@
         :identifier: physical_switch_refresh
       - :name: restart
         :identifier: physical_switch_restart
-  :physical_server_profiles:
-    :description: Physical Server Profiles
-    :identifier: physical_server_profile
-    :options:
-    - :collection
-    :verbs: *gp
-    :klass: PhysicalServerProfile
-    :subcollections:
-    - :event_streams
-    :collection_actions:
-      :get:
-      - :name: read
-        :identifier: physical_server_profile_show_list
-      :post:
-      - :name: query
-        :identifier: physical_server_profile_show_list
-      - :name: assign_server
-        :identifier: physical_server_profile_assign_server
-      - :name: deploy_server
-        :identifier: physical_server_profile_deploy_server
-      - :name: unassign_server
-        :identifier: physical_server_profile_unassign_server
-    :resource_actions:
-      :get:
-      - :name: read
-        :identifier: physical_server_profile_show
-      :post:
-      - :name: assign_server
-        :identifier: physical_server_profile_assign_server
-      - :name: deploy_server
-        :identifier: physical_server_profile_deploy_server
-      - :name: unassign_server
-        :identifier: physical_server_profile_unassign_server
   :pictures:
     :description: Pictures
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -2526,31 +2526,31 @@
     :verbs: *gp
     :klass: PhysicalServerProfile
     :subcollections:
-      - :event_streams
+    - :event_streams
     :collection_actions:
       :get:
-        - :name: read
-          :identifier: physical_server_profile_show_list
+      - :name: read
+        :identifier: physical_server_profile_show_list
       :post:
-        - :name: query
-          :identifier: physical_server_profile_show_list
-        - name: assign_server
-          :identifier: physical_server_profile_assign_server
-        - name: deploy_server
-          :identifier: physical_server_profile_deploy_server
-        - name: unassign_server
-          :identifier: physical_server_profile_unassign_server
+      - :name: query
+        :identifier: physical_server_profile_show_list
+      - :name: assign_server
+        :identifier: physical_server_profile_assign_server
+      - :name: deploy_server
+        :identifier: physical_server_profile_deploy_server
+      - :name: unassign_server
+        :identifier: physical_server_profile_unassign_server
     :resource_actions:
       :get:
-        - :name: read
-          :identifier: physical_server_profile_show
+      - :name: read
+        :identifier: physical_server_profile_show
       :post:
-        - name: assign_server
-          :identifier: physical_server_profile_assign_server
-        - name: deploy_server
-          :identifier: physical_server_profile_deploy_server
-        - name: unassign_server
-          :identifier: physical_server_profile_unassign_server
+      - :name: assign_server
+        :identifier: physical_server_profile_assign_server
+      - :name: deploy_server
+        :identifier: physical_server_profile_deploy_server
+      - :name: unassign_server
+        :identifier: physical_server_profile_unassign_server
   :pictures:
     :description: Pictures
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -2531,10 +2531,26 @@
       :get:
         - :name: read
           :identifier: physical_server_profile_show_list
+      :post:
+        - :name: query
+          :identifier: physical_server_profile_show_list
+        - name: assign_server
+          :identifier: physical_server_profile_assign_server
+        - name: deploy_server
+          :identifier: physical_server_profile_deploy_server
+        - name: unassign_server
+          :identifier: physical_server_profile_unassign_server
     :resource_actions:
       :get:
         - :name: read
           :identifier: physical_server_profile_show
+      :post:
+        - name: assign_server
+          :identifier: physical_server_profile_assign_server
+        - name: deploy_server
+          :identifier: physical_server_profile_deploy_server
+        - name: unassign_server
+          :identifier: physical_server_profile_unassign_server
   :pictures:
     :description: Pictures
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -2518,6 +2518,23 @@
         :identifier: physical_switch_refresh
       - :name: restart
         :identifier: physical_switch_restart
+  :physical_server_profiles:
+    :description: Physical Server Profiles
+    :identifier: physical_server_profile
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: PhysicalServerProfile
+    :subcollections:
+      - :event_streams
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: physical_server_profile_show_list
+    :resource_actions:
+      :get:
+        - :name: read
+          :identifier: physical_server_profile_show
   :pictures:
     :description: Pictures
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -2393,35 +2393,35 @@
     :description: Physical Server Profiles
     :identifier: physical_server_profile
     :options:
-      - :collection
+    - :collection
     :verbs: *gp
     :klass: PhysicalServerProfile
     :subcollections:
-      - :event_streams
+    - :event_streams
     :collection_actions:
       :get:
-        - :name: read
-          :identifier: physical_server_profile_show_list
+      - :name: read
+        :identifier: physical_server_profile_show_list
       :post:
-        - :name: query
-          :identifier: physical_server_profile_show_list
-        - :name: assign_server
-          :identifier: physical_server_profile_assign_server
-        - :name: deploy_server
-          :identifier: physical_server_profile_deploy_server
-        - :name: unassign_server
-          :identifier: physical_server_profile_unassign_server
+      - :name: query
+        :identifier: physical_server_profile_show_list
+      - :name: assign_server
+        :identifier: physical_server_profile_assign_server
+      - :name: deploy_server
+        :identifier: physical_server_profile_deploy_server
+      - :name: unassign_server
+        :identifier: physical_server_profile_unassign_server
     :resource_actions:
       :get:
-        - :name: read
-          :identifier: physical_server_profile_show
+      - :name: read
+        :identifier: physical_server_profile_show
       :post:
-        - :name: assign_server
-          :identifier: physical_server_profile_assign_server
-        - :name: deploy_server
-          :identifier: physical_server_profile_deploy_server
-        - :name: unassign_server
-          :identifier: physical_server_profile_unassign_server
+      - :name: assign_server
+        :identifier: physical_server_profile_assign_server
+      - :name: deploy_server
+        :identifier: physical_server_profile_deploy_server
+      - :name: unassign_server
+        :identifier: physical_server_profile_unassign_server
   :physical_servers:
     :description: Physical Servers
     :identifier: physical_server


### PR DESCRIPTION
This PR adds API support for physical server profiles coming from the **Cisco Intersight provider**.

Beside the basic GET operations, it supports assignment, deployment, and unassignment of servers:

```
POST /api/physical_server_profiles/
{
    "action": "assign_server",
    "resources": [
        {
            "id": "5",
            "server_id": "90"
        }
    ]
}
```

```
POST /api/physical_server_profiles/
{
    "action": "deploy_server",
    "resources": [
        {
            "id": "5"
        }
    ]
}
```

```
POST /api/physical_server_profiles/
{
    "action": "unassign_server",
    "resources": [
        {
            "id": "5"
        }
    ]
}
```

See also related PRs in the [MiQ core repository (21830)](https://github.com/ManageIQ/manageiq/pull/21830) and the [Cisco Intersight provider repository (42)](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/42).