### PR TITLE
[WIP] Add export action to service_dialogs API

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -43,6 +43,11 @@ module Api
       fetch_service_dialogs_content(service_dialog).first
     end
 
+    def export_resource(type, id, _data)
+      service_dialog = resource_search(id, type)
+      DialogSerializer.new.serialize([service_dialog]).first
+    end
+
     def copy_resource(type, id, data)
       service_dialog = resource_search(id, type)
       attributes = data.dup

--- a/config/api.yml
+++ b/config/api.yml
@@ -3741,6 +3741,8 @@
         :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
+      - :name: export
+        :identifier: miq_ae_customization_explorer
       - :name: template_service_dialog
         :identifier: dialog_new_editor
     :resource_actions:
@@ -3758,6 +3760,8 @@
         :identifier: dialog_edit_editor
       - :name: copy
         :identifier: dialog_copy_editor
+      - :name: export
+        :identifier: miq_ae_customization_explorer
       - :name: template_service_dialog
         :identifier: dialog_new_editor
   :service_offerings:

--- a/spec/requests/service_dialogs_spec.rb
+++ b/spec/requests/service_dialogs_spec.rb
@@ -915,4 +915,52 @@ describe "Service Dialogs API" do
       expect(response).to have_http_status(:bad_request)
     end
   end
+
+  context 'Exports service dialogs' do
+    let(:dialog) { FactoryBot.create(:dialog_with_tab_and_group_and_field, :label => 'export_me') }
+
+    it 'forbids export without an appropriate role' do
+      api_basic_authorize
+
+      post(api_service_dialog_url(nil, dialog), :params => {:action => 'export'})
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'exports a single service dialog' do
+      api_basic_authorize collection_action_identifier(:service_dialogs, :export)
+
+      post(api_service_dialog_url(nil, dialog), :params => {:action => 'export'})
+
+      expected = {
+        'label'          => 'export_me',
+        'dialog_tabs'    => a_collection_including(anything),
+        'export_version' => DialogImportService::CURRENT_DIALOG_VERSION
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'exports multiple service dialogs' do
+      dialog2 = FactoryBot.create(:dialog_with_tab_and_group_and_field, :label => 'export_me_too')
+      api_basic_authorize collection_action_identifier(:service_dialogs, :export)
+
+      post(
+        api_service_dialogs_url,
+        :params => {
+          :action    => 'export',
+          :resources => [{:id => dialog.id}, {:id => dialog2.id}]
+        }
+      )
+
+      expected = {
+        'results' => a_collection_containing_exactly(
+          a_hash_including('label' => 'export_me',     'dialog_tabs' => anything),
+          a_hash_including('label' => 'export_me_too', 'dialog_tabs' => anything)
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
SUPER WIP... I just looked to see if we have service dialog import/export via API and apparently import exists so I wanted to see what it would require to do export.  If needed, we can use this mechanism.

Exposes POST /api/service_dialogs/:id with action=export and bulk POST /api/service_dialogs with action=export and resources=[...].

Uses DialogSerializer to produce the same hash structure that the existing import (create_resource) already accepts, making export/import round-trippable through the API without transformation.

The export action reuses the miq_ae_customization_explorer RBAC identifier, consistent with read and copy.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
