### PR TITLE
storage service edit mode: check which attached resources are compliant to selected capabilities

### DIFF
--- a/app/controllers/api/storage_services_controller.rb
+++ b/app/controllers/api/storage_services_controller.rb
@@ -21,5 +21,12 @@ module Api
         {:task_id => storage_service.update_storage_service_queue(User.current_userid, data)}
       end
     end
+
+    def check_compliant_resources_resource(type, id = nil, data = {})
+      data["_id"] = id
+      api_ems_resource(type, data, "Checking Compliant Resources", :supports => :check_compliant_resources) do |ems, storage_service|
+        {:task_id => storage_service.check_compliant_resources_queue(User.current_userid, ems, data)}
+      end
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -4255,6 +4255,7 @@
     :identifier: storage_service
     :options:
     - :collection
+    - :custom_actions
     :verbs: *gpppd
     :klass: StorageService
     :subcollections:
@@ -4273,6 +4274,8 @@
         :identifier: storage_service_refresh
       - :name: query
         :identifier: storage_service_show_list
+      - :name: check_compliant_resources
+        :identifier: check_compliant_resources
     :resource_actions:
       :get:
       - :name: read


### PR DESCRIPTION
issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/8749

added button in service edit mode which enables user to check what currently attached resources will comply with the selected capabilities.

this PR adds the action to the api controller and to api.yml

- [x] note that it is based on the yet to be merged #1216, and should be rebased on master after that is merged. 