### PR TITLE
Fix deprecation in specs

### DIFF
--- a/spec/requests/regions_spec.rb
+++ b/spec/requests/regions_spec.rb
@@ -221,7 +221,8 @@ RSpec.describe "Regions API", :regions do
           expect {
             delete(
               api_region_settings_url(nil, region),
-              :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+              :params => %w[api authentication_timeout],
+              :as     => :json
             )
           }.to change { region.settings_for_resource["api"]["authentication_timeout"] }.from("7331.minutes").to("30.seconds")
 
@@ -234,7 +235,8 @@ RSpec.describe "Regions API", :regions do
           expect {
             delete(
               api_region_settings_url(nil, region),
-              :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+              :params => %w[api authentication_timeout],
+              :as     => :json
             )
           }.not_to change { region.settings_for_resource["api"]["authentication_timeout"] }
 
@@ -245,7 +247,8 @@ RSpec.describe "Regions API", :regions do
           expect {
             delete(
               api_region_settings_url(nil, region),
-              :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+              :params => %w[api authentication_timeout],
+              :as     => :json
             )
           }.not_to change { region.settings_for_resource["api"]["authentication_timeout"] }
 

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -261,7 +261,8 @@ RSpec.describe "Servers" do
         expect {
           delete(
             api_server_settings_url(nil, server),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            :params => %w[api authentication_timeout],
+            :as     => :json
           )
         }.to change { server.settings_for_resource["api"]["authentication_timeout"] }.from("7331.minutes").to("30.seconds")
 
@@ -274,7 +275,8 @@ RSpec.describe "Servers" do
         expect {
           delete(
             api_server_settings_url(nil, server),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            :params => %w[api authentication_timeout],
+            :as     => :json
           )
         }.not_to change { server.settings_for_resource["api"]["authentication_timeout"] }
 
@@ -285,7 +287,8 @@ RSpec.describe "Servers" do
         expect {
           delete(
             api_server_settings_url(nil, server),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            :params => %w[api authentication_timeout],
+            :as     => :json
           )
         }.not_to change { server.settings_for_resource["api"]["authentication_timeout"] }
 

--- a/spec/requests/zones_spec.rb
+++ b/spec/requests/zones_spec.rb
@@ -260,7 +260,8 @@ RSpec.describe "Zones" do
         expect {
           delete(
             api_zone_settings_url(nil, zone),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            :params => %w[api authentication_timeout],
+            :as     => :json
           )
         }.to change { zone.settings_for_resource["api"]["authentication_timeout"] }.from("7331.minutes").to("30.seconds")
 
@@ -273,7 +274,8 @@ RSpec.describe "Zones" do
         expect {
           delete(
             api_zone_settings_url(nil, zone),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            :params => %w[api authentication_timeout],
+            :as     => :json
           )
         }.not_to change { zone.settings_for_resource["api"]["authentication_timeout"] }
 
@@ -284,7 +286,8 @@ RSpec.describe "Zones" do
         expect {
           delete(
             api_zone_settings_url(nil, zone),
-            :params => %i[api authentication_timeout].to_json # => hack because Rails will interpret these as query params in a DELETE
+            :params => %w[api authentication_timeout],
+            :as     => :json
           )
         }.not_to change { zone.settings_for_resource["api"]["authentication_timeout"] }
 


### PR DESCRIPTION
Fixes the deprecation warning:

```
DEPRECATION WARNING: Skipping over leading brackets in parameter name "[\"api\",\"authentication_timeout\"]" is deprecated and will parse differently in Rails 8.1 or Rack 3.0. (called from call at /Users/jfrey/dev/manageiq/lib/request_started_on_middleware.rb:12)
```

Rails 8.0 can process the body of the delete properly now if told to process it `:as => :json`.

@jrafanie Please review.