### PR TITLE
Update Resource Pool API to include type attribute

### DIFF
--- a/app/controllers/api/resource_pools_controller.rb
+++ b/app/controllers/api/resource_pools_controller.rb
@@ -3,5 +3,29 @@ module Api
     include Subcollections::Policies
     include Subcollections::PolicyProfiles
     include Subcollections::Tags
+
+    # GET /api/resource_pools
+    def index
+      if params[:type].present?
+        resource_pools = fetch_resource_pools_by_type(params[:type])
+        res = collection_filterer(resource_pools, :resource_pools, ResourcePool).flatten
+        counts = Api::QueryCounts.new(ResourcePool.count, res.count, resource_pools.count)
+        render_collection(:resource_pools, res, :counts => counts, :expand_resources => @req.expand?(:resources), :name => 'resource_pools')
+      else
+        super
+      end
+    end
+
+    private
+
+    # Fetch resource pools by exact type
+    def fetch_resource_pools_by_type(type)
+      rp = type.safe_constantize unless type.is_a?(Class)
+      if rp && rp <= ResourcePool
+        rp.all
+      else
+        ResourcePool.none
+      end
+    end
   end
 end

--- a/spec/requests/resource_pools_spec.rb
+++ b/spec/requests/resource_pools_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "Resource Pools API" do
+  context "Resource Pool Queries" do
+    before do
+      api_basic_authorize action_identifier(:resource_pools, :read, :collection_actions, :get)
+      FactoryBot.create(:resource_pool, :name => "ResourcePool1", :type => "ManageIQ::Providers::InfraManager::ResourcePool")
+      FactoryBot.create(:resource_pool, :name => "ResourcePool2", :type => "ManageIQ::Providers::CloudManager::ResourcePool")
+    end
+
+    it "returns all resource pools by default" do
+      get api_resource_pools_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("name" => "resource_pools", "subcount" => 2)
+      expect(response.parsed_body["resources"].size).to eq(2)
+      response.parsed_body["resources"].each do |resource|
+        expect(resource).to include("href")
+      end
+    end
+
+    it "returns only the requested attributes" do
+      get api_resource_pools_url, :params => {:expand => 'resources', :attributes => 'name'}
+
+      expect(response).to have_http_status(:ok)
+      response.parsed_body['resources'].each do |resource|
+        expect(resource.keys).to match_array(%w[href id name])
+      end
+    end
+
+    it "supports filtering by type" do
+      get api_resource_pools_url, :params => {:type => "ManageIQ::Providers::InfraManager::ResourcePool"}
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["resources"].size).to eq(1)
+      expect(response.parsed_body["resources"].first).to include("href")
+    end
+  end
+end


### PR DESCRIPTION
Dependent PR for enabling Resource Pool feature under Clouds section(Compute > Clouds > Resource Pools)


- manageiq Core changes
https://github.com/ManageIQ/manageiq/pull/22879

- manageiq-ui-classic changes
https://github.com/ManageIQ/manageiq-ui-classic/pull/8929

- manageiq-schema changes
https://github.com/ManageIQ/manageiq-schema/pull/718

- manageiq-api changes
https://github.com/ManageIQ/manageiq-api/pull/1248