### PR TITLE
Add a `timeout` option to `/services` action `add_provider_vms`

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -90,7 +90,9 @@ module Api
       raise 'Must specify a valid provider href or id' unless provider_id
       provider = resource_search(provider_id, :providers)
 
-      task_id = service.add_provider_vms(provider, data['uid_ems']).miq_task_id
+      timeout = data['timeout'].to_i if data['timeout']
+
+      task_id = service.add_provider_vms(provider, data['uid_ems'], :timeout => timeout).miq_task_id
       action_result(true, "Adding provider vms for #{service_ident(service)}", :task_id => task_id)
     rescue => err
       action_result(false, err.to_s)


### PR DESCRIPTION
Allow the user to specify the timeout for the job created by add_provider_vms.

``` data
POST /api/services/:id
```

``` json
{
  "action" : "add_provider_vms",
  "resource" : { 
    "provider" : { "href" : "http://localhot:3000/api/providers/11" }
    "uid_ems" : [ 
      "provider_vm_id1",
      "provider_vm_id2",
      ... 
    ],
    "timeout" : 600 
  }
}
```


Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23788

Dependents:
* https://github.com/ManageIQ/manageiq-documentation/pull/1886
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
