### PR TITLE
del host initiator

### DIFF
--- a/app/controllers/api/host_initiators_controller.rb
+++ b/app/controllers/api/host_initiators_controller.rb
@@ -11,7 +11,7 @@ module Api
     end
 
     def delete_resource_action(type, id = nil, _data = nil)
-      api_resource(type, id, "Detaching", :supports => :delete) do |host_initiator|
+      api_resource(type, id, "Deleting", :supports => :delete) do |host_initiator|
         {:task_id => host_initiator.delete_host_initiator_queue(User.current_user)}
       end
     end

--- a/app/controllers/api/host_initiators_controller.rb
+++ b/app/controllers/api/host_initiators_controller.rb
@@ -9,5 +9,11 @@ module Api
         {:task_id => klass.create_host_initiator_queue(User.current_userid, ems, data)}
       end
     end
+
+    def delete_resource_action(type, id = nil, _data = nil)
+      api_resource(type, id, "Detaching", :supports => :delete) do |host_initiator|
+        {:task_id => host_initiator.delete_host_initiator_queue(User.current_user)}
+      end
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1786,7 +1786,7 @@
     :identifier: host_initiator
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: HostInitiator
     :subcollections:
     :collection_actions:
@@ -1798,6 +1798,8 @@
         :identifier: host_initiator_new
       - :name: refresh
         :identifier: host_initiator_refresh
+      - :name: delete
+        :identifier: host_initiator_delete
     :resource_actions:
       :get:
       - :name: read
@@ -1805,6 +1807,8 @@
       :post:
       - :name: refresh
         :identifier: host_initiator_refresh
+      - :name: delete
+        :identifier: host_initiator_delete
   :hosts:
     :description: Hosts
     :identifier: host


### PR DESCRIPTION
This PR add new feature for host-initiators (storage), the ability to **delete an existing host-initiator**.

<img width="884" alt="Screen Shot 2022-05-03 at 13 40 41" src="https://user-images.githubusercontent.com/6840118/166441274-073a8d0c-6a8c-4030-9123-85245a50b6fb.png">

<img width="858" alt="Screen Shot 2022-05-03 at 13 41 08" src="https://user-images.githubusercontent.com/6840118/166441293-54baa577-abc5-41e8-99af-b2cee3b877d0.png">


Links
----------------
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8249
- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/147
- [x] https://github.com/ManageIQ/manageiq/pull/21845