### PR TITLE
Add Missing Scope Handling to the Conditions Endpoint

### DIFF
--- a/app/controllers/api/conditions_controller.rb
+++ b/app/controllers/api/conditions_controller.rb
@@ -4,6 +4,7 @@ module Api
       assert_id_not_specified(data, type)
       begin
         data["expression"] = MiqExpression.new(data["expression"]) if data["expression"]
+        data["applies_to_exp"] = MiqExpression.new(data["applies_to_exp"]) if data["applies_to_exp"]
         super(type, id, data)
       rescue => err
         raise BadRequestError, "Failed to create a new condition - #{err}"
@@ -14,6 +15,7 @@ module Api
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
       begin
         data["expression"] = MiqExpression.new(data["expression"]) if data["expression"]
+        data["applies_to_exp"] = MiqExpression.new(data["applies_to_exp"]) if data["applies_to_exp"]
         super(type, id, data)
       rescue => err
         raise BadRequestError, "Failed to update condition - #{err}"

--- a/spec/requests/conditions_spec.rb
+++ b/spec/requests/conditions_spec.rb
@@ -21,10 +21,11 @@ describe "Conditions API" do
   context "Condition CRUD" do
     let(:sample_condition) do
       {
-        :name        => "name",
-        :description => "description",
-        :expression  => {"=" => {"field" => "ContainerImage-architecture", "value" => "dsa"}},
-        :towhat      => "ExtManagementSystem"
+        :name           => "name",
+        :description    => "description",
+        :expression     => {"=" => {"field" => "ContainerImage-architecture", "value" => "dsa"}},
+        :applies_to_exp => {"=" => {"field" => "ExtManagementSystem-type", "value" => "openshift"}},
+        :towhat         => "ExtManagementSystem"
       }
     end
     let(:condition) { FactoryBot.create(:condition) }
@@ -74,6 +75,7 @@ describe "Conditions API" do
       condition_id = response.parsed_body["results"].first["id"]
 
       expect(Condition.find(condition_id).expression.class).to eq(MiqExpression)
+      expect(Condition.find(condition_id).applies_to_exp.class).to eq(MiqExpression)
     end
 
     it "creates new conditions" do
@@ -117,12 +119,18 @@ describe "Conditions API" do
 
     it "edits condition" do
       api_basic_authorize collection_action_identifier(:conditions, :edit)
-      post(api_condition_url(nil, condition), :params => gen_request(:edit, "description" => "change"))
+      edits = {
+        "description"    => "change",
+        "expression"     => {"=" => {"field" => "ContainerImage-architecture", "value" => "dsa"}},
+        "applies_to_exp" => {"=" => {"field" => "ExtManagementSystem-type", "value" => "openshift"}}
+      }
+      post(api_condition_url(nil, condition), :params => gen_request(:edit, edits))
 
       expect(response).to have_http_status(:ok)
 
       expect(Condition.find(condition.id).description).to eq("change")
       expect(Condition.find(condition.id).expression.class).to eq(MiqExpression)
+      expect(Condition.find(condition.id).applies_to_exp.class).to eq(MiqExpression)
     end
 
     it "edits conditions" do


### PR DESCRIPTION
Wrap applies_to_exp in MiqExpression on condition create/edit

applies_to_exp is a guard expression evaluated before the main
expression to determine whether a condition is relevant for a given
record. Like expression, it must be stored as an MiqExpression object.

The expression field was already wrapped in MiqExpression.new on create
and edit, but applies_to_exp was not, so any API request that included
it would persist the wrong type.

@miq-bot add-label enhancement
@miq-bot add-reviewer @jrafanie 
@miq-bot assign @jrafanie 
