### PR TITLE
Ensure EMS subcollections use ems_operations role

### DIFF
--- a/app/controllers/api/subcollections/cloud_networks.rb
+++ b/app/controllers/api/subcollections/cloud_networks.rb
@@ -10,7 +10,7 @@ module Api
         raise 'Must specify a name for the cloud network' unless data[:name]
 
         message = "Creating cloud network"
-        task_id = queue_object_action(provider, message, :method_name => "create_cloud_network", :args => [data])
+        task_id = provider.create_cloud_network_queue(User.current_user.userid, data)
         action_result(true, message, :task_id => task_id)
       rescue => e
         action_result(false, e.to_s)

--- a/app/controllers/api/subcollections/cloud_subnets.rb
+++ b/app/controllers/api/subcollections/cloud_subnets.rb
@@ -11,7 +11,7 @@ module Api
 
         begin
           message = "Creating subnet #{data[:name]}"
-          task_id = queue_object_action(parent, message, :method_name => "create_cloud_subnet", :args => [data])
+          task_id = parent.create_cloud_subnet_queue(User.current_user.userid, data)
           action_result(true, message, :task_id => task_id)
         rescue StandardError => e
           action_result(false, e.to_s)

--- a/app/controllers/api/subcollections/security_groups.rb
+++ b/app/controllers/api/subcollections/security_groups.rb
@@ -10,7 +10,7 @@ module Api
         raise "Cannot add #{security_group} to #{parent.name}" unless parent.supports?(:add_security_group)
 
         message = "Adding security group #{security_group} to #{parent.name}"
-        task_id = queue_object_action(parent, message, :method_name => "add_security_group", :args => [security_group])
+        task_id = parent.add_security_group_queue(User.current_user.userid, security_group)
         action_result(true, message, :task_id => task_id)
       rescue => e
         action_result(false, e.to_s)
@@ -21,7 +21,7 @@ module Api
         raise "Cannot remove #{security_group} from #{parent.name}" unless parent.supports?(:remove_security_group)
 
         message = "Removing security group #{security_group} from #{parent.name}"
-        task_id = queue_object_action(parent, message, :method_name => "remove_security_group", :args => [security_group])
+        task_id = parent.remove_security_group_queue(User.current_user.userid, security_group)
         action_result(true, message, :task_id => task_id)
       rescue => e
         action_result(false, e.to_s)
@@ -32,7 +32,7 @@ module Api
         raise 'Must specify a name for the security group' unless data[:name]
 
         message = "Creating security group"
-        task_id = queue_object_action(provider, message, :method_name => "create_security_group", :args => [data])
+        task_id = provider.create_security_group_queue(User.current_user.userid, data)
         action_result(true, message, :task_id => task_id)
       rescue => e
         action_result(false, e.to_s)

--- a/app/controllers/api/subcollections/security_policies.rb
+++ b/app/controllers/api/subcollections/security_policies.rb
@@ -10,7 +10,7 @@ module Api
         raise 'Must specify a name for the security policy' unless data[:name]
 
         message = "Creating security policy"
-        task_id = queue_object_action(provider, message, :method_name => "create_security_policy", :args => [data])
+        task_id = provider.create_security_policy_queue(User.current_user.userid, data)
         action_result(true, message, :task_id => task_id)
       rescue => e
         action_result(false, e.to_s)

--- a/app/controllers/api/subcollections/security_policy_rules.rb
+++ b/app/controllers/api/subcollections/security_policy_rules.rb
@@ -10,7 +10,7 @@ module Api
         raise 'Must specify a name for the security policy rule' unless data[:name]
 
         message = "Creating security policy rule"
-        task_id = queue_object_action(provider, message, :method_name => "create_security_policy_rule", :args => [data])
+        task_id = provider.create_security_policy_rule_queue(User.current_user.userid, data)
         action_result(true, message, :task_id => task_id)
       rescue => e
         action_result(false, e.to_s)

--- a/spec/requests/cloud_subnets_spec.rb
+++ b/spec/requests/cloud_subnets_spec.rb
@@ -69,6 +69,12 @@ RSpec.describe 'CloudSubnets API' do
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
+
+      queue_item = MiqQueue.find_by(:class_name => ems.class.name, :method_name => "create_cloud_subnet")
+      expect(queue_item).to have_attributes(
+        :zone       => ems.zone_name,
+        :queue_name => ems.queue_name_for_ems_operations
+      )
     end
 
     it "will not create a subnet unless authorized" do

