### PR TITLE
Add missing conf button for volume mappings

### DIFF
--- a/app/controllers/api/volume_mappings_controller.rb
+++ b/app/controllers/api/volume_mappings_controller.rb
@@ -1,5 +1,6 @@
 module Api
-  class VolumeMappingsController < BaseProviderController
+  class VolumeMappingsController < BaseController
+
     def refresh_resource(type, id, _data = nil)
       enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end

--- a/app/controllers/api/volume_mappings_controller.rb
+++ b/app/controllers/api/volume_mappings_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class VolumeMappingsController < BaseController
-
     def refresh_resource(type, id, _data = nil)
       enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end

--- a/config/api.yml
+++ b/config/api.yml
@@ -4764,7 +4764,7 @@
     :identifier: volume_mapping
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: VolumeMapping
     :subcollections:
     :collection_actions:


### PR DESCRIPTION
If we are entering `volume-mapping` from the provider **dashboard** (meaning for a specific EMS) the **configuration button is missing**:
## Before
![image](https://user-images.githubusercontent.com/6840118/176122382-740473ed-68c4-4edc-868f-c8563365154f.png)
![image](https://user-images.githubusercontent.com/6840118/176123149-18ec85a0-3ece-42f5-8dcf-7616da965580.png)

## After
![image](https://user-images.githubusercontent.com/6840118/176123709-7891ac00-7dad-4ae3-b9c4-fe3780fa0b9a.png)

- Now that we have the configuration button for a specific ems we want it to be selected automaticly and disabled if we define a new `volume-mapping` for a specific ems:
![image](https://user-images.githubusercontent.com/6840118/176124055-ffb2fdf5-a890-472d-93af-2f9be3a3ef04.png)

## Links
https://github.com/ManageIQ/manageiq-ui-classic/pull/8337