### PR TITLE
Allow custom_actions option on physical infrastructure collections

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2351,6 +2351,7 @@
     :identifier: physical_chassis
     :options:
     - :collection
+    - :custom_actions
     :verbs: *gp
     :klass: PhysicalChassis
     :subcollections:
@@ -2386,6 +2387,7 @@
     :identifier: physical_rack
     :options:
     - :collection
+    - :custom_actions
     :verbs: *gp
     :klass: PhysicalRack
     :subcollections:
@@ -2443,6 +2445,7 @@
     :identifier: physical_server
     :options:
     - :collection
+    - :custom_actions
     :verbs: *gp
     :klass: PhysicalServer
     :subcollections:
@@ -2521,6 +2524,7 @@
     :identifier: physical_storage
     :options:
     - :collection
+    - :custom_actions
     :verbs: *gpppd
     :klass: PhysicalStorage
     :subcollections:
@@ -2553,6 +2557,7 @@
     :identifier: physical_switch
     :options:
     - :collection
+    - :custom_actions
     :verbs: *gp
     :klass: PhysicalSwitch
     :subcollections:


### PR DESCRIPTION
This comes from the need to enable custom buttons on the physical infrastructure objects such as, **_Physical Server, Physical Rack, Physical Chassis, Physical Storage and Physical Switch_**.

At the moment, the collections for the described classes do not support custom actions and the following response is returned when clicking a custom button:
```js
// api response when trying to submit a dialog from a Physical Server
error: Object { kind: "bad_request", message: "Unsupported Action Custom Button for the physical_servers resource specified", klass: "Api::BadRequestError" }
```

This enabled the custom_actions options for the required collections.

**_Refers to:_**
  -  [ManageIQ/manageiq-providers-cisco_intersight/issues/76](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/issues/76)

**_Depends on:_**: 
  - [ManageIQ/manageiq-ui-classis/pull/8548](https://github.com/ManageIQ/manageiq-ui-classic/pull/8545)
  - [ManageIQ/manageiq/pull/22263](https://github.com/ManageIQ/manageiq/pull/22263)