### PR TITLE
Fix Host verify_credentials_task password expectation

### DIFF
--- a/spec/requests/hosts_spec.rb
+++ b/spec/requests/hosts_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "hosts API" do
 
       verify_options = {
         "authentications" => {
-          "default" => {"userid" => "root", "password" => "abc123"}
+          "default" => {"userid" => "root", "password" => ManageIQ::Password.encrypt("abc123")}
         }
       }
 


### PR DESCRIPTION
The password is encrypted on the queue so we have to update our expectations in this test.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
