### PR TITLE
Add request_id logging to track a single request

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -94,6 +94,7 @@ module Api
       end
 
       def log_request(header, data)
+        data = data.merge(:request_id => request.request_id) if data.respond_to?(:merge)
         api_log_info("#{('%s:' % header).ljust(15)} #{data}")
       end
     end

--- a/spec/requests/logging_spec.rb
+++ b/spec/requests/logging_spec.rb
@@ -22,7 +22,7 @@ describe "Logging" do
       log_io.rewind
       request_log_line = log_io.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
       expect(request_log_line).to include(':path=>"/api/users"', ':collection=>"users"', ":collection_id=>nil",
-                                          ":subcollection=>nil", ":subcollection_id=>nil")
+                                          ":subcollection=>nil", ":subcollection_id=>nil", "request_id=>\"#{request.request_id}\"")
     end
 
     it "logs all hash entries about the request" do
@@ -34,7 +34,7 @@ describe "Logging" do
       request_log_line = log_io.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
       expect(request_log_line).to include(":method", ":action", ":fullpath", ":url", ":base", ":path", ":prefix",
                                           ":version", ":api_prefix", ":collection", ":c_suffix", ":collection_id",
-                                          ":subcollection", ":subcollection_id")
+                                          ":subcollection", ":subcollection_id", ":request_id")
     end
 
     it "filters password attributes in nested parameters" do
@@ -45,7 +45,7 @@ describe "Logging" do
       expect(log_io.string).to include(
         'Parameters:     {"action"=>"create", "controller"=>"api/services", "format"=>"json", ' \
         '"body"=>{"action"=>"create", "resource"=>{"name"=>"new_service_1", ' \
-        '"options"=>{"password"=>"[FILTERED]"}}}}'
+        '"options"=>{"password"=>"[FILTERED]"}}},'
       )
     end
 
@@ -61,8 +61,8 @@ describe "Logging" do
 
         expect(log_io.string).to include(
           "System Auth:    {:x_miq_token=>\"#{miq_token}\", :server_guid=>\"#{server_guid}\", " \
-          ":userid=>\"api_user_id\", :timestamp=>2017-01-01 00:00:00 UTC}",
-          'Authentication: {:type=>"system", :token=>nil, :x_miq_group=>nil, :user=>"api_user_id"}'
+          ":userid=>\"api_user_id\", :timestamp=>2017-01-01 00:00:00 UTC",
+          'Authentication: {:type=>"system", :token=>nil, :x_miq_group=>nil, :user=>"api_user_id"'
         )
       end
     end


### PR DESCRIPTION
This pull request adds the `request.request_id` to most of the logging in the api so you can follow specific requests through completion.  This become more useful when the API is receiving concurrent requests in threads and logging from each request is interspersed.

```
[----] I, [2023-01-27T16:16:49.845003 #27812:5a30c]  INFO -- api: MIQ(Api::EventStreamsController.log_request_initiated)
[----] I, [2023-01-27T16:16:49.845140 #27812:5a30c]  INFO -- api: MIQ(Api::EventStreamsController.log_request) API Request:    {:requested_at=>"2023-01-27 21:16:49 UTC", :method=>"OPTIONS", :url=>"http://localhost:3000/api/event_streams", :request_id=>"cf4c693a-6e71-4837-a03f-6f1bd663adc4"}
[----] I, [2023-01-27T16:16:49.927265 #27812:5a30c]  INFO -- api: MIQ(Api::EventStreamsController.log_request) Authentication: {:type=>"basic", :token=>nil, :x_miq_group=>nil, :user=>"admin", :request_id=>"cf4c693a-6e71-4837-a03f-6f1bd663adc4"}
[----] I, [2023-01-27T16:16:49.929632 #27812:5a30c]  INFO -- api: MIQ(Api::EventStreamsController.log_request) Authorization:  {:user=>"admin", :group=>"EvmGroup-super_administrator", :role=>"EvmRole-super_administrator", :tenant=>"My Company", :request_id=>"cf4c693a-6e71-4837-a03f-6f1bd663adc4"}
[----] I, [2023-01-27T16:16:49.931127 #27812:5a30c]  INFO -- api: MIQ(Api::EventStreamsController.log_request) Request:        {:method=>:options, :action=>"options", :fullpath=>"/api/event_streams", :url=>"http://localhost:3000/api/event_streams", :base=>"http://localhost:3000", :path=>"/api/event_streams", :prefix=>"/api", :version=>"4.4.0-pre", :api_prefix=>"http://localhost:3000/api", :collection=>"event_streams", :c_suffix=>nil, :collection_id=>nil, :subcollection=>nil, :subcollection_id=>nil, :request_id=>"cf4c693a-6e71-4837-a03f-6f1bd663adc4"}
[----] I, [2023-01-27T16:16:49.931352 #27812:5a30c]  INFO -- api: MIQ(Api::EventStreamsController.log_request) Parameters:     {"action"=>"options", "controller"=>"api/event_streams", "format"=>"json", "body"=>{}, "request_id"=>"cf4c693a-6e71-4837-a03f-6f1bd663adc4"}
[----] I, [2023-01-27T16:16:49.939464 #27812:5a30c]  INFO -- api: MIQ(Api::EventStreamsController.log_request) Response:       {:completed_at=>"2023-01-27 21:16:49 UTC", :size=>"2.750 KBytes", :time_taken=>"0.094 Seconds", :status=>200, :request_id=>"cf4c693a-6e71-4837-a03f-6f1bd663adc4"}
```