### PR TITLE
[WIP] Fix post routing error for non post endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,12 @@ Rails.application.routes.draw do
           end
         end
 
+        # Route POST to the controller for primary collections that don't support it so
+        # validate_api_request can return a proper JSON 400 instead of a routing error.
+        if collection.options.include?(:primary) && !collection.verbs.include?(:post)
+          root :action => :update, :via => :post, :as => nil
+        end
+
         # Route POST to the controller for collections that don't support it so
         # validate_api_request can return a proper JSON 400 instead of a routing error.
         if collection.options.include?(:collection) && !collection.verbs.include?(:post)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,17 @@ Rails.application.routes.draw do
           end
         end
 
+        # Route POST to the controller for collections that don't support it so
+        # validate_api_request can return a proper JSON 400 instead of a routing error.
+        if collection.options.include?(:collection) && !collection.verbs.include?(:post)
+          if collection.options.include?(:arbitrary_resource_path)
+            match "(/*c_suffix)", :action => :update, :via => :post
+          else
+            post "/", :action => :create, :constraints => Api::CreateConstraint.new
+            post "(/:c_id)", :action => :update
+          end
+        end
+
         Array(collection.subcollections).each do |subcollection_name|
           # OPTIONS action for each subcollection
           match "/:c_id/#{subcollection_name}", :controller => collection_name, :action => :options, :via => :options, :as => nil, :subcollection => true
@@ -73,7 +84,8 @@ Rails.application.routes.draw do
           else
             subcollection_name_pluralized, subresource_name = Api::Routing.inflections_for_named_route_helpers(subcollection_name.to_s)
 
-            Api::ApiConfig.collections[subcollection_name].verbs.each do |verb|
+            subcollection_verbs = Api::ApiConfig.collections[subcollection_name].verbs
+            subcollection_verbs.each do |verb|
               case verb
               when :get
                 get "/:c_id/#{subcollection_name}", :action => :index, :as => "#{resource_name}_#{subcollection_name_pluralized}"
@@ -88,6 +100,12 @@ Rails.application.routes.draw do
                 post "/:c_id/#{subcollection_name}", :action => :create, :constraints => Api::CreateConstraint.new
                 post "/:c_id/#{subcollection_name}(/:s_id)", :action => :update
               end
+            end
+
+            # Route POST to the controller for subcollections that don't support it so
+            # validate_api_request can return a proper JSON 400 instead of a routing error.
+            unless subcollection_verbs.include?(:post)
+              post "/:c_id/#{subcollection_name}(/:s_id)", :action => :update
             end
           end
         end

--- a/spec/requests/alerts_spec.rb
+++ b/spec/requests/alerts_spec.rb
@@ -186,4 +186,25 @@ describe "Alerts API" do
       )
     end
   end
+
+  describe "POST /api/alerts" do
+    it "rejects POST with a bad request error" do
+      api_basic_authorize
+
+      post(api_alerts_url)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include_error_with_message("Unsupported HTTP Method post for the Collection alerts specified")
+    end
+
+    it "rejects POST to a resource with a bad request error" do
+      api_basic_authorize
+      alert_status = FactoryBot.create(:miq_alert_status)
+
+      post(api_alert_url(nil, alert_status))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include_error_with_message("Unsupported HTTP Method post for the Collection alerts specified")
+    end
+  end
 end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -499,4 +499,15 @@ describe "Authentication API" do
       end
     end
   end
+
+  describe "POST /api/auth" do
+    it "rejects POST with a bad request error" do
+      api_basic_authorize
+
+      post(api_auth_url)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include_error_with_message("Unsupported HTTP Method post for the Collection auth specified")
+    end
+  end
 end

--- a/spec/requests/automate_spec.rb
+++ b/spec/requests/automate_spec.rb
@@ -97,4 +97,15 @@ describe "Automate API" do
       expect(response.parsed_body["resources"]).to match_array([{"name" => "System", "fqname" => "/Custom/Test/System"}])
     end
   end
