### PR TITLE
Fix notifications API for users with belongsto RBAC filters

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -4,7 +4,15 @@ module Api
     def notifications_index_includes(scope)
       return scope unless @req.expand?(:resources)
 
-      scope.includes(:notification => {:notification_type => {}, :subject => [:miq_requests, :services]})
+      associations = {:notification => {:notification_type => {}, :subject => [:miq_requests, :services]}}
+
+      if scope.respond_to?(:includes)
+        scope.includes(associations)
+      else
+        # Preload instead when RBAC returns an Array (e.g., with belongsto filters)
+        MiqPreloader.preload(scope, associations)
+        scope
+      end
     end
 
     def notifications_search_conditions

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -72,6 +72,30 @@ describe 'Notifications API' do
       expect(response_ids).to match_array(notification_ids)
       expect(response_ids & other_user_recipient_ids).to be_empty
     end
+
+    it "works for users with belongsto RBAC filters and expanded resources" do
+      role = FactoryBot.create(:miq_user_role)
+      entitlement = FactoryBot.create(:entitlement, :miq_user_role => role, :filters => {"managed" => [], "belongsto" => ["/managed/infra/1"]})
+      group = FactoryBot.create(:miq_group, :entitlement => entitlement)
+      user_with_filters = FactoryBot.create(:user, :miq_groups => [group])
+
+      notifications = FactoryBot.create_list(:notification, 3, :initiator => user_with_filters)
+      notification_ids = notifications.map { |n| n.notification_recipients.first.id.to_s }
+
+      api_basic_authorize(:user => user_with_filters.userid, :password => "dummy")
+
+      get api_notifications_url, :params => {
+        :expand     => "resources",
+        :attributes => "details",
+        :limit      => 100
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("count" => 3)
+
+      response_ids = response.parsed_body["resources"].map { |r| r["id"] }
+      expect(response_ids).to match_array(notification_ids)
+    end
   end
 
   describe 'notification create' do


### PR DESCRIPTION
# Summary

This PR fixes an issue with the notifications API endpoint when users have RBAC (Role-Based Access Control) `belongsto` filters applied. When RBAC filtering is active, the scope returns an Array instead of an ActiveRecord::Relation, which doesn't respond to the `includes` method. The fix detects this case and uses `MiqPreloader.preload` instead to eager-load associations and avoid N+1 queries.

## Problem

Users with custom groups/roles that have `belongsto` RBAC filters encounter a `NoMethodError: undefined method 'includes' for an instance of Array` when accessing `/api/notifications?expand=resources&limit=100`.

## Root Cause

When users have `belongsto` RBAC filters, the `limit` parameter triggers Ruby-based pagination in RBAC's `Filterer` that returns an Array instead of an ActiveRecord::Relation (because `apply_limit_in_sql` is set to `false` when belongsto filters are present). The original code tried to call `.includes()` on this Array, causing the error.

## Solution

Updated `notifications_index_includes` to handle both Relations and Arrays:
- Uses `.includes()` for ActiveRecord::Relation (SQL eager loading)
- Uses `MiqPreloader.preload()` for Arrays (prevents N+1 queries)
- DRY: associations defined once and reused

## Testing

Added test coverage that verifies the fix works for users with belongsto filters. All 14 notification specs pass.

Fixes #1316
Fixes https://github.com/orgs/ManageIQ/discussions/23708