### PR TITLE
Use standard SupportsFeatureMixin

### DIFF
--- a/spec/requests/cloud_volume_snapshots_spec.rb
+++ b/spec/requests/cloud_volume_snapshots_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "CloudVolumeSnapshots API" do
   let(:ems) { FactoryBot.create(:ems_cinder) }
   let(:cloud_volume) { FactoryBot.create(:cloud_volume_openstack, :ext_management_system => ems) }
   let(:cloud_volume_snapshot) { FactoryBot.create(:cloud_volume_snapshot_openstack, :cloud_volume => cloud_volume, :ext_management_system => ems) }
+  let(:snapshot_klass) { ems.class_by_ems(:CloudVolumeSnapshot) }
 
   describe "as a subcollection of cloud volumes" do
     describe "GET /api/cloud_volumes/:c_id/cloud_volume_snapshots" do
@@ -61,7 +62,7 @@ RSpec.describe "CloudVolumeSnapshots API" do
     describe "POST /api/cloud_volumes/:c_id/cloud_volume_snapshots" do
       it "can queue the creation of a cloud volume snapshot" do
         api_basic_authorize(subcollection_action_identifier(:cloud_volumes, :cloud_volume_snapshots, :create))
-        stub_supports(CloudVolumeSnapshot, :create)
+        stub_supports(snapshot_klass, :create)
 
         post(api_cloud_volume_cloud_volume_snapshots_url(nil, cloud_volume), :params => {:name => "new snapshot"})
 
@@ -70,7 +71,7 @@ RSpec.describe "CloudVolumeSnapshots API" do
 
       it "renders a failed action response if cloud volume snapshotting is not supported" do
         api_basic_authorize(subcollection_action_identifier(:cloud_volumes, :cloud_volume_snapshots, :create))
-        stub_supports_not(ems.class_by_ems(:CloudVolumeSnapshot), :create)
+        stub_supports_not(snapshot_klass, :create)
 
         post(api_cloud_volume_cloud_volume_snapshots_url(nil, cloud_volume), :params => {:name => "Alice's snapshot"})
 
@@ -82,7 +83,7 @@ RSpec.describe "CloudVolumeSnapshots API" do
       it "create & delete cloud volume snapshot" do
         api_basic_authorize('cloud_volume_snapshot_delete')
 
