### PR TITLE
Sort provider subclasses alphabetically

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -154,7 +154,7 @@ module Api
         po.merge(ems.ems_type => ems.options_description)
       end
 
-      supported_providers = supported_types_for_create.map do |klass|
+      supported_providers = supported_types_for_create.sort_by(&:description).map do |klass|
         if klass.supports?(:regions)
           regions = klass.module_parent::Regions.all.sort_by { |r| r[:description] }.map { |r| r.slice(:name, :description) }
         end


### PR DESCRIPTION
This list is shown to the user to select a provider type and it is extremely confusing when it is not sorted alphabetically.

Before:
<img width="482" height="492" alt="image" src="https://github.com/user-attachments/assets/7af8d9e2-7e01-4c39-911e-d083991abcac" />


After:
<img width="482" height="492" alt="image" src="https://github.com/user-attachments/assets/37ba0535-ce86-45a7-8837-b15d460fb497" />

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
