### PR TITLE
Query metric rollups using start_date derived from the first rollup

### DIFF
--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1457,9 +1457,10 @@ describe "Providers API" do
     let(:provider) { FactoryBot.create(:ems_redhat) }
     let(:provider1) { FactoryBot.create(:ems_redhat) }
     let(:url) { api_provider_metric_rollups_url(nil, provider) }
+    let(:first_ts) { 1.hour.ago }
 
     before do
-      FactoryBot.create_list(:metric_rollup_cm_hr, 3, :resource => provider, :timestamp => 1.hour.ago)
+      FactoryBot.create_list(:metric_rollup_cm_hr, 3, :resource => provider, :timestamp => first_ts)
       FactoryBot.create_list(:metric_rollup_cm_daily, 1, :resource => provider)
       FactoryBot.create_list(:metric_rollup_cm_hr, 1, :resource => provider1)
     end
@@ -1467,8 +1468,7 @@ describe "Providers API" do
     it 'returns the metric rollups for the provider' do
       api_basic_authorize subcollection_action_identifier(:providers, :metric_rollups, :read, :get)
 
-      provider.metric_rollups.where(:capture_interval_name => 'hourly').name
-      get(url, :params => { :capture_interval => 'hourly', :start_date => Time.zone.today.to_s })
+      get(url, :params => { :capture_interval => 'hourly', :start_date => first_ts.to_date.to_s })
 
       expected = {
         'count'    => 5,
@@ -1483,7 +1483,7 @@ describe "Providers API" do
     it 'will not return metric rollups without an appropriate role' do
       api_basic_authorize
 
-      get(url, :params => { :capture_interval => 'hourly', :start_date => Time.zone.today.to_s })
+      get(url, :params => { :capture_interval => 'hourly', :start_date => first_ts.to_date.to_s })
 
       expect(response).to have_http_status(:forbidden)
     end


### PR DESCRIPTION
This resolves a time based sporadic failure.  This means it works for many hours of the day but fails with specific ones.

Previously, `Time.zone` is UTC, so `Time.zone.today` when run at August 15th at 12:05 AM UTC would return `Thu, 15 Aug 2024`.

If we created the rollups using `1.hour.ago`, the first one would be August 14th 11:05 PM.

If we our rollups were on August 14th and we're looking for August 15th hourly rollups, we find nothing.

This change ensures both the timestamp on the rollups and the start_date we query the rollups with come from the same time.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
