### PR TITLE
Remove oVirt probes from provider spec

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -465,13 +465,6 @@ describe "Providers API" do
   end
 
   describe "Providers create" do
-    before(:each) do
-      require "ovirtsdk4" # incase it hasn't been autoloaded yet
-
-      allow(OvirtSDK4::Probe).to receive(:probe)
-        .and_return([OvirtSDK4::ProbeResult.new(:version => '3')])
-    end
-
     it 'invokes the DDF creation when ddf=true' do
       api_basic_authorize collection_action_identifier(:providers, :create)
 
@@ -742,13 +735,6 @@ describe "Providers API" do
   end
 
   describe "Providers edit" do
-    before(:each) do
-      require "ovirtsdk4" # incase it hasn't been autoloaded yet
-
-      allow(OvirtSDK4::Probe).to receive(:probe)
-        .and_return([OvirtSDK4::ProbeResult.new(:version => '3')])
-    end
-
     it 'invokes the DDF creation when ddf=true' do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 


### PR DESCRIPTION
- these should be removed due to pluggability reasons

@miq-bot add_label test
@miq-bot assign @Fryguy  
@miq-bot add_reviewer @agrare 