### PR TITLE
Add Configured Systems assignment prefix for tags

### DIFF
--- a/app/controllers/api/mixins/chargeback_assignment.rb
+++ b/app/controllers/api/mixins/chargeback_assignment.rb
@@ -11,7 +11,7 @@ module Api
       }.freeze
 
       ALLOWED_TAG_PREFIXES = {
-        'Compute' => %w[vm container_image],
+        'Compute' => %w[vm container_image configured_system],
         'Storage' => %w[storage]
       }.freeze
 

--- a/spec/requests/chargebacks_spec.rb
+++ b/spec/requests/chargebacks_spec.rb
@@ -301,6 +301,7 @@ RSpec.describe "chargebacks API" do
     it_behaves_like "perform rate assign/unassign action", "Compute", :custom_attribute, :custom_attributes
     it_behaves_like "perform rate assign/unassign action", "Compute", :tag, :tags, "vm"
     it_behaves_like "perform rate assign/unassign action", "Compute", :tag, :tags, "container_image"
+    it_behaves_like "perform rate assign/unassign action", "Compute", :tag, :tags, "configured_system"
 
     it_behaves_like "perform rate assign/unassign action", "Storage", :miq_enterprise, :enterprises
     it_behaves_like "perform rate assign/unassign action", "Storage", :storage, :data_stores


### PR DESCRIPTION
This PR adds configured systems to the hard coded Assignment Prefix array, to allow tagging for configured systems. 

@miq-bot add-reviewer @jrafanie 
@miq-bot add-label enhancement