### PR TITLE
[WIP] Add support for collection attributes (attributes=vms.name)

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -313,12 +313,60 @@ module Api
 
       def fetch_indirect_virtual_attribute(_type, resource, base, attr, object_hash)
         query_related_objects(base, resource, object_hash)
-        return unless attr_accessible?(object_hash[base], attr)
-        value  = virtual_attribute_search(object_hash[base], attr)
+        related_obj = object_hash[base]
+
+        if collection_association?(related_obj) && @req.collection_attributes_for(base).any?
+          fetch_collection_attributes(base, related_obj)
+        else
+          fetch_standard_virtual_attribute(related_obj, base, attr)
+        end
+      end
+
+      def fetch_standard_virtual_attribute(related_obj, base, attr)
+        return unless attr_accessible?(related_obj, attr)
+
+        value  = virtual_attribute_search(related_obj, attr)
         result = {attr => normalize_attr(attr, value)}
-        # set nil vtype above to "#{type}/#{resource.id}/#{base.tr('.', '/')}/#{attr}" to support id normalization
         base.split(".").reverse_each { |level| result = {level => result} }
         [value, result]
+      end
+
+      def fetch_collection_attributes(association_path, collection)
+        collection_type = get_collection_type(collection)
+        requested_attrs = @req.collection_attributes_for(association_path)
+        return [nil, {}] if collection_type.nil? || requested_attrs.empty?
+
+        # TODO: Only physical attributes supported. Virtual attributes on associations (vms.v_total_snapshots)
+        # would cause N+1 queries - one per associated record even with eager loading. Consider adding
+        # aggregated virtuals to primary model instead (e.g., provider.v_total_vms_snapshots).
+        attrs_to_render = (requested_attrs + ['id']).uniq
+        items = collection.map do |item|
+          normalize_hash(collection_type, item, {:render_attributes => attrs_to_render})
+        end
+        association_name = association_path.split(".").last
+        result = {association_name => items}
+        [items, result]
+      end
+
+      # Check for ActiveRecord collections (CollectionProxy, Relation) without triggering queries
+      # Both have .loaded? method, plain Arrays don't
+      def collection_association?(obj)
+        obj.respond_to?(:loaded?)
+      end
+
+      def get_collection_type(collection)
+        klass = if collection_association?(collection)
+                  collection.klass
+                elsif collection.kind_of?(Array) && collection.first
+                  collection.first.class
+                end
+
+        return nil unless klass
+
+        # Use base_model to handle STI classes
+        base_klass = klass.respond_to?(:base_model) ? klass.base_model : klass
+        collection_name = collection_config.name_for_klass(base_klass)
+        collection_name&.to_sym
       end
 
       #
@@ -606,7 +654,25 @@ module Api
       end
 
       def determine_include_for_find(klass)
-        attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
+        attrs = determine_include_for_find_vattrs(klass)
+        collections = determine_include_for_find_collections(klass)
+
+        all_includes = (attrs || []) + collections
+
+        if all_includes.any?
+          all_includes.each_with_object({}) do |key, include_for_find|
+            if (virtual_includes = klass.virtual_includes(key))
+              ActiveRecord::Base.merge_includes(include_for_find, virtual_includes)
+            else
+              nested = include_for_find
+              key.to_s.split(".").each { |k| nested = nested[k] ||= {} }
+            end
+          end
+        end
+      end
+
+      def determine_include_for_find_vattrs(klass)
+        virtual_attributes_for(klass) do |type, attr_name, attr_base|
           if klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name) && attr_base.blank?
             attr_name
           else
@@ -617,18 +683,21 @@ module Api
             attr_base
           end
         end
+      end
 
-        # Handle nested relationships and convert to a hash
-        if attrs
-          attrs.each_with_object({}) do |key, include_for_find|
-            if (virtual_includes = klass.virtual_includes(key))
-              ActiveRecord::Base.merge_includes(include_for_find, virtual_includes)
-            else
-              nested = include_for_find
-              key.split(".").each { |k| nested = nested[k] ||= {} }
+      def determine_include_for_find_collections(klass)
+        # Eager load collection attributes only when sub-attributes requested (e.g., vms.name not just vms)
+        collection_associations = []
+        if @req.collection_attributes?
+          @req.grouped_attributes[:associations].each do |association, sub_attrs|
+            next if sub_attrs.empty?
+
+            if klass.respond_to?(:reflect_on_association) && klass.reflect_on_association(association.to_sym)
+              collection_associations << association
             end
           end
         end
