### PR TITLE
Fix VM Delete issue

### DIFF
--- a/app/controllers/api/instances_controller.rb
+++ b/app/controllers/api/instances_controller.rb
@@ -7,7 +7,7 @@ module Api
     extend Api::Mixins::CentralAdmin
 
     def terminate_resource(type, id = nil, _data = nil)
-      enqueue_ems_action(type, id, "Terminating", :method_name => "vm_destroy")
+      enqueue_ems_action(type, id, "Terminating", :method_name => "vm_destroy", :supports => :terminate)
     end
 
     def stop_resource(type, id = nil, _data = nil)

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -55,7 +55,7 @@ module Api
     end
 
     def terminate_resource(type, id = nil, _data = nil)
-      enqueue_ems_action(type, id, "Terminating", :method_name => "vm_destroy", :supports => true)
+      enqueue_ems_action(type, id, "Terminating", :method_name => "vm_destroy", :supports => :terminate)
     end
 
     def set_owner_resource(type, id = nil, data = nil)

--- a/spec/requests/vms_spec.rb
+++ b/spec/requests/vms_spec.rb
@@ -1193,7 +1193,7 @@ describe "Vms API" do
 
     it "terminates a single valid Vm" do
       api_basic_authorize action_identifier(:vms, :terminate)
-      stub_supports(vm, :vm_destroy)
+      stub_supports(vm, :terminate)
 
       post(vm_url, :params => gen_request(:terminate))
 
@@ -1210,8 +1210,8 @@ describe "Vms API" do
 
     it "terminates multiple valid Vms" do
       api_basic_authorize collection_action_identifier(:vms, :terminate)
-      stub_supports(vm1, :vm_destroy)
-      stub_supports(vm2, :vm_destroy)
+      stub_supports(vm1, :terminate)
+      stub_supports(vm2, :terminate)
 
       post(api_vms_url, :params => gen_request(:terminate, [{"href" => vm1_url}, {"href" => vm2_url}]))
 


### PR DESCRIPTION
Both controllers should pass the correct symbol to enqueue_ems_action for proper capability checking.

- instances_controller: add missing :supports => :terminate to terminate_resource
- vms_controller: correct :supports => true to :supports => :terminate



<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->
Before:
<img width="1113" height="734" alt="Screenshot 2026-07-29 at 8 47 04 PM" src="https://github.com/user-attachments/assets/9f424864-ed0e-4a18-a276-b451acb5c533" />

After:
<img width="1105" height="736" alt="Screenshot 2026-07-29 at 10 15 16 PM" src="https://github.com/user-attachments/assets/8abc18fe-40ec-42da-b572-af62172d54d3" />

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
@miq-bot add-label bug