### PR TITLE
Fail with a BadRequestError on invalid integer params

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -28,6 +28,7 @@ module Api
     before_action :validate_api_request, :except => [:product_info]
     before_action :validate_api_action, :except => [:product_info]
     before_action :validate_response_format, :except => [:destroy]
+    before_action :validate_pagination, :only => :index
     before_action :ensure_pagination, :only => :index
     after_action :log_api_response
 
@@ -162,6 +163,12 @@ module Api
 
       render :json => ErrorSerializer.new(type, error).serialize, :status => Rack::Utils.status_code(type)
       log_api_response
+    end
+
+    def validate_pagination
+      %w[limit offset].each do |param|
+        raise BadRequestError, "Non numeric parameter: #{param}" if params[param]&.match?(/[^0-9]/)
+      end
     end
 
     def ensure_pagination

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -184,8 +184,8 @@ module Api
         options = {:user => User.current_user}
         options[:order] = sort_options if sort_options.present?
         options[:filter] = miq_expression if miq_expression
-        options[:offset] = integer_param('offset') if params['offset']
-        options[:limit] = integer_param('limit') if params['limit']
+        options[:offset] = params['offset'] if params['offset']
+        options[:limit] = params['limit'] if params['limit']
         options[:extra_cols] = determine_extra_cols(klass)
         options[:include_for_find] = determine_include_for_find(klass)
 
@@ -665,13 +665,6 @@ module Api
         else
           :bad_request
         end
-      end
-
-      # currently, this is only called if it has a value
-      def integer_param(param_name)
-        value = params[param_name].to_s
-        raise(ArgumentError, "Non numeric #{param_name}") if value.match?(/[^0-9]/)
-        value
       end
     end
   end

--- a/spec/requests/querying_spec.rb
+++ b/spec/requests/querying_spec.rb
@@ -70,6 +70,36 @@ describe "Querying" do
       expect_result_resources_to_match_hash([{"name" => "ee"}])
     end
 
+    it "raises a BadRequestError for an invalid offset" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      get api_vms_url, :params => { :offset => "0'" }
+
+      expected = {
+        'error' => a_hash_including(
+          'kind'    => 'bad_request',
+          'message' => "Non numeric parameter: offset"
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "raises a BadRequestError for an invalid limit" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      get api_vms_url, :params => { :limit => "0'" }
+
+      expected = {
+        'error' => a_hash_including(
+          'kind'    => 'bad_request',
+          'message' => "Non numeric parameter: limit"
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:bad_request)
+    end
+
     it 'raises a BadRequestError for attributes that do not exist' do
       api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
 


### PR DESCRIPTION
Raising an ArgumentError ends up being caught at the top level and the result is a 500 Internal Server Error, which makes it appear like the server has gone down. DAST tools interpret a 500 as a "successful" hack. Instead we return a 400 error which is more appropriate and shows the invalid data was caught correctly.

Additionally, limit was never actually being checked, because the ensure_pagination would always force the value into a valid number, so this commit also changes the timing of the check to happen before ensure_pagination is called very early in the request.

CP4AIOPS-25044
CP4AIOPS-25045

Follwup to #1303 - This PR effectively reverts #1303 for a different implementation.

@jrafanie Please review.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
