### PR TITLE
Host verify_credentials

### DIFF
--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class HostsController < BaseController
     CREDENTIALS_ATTR = "credentials".freeze
+    AUTH_ATTR = "authentications".freeze
     AUTH_TYPE_ATTR = "auth_type".freeze
     DEFAULT_AUTH_TYPE = "default".freeze
 
@@ -11,21 +12,37 @@ module Api
     include Subcollections::Tags
 
     def edit_resource(type, id, data = {})
+      # TODO: drop 'credentials' parameter field when ui-classic hosts is in react
       credentials = data.delete(CREDENTIALS_ATTR)
+      authentications = data.delete(AUTH_ATTR)
       raise BadRequestError, "Cannot update non-credentials attributes of host resource" if data.any?
       resource_search(id, type).tap do |host|
+        # begin legacy ui-classic
         all_credentials = Array.wrap(credentials).each_with_object({}) do |creds, hash|
           auth_type = creds.delete(AUTH_TYPE_ATTR) || DEFAULT_AUTH_TYPE
           creds.symbolize_keys!
           creds.reverse_merge!(:userid => host.authentication_userid(auth_type))
           hash[auth_type.to_sym] = creds
         end
+        # end legacy ui-classic. if they provided the newer authentications, it will overwrite
+        all_credentials, _ = symbolize_password_keys!(authentications) if authentications
         host.update_authentication(all_credentials) if all_credentials.present?
       end
     end
 
     def check_compliance_resource(type, id, _data = nil)
       enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
+    end
+
+    private
+
+    # takes credentials from params and converts into something for update_authentications
+    def symbolize_password_keys!(authentications)
+      auth_type = authentications.keys.first
+      # symbolize userid, password
+      authentications[auth_type].symbolize_keys!
+
+      return authentications, auth_type
     end
   end
 end

--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -30,6 +30,14 @@ module Api
       end
     end
 
+    def verify_credentials_resource(type, id = nil, data = {})
+      api_resource(type, id, "Verifying Credentials for") do |host|
+        remember_host = data["remember_host"] == "true"
+        authentications, auth_type = symbolize_password_keys!(data[AUTH_ATTR])
+        {:task_id => host.verify_credentials_task(User.current_userid, auth_type, :credentials => authentications, :remember_host => remember_host)}
+      end
+    end
+
     def check_compliance_resource(type, id, _data = nil)
       enqueue_ems_action(type, id, "Check Compliance for", :method_name => "check_compliance", :supports => true)
     end

--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class HostsController < BaseController
+  class HostsController < BaseProviderController
     CREDENTIALS_ATTR = "credentials".freeze
     AUTH_ATTR = "authentications".freeze
     AUTH_TYPE_ATTR = "auth_type".freeze

--- a/config/api.yml
+++ b/config/api.yml
@@ -1888,6 +1888,8 @@
         :identifier: host_show_list
       - :name: edit
         :identifier: host_edit
+      - :name: verify_credentials
+        :identifier: host_edit
     :resource_actions:
       :get:
       - :name: read

--- a/spec/requests/hosts_spec.rb
+++ b/spec/requests/hosts_spec.rb
@@ -1,10 +1,22 @@
 RSpec.describe "hosts API" do
   describe "editing a host's password" do
     context "with an appropriate role" do
+      # credentials parameter is the legacy rail controller format for editing a host
       it "can edit the password on a host" do
         host = FactoryBot.create(:host_with_authentication)
         api_basic_authorize action_identifier(:hosts, :edit)
         options = {:credentials => {:authtype => "default", :password => "abc123"}}
+
+        expect do
+          post api_host_url(nil, host), :params => gen_request(:edit, options)
+        end.to change { host.reload.authentication_password(:default) }.to("abc123")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "can edit the password on a host using new/react format" do
+        host = FactoryBot.create(:host_with_authentication)
+        api_basic_authorize action_identifier(:hosts, :edit)
+        options = {"authentications" => {"default" => {"userid" => "root", "password" => "abc123"}}}
 
         expect do
           post api_host_url(nil, host), :params => gen_request(:edit, options)


### PR DESCRIPTION
- parent PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/8608
- depends upon: https://github.com/ManageIQ/manageiq/pull/22336

Exposes `Host#verify_credentials` for the api

This allows the user to verify credentials for a host.

/cc @MelsHyrule 