+
+  describe "POST /api/automate" do
+    it "rejects POST with a bad request error" do
+      api_basic_authorize
+
+      post(api_automate_url(nil, "custom/test"))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include_error_with_message("Unsupported HTTP Method post for the Collection automate specified")
+    end
+  end
 end

--- a/spec/requests/compliances_spec.rb
+++ b/spec/requests/compliances_spec.rb
@@ -79,5 +79,16 @@ RSpec.describe "Compliances API" do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    describe "POST /api/vms/:c_id/compliances" do
+      it "rejects POST with a bad request error" do
+        api_basic_authorize
+
+        post(api_vm_compliances_url(nil, vm))
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to include_error_with_message("Unsupported HTTP Method post for the Sub-Collection compliances specified")
+      end
+    end
   end
 end

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -137,4 +137,28 @@ RSpec.describe 'Metrics API' do
       expect(response.parsed_body['links'].keys).to match_array(%w[self next first last])
     end
   end
+
+  describe "POST /api/metrics" do
+    it "rejects POST with a bad request error" do
+      api_basic_authorize
+
+      post(api_metrics_url)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include_error_with_message("Unsupported HTTP Method post for the Collection metrics specified")
+    end
+  end
+
+  describe "POST /api/vms/:c_id/metrics" do
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+
+    it "rejects POST as a subcollection with a bad request error" do
+      api_basic_authorize
+
+      post(api_vm_metrics_url(nil, vm))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include_error_with_message("Unsupported HTTP Method post for the Sub-Collection metrics specified")
+    end
+  end
 end


### PR DESCRIPTION
While testing another feature, I noticed that a POST on a GET only endpoint was raising a RoutingError instead of BadRequest.  I enumerated all endpoints that don't support POST and found that they behave similarly.

With this change, we now route correctly, the authentication is handled, and each of these endpoints will correctly raise a BadRequest so it should behave more accurately.

Warning: I don't know if we had code relying on the old behavior.

```
  Primaries:
    /api/auth_key_pairs(/:id) (supports GET and DELETE but no POST)

  Collections:
    /api/alerts(/:id)
    /api/automate(/*path)
    /api/chargeable_fields(/:id)
    /api/cloud_database_flavors(/:id)
    /api/cloud_volume_types(/:id)
    /api/configuration_profiles(/:id)
    /api/configuration_scripts(/:id)
    /api/configured_systems(/:id)
    /api/currencies(/:id)
    /api/enterprises(/:id)
    /api/lans(/:id)
    /api/measures(/:id)
    /api/metric_rollups(/:id)
    /api/metrics(/:id)
    /api/pxe_images(/:id)
    /api/service_offerings(/:id)
    /api/service_parameters_sets(/:id)
    /api/settings(/*path)
    /api/shortcuts(/:id)
    /api/tenant_groups(/:id)

  Subcollections:
    /api/vms/:id/accounts(/:s_id)
    /api/vms/:id/cdroms(/:s_id)
    /api/vms/:id/compliances(/:s_id)
    /api/groups/:id/custom_button_events(/:s_id)
    /api/tenants/:id/custom_button_events(/:s_id)
    /api/users/:id/custom_button_events(/:s_id)
    /api/vms/:id/disks(/:s_id)
    /api/physical_servers/:id/firmware_binaries(/:s_id)
    /api/providers/:id/folders(/:s_id)
    /api/hosts/:id/lans(/:s_id)
    /api/providers/:id/lans(/:s_id)
    /api/providers/:id/metric_rollups(/:s_id)
    /api/services/:id/metric_rollups(/:s_id)
    /api/vms/:id/metric_rollups(/:s_id)
    /api/vms/:id/metrics(/:s_id)
    /api/providers/:id/networks(/:s_id)
    /api/automation_requests/:id/request_logs(/:s_id)
    /api/provision_requests/:id/request_logs(/:s_id)
    /api/requests/:id/request_logs(/:s_id)
    /api/service_requests/:id/request_logs(/:s_id)
    /api/service_templates/:id/resource_actions(/:s_id)
    /api/vms/:id/software(/:s_id)
    /api/providers/:id/configuration_profiles(/:s_id)
    /api/providers/:id/configured_systems(/:s_id)
```
