### PR TITLE
[WIP] Support for issuing a ServiceNow ticket on a physical server profile

### DIFF
--- a/app/controllers/api/physical_server_profiles_controller.rb
+++ b/app/controllers/api/physical_server_profiles_controller.rb
@@ -15,5 +15,8 @@ module Api
     def unassign_server_resource(type, id, _data)
       enqueue_ems_action(type, id, :method_name => :unassign_server)
     end
+
+    # TODO issue_servicenow_ticket
+    
   end
 end


### PR DESCRIPTION
When implemented, this PR will provide an enpoint supporting the creation of a ServiceNow ticket associated to the chosen physical server.

For now, this only contains a stub. I am creating this PR only for planning this feature in this release cycle.

This is related to [this PR in the Cisco Intersight provider repository (77)](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/77).