### PR TITLE
test sub-type search for basic resource listing (GET index)

### DIFF
--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -1007,5 +1007,19 @@ describe "Querying" do
       expect_query_result(:vms, 2, 2)
       expect(response.parsed_body["resources"].collect { |vm| vm["name"] }).to match_array(%w(bb cc))
     end
+
+    it "finds child classes given a parent class" do
+      FactoryBot.create(:vm_vmware, :name => "aa")
+      FactoryBot.create(:vm_vmware_cloud, :name => "bb")
+      FactoryBot.create(:vm_amazon, :name => "cc")
+
+      # parent of amazon and vmware_cloud.
+      vmc = FactoryBot.build(:vm_cloud)
+
+      get api_vms_url, :params => { :expand => "resources", :collection_class => vmc.class.name }
+
+      expect_query_result(:vms, 2, 2)
+      expect(response.parsed_body["resources"].collect { |vm| vm["name"] }).to match_array(%w(bb cc))
+    end
   end
 end


### PR DESCRIPTION
alternative to https://github.com/ManageIQ/manageiq-api/pull/1248

Overview
========

A typical api request views all VMs: `/api/vms`
If a screen displays all of a specific resource (e.g.: all Cloud or Infra VMs), then `collection_class` can be used: e.g.: `/api/vms?collection_class=ManageIQ::Providers::CloudManager::Vm`

Change
======

There was concern that `collection_class` could only handle a leaf class (e.g.: `ManageIQ::Providers::Openstack::CloudManager::Vm`) and would not be able to handle a grouping (e.g.: `ManageIQ::Providers::CloudManager::Vm`).

Originally this was the functionality added to display these resources. But it turns out `collection_class` can handle any approperiate class.

So this test has been converted to a test only PR.

