### PR TITLE
[WIP] Use AS::Dependencies interlock with classic autoloader

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -141,13 +141,13 @@ module Api
     end
 
     def permitted_subclasses
-      ActiveSupport::Dependencies.interlock.loading do
+      AsDependenciesInterlock.loading do
         ManageIQ::Providers::BaseManager.permitted_subclasses
       end
     end
 
     def supported_types_for_create
-      ActiveSupport::Dependencies.interlock.loading do
+      AsDependenciesInterlock.loading do
         ExtManagementSystem.supported_types_for_create
       end
     end

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -25,9 +25,7 @@ module Api
       @time_attributes ||= ApiConfig.collections.each.with_object(Set.new(%w(expires_on))) do |(_, cspec), result|
         next if cspec[:klass].blank?
         klass = nil
-
-        # Ensure we're the only thread trying to autoload classes and their columns
-        ActiveSupport::Dependencies.interlock.loading do
+        AsDependenciesInterlock.loading do
           klass = cspec[:klass].constantize
           klass.columns_hash.each do |name, typeobj|
             result << name if %w(date datetime).include?(typeobj.type.to_s)


### PR DESCRIPTION
Hide the details about inspecting the autoloader by using the core method which will use the interlock with classic and no interlock for zeitwerk.

Depends on: https://github.com/ManageIQ/manageiq/pull/22539
Related: https://github.com/ManageIQ/manageiq/issues/22000