### PR TITLE
storage service edit

### DIFF
--- a/app/controllers/api/storage_services_controller.rb
+++ b/app/controllers/api/storage_services_controller.rb
@@ -15,5 +15,11 @@ module Api
         {:task_id => storage_service.delete_storage_service_queue(User.current_userid)}
       end
     end
+
+    def edit_resource(type, id, data = {})
+      api_resource(type, id, "Updating", :supports => :update) do |storage_service|
+        {:task_id => storage_service.update_storage_service_queue(User.current_userid, data)}
+      end
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -4237,7 +4237,7 @@
     :identifier: storage_service
     :options:
     - :collection
-    :verbs: *gpd
+    :verbs: *gpppd
     :klass: StorageService
     :subcollections:
     :collection_actions:
@@ -4247,6 +4247,8 @@
       :post:
       - :name: create
         :identifier: storage_service_new
+      - :name: edit
+        :identifier: storage_service_edit
       - :name: delete
         :identifier: storage_service_delete
       - :name: refresh

--- a/spec/requests/storage_services_spec.rb
+++ b/spec/requests/storage_services_spec.rb
@@ -1,5 +1,8 @@
 describe "Storage Services API" do
   include Spec::Support::SupportsHelper
+
+  let(:provider) { FactoryBot.create(:ems_autosde) }
+
   context "GET /api/storage_services" do
     it "returns all storage_services" do
       storage_service = FactoryBot.create(:storage_service)
@@ -35,7 +38,6 @@ describe "Storage Services API" do
   context "POST /api/storage_services" do
     it "creates new Storage Service" do
       api_basic_authorize(collection_action_identifier(:storage_services, :create))
-      provider = FactoryBot.create(:ems_autosde)
       request = {
         "action"   => "create",
         "resource" => {
@@ -51,8 +53,7 @@ describe "Storage Services API" do
   end
 
   it "deletes a single Storage Service" do
-    provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
-    service = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::StorageService", :name => 'test_service', :ext_management_system => provider)
+    service = FactoryBot.create(:storage_service, :name => 'test_service', :ext_management_system => provider)
     api_basic_authorize('storage_service_delete')
 
     stub_supports(StorageService, :delete)
@@ -62,9 +63,8 @@ describe "Storage Services API" do
   end
 
   it "deletes multiple Storage Services" do
-    provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
-    service1 = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::StorageService", :name => 'test_service1', :ext_management_system => provider)
-    service2 = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::StorageService", :name => 'test_service2', :ext_management_system => provider)
+    service1 = FactoryBot.create(:storage_service, :name => 'test_service1', :ext_management_system => provider)
+    service2 = FactoryBot.create(:storage_service, :name => 'test_service2', :ext_management_system => provider)
     api_basic_authorize('storage_service_delete')
 
     stub_supports(StorageService, :delete)
@@ -78,5 +78,19 @@ describe "Storage Services API" do
     expect(results[1]["success"]).to match(true)
 
     expect(response).to have_http_status(:ok)
+  end
+
+  context 'Storage Services edit action' do
+    it "PUT /api/storage_services/:id'" do
+      storage_service = FactoryBot.create(:storage_service, :ext_management_system => provider)
+
+      api_basic_authorize('storage_service_edit')
+
+      stub_supports(StorageService, :update)
+      put(api_storage_service_url(nil, storage_service))
+
+      expect(response.parsed_body["message"]).to include("Updating")
+      expect(response).to have_http_status(:ok)
+    end
   end
 end


### PR DESCRIPTION
belongs to issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/8728

depends upon:
- [x] manageiq/manageiq#22425

adds editing/update option to storage service controller and app yaml