+        collection_associations
       end
 
       def determine_extra_cols(klass)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -642,7 +642,21 @@ module Api
       end
 
       def determine_include_for_find(klass)
-        attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
+        includes = virtual_attr_includes_for(klass).to_a + association_attr_includes_for(klass)
+        return unless includes.any?
+
+        includes.each_with_object({}) do |key, include_for_find|
+          if (virtual_includes = klass.virtual_includes(key))
+            ActiveRecord::Base.merge_includes(include_for_find, virtual_includes)
+          else
+            nested = include_for_find
+            key.to_s.split(".").each { |k| nested = nested[k] ||= {} }
+          end
+        end
+      end
+
+      def virtual_attr_includes_for(klass)
+        virtual_attributes_for(klass) do |type, attr_name, attr_base|
           if attr_base.blank?
             # Direct attribute: eager-load if it has virtual includes and isn't SQL-backed
             if klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name)
@@ -660,26 +674,14 @@ module Api
             attr_base
           end
         end
+      end
 
-        # Eager-load has_many associations when sub-attributes are requested (e.g., vms.name)
-        collection_associations = []
-        if @req.association_attributes?
-          @req.association_attributes.each do |association, _sub_attrs|
-            collection_associations << association if klass.reflect_on_association(association.to_sym)
-          end
-        end
+      # Associations with sub-attributes requested (e.g., vms.name) need to be eager-loaded
+      def association_attr_includes_for(klass)
+        return [] unless @req.association_attributes?
 
-        all_includes = (attrs || []) + collection_associations
-        return unless all_includes.any?
-
-        # Handle nested relationships and convert to a hash
-        all_includes.each_with_object({}) do |key, include_for_find|
-          if (virtual_includes = klass.virtual_includes(key))
-            ActiveRecord::Base.merge_includes(include_for_find, virtual_includes)
-          else
-            nested = include_for_find
-            key.to_s.split(".").each { |k| nested = nested[k] ||= {} }
-          end
+        @req.association_attributes.filter_map do |association, _sub_attrs|
+          association if klass.reflect_on_association(association.to_sym)
         end
       end
 

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -643,22 +643,19 @@ module Api
 
       def determine_include_for_find(klass)
         attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
-          # Case 1: Direct virtual attribute (e.g., "ram_size")(Not association.column format (dot notation), therefore attr_base is blank)
-          if klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name) && attr_base.blank?
-            attr_name
-          # Case 2: Direct association (e.g., "snapshots", "storage", "ems_cluster")
-          # Eager load associations (RBAC participating or not) to reduce N+1 queries.
-          elsif attr_base.blank?
-            reflection = klass.reflect_on_association(attr_name.to_sym)
-            if reflection && [:has_many, :has_one, :has_and_belongs_to_many, :belongs_to].include?(reflection.macro)
+          if attr_base.blank?
+            # Direct attribute: eager-load if it has virtual includes and isn't SQL-backed
+            if klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name)
+              attr_name
+            # Direct association (e.g., "snapshots", "storage", "ems_cluster"): eager-load to avoid N+1
+            elsif klass.reflect_on_association(attr_name.to_sym)&.macro&.in?([:has_many, :has_one, :has_and_belongs_to_many, :belongs_to])
               attr_name
             else
               next
             end
-          # Case 3: Nested attribute (e.g., "hardware.host.name")
-          # Eager load nested associations (RBAC participating or not) to reduce N+1 queries.
-          # Exception: custom virtual_attribute_accessor (handled via accessor).
           else
+            # Nested attribute (e.g., "hardware.host.name"): eager-load the base association,
+            # unless it's handled by a custom virtual_attribute_accessor.
             next if virtual_attribute_accessor(type, attr_name)
             attr_base
           end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -313,12 +313,48 @@ module Api
 
       def fetch_indirect_virtual_attribute(_type, resource, base, attr, object_hash)
         query_related_objects(base, resource, object_hash)
