### PR TITLE
Added endpoints for physical storage families, resources and services

### DIFF
--- a/app/controllers/api/physical_storage_families_controller.rb
+++ b/app/controllers/api/physical_storage_families_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class PhysicalStorageFamiliesController < BaseController
+  end
+end

--- a/app/controllers/api/storage_resources_controller.rb
+++ b/app/controllers/api/storage_resources_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class StorageResourcesController < BaseController
+  end
+end

--- a/app/controllers/api/storage_services_controller.rb
+++ b/app/controllers/api/storage_services_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class StorageServicesController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2494,6 +2494,24 @@
         :identifier: physical_server_decommission
       - :name: recommission_server
         :identifier: physical_server_recommission
+  :physical_storage_families:
+    :description: Physical Storage Families
+    :identifier: physical_storage_family
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: PhysicalStorageFamily
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: physical_storage_family_show_list
+      :post:
+      - :name: query
+        :identifier: physical_storage_family_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: physical_storage_family_show
   :physical_storages:
     :description: Physical Storages
     :identifier: physical_storage
@@ -4165,6 +4183,42 @@
     - :subcollection
     :verbs: *g
     :klass: GuestApplication
+  :storage_resources:
+    :description: Storage Resources
+    :identifier: storage_resource
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: StorageResource
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: storage_resource_show_list
+      :post:
+      - :name: query
+        :identifier: storage_resource_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: storage_resource_show
+  :storage_services:
+    :description: Storage Services
+    :identifier: storage_service
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: StorageService
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: storage_service_show_list
+      :post:
+      - :name: query
+        :identifier: storage_service_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: storage_service_show
   :switches:
     :description: Switches
     :identifier: infra_networking

--- a/spec/requests/physical_storage_families_spec.rb
+++ b/spec/requests/physical_storage_families_spec.rb
@@ -1,0 +1,33 @@
+describe "Physical Storage Families API" do
+  context "GET /api/physical_storage_families" do
+    it "returns all physical_storage_families" do
+      physical_storage_family = FactoryBot.create(:physical_storage_family)
+      api_basic_authorize('physical_storage_family_show_list')
+
+      get(api_physical_storage_families_url)
+
+      expected = {
+        "name"      => "physical_storage_families",
+        "resources" => [{"href" => api_physical_storage_family_url(nil, physical_storage_family)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "GET /api/physical_storage_families/:id" do
+    it "returns one physical_storage_family" do
+      physical_storage_family = FactoryBot.create(:physical_storage_family)
+      api_basic_authorize('physical_storage_family_show')
+
+      get(api_physical_storage_family_url(nil, physical_storage_family))
+
+      expected = {
+        "name" => physical_storage_family.name,
+        "href" => api_physical_storage_family_url(nil, physical_storage_family)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+end

--- a/spec/requests/storage_resources_spec.rb
+++ b/spec/requests/storage_resources_spec.rb
@@ -1,0 +1,33 @@
+describe "Storage Resources API" do
+  fcontext "GET /api/storage_resources" do
+    it "returns all storage_resources" do
+      storage_resource = FactoryBot.create(:storage_resource)
+      api_basic_authorize('storage_resource_show_list')
+
+      get(api_storage_resources_url)
+
+      expected = {
+        "name"      => "storage_resources",
+        "resources" => [{"href" => api_storage_resource_url(nil, storage_resource)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "GET /api/storage_resources/:id" do
+    it "returns one storage_resource" do
+      storage_resource = FactoryBot.create(:storage_resources)
+      api_basic_authorize('storage_resource_show')
+
+      get(api_storage_resource_url(nil, storage_resource))
+
+      expected = {
+        "name" => storage_resource.name,
+        "href" => api_storage_resource_url(nil, storage_resource)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+end

--- a/spec/requests/storage_services_spec.rb
+++ b/spec/requests/storage_services_spec.rb
@@ -1,0 +1,33 @@
+describe "Storage Services API" do
+  fcontext "GET /api/storage_services" do
+    it "returns all storage_services" do
+      storage_service = FactoryBot.create(:storage_service)
+      api_basic_authorize('storage_service_show_list')
+
+      get(api_storage_services_url)
+
+      expected = {
+        "name"      => "storage_services",
+        "resources" => [{"href" => api_storage_service_url(nil, storage_service)}]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  context "GET /api/storage_services/:id" do
+    it "returns one storage_service" do
+      storage_service = FactoryBot.create(:storage_services)
+      api_basic_authorize('storage_service_show')
+
+      get(api_storage_service_url(nil, storage_service))
+
+      expected = {
+        "name" => storage_service.name,
+        "href" => api_storage_service_url(nil, storage_service)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+end


### PR DESCRIPTION
We added the relevant endpoints and controllers.
They will be needed to access capability values fields added in:
https://github.com/ManageIQ/manageiq-schema/pull/676

<img width="1497" alt="Screen Shot 2022-12-04 at 16 35 16" src="https://user-images.githubusercontent.com/74841666/205496774-c31ec123-32d1-4a1f-aac7-9cadfd0aa075.png">

<img width="1489" alt="Screen Shot 2022-12-04 at 16 36 05" src="https://user-images.githubusercontent.com/74841666/205496805-6cdb7b06-87fd-4711-aeaa-38726fa1835e.png">

<img width="1498" alt="Screen Shot 2022-12-04 at 16 36 46" src="https://user-images.githubusercontent.com/74841666/205496840-bc147753-4b6e-4b72-ab48-4b906f87d1ec.png">

W/ @OrGur1987