### PR TITLE
remove unneeded responders

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -31,8 +31,6 @@ module Api
     before_action :ensure_pagination, :only => :index
     after_action :log_api_response
 
-    respond_to :json
-
     # Order *Must* be from most generic to most specific
     rescue_from(StandardError)                  { |e| api_error(:internal_server_error, e) }
     rescue_from(NoMethodError)                  { |e| api_error(:internal_server_error, e) }


### PR DESCRIPTION
we are not using respond_with, so no need to setup responders gem with respond_to

this removes the dependency on `responders` gem

part of https://github.com/ManageIQ/manageiq/pull/22490