### PR TITLE
Use standard create/update/delete features for Authentications

### DIFF
--- a/app/controllers/api/subcollections/authentications.rb
+++ b/app/controllers/api/subcollections/authentications.rb
@@ -5,8 +5,11 @@ module Api
         object.respond_to?(:authentications) ? object.authentications : []
       end
 
-      def authentications_create_resource(parent, _type, _id, data)
-        task_id = AuthenticationService.create_authentication_task(parent.manager, data)
+      def authentications_create_resource(parent, type, _id, data)
+        klass = ::Authentication.descendant_get(data['type'])
+        ensure_supports(type, klass, :create)
+
+        task_id = klass.create_in_provider_queue(parent.manager.id, data.deep_symbolize_keys)
         action_result(true, 'Creating Authentication', :task_id => task_id)
       rescue => err
         action_result(false, err.to_s)

--- a/lib/services/api/authentication_service.rb
+++ b/lib/services/api/authentication_service.rb
@@ -1,9 +1,0 @@
-module Api
-  class AuthenticationService
-    def self.create_authentication_task(manager_resource, attrs)
-      klass = ::Authentication.descendant_get(attrs['type'])
-      raise 'type not currently supported' unless klass.respond_to?(:create_in_provider_queue)
-      klass.create_in_provider_queue(manager_resource.id, attrs.deep_symbolize_keys)
-    end
-  end
-end

--- a/spec/requests/configuration_script_payloads_spec.rb
+++ b/spec/requests/configuration_script_payloads_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe 'Configuration Script Payloads API' do
+  include Spec::Support::SupportsHelper
+
   describe 'GET /api/configuration_script_payloads' do
     it 'lists all the configuration script payloads with an appropriate role' do
       script_payload = FactoryBot.create(:configuration_script_payload)
@@ -227,7 +229,7 @@ RSpec.describe 'Configuration Script Payloads API' do
 
       expected = {
         'results' => [
-          { 'success' => false, 'message' => 'type not currently supported' }
+          { 'success' => false, 'message' => 'Create for Authentications: Feature not available/supported' }
         ]
       }
       expect(response).to have_http_status(:bad_request)
@@ -236,6 +238,7 @@ RSpec.describe 'Configuration Script Payloads API' do
 
     it 'creates a new authentication with an appropriate role' do
       api_basic_authorize subcollection_action_identifier(:configuration_script_payloads, :authentications, :create)
+      stub_supports(Authentication, :create)
 
       post(api_configuration_script_payload_authentications_url(nil, playbook), :params => params)
 


### PR DESCRIPTION
Move the `/api/authentications` endpoint towards using standard create/update/delete supports features rather than checking for specific methods.

The goal is to use the standard `create_ems_resource` and `ems_resource` actions here

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/22894
- [x] https://github.com/ManageIQ/manageiq-providers-awx/pull/24