### PR TITLE
Drop include_concern

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -7,16 +7,16 @@ module Api
     #
     ID_ATTRS = %w(href id).freeze
 
-    include_concern 'Parameters'
-    include_concern 'Parser'
-    include_concern 'Manager'
-    include_concern 'Action'
-    include_concern 'Logger'
-    include_concern 'Normalizer'
-    include_concern 'Renderer'
-    include_concern 'Results'
-    include_concern 'Generic'
-    include_concern 'Authentication'
+    include Parameters
+    include Parser
+    include Manager
+    include Action
+    include Logger
+    include Normalizer
+    include Renderer
+    include Results
+    include Generic
+    include Authentication
     include ActionController::HttpAuthentication::Basic::ControllerMethods
     include ActionController::RequestForgeryProtection
 


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854