### PR TITLE
[WIP] Basic CRUD support for configuration script source payloads

### DIFF
--- a/app/controllers/api/configuration_script_payloads_controller.rb
+++ b/app/controllers/api/configuration_script_payloads_controller.rb
@@ -14,6 +14,29 @@ module Api
       %w[include_encrypted_attributes]
     end
 
+    def create_resource(type, _id, data)
+      # Get source_id and manager_id from configuration_script_source if provided
+      source_id = parse_id(data.delete('configuration_script_source'), :configuration_script_sources)
+      manager_id = parse_id(data.delete('manager_resource'), :providers) || data.delete('ems_id')
+
+      raise BadRequestError, _("Must specify name") unless data['name']
+      raise BadRequestError, _("Must specify payload") unless data['payload']
+      raise BadRequestError, _("Must specify manager_resource or configuration_script_source") unless manager_id || source_id
+
+      # Get manager_id from source if not already provided
+      if source_id && !manager_id
+        source = resource_search(source_id, :configuration_script_sources)
+        manager_id = source.manager_id
+      end
+
+      payload_attrs = data.slice('name', 'description', 'payload', 'payload_type').deep_symbolize_keys
+      payload_attrs[:manager_id] = manager_id
+      payload_attrs[:configuration_script_source_id] = source_id if source_id
+      payload_attrs[:payload_type] ||= 'json'
+
+      ConfigurationScriptPayload.create!(payload_attrs)
+    end
+
     def edit_resource(type, id, data)
       resource = resource_search(id, type)
 

--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -20,8 +20,25 @@ module Api
       # Since we are passing a custom hash to create_ems_resource (instead of data variable)
       # we need to manually remove it from data.
       data.delete('id')
-      create_ems_resource(type, {'ems_id' => manager_id, 'name' => data['name']}, :supports => true) do |_manager, klass|
-        {:task_id => klass.create_in_provider_queue(manager_id, data.deep_symbolize_keys)}
+
+      # Handle manual scm_type - create directly without provider queue
+      if data['scm_type'] == 'manual'
+        raise BadRequestError, _("Must specify name") unless data['name']
+        raise BadRequestError, _("Must specify manager_resource or ems_id") unless manager_id
+
+        # Create the script source directly
+        script_source = ConfigurationScriptSource.create!(
+          :name        => data['name'],
+          :description => data['description'],
+          :manager_id  => manager_id,
+          :scm_type    => 'manual'
+        )
+        script_source
+      else
+        # Use provider queue for git and other scm_types
+        create_ems_resource(type, {'ems_id' => manager_id, 'name' => data['name']}, :supports => true) do |_manager, klass|
+          {:task_id => klass.create_in_provider_queue(manager_id, data.deep_symbolize_keys)}
+        end
       end
     end
 

--- a/app/controllers/api/subcollections/configuration_script_payloads.rb
+++ b/app/controllers/api/subcollections/configuration_script_payloads.rb
@@ -4,6 +4,13 @@ module Api
       def configuration_script_payloads_query_resource(object)
         object.configuration_script_payloads
       end
+
+      def create_resource_configuration_script_payloads(parent, _type, _id, data)
+        # When creating as a subcollection, automatically associate with parent script source
+        data['configuration_script_source'] = {"id" => parent.id.to_s}
+        data['manager_resource'] = {"id" => parent.manager_id.to_s} if parent.manager_id
+        create_resource(:configuration_script_payloads, nil, data)
+      end
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1000,6 +1000,8 @@
       - :name: read
         :identifier: embedded_configuration_script_payload_view
       :post:
+      - :name: create
+        :identifier: embedded_configuration_script_payload_add
       - :name: edit
         :identifier: embedded_configuration_script_payload_edit
     :resource_actions:
@@ -1013,6 +1015,9 @@
       :get:
       - :name: read
         :identifier: embedded_configuration_script_payload_view
+      :post:
+      - :name: create
+        :identifier: embedded_configuration_script_payload_add
     :authentications_subcollection_actions:
       :get:
       - :name: read


### PR DESCRIPTION
This should start to enable service composition UI by allowing the json payload to be persisted.

CP4AIOPS-11000

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
