### PR TITLE
Handle params_for_create that take parameters

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -567,7 +567,8 @@ module Api
         raise BadRequestError, "No #{type.to_s.titleize} support for - #{ems.name}" unless klass
         raise BadRequestError, klass.unsupported_reason(:create) unless klass.supports?(:create)
 
-        render_options(type, :form_schema => klass.params_for_create(ems))
+        schema = klass.method(:params_for_create).arity == 0 ? klass.params_for_create : klass.params_for_create(ems)
+        render_options(type, :form_schema => schema)
       end
 
       # This is a helper method used by both .determine_include_for_find and


### PR DESCRIPTION
Some providers define options that take an ems.
This tends to be for populating drop downs.

Others do not need them.

/cc @MelsHyrule 