-        return unless attr_accessible?(object_hash[base], attr)
-        value  = virtual_attribute_search(object_hash[base], attr)
-        result = {attr => normalize_attr(attr, value)}
-        # set nil vtype above to "#{type}/#{resource.id}/#{base.tr('.', '/')}/#{attr}" to support id normalization
-        base.split(".").reverse_each { |level| result = {level => result} }
-        [value, result]
+        related_obj = object_hash[base]
+
+        if collection_association?(related_obj) && @req.association_attributes_for(base).any?
+          fetch_collection_attributes(base, related_obj)
+        else
+          return unless attr_accessible?(related_obj, attr)
+          value  = virtual_attribute_search(related_obj, attr)
+          result = {attr => normalize_attr(attr, value)}
+          base.split(".").reverse_each { |level| result = {level => result} }
+          [value, result]
+        end
+      end
+
+      def fetch_collection_attributes(association, collection)
+        collection_type = collection_type_for(collection)
+        requested_attrs = @req.association_attributes_for(association)
+        return [nil, {}] if collection_type.nil? || requested_attrs.empty?
+
+        # TODO: Only physical attributes supported. Virtual attributes on associations (vms.v_total_snapshots)
+        # would cause N+1 queries - one per associated record even with eager loading. Consider adding
+        # aggregated virtuals to primary model instead (e.g., provider.v_total_vms_snapshots).
+        attrs_to_render = (requested_attrs + ['id']).uniq
+        items = collection.map { |item| normalize_hash(collection_type, item, :render_attributes => attrs_to_render) }
+        [items, {association => items}]
+      end
+
+      # ActiveRecord CollectionProxy and Relation respond to .loaded?; plain Arrays do not
+      def collection_association?(obj)
+        obj.respond_to?(:loaded?)
+      end
+
+      def collection_type_for(collection)
+        klass = if collection_association?(collection)
+                  collection.klass
+                elsif collection.kind_of?(Array) && collection.first
+                  collection.first.class
+                end
+
+        return nil unless klass
+
+        base_klass = klass.respond_to?(:base_model) ? klass.base_model : klass
+        collection_config.name_for_klass(base_klass)&.to_sym
       end
 
       #
@@ -628,15 +664,24 @@ module Api
           end
         end
 
+        # Eager-load has_many associations when sub-attributes are requested (e.g., vms.name)
+        collection_associations = []
+        if @req.association_attributes?
+          @req.association_attributes.each do |association, _sub_attrs|
+            collection_associations << association if klass.reflect_on_association(association.to_sym)
+          end
+        end
+
+        all_includes = (attrs || []) + collection_associations
+        return unless all_includes.any?
+
         # Handle nested relationships and convert to a hash
-        if attrs
-          attrs.each_with_object({}) do |key, include_for_find|
-            if (virtual_includes = klass.virtual_includes(key))
-              ActiveRecord::Base.merge_includes(include_for_find, virtual_includes)
-            else
-              nested = include_for_find
-              key.split(".").each { |k| nested = nested[k] ||= {} }
-            end
+        all_includes.each_with_object({}) do |key, include_for_find|
+          if (virtual_includes = klass.virtual_includes(key))
+            ActiveRecord::Base.merge_includes(include_for_find, virtual_includes)
+          else
+            nested = include_for_find
+            key.to_s.split(".").each { |k| nested = nested[k] ||= {} }
           end
         end
       end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -658,22 +658,26 @@ module Api
       def virtual_attr_includes_for(klass)
         virtual_attributes_for(klass) do |type, attr_name, attr_base|
           if attr_base.blank?
-            # Direct attribute: eager-load if it has virtual includes and isn't SQL-backed
-            if klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name)
-              attr_name
-            # Direct association (e.g., "snapshots", "storage", "ems_cluster"): eager-load to avoid N+1
-            elsif klass.reflect_on_association(attr_name.to_sym)&.macro&.in?([:has_many, :has_one, :has_and_belongs_to_many, :belongs_to])
-              attr_name
-            else
-              next
-            end
-          else
+            attr_name if virtual_with_includes?(klass, attr_name) || real_association?(klass, attr_name)
+          elsif !virtual_attribute_accessor(type, attr_name)
             # Nested attribute (e.g., "hardware.host.name"): eager-load the base association,
             # unless it's handled by a custom virtual_attribute_accessor.
-            next if virtual_attribute_accessor(type, attr_name)
             attr_base
           end
         end
