### PR TITLE
change `StorageServicesController` base class to `BaseProviderController`

### DIFF
--- a/app/controllers/api/storage_services_controller.rb
+++ b/app/controllers/api/storage_services_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class StorageServicesController < BaseController
+  class StorageServicesController < BaseProviderController
     def refresh_resource(type, id, _data = nil)
       enqueue_ems_action(type, id, "Refreshing", :method_name => :refresh_ems)
     end


### PR DESCRIPTION
changed `StorageServicesController` base class to `BaseProviderController` so we could generate params for create from the model.

part of issue:
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/issues/8701