### PR TITLE
Treat result of to_h to be hashes recursively (support config gem 3+)

### DIFF
--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -75,7 +75,7 @@ describe "Authentication API" do
 
       get api_entrypoint_url
 
-      collection_names = Api::ApiConfig.collections.to_h.select { |_, v| v.options.include?(:collection) }.keys
+      collection_names = Api::ApiConfig.collections.to_h.select { |_, v| v[:options].include?(:collection) }.keys
       hrefs = collection_names.collect { |name| url_for(:controller => name, :action => "index") }
       expected = {
         "collections" => a_collection_containing_exactly(


### PR DESCRIPTION
Config gem version 3.0 removed the dot access from .to_h resulting values intentionally. See: https://www.github.com/rubyconfig/config/issues/217

In config 2.2.3, the result of:

```
Api::ApiConfig.collections.to_h
```

was:

```
(byebug) Api::ApiConfig.collections.to_h
{:accounts=>#<Config::Options description="Accounts", options=[:subcollection], verbs=[:get], klass="Account">, :actions=>#<Config::Options description="Actions", identifier="miq_action", options=[:collection], verbs=[:get, :put, :post,
...
```

With values being Config::Options objects.

In config gem 5.5.2, they're hashes all the way down:

```
(byebug) Api::ApiConfig.collections.to_h
{:accounts=>{:description=>"Accounts", :options=>[:subcollection], :verbs=>[:get], :klass=>"Account"}, :actions=>{:description=>"Actions", :identifier=>"miq_action", :options=>[:collection], :verbs=>[:get, :put, :post, :patch, :delete],
...
```

Note, if you don't convert to hash, you retain the Config::Options structure and API:

```
(byebug) Api::ApiConfig.collections
...
```

It's easy enough to change the access to assume nested hashes all the way down, which is also compatible with existing Config::Options behavior.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
