### PR TITLE
Include direct associations in eager loading when requested

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -607,10 +607,21 @@ module Api
 
       def determine_include_for_find(klass)
         attrs = virtual_attributes_for(klass) do |type, attr_name, attr_base|
+          # Case 1: Direct virtual attribute (e.g., "ram_size")(Not association.column format (dot notation), therefore attr_base is blank)
           if klass.virtual_includes(attr_name) && !klass.attribute_supported_by_sql?(attr_name) && attr_base.blank?
             attr_name
+          # Case 2: Direct association (e.g., "snapshots", "storage", "ems_cluster")
+          # Not dot notation, check if the requested attribute is a direct association and include it
+          elsif attr_base.blank?
+            reflection = klass.reflect_on_association(attr_name.to_sym)
+            if reflection && [:has_many, :has_one, :has_and_belongs_to_many, :belongs_to].include?(reflection.macro)
+              attr_name
+            else
+              next
+            end
+          # Case 3: Nested attribute (e.g., "hardware.host.name")
+          # Include the base path for eager loading with specific exceptions
           else
-            next if attr_base.blank?
             next if virtual_attribute_accessor(type, attr_name)
             next if attr_base_uses_rbac?(attr_base)
 

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -300,6 +300,74 @@ describe "Vms API" do
     end
   end
 
+  # Query count expectations for eager loading:
+  # - has_many associations: 6 queries
+  #   * 3 pagination queries (count filtered results, get page of IDs, recount for subquery)
+  #   * 1 total count query (for collection metadata)
+  #   * 2 data queries (get distinct IDs, fetch VMs with associations eagerly loaded)
+  # - belongs_to associations: 4 queries
+  #   * 2 pagination queries (count filtered results, get page of IDs)
+  #   * 1 total count query (for collection metadata)
+  #   * 1 data query (fetch VMs with association eagerly loaded via LEFT OUTER JOIN)
+  context "eager loads requested direct associations" do
+    let!(:vm_with_associations) do
+      FactoryBot.create(
+        :vm_vmware,
+        :host                  => host,
+        :ext_management_system => ems,
+        :ems_cluster           => FactoryBot.create(:ems_cluster, :ext_management_system => ems),
+        :storage               => FactoryBot.create(:storage),
+        :tags                  => [FactoryBot.create(:tag)],
+        :snapshots             => [FactoryBot.create(:snapshot)]
+      )
+    end
+
+    it "snapshots" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms", "snapshots")
+
+      expect do
+        get api_vms_url, :params => {:expand => "resources", :attributes => "snapshots", :filter => ["id=#{vm_with_associations.id}"]}
+      end.to make_database_queries(:count => 6, :matching => query_match) # 6 queries for has_many (see comment above)
+    end
+
+    it "storage" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms", "storages")
+
+      expect do
+        get api_vms_url, :params => {:expand => "resources", :attributes => "storage", :filter => ["id=#{vm_with_associations.id}"]}
+      end.to make_database_queries(:count => 4, :matching => query_match) # 4 queries for belongs_to (see comment above)
+    end
+
+    it "tags" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms", "taggings", "tags")
+
+      expect do
+        get api_vms_url, :params => {:expand => "resources", :attributes => "tags", :filter => ["id=#{vm_with_associations.id}"]}
+      end.to make_database_queries(:count => 6, :matching => query_match) # 6 queries for has_many (see comment above)
+    end
+
+    it "ems_cluster" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms", "ems_clusters")
+
+      expect do
+        get api_vms_url, :params => {:expand => "resources", :attributes => "ems_cluster", :filter => ["id=#{vm_with_associations.id}"]}
+      end.to make_database_queries(:count => 4, :matching => query_match) # 4 queries for belongs_to (see comment above)
+    end
+
+    it "multiple associations" do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      query_match = query_match_regexp("vms", "snapshots", "storages", "taggings", "tags")
+
+      expect do
+        get api_vms_url, :params => {:expand => "resources", :attributes => "snapshots,storage,tags", :filter => ["id=#{vm_with_associations.id}"]}
+      end.to make_database_queries(:count => 6, :matching => query_match) # 6 queries when mixing has_many and belongs_to (see comment above)
+    end
+  end
+
   context "Vm index with nested indirect virtual attribute that participates in Rbac ('hardware.host.name')" do
     # Can't have `expect(Rbac).to receive(:filtered_object).never` in this block
     before do


### PR DESCRIPTION
When associations like snapshots, tags, storages, etc. are explicitly requested in the attributes parameter, they should be eager-loaded to prevent N+1 queries.

Previously, only associations with virtual_includes defined or nested associations (e.g., hardware.disks) were included. Direct associations were skipped, causing N+1 queries.

This change checks if a requested direct attribute is an ActiveRecord association and includes it in the eager loading if so.

For example, in a specific database setup with 1000 vms returned, and the following API request:

http://localhost:3000/api/vms?expand=resources&attributes=snapshots,tags,storages

The query count looks like this:

Before:
Completed 200 OK in 6631ms (Views: 0.3ms | ActiveRecord: 2005.1ms (3017 queries, 0 cached) | GC: 578.6ms)

After:
Completed 200 OK in 5972ms (Views: 0.3ms | ActiveRecord: 1684.1ms (1019 queries, 1 cached) | GC: 577.6ms)

It still can be an enormous payload because we're asking for N number of things with a large number of default attributes for 1000 vms, but this will ensure we eager load it because we asked for it.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
