### PR TITLE
loading is not needed with zeitwerk autoloader

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -141,15 +141,11 @@ module Api
     end
 
     def permitted_subclasses
-      ActiveSupport::Dependencies.interlock.loading do
-        ManageIQ::Providers::BaseManager.permitted_subclasses
-      end
+      ManageIQ::Providers::BaseManager.permitted_subclasses
     end
 
     def supported_types_for_create
-      ActiveSupport::Dependencies.interlock.loading do
-        ExtManagementSystem.supported_types_for_create
-      end
+      ExtManagementSystem.supported_types_for_create
     end
 
     def providers_options

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -24,14 +24,10 @@ module Api
     def self.time_attributes
       @time_attributes ||= ApiConfig.collections.each.with_object(Set.new(%w(expires_on))) do |(_, cspec), result|
         next if cspec[:klass].blank?
-        klass = nil
 
-        # Ensure we're the only thread trying to autoload classes and their columns
-        ActiveSupport::Dependencies.interlock.loading do
-          klass = cspec[:klass].constantize
-          klass.columns_hash.each do |name, typeobj|
-            result << name if %w(date datetime).include?(typeobj.type.to_s)
-          end
+        klass = cspec[:klass].constantize
+        klass.columns_hash.each do |name, typeobj|
+          result << name if %w(date datetime).include?(typeobj.type.to_s)
         end
       end
     end


### PR DESCRIPTION
This was only needed for classic autoloader.  The core "freedom" patch made zeitwerk autoloader bypass the interlock anyway, so now that we're only supporting zeitwerk, this is no longer needed.

Co-dependency:
https://github.com/ManageIQ/manageiq/pull/22801

Part of the rails 7 upgrade: https://github.com/ManageIQ/manageiq/issues/22052