### PR TITLE
Fix API counts to honor RBAC

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -1,28 +1,10 @@
 module Api
   # NOTE: This uses the NotificationRecipients model to then map to notifications
   class NotificationsController < BaseController
-    # based upon BaseController#index
-    def index
-      klass = collection_class(@req.subject)
-      res, subquery_count = collection_search(@req.subcollection?, @req.subject, klass)
+    def notifications_index_includes(scope)
+      return scope unless @req.expand?(:resources)
 
-      res_count = (res.kind_of?(ActiveRecord::Relation) ? res.except(:select) : res).count
-      expand_resources = @req.expand?(:resources)
-
-      opts = {
-        :name                  => @req.subject,
-        :is_subcollection      => @req.subcollection?,
-        :expand_actions        => true,
-        :expand_custom_actions => false,
-        :expand_resources      => expand_resources,
-        :counts                => Api::QueryCounts.new(klass.count, res_count, subquery_count)
-      }
-
-      # added line
-      res = res.includes(:notification => {:notification_type => {}, :subject => [:miq_requests, :services]}) if expand_resources
-      # end added line
-
-      render_collection(@req.subject, res, opts)
+      scope.includes(:notification => {:notification_type => {}, :subject => [:miq_requests, :services]})
     end
 
     def notifications_search_conditions

--- a/spec/requests/automation_requests_spec.rb
+++ b/spec/requests/automation_requests_spec.rb
@@ -37,7 +37,7 @@ describe "Automation Requests API" do
       get api_automation_requests_url
 
       expected = {
-        "count"     => 2,
+        "count"     => 1,
         "subcount"  => 1,
         "resources" => a_collection_containing_exactly(
           "href" => api_automation_request_url(nil, automation_request2),

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -172,7 +172,8 @@ describe "Rest API Collections" do
       @user.miq_groups << FactoryBot.create(:miq_group)
       api_basic_authorize collection_action_identifier(:groups, :read, :get)
       get api_groups_url, :params => { :expand => 'resources' }
-      expect_query_result(:groups, MiqGroup.non_tenant_groups.count, MiqGroup.count)
+      expected_counts = MiqGroup.non_tenant_groups.count
+      expect_query_result(:groups, expected_counts, expected_counts)
       expect_result_resources_to_include_data('resources', 'id' => MiqGroup.non_tenant_groups.pluck(:id).collect(&:to_s))
     end
 

--- a/spec/requests/provision_requests_spec.rb
+++ b/spec/requests/provision_requests_spec.rb
@@ -211,7 +211,7 @@ describe "Provision Requests API" do
       get api_provision_requests_url
 
       expected = {
-        "count"     => 2,
+        "count"     => 1,
         "subcount"  => 1,
         "resources" => a_collection_containing_exactly(
           "href" => api_provision_request_url(nil, provision_request2),

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Requests API" do
       get api_requests_url
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("name" => "requests", "count" => 1, "subcount" => 0)
+      expect(response.parsed_body).to include("name" => "requests", "count" => 0, "subcount" => 0)
     end
 
     it "does not show another user's request" do

--- a/spec/requests/service_orders_spec.rb
+++ b/spec/requests/service_orders_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "service orders API" do
     get api_service_orders_url
 
     expected = {
-      "count"     => 2,
+      "count"     => 1,
       "subcount"  => 1,
       "resources" => [{"href" => api_service_order_url(nil, shopping_cart_for_user)}]
     }

--- a/spec/requests/service_requests_spec.rb
+++ b/spec/requests/service_requests_spec.rb
@@ -183,7 +183,7 @@ describe "Service Requests API" do
       get api_service_requests_url
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("name" => "service_requests", "count" => 1, "subcount" => 0)
+      expect(response.parsed_body).to include("name" => "service_requests", "count" => 0, "subcount" => 0)
     end
 
     it "does not show another user's request" do

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -81,7 +81,7 @@ describe "Services API" do
       api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
 
       # Once for the main query and counts, and 3 for the `all_service_children`
-      expect(Rbac).to receive(:filtered).exactly(5).times.and_call_original
+      expect(Rbac).to receive(:filtered).exactly(6).times.and_call_original
       expect(Rbac).to receive(:filtered_object).never
 
       get api_services_url, :params => search_filters
@@ -99,7 +99,7 @@ describe "Services API" do
         api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
 
         # Once for the main query and counts, and 1 for the `all_service_children`
-        expect(Rbac).to receive(:filtered).exactly(3).times.and_call_original
+        expect(Rbac).to receive(:filtered).exactly(4).times.and_call_original
         expect(Rbac).to receive(:filtered_object).never
 
         get api_services_url, :params => search_filters
@@ -625,7 +625,7 @@ describe "Services API" do
     it "can query vms as subcollection" do
       get(api_service_vms_url(nil, svc1))
 
-      expect_query_result(:vms, 2, 3)
+      expect_query_result(:vms, 2, 2)
       expect_result_resources_to_include_hrefs("resources",
                                                [api_service_vm_url(nil, svc1, vm1),
                                                 api_service_vm_url(nil, svc1, vm2)])

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -63,7 +63,7 @@ describe "Vms API" do
       _vms = [vm, vm1, vm2, vm_openstack, vm_openstack1, vm_openstack2]
 
       # Only once for the main query
-      expect(Rbac).to receive(:filtered).exactly(1).times.and_call_original
+      expect(Rbac).to receive(:filtered).exactly(2).times.and_call_original
       expect(Rbac).to receive(:filtered_object).never
     end
 


### PR DESCRIPTION
The original idea behind the full count was to show that there are extra records that could be returned if different filters were applied. However, this does not need to apply to RBAC as users do not need to know about these records.

@kbrock Please review.

This does not solve https://github.com/ManageIQ/manageiq-ui-classic/issues/9448 directly, but is required as a first step to fix it.  It can be merged independently.