### PR TITLE
Fix security headers spec broken by Rack 3 lowercase header requirement caused by secure_headers upgrade

### DIFF
--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -71,14 +71,11 @@ RSpec.describe "Headers" do
 
       get(api_entrypoint_url)
 
-      expected = {
-        "X-Content-Type-Options"            => "nosniff",
-        "X-Download-Options"                => "noopen",
-        "X-Frame-Options"                   => "SAMEORIGIN",
-        "X-Permitted-Cross-Domain-Policies" => "none",
-        "X-XSS-Protection"                  => "1; mode=block"
-      }
-      expect(response.headers.to_h).to include(expected)
+      expect(response.headers["x-content-type-options"]).to eq("nosniff")
+      expect(response.headers["x-download-options"]).to eq("noopen")
+      expect(response.headers["x-frame-options"]).to eq("SAMEORIGIN")
+      expect(response.headers["x-permitted-cross-domain-policies"]).to eq("none")
+      expect(response.headers["x-xss-protection"]).to eq("1; mode=block")
       expect(content_security_policy_for("default-src")).to include("'self'")
       expect(content_security_policy_for("connect-src")).to include("'self'")
       expect(content_security_policy_for("frame-src") || content_security_policy_for("child-src")).to include("'self'")
@@ -87,7 +84,7 @@ RSpec.describe "Headers" do
     end
 
     def content_security_policy_for(src)
-      response.headers["Content-Security-Policy"].split(/\s*;\s*/).detect { |p| p.start_with?(src) }
+      response.headers["content-security-policy"].split(/\s*;\s*/).detect { |p| p.start_with?(src) }
     end
   end
 end


### PR DESCRIPTION
We updated secure_headers from 3.x to 7.x:
https://github.com/ManageIQ/manageiq/pull/23912

Rack 3 requires all response header names to be lowercase. secure_headers complied by lowercasing its HEADER_NAME constants (x-frame-options, content-security-policy, etc.) so it no longer conflicts with Rack::Lint.

The old assertions compared title-case keys (X-Frame-Options) against the actual headers hash and always missed, producing a wall of diff noise.

Switch to individual per-header eq assertions using response.headers[] which does case-insensitive lookup via Rack's HeaderHash, so the test works regardless of the casing used by secure_headers or Rails. Also lowercase the key in the content_security_policy_for helper to match.

Related to:
https://www.github.com/github/secure_headers/pull/533
https://www.github.com/github/secure_headers/pull/551

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
