### PR TITLE
rails 7.1: response.parsed_body is now a HashWithIndifferentAccess

### DIFF
--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -2179,7 +2179,7 @@ describe "Vms API" do
 
       options(api_vm_snapshots_url(nil, vm))
 
-      expect(response.parsed_body['data']['snapshot_form_schema']).to be_an_instance_of(Hash)
+      expect(response.parsed_body['data']['snapshot_form_schema']).to be_kind_of(Hash)
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
I don't think we care about this being a hash, just a kind of hash.

Rails 7.1 changed the testing of responses in this PR to use a HWIA: https://www.github.com/rails/rails/pull/49003

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
