### PR TITLE
return task_id from widget refresh [Najdorf]

### DIFF
--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -12,8 +12,9 @@ module Api
 
     def generate_widget_content(widget)
       desc = "#{widget_ident(widget)} content generation"
-      widget.queue_generate_content
-      action_result(true, desc)
+      task_id = widget.queue_generate_content
+      task_results = task_id ? {:task_id => task_id} : {}
+      action_result(true, desc, task_results)
     rescue => err
       action_result(false, err.to_s)
     end

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -106,7 +106,7 @@ describe "Widgets API" do
         it "generates single widget content" do
           expect(miq_widget.miq_widget_contents.count).to eq(0)
           post(api_widget_url(nil, miq_widget), :params => gen_request(:generate_content))
-          expect(response).to have_http_status(:ok)
+          expect_single_action_result(:success => true, :task_id => true, :message => /content generation/)
           expect(MiqTask.count).to eq(1)
           expect(MiqQueue.count).to eq(1)
         end
@@ -116,7 +116,7 @@ describe "Widgets API" do
 
           expect(MiqTask.count).to eq(0)
           post(api_widgets_url, :params => gen_request(:generate_content, [{"href" => api_widget_url(nil, miq_widget)}, {"href" => api_widget_url(nil, second_miq_widget)}]))
-          expect(response).to have_http_status(:ok)
+          expect_multiple_action_result(2, :success => true, :task_id => true, :message => /content generation/)
           expect(MiqTask.count).to eq(2)
           expect(MiqQueue.count).to eq(2)
         end


### PR DESCRIPTION
based upon 8fddecfafa73c0c965ac58e093c7937f2d7fb89a / #1165

the PR https://github.com/ManageIQ/manageiq-api/pull/1133 is not on najdorf (and is a little too big for us to backport)
This causes a merge conflict.

This is the najdorf version of the PR.