### PR TITLE
Fix specs requiring memcached

### DIFF
--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -243,10 +243,14 @@ describe "Authentication API" do
     end
   end
 
-  context "Token Based Authentication" do
+  describe "Token Based Authentication" do
     %w(sql memory cache).each do |session_store|
       context "when using a #{session_store} session store" do
-        before { stub_settings_merge(:server => {:session_store => session_store}) }
+        before do
+          MiqMemcached.client({}).get("test") if session_store == "cache"
+
+          stub_settings_merge(:server => {:session_store => session_store})
+        end
 
         it "gets a token based identifier" do
           api_basic_authorize

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -614,163 +614,164 @@ RSpec.describe "users API" do
     end
   end
 
-  context "Revoking Sessions" do
-    before do
-      # Keep this outside of the loop below with the `let` providing the value
-      # for the stub, otherwise it will not work as expected
-      stub_settings_merge(:server => {:session_store => session_store_value})
-      TokenStore.token_caches.clear
-    end
+  describe "Revoking Sessions" do
+    %w[sql memory cache].each do |session_store|
+      context "when using a #{session_store} session store" do
+        before do
+          MiqMemcached.client({}).get("test") if session_store == "cache"
 
-    after { TokenStore.token_caches.clear }
+          stub_settings_merge(:server => {:session_store => session_store})
 
-    %w[cache sql memory].each do |session_store|
-      let(:session_store_value) { session_store }
-
-      it "revokes all own sessions of authenticated user with #{session_store}" do
-        api_basic_authorize
-
-        FactoryBot.create(:session, :user_id => @user.id)
-        expect(Session.where(:user_id => @user.id).count).to eq(1)
-
-        ts = TokenStore.acquire("api", 100)
-
-        ts.create_user_token("my_token", {:userid => @user.userid, :expires_on => Time.zone.now + 100.days}, {:expires_in => 100})
-
-        expect(ts.read("my_token")).not_to be_nil
-
-        if ::Settings.server.session_store == "sql"
-          expect(ts.read("my_token")[:userid]).to eq(@user.userid)
-        else
-          expect(ts.read("tokens_for_#{@user.userid}")).not_to be_nil
+          TokenStore.token_caches.clear
         end
 
-        ts.create_user_token("his_token", {:userid => user1.userid, :expires_on => Time.zone.now + 100.days}, {:expires_in => 100})
-        expect(ts.read("his_token")).not_to be_nil
+        after { TokenStore.token_caches.clear }
 
-        if ::Settings.server.session_store == "sql"
-          expect(ts.read("my_token")[:userid]).to eq(@user.userid)
-        else
-          expect(ts.read("tokens_for_#{@user.userid}")).not_to be_nil
-        end
+        it "revokes all own sessions of authenticated user" do
+          api_basic_authorize
 
-        post(api_users_url, :params => {'action' => "revoke_sessions"})
+          FactoryBot.create(:session, :user_id => @user.id)
+          expect(Session.where(:user_id => @user.id).count).to eq(1)
 
-        expect(Session.where(:user_id => @user.id).count).to eq(0)
+          ts = TokenStore.acquire("api", 100)
 
-        expect(response).to have_http_status(:ok)
-        expect(ts.read("my_token")).to be_nil
+          ts.create_user_token("my_token", {:userid => @user.userid, :expires_on => Time.zone.now + 100.days}, {:expires_in => 100})
 
-        unless ::Settings.server.session_store == "sql"
-          expect(ts.read("tokens_for_#{@user.userid}")).to be_nil
-        end
+          expect(ts.read("my_token")).not_to be_nil
 
-        expect(ts.read("his_token")).not_to be_nil
+          if ::Settings.server.session_store == "sql"
+            expect(ts.read("my_token")[:userid]).to eq(@user.userid)
+          else
+            expect(ts.read("tokens_for_#{@user.userid}")).not_to be_nil
+          end
 
-        unless ::Settings.server.session_store == "sql"
-          expect(ts.read("tokens_for_#{user1.userid}")).not_to be_nil
-        end
-      end
+          ts.create_user_token("his_token", {:userid => user1.userid, :expires_on => Time.zone.now + 100.days}, {:expires_in => 100})
+          expect(ts.read("his_token")).not_to be_nil
 
-      context "target user is other than authenticated user with #{session_store}" do
-        it "revokes sessions of resource user" do
-          api_basic_authorize :revoke_user_sessions
-          user1.miq_groups << @user.miq_groups.first
-          user1.save
+          if ::Settings.server.session_store == "sql"
+            expect(ts.read("my_token")[:userid]).to eq(@user.userid)
+          else
+            expect(ts.read("tokens_for_#{@user.userid}")).not_to be_nil
+          end
 
