### PR TITLE
Add service template restriction support to roles API

### DIFF
--- a/app/controllers/api/roles_controller.rb
+++ b/app/controllers/api/roles_controller.rb
@@ -62,7 +62,12 @@ module Api
     end
 
     def get_role_settings(data)
-      restrictions = {:vms => data['settings']['restrictions']['vms'].to_sym}
+      restrictions = {}
+      if data['settings']['restrictions']
+        data['settings']['restrictions'].each do |key, value|
+          restrictions[key.to_sym] = value.to_sym
+        end
+      end
       data['settings'].delete('restrictions')
       restrictions
     end

--- a/app/controllers/api/roles_controller.rb
+++ b/app/controllers/api/roles_controller.rb
@@ -2,6 +2,8 @@ module Api
   class RolesController < BaseController
     include Subcollections::Features
 
+    PERMITTED_ROLE_RESTRICTIONS = %i[service_templates vms].freeze
+
     def create_resource(type, _id = nil, data = {})
       assert_id_not_specified(data, type)
 
@@ -63,10 +65,10 @@ module Api
 
     def get_role_settings(data)
       restrictions = {}
-      if data['settings']['restrictions']
-        data['settings']['restrictions'].each do |key, value|
-          restrictions[key.to_sym] = value.to_sym
-        end
+      data['settings']['restrictions']&.each do |key, value|
+        next unless PERMITTED_ROLE_RESTRICTIONS.include?(key.to_sym)
+
+        restrictions[key.to_sym] = value.to_sym
       end
       data['settings'].delete('restrictions')
       restrictions

--- a/spec/requests/roles_spec.rb
+++ b/spec/requests/roles_spec.rb
@@ -179,6 +179,56 @@ describe "Roles API" do
         expect(role2.allows?(**feature)).to be_truthy
       end
     end
+
+    it "supports role creation with service_templates restriction" do
+      api_basic_authorize collection_action_identifier(:roles, :create)
+
+      role_with_service_template_restriction = {
+        "name"     => "role_with_service_templates",
+        "settings" => {"restrictions" => {"service_templates" => "user"}},
+        "features" => [
+          {:identifier => "vm_explorer"}
+        ]
+      }
+
+      post(api_roles_url, :params => role_with_service_template_restriction)
+
+      expect(response).to have_http_status(:ok)
+      expect_result_resources_to_include_keys("results", expected_attributes)
+
+      role_id = response.parsed_body["results"].first["id"]
+      role = MiqUserRole.find(role_id)
+
+      expect(role.settings[:restrictions][:service_templates]).to eq(:user)
+    end
+
+    it "supports role creation with both vms and service_templates restrictions" do
+      api_basic_authorize collection_action_identifier(:roles, :create)
+
+      role_with_both_restrictions = {
+        "name"     => "role_with_both_restrictions",
+        "settings" => {
+          "restrictions" => {
+            "vms"               => "user",
+            "service_templates" => "user_or_group"
+          }
+        },
+        "features" => [
+          {:identifier => "vm_explorer"}
+        ]
+      }
+
+      post(api_roles_url, :params => role_with_both_restrictions)
+
+      expect(response).to have_http_status(:ok)
+      expect_result_resources_to_include_keys("results", expected_attributes)
+
+      role_id = response.parsed_body["results"].first["id"]
+      role = MiqUserRole.find(role_id)
+
+      expect(role.settings[:restrictions][:vms]).to eq(:user)
+      expect(role.settings[:restrictions][:service_templates]).to eq(:user_or_group)
+    end
   end
 
   describe "Roles edit" do
@@ -217,6 +267,61 @@ describe "Roles API" do
                                    "settings" => {"restrictions" => {"vms" => "user_or_group"}})
       expect(role.reload.name).to eq("updated role")
       expect(role.settings[:restrictions][:vms]).to eq(:user_or_group)
+    end
+
+    it "supports role edit with service_templates restriction" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+
+      role = FactoryBot.create(:miq_user_role)
+
+      post(
+        api_role_url(nil, role),
+        :params => gen_request(
+          :edit,
+          "name"     => "updated role with service_templates",
+          "settings" => {"restrictions" => {"service_templates" => "user"}}
+        )
+      )
+
+      expect_single_resource_query("id"       => role.id.to_s,
+                                   "name"     => "updated role with service_templates",
+                                   "settings" => {"restrictions" => {"service_templates" => "user"}})
+      expect(role.reload.name).to eq("updated role with service_templates")
+      expect(role.settings[:restrictions][:service_templates]).to eq(:user)
+    end
+
+    it "supports role edit with both vms and service_templates restrictions" do
+      api_basic_authorize collection_action_identifier(:roles, :edit)
+
+      role = FactoryBot.create(:miq_user_role)
+
+      post(
+        api_role_url(nil, role),
+        :params => gen_request(
+          :edit,
+          "name"     => "updated role with both restrictions",
+          "settings" => {
+            "restrictions" => {
+              "vms"               => "user",
+              "service_templates" => "user_or_group"
+            }
+          }
+        )
+      )
+
+      expect_single_resource_query(
+        "id"       => role.id.to_s,
+        "name"     => "updated role with both restrictions",
+        "settings" => {
+          "restrictions" => {
+            "vms"               => "user",
+            "service_templates" => "user_or_group"
+          }
+        }
+      )
+      expect(role.reload.name).to eq("updated role with both restrictions")
+      expect(role.settings[:restrictions][:vms]).to eq(:user)
+      expect(role.settings[:restrictions][:service_templates]).to eq(:user_or_group)
     end
 
     it "supports multiple role edits" do

--- a/spec/requests/roles_spec.rb
+++ b/spec/requests/roles_spec.rb
@@ -229,6 +229,38 @@ describe "Roles API" do
       expect(role.settings[:restrictions][:vms]).to eq(:user)
       expect(role.settings[:restrictions][:service_templates]).to eq(:user_or_group)
     end
+
+    it "silently filters out unsupported restriction types" do
+      api_basic_authorize collection_action_identifier(:roles, :create)
+
+      role_with_unsupported_restriction = {
+        "name"     => "role_with_unsupported",
+        "settings" => {
+          "restrictions" => {
+            "vms"               => "user",
+            "unsupported_type"  => "some_value",
+            "service_templates" => "user_or_group"
+          }
+        },
+        "features" => [
+          {:identifier => "vm_explorer"}
+        ]
+      }
+
+      post(api_roles_url, :params => role_with_unsupported_restriction)
+
+      expect(response).to have_http_status(:ok)
+      expect_result_resources_to_include_keys("results", expected_attributes)
+
+      role_id = response.parsed_body["results"].first["id"]
+      role = MiqUserRole.find(role_id)
+
+      # Supported restrictions should be saved
+      expect(role.settings[:restrictions][:vms]).to eq(:user)
+      expect(role.settings[:restrictions][:service_templates]).to eq(:user_or_group)
+      # Unsupported restriction should be filtered out
+      expect(role.settings[:restrictions][:unsupported_type]).to be_nil
+    end
   end
 
   describe "Roles edit" do


### PR DESCRIPTION
This PR adds support for service_template_restriction in the Roles API, enabling users to set service template restrictions when creating or updating roles via the API. Previously, the API only supported vms restriction. 

Example:
```
POST /api/roles
{
  "name": "Admin",
  "settings": {
    "restrictions": {
      "vms": "user",
      "service_templates": "user_or_group"
    }
  },
  "features": [{"identifier": "vm_explorer"}]
}
```


@miq-bot add-label enhancement
@miq-bot add-reviewer @jrafanie 