### PR TITLE
Test each subhash for included attributes, not subhash equality

### DIFF
--- a/spec/requests/chargebacks_spec.rb
+++ b/spec/requests/chargebacks_spec.rb
@@ -29,11 +29,12 @@ RSpec.describe "chargebacks API" do
 
     get api_rates_url, :params => request_attributes
 
-    expect(response.parsed_body['resources'][0]).to include("chargeback_tiers" => [expected_tier],
-                                                            "chargeable_field" => expected_chargeable_field,
-                                                            "chargeback_rate"  => expected_chargeback_rate,
-                                                            "detail_currency"  => expected_currency,
-                                                            "detail_measure"   => expected_measure)
+    response_first_resource = response.parsed_body["resources"][0]
+    expect(response_first_resource["chargeback_tiers"].first).to include(expected_tier)
+    expect(response_first_resource["chargeable_field"]).to include(expected_chargeable_field)
+    expect(response_first_resource["chargeback_rate"]).to include(expected_chargeback_rate)
+    expect(response_first_resource["detail_currency"]).to include(expected_currency)
+    expect(response_first_resource["detail_measure"]).to include(expected_measure)
 
     expect_result_to_match_hash(response.parsed_body, "count" => 1)
     expect(response).to have_http_status(:ok)


### PR DESCRIPTION
rails 7.1 adds id_value attribute alias, see:
https://www.github.com/rails/rails/pull/48930

We only care about the subhash includes some attributes, not that the subhashes match all attributes.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