-          post(api_user_url(nil, user1), :params => {'action' => "revoke_sessions"})
+          post(api_users_url, :params => {'action' => "revoke_sessions"})
+
+          expect(Session.where(:user_id => @user.id).count).to eq(0)
 
           expect(response).to have_http_status(:ok)
+          expect(ts.read("my_token")).to be_nil
 
-          expect(response.parsed_body["success"]).to be_truthy
-          expect(response.parsed_body["message"]).to eq("All sessions revoked successfully for user #{user1.userid}.")
+          unless ::Settings.server.session_store == "sql"
+            expect(ts.read("tokens_for_#{@user.userid}")).to be_nil
+          end
+
+          expect(ts.read("his_token")).not_to be_nil
+
+          unless ::Settings.server.session_store == "sql"
+            expect(ts.read("tokens_for_#{user1.userid}")).not_to be_nil
+          end
         end
 
-        it "doesn't allow to revoke resource user sessions when authenticated user doesn't have access to resource user due to RBAC" do
-          api_basic_authorize :revoke_user_sessions
+        context "target user is other than authenticated user" do
+          it "revokes sessions of resource user" do
+            api_basic_authorize :revoke_user_sessions
+            user1.miq_groups << @user.miq_groups.first
+            user1.save
 
-          post(api_user_url(nil, user_admin), :params => {'action' => "revoke_sessions"})
+            post(api_user_url(nil, user1), :params => {'action' => "revoke_sessions"})
 
-          expect(response.parsed_body["success"]).to be_falsey
-          expect(response.parsed_body["message"]).to eq("Access to the resource users/#{user_admin.id} is forbidden")
-        end
+            expect(response).to have_http_status(:ok)
 
-        it "doesn't allow to revoke resource user sessions when authenticated user doesn't have access to resource user due to missing entitlement" do
-          api_basic_authorize
-          user1.miq_groups << @user.miq_groups.first
-          user1.save
+            expect(response.parsed_body["success"]).to be_truthy
+            expect(response.parsed_body["message"]).to eq("All sessions revoked successfully for user #{user1.userid}.")
+          end
 
-          post(api_user_url(nil, user1), :params => {'action' => "revoke_sessions"})
+          it "doesn't allow to revoke resource user sessions when authenticated user doesn't have access to resource user due to RBAC" do
+            api_basic_authorize :revoke_user_sessions
 
-          expect(response.parsed_body["success"]).to be_falsey
-          expect(response.parsed_body["message"]).to eq("The user is not authorized for this task or item.")
-        end
+            post(api_user_url(nil, user_admin), :params => {'action' => "revoke_sessions"})
 
-        let(:user_admin) do
-          User.all.detect(&:super_admin_user?) || FactoryBot.create(:user_admin, :userid => "admin")
-        end
+            expect(response.parsed_body["success"]).to be_falsey
+            expect(response.parsed_body["message"]).to eq("Access to the resource users/#{user_admin.id} is forbidden")
+          end
 
-        it "does allow to revoke resource user sessions when authenticated user is super_admin" do
-          api_basic_authorize
-          @user = user_admin
-          User.current_user = user_admin
-          allow(User).to receive(:current_user).and_return(user_admin)
+          it "doesn't allow to revoke resource user sessions when authenticated user doesn't have access to resource user due to missing entitlement" do
+            api_basic_authorize
+            user1.miq_groups << @user.miq_groups.first
+            user1.save
 
-          post(api_user_url(nil, user1), :params => {'action' => "revoke_sessions"})
+            post(api_user_url(nil, user1), :params => {'action' => "revoke_sessions"})
 
-          expect(response.parsed_body["success"]).to be_truthy
-          expect(response.parsed_body["message"]).to eq("All sessions revoked successfully for user #{user1.userid}.")
-        end
+            expect(response.parsed_body["success"]).to be_falsey
+            expect(response.parsed_body["message"]).to eq("The user is not authorized for this task or item.")
+          end
 
-        let!(:user3) { FactoryBot.create(:user, :userid => "userX") }
+          let(:user_admin) do
+            User.all.detect(&:super_admin_user?) || FactoryBot.create(:user_admin, :userid => "admin")
+          end
 
