### PR TITLE
Allow configuration_script_payloads#credentials to be shown

### DIFF
--- a/app/controllers/api/configuration_script_payloads_controller.rb
+++ b/app/controllers/api/configuration_script_payloads_controller.rb
@@ -2,6 +2,18 @@ module Api
   class ConfigurationScriptPayloadsController < BaseController
     include Subcollections::Authentications
 
+    def api_resource_action_options
+      # ConfigurationScriptPayloads do not have any passwords stored directly
+      # in the record, they reference the Authentication model via the
+      # credentials jsonb mapping.  The names of these mappings are user defined
+      # and can include e.g. "api_password" => {"credential_ref" => ..} and this
+      # entire key would be removed from the payload.
+      #
+      # Since there aren't any encrypted attributes in this record it is safe
+      # to include encrypted attributes in the payload response.
+      %w[include_encrypted_attributes]
+    end
+
     def edit_resource(type, id, data)
       resource = resource_search(id, type)
 

--- a/spec/requests/configuration_script_payloads_spec.rb
+++ b/spec/requests/configuration_script_payloads_spec.rb
@@ -105,7 +105,22 @@ RSpec.describe 'Configuration Script Payloads API' do
         it "adds the authentication to the configuration_script_payload.authentications" do
           api_basic_authorize collection_action_identifier(:configuration_script_payloads, :edit, :post)
 
-          post(api_configuration_script_payloads_url, :params => {:action => 'edit', :resources => [{:id => script_payload.id, :name => 'foo', :credentials => {"my-cred" => {"credential_ref" => "my-credential", "credential_field" => "userid"}}}]})
+          expected_credentials = {
+            "my-cred-user"     => {"credential_ref" => "my-credential", "credential_field" => "userid"},
+            "my-cred-password" => {"credential_ref" => "my-credential", "credential_field" => "password"},
+          }
+
+          resource = {
+            :id          => script_payload.id,
+            :name        => 'foo',
+            :credentials => expected_credentials
+          }
+
+          post(api_configuration_script_payloads_url, :params => {:action => 'edit', :resources => [resource]})
+
+          expect(response.parsed_body["results"].first).to include(
+            "credentials" => expected_credentials
+          )
           expect(script_payload.reload.authentications).to include(authentication)
         end
 


### PR DESCRIPTION
The configuration_script_payloads#credentials jsonb column does not contain credentials but based on how the user names the keys (e.g. `"vcenter_password": {"credential_ref": "vcenter_credential", "credential_field": "password"}` the payload will be stripped which causes issues for the UI to display these.


```
>> pp ConfigurationScriptPayload.first.credentials
=> 
{"manageiq_api_user"=>{"credential_ref"=>"manageiq-api", "credential_field"=>"userid"},
 "manageiq_api_password"=>{"credential_ref"=>"manageiq-api", "credential_field"=>"password"}}
```

Problem:
```
GET /api/configuration_script_payloads/1
{
  "href": "http://localhost:3000/api/configuration_script_payloads/1",
  "id": "1",
  "manager_id": "2",
  ...
  "credentials": {
    "manageiq_api_user": {
      "credential_ref": "manageiq-api",
      "credential_field": "userid"
    }
  },
```

With this PR:
```
GET /api/configuration_script_payloads/1
{
  "href": "http://localhost:3000/api/configuration_script_payloads/1",
  "id": "1",
  "manager_id": "2",
  ...
  "credentials": {
    "manageiq_api_user": {
      "credential_ref": "manageiq-api",
      "credential_field": "userid"
    },
    "manageiq_api_password": {
      "credential_ref": "manageiq-api",
      "credential_field": "password"
    }
  },
```