--- a/spec/requests/security_groups_spec.rb
+++ b/spec/requests/security_groups_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe 'Security Groups API' do
+  include Spec::Support::SupportsHelper
+
+  let(:ems) { FactoryBot.create(:ems_network) }
+
+  describe "GET /api/providers/:id/security_groups" do
+    let!(:security_group) { FactoryBot.create(:security_group, :ext_management_system => ems) }
+
+    it "rejects request without appropriate role" do
+      api_basic_authorize
+
+      get api_provider_security_groups_url(nil, ems)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can list security groups' do
+      api_basic_authorize collection_action_identifier(:security_groups, :read, :get)
+
+      get api_provider_security_groups_url(nil, ems), :params => {:expand => "resources"}
+
+      expect_query_result(:security_groups, 1)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /api/providers/:id/security_groups" do
+    it "queues creation of the security group" do
+      api_basic_authorize subcollection_action_identifier(:providers, :security_groups, :create)
+      post api_provider_security_groups_url(nil, ems), :params => {:name => "new security group"}
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "success"   => true,
+            "message"   => "Creating security group",
+            "task_id"   => anything,
+            "task_href" => a_string_matching(api_tasks_url)
+          )
+        ]
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+
+      queue_item = MiqQueue.find_by(:class_name => ems.class.name, :method_name => "create_security_group")
+      expect(queue_item).to have_attributes(
+        :zone       => ems.zone_name,
+        :queue_name => ems.queue_name_for_ems_operations
+      )
+    end
+  end
+end

--- a/spec/requests/security_policies_spec.rb
+++ b/spec/requests/security_policies_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe 'Security Policies API' do
+  include Spec::Support::SupportsHelper
+
+  let(:ems) { FactoryBot.create(:ems_network) }
+
+  describe "GET /api/providers/:id/security_policies" do
+    let!(:security_policy) { FactoryBot.create(:security_policy, :ext_management_system => ems) }
+
+    it "rejects request without appropriate role" do
+      api_basic_authorize
+
+      get api_provider_security_policies_url(nil, ems)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can list security policies' do
+      api_basic_authorize collection_action_identifier(:security_policies, :read, :get)
+
+      get api_provider_security_policies_url(nil, ems), :params => {:expand => "resources"}
+
+      expect_query_result(:security_policies, 1)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /api/providers/:id/security_policies" do
+    it "queues creation of the security policy" do
+      api_basic_authorize subcollection_action_identifier(:providers, :security_policies, :create)
+      post api_provider_security_policies_url(nil, ems), :params => {:name => "new security policy"}
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "success"   => true,
+            "message"   => "Creating security policy",
+            "task_id"   => anything,
+            "task_href" => a_string_matching(api_tasks_url)
+          )
+        ]
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+
+      queue_item = MiqQueue.find_by(:class_name => ems.class.name, :method_name => "create_security_policy")
+      expect(queue_item).to have_attributes(
+        :zone       => ems.zone_name,
+        :queue_name => ems.queue_name_for_ems_operations
+      )
+    end
+  end
+end

--- a/spec/requests/security_policy_rules_spec.rb
+++ b/spec/requests/security_policy_rules_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe 'Security Policy Rules API' do
+  include Spec::Support::SupportsHelper
+
+  let(:ems) { FactoryBot.create(:ems_network) }
+
+  describe "GET /api/providers/:id/security_policy_rules" do
+    let!(:security_policy)      { FactoryBot.create(:security_policy, :ext_management_system => ems) }
+    let!(:security_policy_rule) { FactoryBot.create(:security_policy_rule, :ext_management_system => ems, :security_policy => security_policy) }
+
+    it "rejects request without appropriate role" do
+      api_basic_authorize
+
+      get api_provider_security_policy_rules_url(nil, ems)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can list security policy rules' do
+      api_basic_authorize collection_action_identifier(:security_policy_rules, :read, :get)
+
+      get api_provider_security_policy_rules_url(nil, ems), :params => {:expand => "resources"}
+
+      expect_query_result(:security_policy_rules, 1)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /api/providers/:id/security_policy_rules" do
+    it "queues creation of the security policy" do
+      api_basic_authorize subcollection_action_identifier(:providers, :security_policy_rules, :create)
+      post api_provider_security_policy_rules_url(nil, ems), :params => {:name => "new security policy rule"}
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "success"   => true,
+            "message"   => "Creating security policy rule",
+            "task_id"   => anything,
+            "task_href" => a_string_matching(api_tasks_url)
+          )
+        ]
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+
+      queue_item = MiqQueue.find_by(:class_name => ems.class.name, :method_name => "create_security_policy_rule")
+      expect(queue_item).to have_attributes(
+        :zone       => ems.zone_name,
+        :queue_name => ems.queue_name_for_ems_operations
+      )
+    end
+  end
+end


### PR DESCRIPTION
Any create/update/delete actions on ems subcollections should use the ems_operations role, either via queue_object_action or by using the appropriate `*_queue()` method

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23590

Follow-up to https://github.com/ManageIQ/manageiq-api/pull/1298
TODO:
- [x] Ensure tests covering these endpoints
- [x] Add `*_queue()` methods where missing or where they do not create a miq_task

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/986
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
