### PR TITLE
Associate disassociate floating ip

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -200,6 +200,22 @@ module Api
       render_options(@req.collection.to_sym, send(subcollection_options_method, vm))
     end
 
+    def associate_resource(type, id, data)
+      raise BadRequestError, "Must specify a floating_ip" if data["floating_ip"].nil?
+
+      api_resource(type, id, "Associating resource to", :supports => :associate_floating_ip) do |vm|
+        {:task_id => vm.associate_floating_ip_queue(User.current_userid, data["floating_ip"])}
+      end
+    end
+
+    def disassociate_resource(type, id, data)
+      raise BadRequestError, "Must specify a floating_ip" if data["floating_ip"].nil?
+
+      api_resource(type, id, "Disassociating resource from", :supports => :disassociate_floating_ip) do |vm|
+        {:task_id => vm.disassociate_floating_ip_queue(User.current_userid, data["floating_ip"])}
+      end
+    end
+
     private
 
     def lifecycle_event_from_data(data)

--- a/config/api.yml
+++ b/config/api.yml
@@ -4525,6 +4525,10 @@
         - vm_show_list
         - sui_vm_details_view
       :post:
+      - :name: associate
+        :identifier: vm_edit
+      - :name: disassociate
+        :identifier: vm_edit
       - :name: query
         :identifier:
         - vm_show_list
@@ -4674,6 +4678,10 @@
         :identifier: vm_scan
       - :name: simulate_policy
         :identifier: policy_simulation
+      - :name: associate
+        :identifier: vm_edit
+      - :name: disassociate
+        :identifier: vm_edit
     :disks_subcollection_actions:
       :get:
       - :name: read


### PR DESCRIPTION
Creating endpoints for the UI to hit on associating and disassociating floating ips to vms. 

Required for https://github.com/ManageIQ/manageiq-ui-classic/pull/8422, which is part of https://github.com/ManageIQ/manageiq-ui-classic/issues/7603