### PR TITLE
Add YAML response support for settings subcollection

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -136,8 +136,13 @@ module Api
 
     def validate_response_format
       accept = request.headers["Accept"]
-      return if accept.blank? || accept.include?("json") || accept.include?("*/*")
+      return if accept.blank? || accept.include?("json") || accept.include?("*/*") || accept.include?("yaml")
+
       raise UnsupportedMediaTypeError, "Invalid Response Format #{accept} requested"
+    end
+
+    def yaml_request?
+      request.headers["Accept"].to_s.include?("yaml")
     end
 
     def set_access_control_headers

--- a/app/controllers/api/subcollections/settings.rb
+++ b/app/controllers/api/subcollections/settings.rb
@@ -21,7 +21,10 @@ module Api
           return
         end
 
-        render_resource :settings, resource_settings(resource)
+        settings = resource_settings(resource)
+        return render(:plain => settings.to_yaml, :content_type => "application/yaml") if yaml_request?
+
+        render_resource(:settings, settings)
       end
 
       def settings_query_resource(resource)

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -172,6 +172,15 @@ RSpec.describe "Servers" do
     let(:original_timeout) { server.settings_for_resource[:api][:authentication_timeout] }
     let(:super_admin) { FactoryBot.create(:user, :role => 'super_administrator', :userid => 'alice', :password => 'alicepassword') }
 
+    it "returns settings as YAML when Accept: application/yaml is requested" do
+      api_basic_authorize(:ops_settings)
+
+      get(api_server_settings_url(nil, server), :headers => {"Accept" => "application/yaml"})
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("application/yaml")
+      expect { YAML.safe_load(response.body) }.not_to raise_error
+    end
 
     it "shows the settings to an authenticated user with the proper role" do
       api_basic_authorize(:ops_settings)

--- a/spec/requests/servers_spec.rb
+++ b/spec/requests/servers_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe "Servers" do
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to include("application/yaml")
       expect { YAML.safe_load(response.body) }.not_to raise_error
+      expect { JSON.parse(response.body) }.to raise_error(JSON::ParserError)
     end
 
     it "shows the settings to an authenticated user with the proper role" do


### PR DESCRIPTION
Add YAML response for settings subcollection, to allow ui-classic to pull settings hash for advanced settings editing. 

@miq-bot add-label enhancement
@miq-bot add-reviewer @Fryguy
@miq-bot assign @Fryguy
