### PR TITLE
Support newer ruby versions

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -57,8 +57,8 @@ module Api
       end
 
       def api_get_method_name(call_stack, method)
-        match = /`(?<mname>[^']*)'/.match(call_stack)
-        (match ? match[:mname] : method).sub(/block .*in /, "")
+        match = /['`](?<mname>[^']*)'/.match(call_stack)
+        (match ? match[:mname] : method.to_s).sub(/block .*in /, "")
       end
 
       def api_log_error(msg)


### PR DESCRIPTION
Not sure why my system decided it was a good idea to run under ruby 3.4...
Ruby changed the way they report backtraces

```diff
- app/controllers/api/base_controller/logger.rb:61:in `Api::BaseController::Logger#api_get_method_name'
+ app/controllers/api/base_controller/logger.rb:61:in 'Api::BaseController::Logger#api_get_method_name'
```

The code was no longer able to determine the method name in recent ruby versions.
This meant that it would use the method (symbol) and `Symbol#sub` doesn't work.

So we did 2 things:

- match backtraces for older rubies and newer versions.
- Convert `method` to a String so `String#sub` will work.

Reproducer
==========

(pretty much every request test fails along with every api request)

```
$ chruby 3.4.7
$ be rspec spec/requests/logging_spec.rb
```

Before
======

```
Causes:
NoMethodError (undefined method 'sub' for an instance of Symbol)

app/controllers/api/base_controller/logger.rb:61:in 'Api::BaseController::Logger#api_get_method_name'
```

After
=====

other test failures (since string concatenation changed across ruby versions)

But at least the app *seems* to work.