### PR TITLE
Add support for edit configuration_script_payloads

### DIFF
--- a/app/controllers/api/configuration_script_payloads_controller.rb
+++ b/app/controllers/api/configuration_script_payloads_controller.rb
@@ -11,6 +11,31 @@ module Api
       unpermitted_params = data.keys.map(&:to_s) - allowed_params
       raise BadRequestError, _("Invalid parameters: %{params}" % {:params => unpermitted_params.join(", ")}) if unpermitted_params.any?
 
+      # If a credentials payload is provided, map any requested authentication
+      # records to the configuration_script_payload via the
+      # authentications_configuration_script_payloads join table.
+      unless data["credentials"].nil?
+        # Credentials can be a static string or a payload with an external
+        # Authentication record referenced by credential_ref and credential_field.
+        credential_refs = data["credentials"].values.select { |val| val.kind_of?(Hash) }.pluck("credential_ref")
+        # Lookup the Authentication record by ems_ref in the parent manager's
+        # list of authentications.
+        credentials     = resource.manager&.authentications&.where(:ems_ref => credential_refs) || []
+        # Filter the collection based on the current user's RBAC roles.
+        credentials, _  = collection_filterer(credentials, "authentications", ::Authentication)
+        # If any requested authentications were unable to be found, either due
+        # to a bad credential_ref or due to RBAC then raise a 400 BadRequestError.
+        missing_credential_refs = credential_refs - credentials.pluck(:ems_ref)
+        if missing_credential_refs.any?
+          raise BadRequestError,
+                _("Could not find credentials %{missing_credential_refs}") %
+                {:missing_credential_refs => missing_credential_refs}
+        end
+        # Reset the authentications collection with the current set of credentials.
+        # This will also remove any credential references not in the new payload.
+        resource.authentications = credentials
+      end
+
       resource.update!(data.except(*ID_ATTRS))
       resource
     end

--- a/app/controllers/api/configuration_script_payloads_controller.rb
+++ b/app/controllers/api/configuration_script_payloads_controller.rb
@@ -1,5 +1,18 @@
 module Api
   class ConfigurationScriptPayloadsController < BaseController
     include Subcollections::Authentications
+
+    def edit_resource(type, id, data)
+      resource = resource_search(id, type)
+
+      allowed_params  = %w[description credentials]
+      allowed_params += %w[name payload payload_type] if resource.configuration_script_source.nil?
+
+      unpermitted_params = data.keys.map(&:to_s) - allowed_params
+      raise BadRequestError, _("Invalid parameters: %{params}" % {:params => unpermitted_params.join(", ")}) if unpermitted_params.any?
+
+      resource.update!(data.except(*ID_ATTRS))
+      resource
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -986,7 +986,11 @@
     :options:
     - :collection
     - :subcollection
-    :verbs: *g
+    :verbs:
+    - :get
+    - :put
+    - :post
+    - :patch
     :klass: ConfigurationScriptPayload
     :subcollections:
     - :authentications
@@ -994,10 +998,16 @@
       :get:
       - :name: read
         :identifier: embedded_configuration_script_payload_view
+      :post:
+      - :name: edit
+        :identifier: embedded_configuration_script_payload_edit
     :resource_actions:
       :get:
       - :name: read
         :identifier: embedded_configuration_script_payload_view
+      :post:
+      - :name: edit
+        :identifier: embedded_configuration_script_payload_edit
     :subcollection_actions:
       :get:
       - :name: read

--- a/config/api.yml
+++ b/config/api.yml
@@ -23,6 +23,11 @@
     - :get
     - :post
     - :delete
+    :gppp: &gppp
+    - :get
+    - :put
+    - :post
+    - :patch
     :gpppd: &gpppd
     - :get
     - :put
@@ -986,11 +991,7 @@
     :options:
     - :collection
     - :subcollection
-    :verbs:
-    - :get
-    - :put
-    - :post
-    - :patch
+    :verbs: *gppp
     :klass: ConfigurationScriptPayload
     :subcollections:
     - :authentications


### PR DESCRIPTION
Workflows have a credentials jsonb column which allows users to map credentials to values being requested by the workflow.  This means we have to allow for a user to edit configuration_script_payloads to do this mapping.

`PATCH /api/configuration_script_payloads/:id {"credentials":{"api_user":{"credential_ref": "manageiq_api", "credential_field": "userid"}, "api_password":{"credential_ref": "manageiq_api", "credential_field": "password"}}`

Follow-up:
* https://github.com/ManageIQ/manageiq-providers-workflows/pull/40

TODO:
- [x] Fail the request if any of the credentials can't be found
- [x] Add specs for authentications owned by other user/tenant