### PR TITLE
Implement cloud snapshot collector, list page, create & delete methods

### DIFF
--- a/app/controllers/api/cloud_volume_snapshots_controller.rb
+++ b/app/controllers/api/cloud_volume_snapshots_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  class CloudVolumeSnapshotsController < BaseController
+    def delete_resource_action(type, id = nil, _data = nil)
+      api_resource(type, id, "Deleting", :supports => :delete) do |snapshot|
+        {:task_id => snapshot.delete_snapshot_queue(User.current_userid)}
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -758,10 +758,26 @@
         :identifier: cloud_tenant_tag
   :cloud_volume_snapshots:
     :description: Cloud Volume Snapshots
+    :identifier: cloud_volume_snapshots
     :options:
-    - :subcollection
-    :verbs: *gpppd
+    - :collection
+    :verbs: *gpd
     :klass: CloudVolumeSnapshot
+    :subcollections:
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: cloud_volume_snapshot_view
+      :post:
+      - :name: delete
+        :identifier: cloud_volume_snapshot_delete
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: cloud_volume_snapshot_view
+      :post:
+      - :name: delete
+        :identifier: cloud_volume_snapshot_delete
   :cloud_volume_types:
     :description: Cloud Volume Types
     :identifier: cloud_volume_type

--- a/config/api.yml
+++ b/config/api.yml
@@ -758,10 +758,10 @@
         :identifier: cloud_tenant_tag
   :cloud_volume_snapshots:
     :description: Cloud Volume Snapshots
-    :identifier: cloud_volume_snapshots
+    :identifier: cloud_volume_snapshot
     :options:
     - :collection
-    :verbs: *gpd
+    :verbs: *gpppd
     :klass: CloudVolumeSnapshot
     :subcollections:
     :collection_actions:

--- a/spec/requests/cloud_volume_snapshots_spec.rb
+++ b/spec/requests/cloud_volume_snapshots_spec.rb
@@ -77,5 +77,16 @@ RSpec.describe "CloudVolumeSnapshots API" do
         expect_bad_request(/Feature not .*supported/)
       end
     end
+
+    describe "DELETE /api/cloud_volumes/:c_id/cloud_volume_snapshots/:s_id" do
+      it "create & delete cloud volume snapshot" do
+        api_basic_authorize('cloud_volume_snapshot_delete')
+
+        stub_supports(CloudVolumeSnapshot, :delete)
+        post(api_cloud_volume_snapshot_url(nil, cloud_volume_snapshot), :params => gen_request(:delete))
+
+        expect_single_action_result(:success => true, :message => /Deleting Cloud Volume Snapshot id: #{cloud_volume_snapshot.id} name: '#{cloud_volume_snapshot.name}'/)
+      end
+    end
   end
 end


### PR DESCRIPTION
We have developed an integration with a new resource type - "cloud volume snapshot" on the Autosde side. Now, we can provide a list of snapshots from the attached physical storage, create a new one based on a particular volume object and delete it - by using the Autosde rest endpoint (The Autosde GEM is already updated with these new features).
Following these new features, I have added to our (MIQ Autosde provider) collector and refresher to pull snapshots from Autosde and show them in the right place - Cloud Volume Snapshots. I also added the counter component to the provider dashboard.

List page:
![image](https://user-images.githubusercontent.com/33315712/218869146-daaa2529-3fdd-45e9-ac3c-2570896271a0.png)

Snapshot summary page:
![image](https://user-images.githubusercontent.com/33315712/218869307-c048bcaf-2d0c-4440-b424-dc4d41eac5da.png)

Dashboard:
![image](https://user-images.githubusercontent.com/33315712/218869365-be4953bf-936c-4728-bc7c-b682b6fb9078.png)

Create snapshot from cloud volume:
1.
![image](https://user-images.githubusercontent.com/33315712/220778117-7cc9327c-6ec9-4429-a310-8ddc7453c976.png)
2.
![image](https://user-images.githubusercontent.com/33315712/220781667-0899679b-7972-42c8-9dcd-87a2ffca9968.png)

Delete button exists as well at the snapshots page
# related PRs:
- https://github.com/ManageIQ/manageiq-ui-classic/pull/8647
- https://github.com/ManageIQ/manageiq-providers-autosde/pull/210
- https://github.com/ManageIQ/manageiq/pull/22359