### PR TITLE
Filter uses a regular expression

### DIFF
--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -1,5 +1,6 @@
 module Api
   class Filter
+    OPERATOR_REGEXP = /^ *([^=!>< ]+) *(!==?|[=!]~|[<>=]=?) *(.*?) *$/.freeze
     OPERATORS = {
       "!="  => {:default => "!=", :regex => "REGULAR EXPRESSION DOES NOT MATCH", :null => "IS NOT NULL"},
       "<="  => {:default => "<="},
@@ -121,22 +122,13 @@ module Api
     end
 
     def split_filter_string(filter)
-      operator = nil
-      operators_from_longest_to_shortest = OPERATORS.keys.sort_by(&:size).reverse
-      filter.size.times do |i|
-        operator = operators_from_longest_to_shortest.detect do |o|
-          o == filter[(i..(i + o.size - 1))]
-        end
-        break if operator
-      end
+      filter_match = OPERATOR_REGEXP.match(filter)
+      filter_attr, operator, filter_value = filter_match&.captures
 
-      if operator.blank?
+      unless OPERATORS.key?(operator)
         raise BadRequestError, "Unknown operator specified in filter #{filter}"
       end
 
-      filter_attr, _op, filter_value = filter.partition(operator)
-      filter_value.strip!
-      filter_attr.strip!
       *associations, attr_name = filter_attr.split(".")
       [MiqExpression::Field.new(model, associations, attr_name), operator, filter_value]
     end

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -68,7 +68,6 @@ module Api
       methods = OPERATORS[operator]
 
       is_regex = filter_value =~ /%|\*/ && methods[:regex]
-      str_method = is_regex ? methods[:regex] : methods[:default]
 
       filter_value, method = case filter_value
                              when /^\[(.*)\]$/
@@ -82,8 +81,10 @@ module Api
                                unquoted_filter_value = $1
                                if filter_field.column_type == :string_set && methods[:string_set]
                                  [unquoted_filter_value, methods[:string_set]]
+                               elsif is_regex
+                                 [unquoted_filter_value, methods[:regex]]
                                else
-                                 [unquoted_filter_value, str_method]
+                                 [unquoted_filter_value, methods[:default]]
                                end
                              when /^(NULL|nil)$/i
                                [nil, methods[:null] || methods[:default]]

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -441,6 +441,7 @@ RSpec.describe Api::Filter do
 
     [
       'name^bb',
+      '=bb',
       'name',
     ].each do |str|
       it "complains about '#{str}'" do


### PR DESCRIPTION
Overview
========

Instead of going through each character to find the operators,
use a regular expression that is coded to handle all the operators

Depends
=======

test helper

- https://github.com/ManageIQ/manageiq/pull/22615

Before
======

Loop through all characters in the filter
Loop through all operators
break when there is a match

After
=====

Use a regular expression to parse the filter


Notes
=====

This assumes a filter is made up of a name, operator, and value.
These assumptions seem to protect the code later on.

The original regular expression for the operator was: `/[!<>=][=~]=?/`
While easier to read, it had quite a few false positives.
The false positives were caught by the OPERATORS.key?, so not a big thing.
Possibly just using a long `/(a|b|c|d)/` may be a better route

I do wonder if we should be more greedy matching operator punctuation, and then
raising an error. The pedantic approach may make for a better developer
experience, but leaving it as it was for now.