-        stub_supports(CloudVolumeSnapshot, :delete)
+        stub_supports(snapshot_klass, :delete)
         post(api_cloud_volume_snapshot_url(nil, cloud_volume_snapshot), :params => gen_request(:delete))
 
         expect_single_action_result(:success => true, :message => /Deleting Cloud Volume Snapshot id: #{cloud_volume_snapshot.id} name: '#{cloud_volume_snapshot.name}'/)

--- a/spec/requests/cloud_volumes_spec.rb
+++ b/spec/requests/cloud_volumes_spec.rb
@@ -266,7 +266,7 @@ describe "Cloud Volumes API" do
 
     it 'attach raise an error if the cloud volume does not support attach' do
       cloud_volume = FactoryBot.create(:cloud_volume_autosde)
-      stub_supports_not(:cloud_volume, :attach)
+      stub_supports_not(cloud_volume, :attach)
 
       api_basic_authorize(action_identifier(:cloud_volumes, :attach, :resource_actions, :post))
 
@@ -281,7 +281,7 @@ describe "Cloud Volumes API" do
 
     it 'detach raise an error if the cloud volume does not support detach' do
       cloud_volume = FactoryBot.create(:cloud_volume_autosde)
-      stub_supports_not(:cloud_volume, :detach)
+      stub_supports_not(cloud_volume, :detach)
 
       api_basic_authorize(action_identifier(:cloud_volumes, :detach, :resource_actions, :post))
 

--- a/spec/requests/host_initiator_groups_spec.rb
+++ b/spec/requests/host_initiator_groups_spec.rb
@@ -1,4 +1,7 @@
 describe "Host Initiator Groups API" do
+  let(:provider) { FactoryBot.create(:ems_autosde, :name => 'Autosde') }
+  let(:host_initiator_group_klass) { provider.class_by_ems('HostInitiatorGroup') }
+  
   include Spec::Support::SupportsHelper
   context "POST /api/host_initiator_groups" do
     it "with an invalid ems_id it responds with 404 Not Found" do
@@ -20,7 +23,7 @@ describe "Host Initiator Groups API" do
 
     it "creates new Host Initiator Group" do
       api_basic_authorize(collection_action_identifier(:host_initiator_groups, :create))
-      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
+
       request = {
         "action"   => "create",
         "resource" => {
@@ -37,7 +40,7 @@ describe "Host Initiator Groups API" do
 
     it "Refuses to create without appropriate role" do
       api_basic_authorize
-      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
+
       request = {
         "action"   => "create",
         "resource" => {
@@ -53,9 +56,8 @@ describe "Host Initiator Groups API" do
 
     it "Won't create for unsupported models" do
       api_basic_authorize(collection_action_identifier(:host_initiator_groups, :create))
-      provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
 
-      stub_supports_not(ManageIQ::Providers::Autosde::StorageManager::HostInitiatorGroup, :create)
+      stub_supports_not(host_initiator_group_klass, :create)
 
       request = {
         "action"   => "create",
@@ -73,23 +75,21 @@ describe "Host Initiator Groups API" do
   end
 
   it "deletes a single Host Initiator Group" do
-    provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
-    host_initiator_group = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::HostInitiatorGroup", :name => 'test_host_initiator_group', :ext_management_system => provider)
+    host_initiator_group = FactoryBot.create(host_initiator_group_klass.name, :name => 'test_host_initiator_group', :ext_management_system => provider)
     api_basic_authorize('host_initiator_group_delete')
 
-    stub_supports(HostInitiatorGroup, :delete)
+    stub_supports(host_initiator_group_klass, :delete)
     post(api_host_initiator_group_url(nil, host_initiator_group), :params => gen_request(:delete))
 
     expect_single_action_result(:success => true, :message => /Deleting Host Initiator Group id: #{host_initiator_group.id} name: '#{host_initiator_group.name}'/)
   end
 
   it "deletes multiple Host Initiator Groups" do
-    provider = FactoryBot.create(:ems_autosde, :name => 'Autosde')
-    host_initiator_group1 = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::HostInitiatorGroup", :name => 'test_host_initiator_group1', :ext_management_system => provider)
-    host_initiator_group2 = FactoryBot.create("ManageIQ::Providers::Autosde::StorageManager::HostInitiatorGroup", :name => 'test_host_initiator_group2', :ext_management_system => provider)
+    host_initiator_group1 = FactoryBot.create(host_initiator_group_klass.name, :name => 'test_host_initiator_group1', :ext_management_system => provider)
+    host_initiator_group2 = FactoryBot.create(host_initiator_group_klass.name, :name => 'test_host_initiator_group2', :ext_management_system => provider)
     api_basic_authorize('host_initiator_group_delete')
 
-    stub_supports(HostInitiatorGroup, :delete)
+    stub_supports(host_initiator_group_klass, :delete)
     post(api_host_initiator_groups_url, :params => gen_request(:delete, [{"href" => api_host_initiator_group_url(nil, host_initiator_group1)}, {"href" => api_host_initiator_group_url(nil, host_initiator_group2)}]))
 
     results = response.parsed_body["results"]

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1629,6 +1629,7 @@ describe "Providers API" do
       context 'valid provider' do
         before do
           class DummyProvider
+            include SupportsFeatureMixin
             def self.permitted?
               true
             end

--- a/spec/requests/storage_services_spec.rb
+++ b/spec/requests/storage_services_spec.rb
@@ -2,6 +2,7 @@ describe "Storage Services API" do
   include Spec::Support::SupportsHelper
 
   let(:provider) { FactoryBot.create(:ems_autosde) }
+  let(:storage_service_klass) { FactoryBot.build(:storage_service).class }
 
   context "GET /api/storage_services" do
     it "returns all storage_services" do
@@ -46,7 +47,7 @@ describe "Storage Services API" do
           "description" => "description of test_storage_service",
         }
       }
-      stub_supports(StorageService, :create)
+      stub_supports(storage_service_klass, :create)
       post(api_storage_services_url, :params => request)
       expect_multiple_action_result(1, :success => true, :message => /Creating Storage Service test_storage_service for Provider #{provider.name}/, :task => true)
     end
@@ -56,7 +57,7 @@ describe "Storage Services API" do
     service = FactoryBot.create(:storage_service, :name => 'test_service', :ext_management_system => provider)
     api_basic_authorize('storage_service_delete')
 
-    stub_supports(StorageService, :delete)
+    stub_supports(storage_service_klass, :delete)
     post(api_storage_service_url(nil, service), :params => gen_request(:delete))
 
     expect_single_action_result(:success => true, :message => /Deleting Storage Service id: #{service.id} name: '#{service.name}'/)
@@ -67,7 +68,7 @@ describe "Storage Services API" do
     service2 = FactoryBot.create(:storage_service, :name => 'test_service2', :ext_management_system => provider)
     api_basic_authorize('storage_service_delete')
 
-    stub_supports(StorageService, :delete)
+    stub_supports(storage_service_klass, :delete)
     post(api_storage_services_url, :params => gen_request(:delete, [{"href" => api_storage_service_url(nil, service1)}, {"href" => api_storage_service_url(nil, service2)}]))
 
     results = response.parsed_body["results"]
@@ -86,7 +87,7 @@ describe "Storage Services API" do
 
       api_basic_authorize('storage_service_edit')
 
-      stub_supports(StorageService, :update)
+      stub_supports(storage_service_klass, :update)
       put(api_storage_service_url(nil, storage_service))
 
       expect(response.parsed_body["message"]).to include("Updating")


### PR DESCRIPTION
I'm reworking the way stub_supports works.
These two examples are not working well (and don't look valid to me)

stub_supports(klass, :feature)

- klass extends SupportsFeatureMixin
- pass the klass and not a symbol
