### PR TITLE
Add support for the native console protocol

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -4605,9 +4605,11 @@
         :identifier:
         - vm_html5_console
         - vm_vmrc_console
+        - vm_native_console
         - sui_vm_html5_console
         - sui_vm_vmrc_console
         - sui_vm_web_console
+        - sui_vm_native_console
       - :name: reset
         :identifier: vm_reset
       - :name: retire
@@ -4685,9 +4687,11 @@
         :identifier:
         - vm_html5_console
         - vm_vmrc_console
+        - vm_native_console
         - sui_vm_html5_console
         - sui_vm_vmrc_console
         - sui_vm_web_console
+        - sui_vm_native_console
       - :name: reset
         :identifier: vm_reset
       - :name: retire


### PR DESCRIPTION
Add support for requesting the "native" protocol for a VM's console.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/22308

Fixes https://github.com/ManageIQ/manageiq-api/issues/1194