### PR TITLE
Fix Provider#verify_credentials

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -102,15 +102,17 @@ module Api
       end
     end
 
-    # NOTE: _type == :providers
-    def verify_credentials_resource(_type, id = nil, data = {})
-      klass = fetch_provider_klass(collection_class(:providers), data)
-      zone_name = data.delete('zone_name')
-      data['id'] = id if id
-      task_id = klass.verify_credentials_task(current_user.userid, zone_name, data)
-      action_result(true, 'Credentials sent for verification', :task_id => task_id)
-    rescue => err
-      action_result(false, err.to_s)
+    # NOTE: the ui's zone drop down is currently passing the zone_id
+    def verify_credentials_resource(type, id = nil, data = {})
+      api_action(type, id) do |klass|
+        ems_klass = fetch_provider_klass(klass, data)
+        zone_name = data.delete('zone_name')
+        zone_id = data.delete('zone_id')
+        zone_name ||= resource_search(zone_id, :zones)&.name if zone_id
+        data['id'] = id if id
+        task_id = ems_klass.verify_credentials_task(current_user.userid, zone_name, data)
+        action_result(true, 'Credentials sent for verification', :task_id => task_id)
+      end
     end
 
     def check_compliance_resource(type, id, _data = nil)

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -464,6 +464,22 @@ describe "Providers API" do
     end
   end
 
+  describe "verify_credentials" do
+    it "creates a task" do
+      api_basic_authorize collection_action_classed_identifier(:providers, :create, :post, "ManageIQ::Providers::InfraManager")
+      data = {
+        "type"            => "ManageIQ::Providers::Vmware::InfraManager",
+        "authentications" => {"userid" => "user", "password" => "pass"},
+        "endpoints"       => {"default" => {"hostname"=>"host"}}
+      }
+
+      expect(ManageIQ::Providers::Vmware::InfraManager).to receive(:verify_credentials_task).with(@user.userid, @zone.name, data).and_call_original
+
+      post(api_providers_url, :params => gen_request("verify_credentials", data.merge("zone_id" => @zone.id)))
+      expect_multiple_action_result(1, :success => true, :message => /verification/i, :task => true)
+    end
+  end
+
   describe "Providers create" do
     it 'invokes the DDF creation when ddf=true' do
       api_basic_authorize collection_action_identifier(:providers, :create)


### PR DESCRIPTION
Currently, `Providers#verify_credentials` is not looking at the right place for the zone. This fixes this bug

pulled out of #1202 

- Use type instead of hard coding the value (both are :providers)
- Use api_action - it is the common way of catching
- Handle zone coming in as zone_name or zone_id (current case)