### PR TITLE
[WIP] Expose request_logs as a read-only subcollection of all request types

### DIFF
--- a/app/controllers/api/automation_requests_controller.rb
+++ b/app/controllers/api/automation_requests_controller.rb
@@ -3,6 +3,7 @@ module Api
     include Api::Mixins::ResourceCancel
     include Api::Mixins::ResourceApproveDeny
     include Subcollections::RequestTasks
+    include Subcollections::RequestLogs
 
     def create_resource(type, _id, data)
       assert_id_not_specified(data, type)

--- a/app/controllers/api/provision_requests_controller.rb
+++ b/app/controllers/api/provision_requests_controller.rb
@@ -3,6 +3,7 @@ module Api
     include Api::Mixins::ResourceCancel
     include Api::Mixins::ResourceApproveDeny
     include Subcollections::RequestTasks
+    include Subcollections::RequestLogs
 
     def create_resource(type, _id, data)
       assert_id_not_specified(data, type)

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -3,6 +3,7 @@ module Api
     include Api::Mixins::ResourceCancel
     include Api::Mixins::ResourceApproveDeny
     include Subcollections::RequestTasks
+    include Subcollections::RequestLogs
 
     def create_resource(type, _id, data)
       assert_id_not_specified(data, type)

--- a/app/controllers/api/service_requests_controller.rb
+++ b/app/controllers/api/service_requests_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class ServiceRequestsController < BaseController
     include Subcollections::RequestTasks
+    include Subcollections::RequestLogs
     include Api::Mixins::Pictures
     include Api::Mixins::ResourceCancel
     include Api::Mixins::ResourceApproveDeny

--- a/app/controllers/api/subcollections/request_logs.rb
+++ b/app/controllers/api/subcollections/request_logs.rb
@@ -1,0 +1,12 @@
+module Api
+  module Subcollections
+    module RequestLogs
+      def request_logs_query_resource(object)
+        # object is the parent MiqRequest (or subclass), already RBAC-filtered by
+        # parent_resource_obj before this method is called, so no additional check is needed.
+        klass = collection_class(:request_logs)
+        object ? klass.where(:resource_id => object.id) : {}
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -345,6 +345,7 @@
     :klass: AutomationRequest
     :subcollections:
     - :request_tasks
+    - :request_logs
     :collection_actions:
       :get:
       - :name: read
@@ -2989,6 +2990,7 @@
     :klass: MiqProvisionRequest
     :subcollections:
     - :request_tasks
+    - :request_logs
     :collection_actions:
       :get:
       - :name: read
@@ -3275,7 +3277,20 @@
       - :name: cancel
         :identifier: miq_request_control
       - :name: edit
-        :identifier: miq_request_edit
+  :request_logs:
+    :description: Request Logs
+    :options:
+    - :subcollection
+    :verbs: *g
+    :klass: RequestLog
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show
   :requests:
     :description: Requests
     :identifier: miq_request
@@ -3285,6 +3300,7 @@
     :klass: MiqRequest
     :subcollections:
     - :request_tasks
+    - :request_logs
     :collection_actions:
       :get:
       - :name: read
@@ -3859,6 +3875,7 @@
     :klass: ServiceTemplateProvisionRequest
     :subcollections:
     - :request_tasks
+    - :request_logs
     :collection_actions:
       :get:
       - :name: read

--- a/spec/requests/request_logs_spec.rb
+++ b/spec/requests/request_logs_spec.rb
@@ -1,0 +1,99 @@
+RSpec.describe "Request Logs Subcollection API" do
+  # request_logs is authorized via miq_request_show (the per-resource identifier), not the parent
+  # collection's miq_request_show_list. subcollection_action_identifier resolves this correctly.
+  shared_examples "request_logs subcollection" do |parent_collection, parent_factory, logs_url_helper, log_url_helper|
+    let(:request) { FactoryBot.create(parent_factory, :requester => @user) }
+    let(:log)     { FactoryBot.create(:request_log, :resource => request) }
+
+    context "listing logs" do
+      it "is forbidden without appropriate role" do
+        api_basic_authorize
+
+        get send(logs_url_helper, nil, request)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns only logs belonging to the parent request" do
+        other_request = FactoryBot.create(parent_factory, :requester => @user)
+        log
+        other_log = FactoryBot.create(:request_log, :resource => other_request)
+        api_basic_authorize subcollection_action_identifier(parent_collection, :request_logs, :read, :get)
+
+        get send(logs_url_helper, nil, request), :params => {:expand => :resources}
+
+        expect(response).to have_http_status(:ok)
+        returned_ids = response.parsed_body["resources"].map { |r| r["id"] }
+        expect(returned_ids).to include(log.id.to_s)
+        expect(returned_ids).not_to include(other_log.id.to_s)
+      end
+
+      it "returns all logs for the request" do
+        log1 = FactoryBot.create(:request_log, :resource => request, :message => "first")
+        log2 = FactoryBot.create(:request_log, :resource => request, :message => "second")
+        api_basic_authorize subcollection_action_identifier(parent_collection, :request_logs, :read, :get)
+
+        get send(logs_url_helper, nil, request), :params => {:expand => :resources}
+
+        expect(response).to have_http_status(:ok)
+        returned_ids = response.parsed_body["resources"].map { |r| r["id"] }
+        expect(returned_ids).to match_array([log1.id.to_s, log2.id.to_s])
+      end
+    end
+
+    context "showing a single log" do
+      it "is forbidden without appropriate role" do
+        api_basic_authorize
+
+        get send(log_url_helper, nil, request, log)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns the log" do
+        api_basic_authorize subcollection_action_identifier(parent_collection, :request_logs, :read, :get)
+
+        get send(log_url_helper, nil, request, log)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to include(
+          "id"       => log.id.to_s,
+          "message"  => log.message,
+          "severity" => log.severity
+        )
+      end
+    end
+  end
+
+  context "under /requests" do
+    include_examples "request_logs subcollection",
+                     :requests,
+                     :service_template_provision_request,
+                     :api_request_request_logs_url,
+                     :api_request_request_log_url
+  end
+
+  context "under /service_requests" do
+    include_examples "request_logs subcollection",
+                     :service_requests,
+                     :service_template_provision_request,
+                     :api_service_request_request_logs_url,
+                     :api_service_request_request_log_url
+  end
+
+  context "under /automation_requests" do
+    include_examples "request_logs subcollection",
+                     :automation_requests,
+                     :automation_request,
+                     :api_automation_request_request_logs_url,
+                     :api_automation_request_request_log_url
+  end
+
+  context "under /provision_requests" do
+    include_examples "request_logs subcollection",
+                     :provision_requests,
+                     :miq_provision_request,
+                     :api_provision_request_request_logs_url,
+                     :api_provision_request_request_log_url
+  end
+end


### PR DESCRIPTION
Request logs were already being tracked per-request in the database but were
not exposed through the API. This changes makes them accessible without
introducing new RBAC complexity - if a user can view the request, they can
view its logs.

The subcollection reuses the miq_request_show identifier so no new product
features need to be defined or granted. The same pattern is applied across
all four request collections (requests, service_requests, provision_requests,
and automation_requests) for consistency.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
