### PR TITLE
[WIP] Skip writing session for all API GET requests

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,11 @@
 module Api
   class BaseController < ActionController::API
+    after_action :skip_session_write
+
+    def skip_session_write
+      request.session_options[:skip] = true if %w[GET HEAD OPTIONS].include?(request.request_method)
+    end
+
     TAG_NAMESPACE = "/managed".freeze
 
     #


### PR DESCRIPTION
TODO: Determine if we can filter this to just GET requests and if we need to watch for the CSRF protections which generally require saving cookies.

NOTE:  This PR doesn't address /ws/notifications at this time.

### Before

Note the /api/notifications write_session below:

```
[----] D, [...#59755:c954] DEBUG -- development: RackSessionDalliLogger#find_session   id: a6562c80-e08c-48f9-821c-1c2da016cd02 method: GET fullpath: /dashboard/show
[----] D, [...#59755:c954] DEBUG -- development: RackSessionDalliLogger#write_session  id: a6562c80-e08c-48f9-821c-1c2da016cd02 method: GET fullpath: /dashboard/show
[----] D, [...#59755:f57bc] DEBUG -- development: RackSessionDalliLogger#find_session   id: 770573c7-586c-4a3c-967f-88a96b8b3a56 method: GET fullpath: /ws/notifications
[----] D, [...#59755:f57bc] DEBUG -- development: RackSessionDalliLogger#write_session  id: 770573c7-586c-4a3c-967f-88a96b8b3a56 method: GET fullpath: /ws/notifications
[----] D, [...#59755:f57a8] DEBUG -- development: RackSessionDalliLogger#find_session   id: d97be5db-108a-43eb-9e14-19dd7ae8c824 method: GET fullpath: /api/notifications?expand=resources&attributes=details&sort_by=id&sort_order=desc&limit=100
[----] D, [...#59755:f5910] DEBUG -- development: RackSessionDalliLogger#find_session   id: f6caa941-b1bb-4406-8a49-7a778b6d3baf method: GET fullpath: /dashboard/widget_report_data/24
[----] D, [...#59755:f58fc] DEBUG -- development: RackSessionDalliLogger#find_session   id: d170f7cd-3bec-4a36-8834-6014a71c3e1c method: GET fullpath: /dashboard/widget_chart_data/9
[----] D, [...#59755:c954] DEBUG -- development: RackSessionDalliLogger#find_session   id: 8b81f793-5d7e-494c-9881-42f595c4cd24 method: GET fullpath: /dashboard/widget_report_data/22
[----] D, [...#59755:f57bc] DEBUG -- development: RackSessionDalliLogger#find_session   id: 5eb52e22-0caf-4a6a-9a1e-6d4b10f60e8e method: GET fullpath: /dashboard/widget_report_data/21
[----] D, [...#59755:f57a8] DEBUG -- development: RackSessionDalliLogger#write_session  id: d97be5db-108a-43eb-9e14-19dd7ae8c824 method: GET fullpath: /api/notifications?expand=resources&attributes=details&sort_by=id&sort_order=desc&limit=100
[----] D, [...#59755:f5910] DEBUG -- development: RackSessionDalliLogger#find_session   id: a8843da1-b002-4c64-81fb-fb57415cbe90 method: GET fullpath: /dashboard/widget_chart_data/10
```


### After

Including the UI classic change in https://github.com/ManageIQ/manageiq-ui-classic/pull/9533

Note, there is no /api/notifications GET write_session line:

```
[----] D, [...#59627:c954] DEBUG -- development: RackSessionDalliLogger#find_session   id: e2d98313-97db-4f2c-9353-d0173e416eea method: GET fullpath: /dashboard/show
[----] D, [...#59627:c954] DEBUG -- development: RackSessionDalliLogger#write_session  id: e2d98313-97db-4f2c-9353-d0173e416eea method: GET fullpath: /dashboard/show
[----] D, [...#59627:f5794] DEBUG -- development: RackSessionDalliLogger#find_session   id: 60446a89-c410-4b13-ad98-d6cfddb0ae70 method: GET fullpath: /api/notifications?expand=resources&attributes=details&sort_by=id&sort_order=desc&limit=100
[----] D, [...#59627:f5780] DEBUG -- development: RackSessionDalliLogger#find_session   id: 2c076af9-89e5-4938-836d-3da42ca1a1eb method: GET fullpath: /ws/notifications
[----] D, [...#59627:f5780] DEBUG -- development: RackSessionDalliLogger#write_session  id: 2c076af9-89e5-4938-836d-3da42ca1a1eb method: GET fullpath: /ws/notifications
[----] D, [...#59627:f5780] DEBUG -- development: RackSessionDalliLogger#find_session   id: b5f7219e-1c9c-4049-8d2a-71e7e8edd277 method: GET fullpath: /dashboard/widget_report_data/21
[----] D, [...#59627:f58e8] DEBUG -- development: RackSessionDalliLogger#find_session   id: 34228ef9-1f06-4e6b-9447-15704505db12 method: GET fullpath: /dashboard/widget_report_data/22
[----] D, [...#59627:c954] DEBUG -- development: RackSessionDalliLogger#find_session   id: 6cb372fd-8f02-4dbd-807f-08eb712896d2 method: GET fullpath: /dashboard/widget_report_data/24
[----] D, [...#59627:f58d4] DEBUG -- development: RackSessionDalliLogger#find_session   id: 1fbacc6d-910f-4136-9147-1057ce829b21 method: GET fullpath: /dashboard/widget_chart_data/9
[----] D, [...#59627:f5780] DEBUG -- development: RackSessionDalliLogger#find_session   id: be3684f0-f830-46ca-bd96-b17db9f4cd02 method: GET fullpath: /dashboard/widget_chart_data/10
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
