### PR TITLE
Snapshot Operations should queue_object_action with role=ems_operations

### DIFF
--- a/app/controllers/api/subcollections/snapshots.rb
+++ b/app/controllers/api/subcollections/snapshots.rb
@@ -14,6 +14,7 @@ module Api
           parent,
           message,
           :method_name => "create_snapshot",
+          :role        => "ems_operations",
           :args        => [data["name"], data["description"], data.fetch("memory", false)]
         )
 
@@ -28,7 +29,7 @@ module Api
           raise parent.unsupported_reason(:remove_snapshot) unless parent.supports?(:remove_snapshot)
 
           message = "Deleting snapshot #{snapshot.name} for #{snapshot_ident(parent)}"
-          task_id = queue_object_action(parent, message, :method_name => "remove_snapshot", :args => [id])
+          task_id = queue_object_action(parent, message, :method_name => "remove_snapshot", :role => "ems_operations", :args => [id])
           action_result(true, message, :task_id => task_id)
         rescue => e
           action_result(false, e.to_s)
@@ -41,7 +42,7 @@ module Api
         snapshot = resource_search(id, type)
 
         message = "Reverting to snapshot #{snapshot.name} for #{snapshot_ident(parent)}"
-        task_id = queue_object_action(parent, message, :method_name => "revert_to_snapshot", :args => [id])
+        task_id = queue_object_action(parent, message, :method_name => "revert_to_snapshot", :role => "ems_operations", :args => [id])
         action_result(true, message, :task_id => task_id)
       rescue => e
         action_result(false, e.to_s)

--- a/spec/requests/snapshots_spec.rb
+++ b/spec/requests/snapshots_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe "Snapshots API" do
         }
         expect(response.parsed_body).to include(expected)
         expect(response).to have_http_status(:ok)
+
+        queue_item = MiqQueue.find_by(:class_name => vm.class.name, :method_name => "create_snapshot")
+        expect(queue_item).to have_attributes(
+          :zone       => ems.zone_name,
+          :queue_name => ems.queue_name_for_ems_operations
+        )
       end
 
       it "renders a failed action response if snapshotting is not supported" do
@@ -168,8 +174,15 @@ RSpec.describe "Snapshots API" do
           "task_href" => a_string_matching(api_tasks_url),
           "task_id"   => anything
         }
+
         expect(response.parsed_body).to include(expected)
         expect(response).to have_http_status(:ok)
+
+        queue_item = MiqQueue.find_by(:class_name => vm.class.name, :method_name => "revert_to_snapshot")
+        expect(queue_item).to have_attributes(
+          :zone       => ems.zone_name,
+          :queue_name => ems.queue_name_for_ems_operations
+        )
       end
 
       it "renders a failed action response if reverting is not supported" do
@@ -216,6 +229,12 @@ RSpec.describe "Snapshots API" do
         }
         expect(response.parsed_body).to include(expected)
         expect(response).to have_http_status(:ok)
+
+        queue_item = MiqQueue.find_by(:class_name => vm.class.name, :method_name => "remove_snapshot")
+        expect(queue_item).to have_attributes(
+          :zone       => ems.zone_name,
+          :queue_name => ems.queue_name_for_ems_operations
+        )
       end
 
       it "renders a failed action response if deleting is not supported" do


### PR DESCRIPTION
Snapshot operations were being queued for the generic role when they should be queued on the ems_operations role

$ curl --user admin:smartvm -X POST -H "Content-Type: application/json" http://localhost:3000/api/vms/281/snapshots/3 -d '{"action": "delete"}'

<img width="1255" height="537" alt="image" src="https://github.com/user-attachments/assets/418b67b8-e177-4813-ac80-d7f9a9bd50fc" />

Fixes https://github.com/ManageIQ/manageiq/issues/23588
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
