### PR TITLE
Use pluggable credential types method call

### DIFF
--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -37,7 +37,7 @@ module Api
 
     def build_additional_fields
       {
-        :credential_types => ::Authentication.build_credential_options
+        :credential_types => ::Authentication.credential_types
       }
     end
 


### PR DESCRIPTION
Originally credential types were hard coded in the `Authentication` class. With this change we can define credential types in the respective classes and then pull the info for the OPTIONS call from the new `Authentications.credential_types` method

Needed for:
- [ ] https://github.com/ManageIQ/manageiq/pull/22995

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_labels enhancement