### PR TITLE
use stub_settings_merge in specs

### DIFF
--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -344,7 +344,7 @@ describe "Authentication API" do
         end
 
         it "gets a token based identifier with an updated UI based token_ttl" do
-          ::Settings.session.timeout = 1234
+          stub_settings_merge(:session => {:timeout => 1234})
           api_basic_authorize
 
           get api_auth_url, :params => { :requester_type => "ui" }

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -85,7 +85,7 @@ describe "Widgets API" do
       context "generate_content for group" do
         before do
           api_basic_authorize('widget_generate_content')
-          stub_settings(::Settings.to_hash.merge(:product => {:report_sync => true}))
+          stub_settings_merge(:product => {:report_sync => true})
         end
 
         it "generates single widget content" do


### PR DESCRIPTION
best to not alter settings between tests but rather stub settings.
These can lead to sporadic test failures.