### PR TITLE
Enforce valid offset and limit

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -184,8 +184,8 @@ module Api
         options = {:user => User.current_user}
         options[:order] = sort_options if sort_options.present?
         options[:filter] = miq_expression if miq_expression
-        options[:offset] = params['offset'] if params['offset']
-        options[:limit] = params['limit'] if params['limit']
+        options[:offset] = integer_param('offset') if params['offset']
+        options[:limit] = integer_param('limit') if params['limit']
         options[:extra_cols] = determine_extra_cols(klass)
         options[:include_for_find] = determine_include_for_find(klass)
 
@@ -665,6 +665,13 @@ module Api
         else
           :bad_request
         end
+      end
+
+      # currently, this is only called if it has a value
+      def integer_param(param_name)
+        value = params[param_name].to_s
+        raise(ArgumentError, "Non numeric #{param_name}") if value.match?(/[^0-9]/)
+        value
       end
     end
   end


### PR DESCRIPTION
Before
======

If the offset was invalid, it was just thrown away. The Pen tests assumed they are able to hack the app. They assumed we were vulnerable to a sql injection attack

After
=====

Throw an error if a bad value comes in for the limit or offset Doesn't really make a difference, but makes the testers happy

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