+      end
+
+      # Returns true if the attribute is a virtual attribute that requires eager-loading
+      # its associated data (i.e., it has virtual_includes and cannot be computed in SQL).
+      # Example: ram_size, which is backed by the hardware association.
+      def virtual_with_includes?(klass, attr_name)
+        klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name)
+      end
+
+      # Returns true if the attribute is a real AR association (has_many, has_one, belongs_to, habtm).
+      # Note: virtual associations (virtual_has_many etc.) without uses: are intentionally excluded here.
+      def real_association?(klass, attr_name)
+        klass.reflect_on_association(attr_name.to_sym)&.macro&.in?([:has_many, :has_one, :has_and_belongs_to_many, :belongs_to])
       end
 
       # Associations with sub-attributes requested (e.g., vms.name) need to be eager-loaded

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -93,7 +93,7 @@ module Api
         collection_class = collection_class(type)
 
         # Ensures hrefs are consistent with those of the collection they were requested from
-        return reftype if collection_class == rclass || collection_class.descendants.include?(rclass)
+        return reftype if collection_class && (collection_class == rclass || collection_class.descendants.include?(rclass))
 
         collection_config.name_for_klass(rclass) || collection_config.name_for_subclass(rclass)
       end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1439,6 +1439,13 @@
     - :subcollection
     :verbs: *g
     :klass: Disk
+  :endpoints:
+    :description: Endpoints
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *g
+    :klass: Endpoint
   :enterprises:
     :description: Enterprises
     :options:

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -83,7 +83,7 @@ module Api
     end
 
     def klass(collection_name)
-      self[collection_name][:klass].try(:constantize)
+      self[collection_name]&.[](:klass).try(:constantize)
     end
 
     def name_for_klass(resource_klass)

--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -43,6 +43,37 @@ module Api
       @attributes ||= @params['attributes'].to_s.split(',')
     end
 
+    # Groups attributes by association path. Only supports one level deep (vms.name). TODO: support nested (vms.ipaddresses.address)
+    # Returns: { direct: [:name], associations: { "vms" => [:name, :cpu_count] } }
+    def grouped_attributes
+      @grouped_attributes ||= begin
+        result = {:direct => [], :associations => {}}
+        attributes.each do |attr|
+          parts = attr.split('.')
+          if parts.length == 1
+            result[:direct] << attr
+          else
+            association = parts[0]
+            attribute = parts[1]
+            result[:associations][association] ||= []
+            result[:associations][association] << attribute
+          end
+        end
+        result
+      end
+    end
+
+    # Returns attributes requested for a specific association
+    # Example: collection_attributes_for("vms") => [:name, :cpu_count]
+    def collection_attributes_for(association)
+      grouped_attributes[:associations][association.to_s] || []
+    end
+
+    # Returns true if any collection attributes are requested
+    def collection_attributes?
+      grouped_attributes[:associations].any?
+    end
+
     def base
       url.partition(fullpath)[0] # http://target
     end

--- a/lib/api/request_adapter.rb
+++ b/lib/api/request_adapter.rb
@@ -43,6 +43,26 @@ module Api
       @attributes ||= @params['attributes'].to_s.split(',')
     end
 
+    # Returns the attributes requested for a specific association (e.g., "vms" => ["name", "vendor"])
+    # Only supports one level deep (vms.name). TODO: support nested (vms.ipaddresses.address)
+    def association_attributes
+      @association_attributes ||= attributes.each_with_object({}) do |attr, result|
+        association, sub_attr = attr.split(".", 2)
+        next unless sub_attr
+
+        result[association] ||= []
+        result[association] << sub_attr
+      end
+    end
+
+    def association_attributes_for(association)
+      association_attributes[association.to_s] || []
+    end
+
+    def association_attributes?
+      association_attributes.any?
+    end
+
     def base
       url.partition(fullpath)[0] # http://target
     end

--- a/spec/lib/api/api_config_spec.rb
+++ b/spec/lib/api/api_config_spec.rb
@@ -16,7 +16,7 @@ describe 'API configuration (config/api.yml)' do
           v.options.index(:collection) &&
             v.collection_actions&.[](:get)&.find { |h| h[:name] == 'read' }&.identifier.nil?
         end.map(&:first).sort
-        expect(whitelisted).to eq(%i[automate_workspaces currencies features measures notifications pictures])
+        expect(whitelisted).to eq(%i[automate_workspaces currencies endpoints features measures notifications pictures])
       end
 
       it 'actions have associated options' do

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1800,6 +1800,115 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
     end
