### PR TITLE
Fix cloud_volume clone supports spec

### DIFF
--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -326,8 +326,8 @@ describe "Cloud Volumes API" do
       end
 
       it 'clone raises an error if the cloud volume does not support clone' do
-        cloud_volume = FactoryBot.create(:cloud_volume_autosde)
-        stub_supports_not(:cloud_volume, :clone)
+        cloud_volume = FactoryBot.create(:cloud_volume)
+        stub_supports_not(cloud_volume, :clone)
 
         api_basic_authorize(action_identifier(:cloud_volumes, :clone, :resource_actions, :post))
 


### PR DESCRIPTION
The spec was using stub_supports_not on the class, not the specific cloud_volume which meant when autosde added clone support the spec began to fail.

We should be using a generic factory not a provider specific factory, and we should stub_supports_not on the object not just the class.