### PR TITLE
drop Vmdb::GlobalMethod#column_type

### DIFF
--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -64,26 +64,8 @@ module Api
 
     def parse_filter(filter)
       logical_or = filter.gsub!(/^or /i, '').present?
-
-      operator = nil
-      operators_from_longest_to_shortest = OPERATORS.keys.sort_by(&:size).reverse
-      filter.size.times do |i|
-        operator = operators_from_longest_to_shortest.detect do |o|
-          o == filter[(i..(i + o.size - 1))]
-        end
-        break if operator
-      end
-
-      if operator.blank?
-        raise BadRequestError, "Unknown operator specified in filter #{filter}"
-      end
-
+      filter_field, operator, filter_value = split_filter_string(filter)
       methods = OPERATORS[operator]
-      filter_attr, _, filter_value = filter.partition(operator)
-      filter_attr.strip!
-      filter_value.strip!
-      *associations, attr = filter_attr.split(".")
-      filter_field = MiqExpression::Field.new(model, associations, attr)
 
       is_regex = filter_value =~ /%|\*/ && methods[:regex]
       str_method = is_regex ? methods[:regex] : methods[:default]
@@ -135,6 +117,27 @@ module Api
 
     def single_expression(field, operator, value)
       {operator => {"field" => field.to_s, "value" => value}}
+    end
+
+    def split_filter_string(filter)
+      operator = nil
+      operators_from_longest_to_shortest = OPERATORS.keys.sort_by(&:size).reverse
+      filter.size.times do |i|
+        operator = operators_from_longest_to_shortest.detect do |o|
+          o == filter[(i..(i + o.size - 1))]
+        end
+        break if operator
+      end
+
+      if operator.blank?
+        raise BadRequestError, "Unknown operator specified in filter #{filter}"
+      end
+
+      filter_attr, _op, filter_value = filter.partition(operator)
+      filter_value.strip!
+      filter_attr.strip!
+      *associations, attr_name = filter_attr.split(".")
+      [MiqExpression::Field.new(model, associations, attr_name), operator, filter_value]
     end
   end
 end

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -387,5 +387,23 @@ RSpec.describe Api::Filter do
       expected = {"REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "MiqReport-name", "value" => "/foo/i"}}
       expect(actual.exp).to eq(expected)
     end
+
+    it "supports filtering with operators in the strings" do
+      filters = ["host.name='foo='"]
+
+      actual = described_class.parse(filters, Vm)
+
+      expected = {"=" => {"field" => "Vm.host-name", "value" => "foo="}}
+      expect(actual.exp).to eq(expected)
+    end
+
+    it "supports filtering with multiple operators in the strings" do
+      filters = ["host.name<'<=foo=>'"]
+
+      actual = described_class.parse(filters, Vm)
+
+      expected = {"<" => {"field" => "Vm.host-name", "value" => "<=foo=>"}}
+      expect(actual.exp).to eq(expected)
+    end
   end
 end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "categories API" do
 
     get api_categories_url, :params => { :filter => ["not_an_attribute=foo"] }
 
-    expect_bad_request(/attribute not_an_attribute does not exist/)
+    expect_bad_request(/attribute Category-not_an_attribute does not exist/)
   end
 
   it "can read a category" do

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -710,7 +710,7 @@ describe "Querying" do
       expected = {
         "error" => a_hash_including(
           "kind"    => "bad_request",
-          "message" => "Must filter on valid attributes for resource"
+          "message" => /attribute Vm-destroy does not exist/
         )
       }
       expect(response.parsed_body).to include(expected)


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/22520

- Don't traverse MiqExpression::Field associations, but use MiqExpression to do it.
- Use `column_type` in `MiqExpression::Field` instead of the `Vmdb::GlobalMethod#column_type`

Side effects: Api used to only have the input parameter to determine what to do with parameters. Now it has an MiqExpression::Field with all the metadata and introspection. There is a lot of potential here. 