-        let!(:resource_parameters) { [{"id" => user3.id.to_s}, {"id" => user1.id.to_s}, {"foo" => "bar"}, {"id" => "999_999"}] }
+          it "does allow to revoke resource user sessions when authenticated user is super_admin" do
+            api_basic_authorize
+            @user = user_admin
+            User.current_user = user_admin
+            allow(User).to receive(:current_user).and_return(user_admin)
 
-        let(:expected_result_user3) do
-          {
-            "success" => false,
-            "message" => "Access to the resource users/#{user3.id} is forbidden",
-            "href"    => "http://www.example.com/api/users/#{user3.id}"
-          }
-        end
+            post(api_user_url(nil, user1), :params => {'action' => "revoke_sessions"})
 
-        let(:expected_result_user1) do
-          {
-            "success" => true,
-            "message" => "All sessions revoked successfully for user #{user1.userid}.",
-            "href"    => "http://www.example.com/api/users/#{user1.id}"
-          }
-        end
+            expect(response.parsed_body["success"]).to be_truthy
+            expect(response.parsed_body["message"]).to eq("All sessions revoked successfully for user #{user1.userid}.")
+          end
 
-        let(:expected_result_invalid_id) do
-          {
-            "success" => false,
-            "message" => "Invalid User id nil specified",
-            "href"    => "http://www.example.com/api/users/"
-          }
-        end
+          let!(:user3) { FactoryBot.create(:user, :userid => "userX") }
 
-        let(:expected_result_not_found) do
-          {
-            "success" => false,
-            "message" => "Couldn't find User with 'id'=999999",
-            "href"    => "http://www.example.com/api/users/999999"
-          }
-        end
+          let!(:resource_parameters) { [{"id" => user3.id.to_s}, {"id" => user1.id.to_s}, {"foo" => "bar"}, {"id" => "999_999"}] }
 
-        let(:expected_results) do
-          [expected_result_user3, expected_result_user1, expected_result_invalid_id, expected_result_not_found]
-        end
+          let(:expected_result_user3) do
+            {
+              "success" => false,
+              "message" => "Access to the resource users/#{user3.id} is forbidden",
+              "href"    => "http://www.example.com/api/users/#{user3.id}"
+            }
+          end
 
-        it "tries to revoke resource users sessions when authenticated user doesn't have access to all users" do
-          api_basic_authorize :revoke_user_sessions
+          let(:expected_result_user1) do
+            {
+              "success" => true,
+              "message" => "All sessions revoked successfully for user #{user1.userid}.",
+              "href"    => "http://www.example.com/api/users/#{user1.id}"
+            }
+          end
 
-          user1.miq_groups << @user.miq_groups.first
-          user1.save
+          let(:expected_result_invalid_id) do
+            {
+              "success" => false,
+              "message" => "Invalid User id nil specified",
+              "href"    => "http://www.example.com/api/users/"
+            }
+          end
 
-          post(api_users_url, :params => {"action" => "revoke_sessions", "resources" => resource_parameters})
+          let(:expected_result_not_found) do
+            {
+              "success" => false,
+              "message" => "Couldn't find User with 'id'=999999",
+              "href"    => "http://www.example.com/api/users/999999"
+            }
+          end
 
-          expect(response.parsed_body["results"]).to match_array(expected_results)
+          let(:expected_results) do
+            [expected_result_user3, expected_result_user1, expected_result_invalid_id, expected_result_not_found]
+          end
+
+          it "tries to revoke resource users sessions when authenticated user doesn't have access to all users" do
+            api_basic_authorize :revoke_user_sessions
+
+            user1.miq_groups << @user.miq_groups.first
+            user1.save
+
+            post(api_users_url, :params => {"action" => "revoke_sessions", "resources" => resource_parameters})
+
+            expect(response.parsed_body["results"]).to match_array(expected_results)
+          end
         end
       end
     end


### PR DESCRIPTION
When memcached was not available, the specs would fail, but not in the way that was expected. Before this commit, fetching a value would just return nil, and while the spec would fail, it was misleading. Now, the spec will fail early if memcached is not available and it is clear why the spec fails.

Additionally, it was found that the closures in users_spec were invalid, so while the spec was written to test sql, memory, and cache, due to the closures all 3 sets of tests were actually running cache. This was more evident when the memcached checks were added because both sql and memory were both failing in the abscence of memcached. This commit fixes those closures so they run accurately.

@jrafanie or @kbrock Please review.  This is much easier to review with whitespace turned off: https://github.com/ManageIQ/manageiq-api/pull/1212/files?w=1

Also note that this is why cross-repo tests continually fail on api - it's because we don't have memcached running there.  Separate PR incoming for that: https://github.com/ManageIQ/manageiq-cross_repo/pull/98