+
+    it 'supports single attribute on has_many association' do
+      ems = FactoryBot.create(:ext_management_system, :name => "Test Provider")
+      vm1 = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM1")
+      vm2 = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM2")
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      get(api_providers_url, :params => {:expand => 'resources', :attributes => 'name,vms.name'})
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['name']).to eq('providers')
+      expect(response.parsed_body['resources'].length).to eq(1)
+
+      provider = response.parsed_body['resources'].first
+      expect(provider['href']).to eq(api_provider_url(nil, ems))
+      expect(provider['id']).to eq(ems.id.to_s)
+      expect(provider['name']).to eq('Test Provider')
+      expect(provider['vms']).to be_an(Array)
+      expect(provider['vms'].length).to eq(2)
+
+      # Check VMs are present (order-independent)
+      vm_ids = provider['vms'].map { |v| v['id'] }
+      expect(vm_ids).to contain_exactly(vm1.id.to_s, vm2.id.to_s)
+      provider['vms'].each do |vm|
+        expect(vm).to have_key('href')
+        expect(vm).to have_key('id')
+        expect(vm).to have_key('name')
+        expect(vm['href']).to match(%r{/api/vms/\d+})
+      end
+    end
+
+    it 'supports multiple attributes on has_many association' do
+      ems = FactoryBot.create(:ext_management_system, :name => "Test Provider")
+      vm1 = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM1", :vendor => "amazon")
+      vm2 = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM2", :vendor => "amazon")
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      get(api_providers_url, :params => {:expand => 'resources', :attributes => 'name,vms.name,vms.vendor'})
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['name']).to eq('providers')
+      expect(response.parsed_body['resources'].length).to eq(1)
+
+      provider = response.parsed_body['resources'].first
+      expect(provider['href']).to eq(api_provider_url(nil, ems))
+      expect(provider['id']).to eq(ems.id.to_s)
+      expect(provider['name']).to eq('Test Provider')
+      expect(provider['vms']).to be_an(Array)
+      expect(provider['vms'].length).to eq(2)
+
+      # Check VMs have all requested attributes (order-independent)
+      vm_ids = provider['vms'].map { |v| v['id'] }
+      expect(vm_ids).to contain_exactly(vm1.id.to_s, vm2.id.to_s)
+      provider['vms'].each do |vm|
+        expect(vm).to have_key('href')
+        expect(vm).to have_key('id')
+        expect(vm).to have_key('name')
+        expect(vm).to have_key('vendor')
+        expect(vm['vendor']).to eq('amazon')
+        expect(vm['href']).to match(%r{/api/vms/\d+})
+      end
+    end
+
+    it 'returns empty array for provider with no vms' do
+      ems = FactoryBot.create(:ext_management_system, :name => "Empty Provider")
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      get(api_providers_url, :params => {:expand => 'resources', :attributes => 'name,vms.name'})
+
+      expected = {
+        'name'      => 'providers',
+        'resources' => [
+          a_hash_including(
+            'href' => api_provider_url(nil, ems),
+            'id'   => ems.id.to_s,
+            'name' => 'Empty Provider',
+            'vms'  => []
+          )
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'silently ignores non-existent attributes on collection' do
+      ems = FactoryBot.create(:ext_management_system, :name => "Test Provider")
+      vm = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM1")
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      get(api_providers_url, :params => {:expand => 'resources', :attributes => 'name,vms.name,vms.nonexistent_field'})
+
+      expected = {
+        'name'      => 'providers',
+        'resources' => [
+          a_hash_including(
+            'href' => api_provider_url(nil, ems),
+            'id'   => ems.id.to_s,
+            'name' => 'Test Provider',
+            'vms'  => [
+              a_hash_including('href' => api_vm_url(nil, vm), 'id' => vm.id.to_s, 'name' => 'VM1')
+            ]
+          )
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+      # Verify nonexistent_field is not in the response
+      expect(response.parsed_body['resources'].first['vms'].first).not_to have_key('nonexistent_field')
+    end
   end
 
   context 'Folders subcollection' do

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1736,16 +1736,31 @@ describe "Providers API" do
   end
 
   context 'GET /api/providers/:id' do
-    it 'includes endpoints and authentications attributes when explcitly asked' do
+    it 'includes endpoints and authentications attributes when explicitly asked' do
       ems = FactoryBot.create(:ext_management_system)
       api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
 
       get(api_provider_url(nil, ems), :params => {:attributes => 'endpoints,authentications'})
 
+      expect(response).to have_http_status(:ok)
       expect(response.parsed_body['authentications']).to be_an_instance_of(Array)
       expect(response.parsed_body['endpoints']).to be_an_instance_of(Array)
+    end
+
+    it 'includes plain has_many association attributes on a resource show request' do
+      ems = FactoryBot.create(:ext_management_system)
+      FactoryBot.create(:authentication, :resource => ems)
+      FactoryBot.create(:endpoint, :resource => ems)
+
+      api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
+
+      get(api_provider_url(nil, ems), :params => {:attributes => 'endpoints,authentications'})
 
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['authentications']).to be_an_instance_of(Array)
+      expect(response.parsed_body['endpoints']).to be_an_instance_of(Array)
+      expect(response.parsed_body['authentications'].first).to include('href', 'id')
+      expect(response.parsed_body['endpoints'].first).to include('href', 'id')
     end
 
     it 'does not include endpoints and authentications attributes by default' do

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1815,6 +1815,115 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
     end
+
+    it 'supports single attribute on has_many association' do
+      ems = FactoryBot.create(:ext_management_system, :name => "Test Provider")
+      vm1 = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM1")
+      vm2 = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM2")
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      get(api_providers_url, :params => {:expand => 'resources', :attributes => 'name,vms.name'})
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['name']).to eq('providers')
+      expect(response.parsed_body['resources'].length).to eq(1)
+
+      provider = response.parsed_body['resources'].first
+      expect(provider['href']).to eq(api_provider_url(nil, ems))
+      expect(provider['id']).to eq(ems.id.to_s)
+      expect(provider['name']).to eq('Test Provider')
+      expect(provider['vms']).to be_an(Array)
+      expect(provider['vms'].length).to eq(2)
+
+      # Check VMs are present (order-independent)
+      vm_ids = provider['vms'].map { |v| v['id'] }
+      expect(vm_ids).to contain_exactly(vm1.id.to_s, vm2.id.to_s)
+      provider['vms'].each do |vm|
+        expect(vm).to have_key('href')
+        expect(vm).to have_key('id')
+        expect(vm).to have_key('name')
+        expect(vm['href']).to match(%r{/api/vms/\d+})
+      end
+    end
+
+    it 'supports multiple attributes on has_many association' do
+      ems = FactoryBot.create(:ext_management_system, :name => "Test Provider")
+      vm1 = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM1", :vendor => "amazon")
+      vm2 = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM2", :vendor => "amazon")
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      get(api_providers_url, :params => {:expand => 'resources', :attributes => 'name,vms.name,vms.vendor'})
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['name']).to eq('providers')
+      expect(response.parsed_body['resources'].length).to eq(1)
+
+      provider = response.parsed_body['resources'].first
+      expect(provider['href']).to eq(api_provider_url(nil, ems))
+      expect(provider['id']).to eq(ems.id.to_s)
+      expect(provider['name']).to eq('Test Provider')
+      expect(provider['vms']).to be_an(Array)
+      expect(provider['vms'].length).to eq(2)
+
+      # Check VMs have all requested attributes (order-independent)
+      vm_ids = provider['vms'].map { |v| v['id'] }
+      expect(vm_ids).to contain_exactly(vm1.id.to_s, vm2.id.to_s)
+      provider['vms'].each do |vm|
+        expect(vm).to have_key('href')
+        expect(vm).to have_key('id')
+        expect(vm).to have_key('name')
+        expect(vm).to have_key('vendor')
+        expect(vm['vendor']).to eq('amazon')
+        expect(vm['href']).to match(%r{/api/vms/\d+})
+      end
+    end
+
+    it 'returns empty array for provider with no vms' do
+      ems = FactoryBot.create(:ext_management_system, :name => "Empty Provider")
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      get(api_providers_url, :params => {:expand => 'resources', :attributes => 'name,vms.name'})
+
+      expected = {
+        'name'      => 'providers',
+        'resources' => [
+          a_hash_including(
+            'href' => api_provider_url(nil, ems),
+            'id'   => ems.id.to_s,
+            'name' => 'Empty Provider',
+            'vms'  => []
+          )
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'silently ignores non-existent attributes on collection' do
+      ems = FactoryBot.create(:ext_management_system, :name => "Test Provider")
+      vm = FactoryBot.create(:vm_amazon, :ext_management_system => ems, :name => "VM1")
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      get(api_providers_url, :params => {:expand => 'resources', :attributes => 'name,vms.name,vms.nonexistent_field'})
+
+      expected = {
+        'name'      => 'providers',
+        'resources' => [
+          a_hash_including(
+            'href' => api_provider_url(nil, ems),
+            'id'   => ems.id.to_s,
+            'name' => 'Test Provider',
+            'vms'  => [
+              a_hash_including('href' => api_vm_url(nil, vm), 'id' => vm.id.to_s, 'name' => 'VM1')
+            ]
+          )
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+      # Verify nonexistent_field is not in the response
+      expect(response.parsed_body['resources'].first['vms'].first).not_to have_key('nonexistent_field')
+    end
   end
 
   context 'Folders subcollection' do

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -320,7 +320,7 @@ describe "Vms API" do
           :expand     => "resources",
           :attributes => "hardware.host.name,name"
         }
-      }.to make_database_queries(:count => 21, :matching => query_match)
+      }.to make_database_queries(:count => 15, :matching => query_match)
 
       expected = {
         "resources" => a_collection_including(

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -358,6 +358,15 @@ describe "Vms API" do
       end.to make_database_queries(:count => 4, :matching => query_match)
     end
 
+    it "hardware (has_one)" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms", "hardwares")
+
+      expect do
+        get api_vms_url, :params => {:expand => "resources", :attributes => "hardware", :filter => ["id=#{vm_with_associations.id}"]}
+      end.to make_database_queries(:count => 4, :matching => query_match)
+    end
+
     it "multiple associations" do
       api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
       query_match = query_match_regexp("vms", "snapshots", "storages", "taggings", "tags")
@@ -365,6 +374,61 @@ describe "Vms API" do
       expect do
         get api_vms_url, :params => {:expand => "resources", :attributes => "snapshots,storage,tags", :filter => ["id=#{vm_with_associations.id}"]}
       end.to make_database_queries(:count => 6, :matching => query_match)
+    end
+  end
+
+  context "does not eager load when no join is needed" do
+    before { add_hardware_and_os_to_vms }
+
+    # provisioned_storage is a SQL-computable virtual column (attribute_supported_by_sql? == true),
+    # so virtual_with_includes? returns false and no eager load join should be added.
+    it "SQL-computable virtual column (provisioned_storage) does not add an extra join" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms")
+
+      expect {
+        get api_vms_url, :params => {
+          :expand     => "resources",
+          :attributes => "provisioned_storage,name"
+        }
+      }.to make_database_queries(:count => 3, :matching => query_match)
+
+      expect(response.parsed_body["resources"].first).to include("provisioned_storage", "name")
+    end
+
+    # active is a plain virtual column computed entirely from other columns -- no virtual_includes,
+    # not a real association -- so neither virtual_with_includes? nor real_association? fires.
+    it "plain virtual column with no includes (active) does not add an extra join" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms")
+
+      expect {
+        get api_vms_url, :params => {
+          :expand     => "resources",
+          :attributes => "active,name"
+        }
+      }.to make_database_queries(:count => 3, :matching => query_match)
+
+      expect(response.parsed_body["resources"].first).to include("active", "name")
+    end
+
+    # direct_service is a virtual_has_one without uses:, so reflect_on_association returns nil
+    # (it is not a real AR association) and virtual_includes returns nil (no uses:).
+    # Neither virtual_with_includes? nor real_association? fires -- no eager load join is added.
+    # This documents the current behavior: if this test fails, something changed the eager-load
+    # decision for no-uses: virtual associations (e.g., switching to reflection_with_virtual).
+    it "virtual_has_one without uses: (direct_service) does not add an extra join" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms")
+
+      expect {
+        get api_vms_url, :params => {
+          :expand     => "resources",
+          :attributes => "direct_service,name"
+        }
+      }.to make_database_queries(:count => 3, :matching => query_match)
+
+      expect(response.parsed_body["resources"].first).to include("direct_service", "name")
     end
   end
 


### PR DESCRIPTION
Enables requesting specific attributes on has_many associations using dot notation.

Before: attributes=vms.name returned {"vms": {"name": "Vm"}}
After: Returns array of VMs with requested attributes plus href and id

Uses eager loading to prevent N+1 queries.

Fixes #871

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
