### PR TITLE
Remove unpermitted parameters warning

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -33,7 +33,7 @@ module Api
         return unless api_log_info?
         log_request("Request", @req.to_hash)
         unfiltered_params = request.query_parameters
-                                   .merge(params.permit(:action, :controller, :format).to_h)
+                                   .merge(params.slice(:action, :controller, :format).permit!)
                                    .merge("body" => @req.json_body)
         log_request("Parameters", @parameter_filter.filter(unfiltered_params))
         log_request_body


### PR DESCRIPTION
pulled out of #1300 - it is unrelated

We always pass a few parameters. these parameters come from query_parameters.
These were triggering a warning in our logging.

Rails adds parameters from routes and actionpack. like :c_id, :s_id, :action, :controller, :format

We only care about a few of these. So only outputting the ones we care about and ignoring the rest

```
[----] D, [2025-10-28T23:00:25.289277#13035:5200] DEBUG -- : Unpermitted parameters: :expand, :attributes, :c_id. [...]
```

/cc @jrafanie not sure if you have an opinion on this