### PR TITLE
[QUINTEROS] Fix Host verify_credentials_task password expectation

### DIFF
--- a/spec/requests/hosts_spec.rb
+++ b/spec/requests/hosts_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "hosts API" do
 
       verify_options = {
         :credentials   => {
-          "default" => {:userid => "root", :password => "abc123"}
+          "default" => {:userid => "root", :password => ManageIQ::Password.encrypt("abc123")}
         },
         :remember_host => true
       }


### PR DESCRIPTION
Quinteros direct backport of https://github.com/ManageIQ/manageiq-api/pull/1271

Fix Host verify_credentials_task password expectation

(cherry picked from commit e83ac86008e00d7c6f68c5fc1d0db5f26d4425d1)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
