### PR TITLE
Drop codeclimate-test-reporter

### DIFF
--- a/manageiq-api.gemspec
+++ b/manageiq-api.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   # See: https://github.com/rails/jbuilder/issues/461
   spec.add_dependency "jbuilder", "~> 2.5", "!= 2.9.0"
 
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"
 end


### PR DESCRIPTION
This is no longer needed now that we use paambaati/codeclimate-action.

@agare Please review.
