### PR TITLE
Add assign custom button actions for button sets and service templates

### DIFF
--- a/app/controllers/api/custom_button_sets_controller.rb
+++ b/app/controllers/api/custom_button_sets_controller.rb
@@ -14,5 +14,12 @@ module Api
         action_result(true, "Button Group Reorder saved")
       end
     end
+
+    def assign_custom_button_resource(type, id, data)
+      api_action(type, id) do
+        CustomButtonSet.find(id).assign_button(data["button_id"])
+        action_result(true, "Button assigned to group")
+      end
+    end
   end
 end

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -49,6 +49,13 @@ module Api
       action_result(false, "Could not unarchive Service Template - #{err}")
     end
 
+    def assign_custom_button_resource(type, id, data)
+      api_action(type, id) do
+        resource_search(id, type).assign_custom_button(data["button_id"])
+        action_result(true, "Button added to Service Template order")
+      end
+    end
+
     private
 
     def set_additional_attributes

--- a/config/api.yml
+++ b/config/api.yml
@@ -1318,6 +1318,8 @@
         :identifier: ab_group_edit
       - :name: delete
         :identifier: ab_group_delete
+      - :name: assign_custom_button
+        :identifier: ab_button_new
   :custom_buttons:
     :description: Custom Buttons
     :identifier: ab_buttons_accord
@@ -4024,6 +4026,8 @@
         :identifier: svc_catalog_archive
       - :name: unarchive
         :identifier: svc_catalog_unarchive
+      - :name: assign_custom_button
+        :identifier: ab_button_new
       - :name: set_ownership
         :identifier: catalogitem_ownership
     :subresource_actions:

--- a/spec/requests/custom_button_sets_spec.rb
+++ b/spec/requests/custom_button_sets_spec.rb
@@ -144,6 +144,48 @@ RSpec.describe 'CustomButtonSets API' do
       expect(response.parsed_body).to include(request.except('action'))
     end
 
+    it 'can assign a custom button to a custom button set' do
+      button = FactoryBot.create(:custom_button, :applies_to_class => 'Service')
+      api_basic_authorize action_identifier(:custom_button_sets, :assign_custom_button, :resource_actions, :post)
+
+      post(api_custom_button_set_url(nil, cb_set), :params => { :action => 'assign_custom_button', :button_id => button.id })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('message' => 'Button assigned to group')
+      expect(cb_set.reload.set_data[:button_order]).to include(button.id)
+    end
+
+    it 'is idempotent when assigning a custom button to a custom button set' do
+      button = FactoryBot.create(:custom_button, :applies_to_class => 'Service')
+      api_basic_authorize action_identifier(:custom_button_sets, :assign_custom_button, :resource_actions, :post)
+
+      2.times do
+        post(api_custom_button_set_url(nil, cb_set), :params => { :action => 'assign_custom_button', :button_id => button.id })
+        expect(response).to have_http_status(:ok)
+      end
+
+      expect(cb_set.reload.set_data[:button_order]).to eq([button.id])
+    end
+
+    it 'is forbidden to assign a custom button to a custom button set without the appropriate role' do
+      button = FactoryBot.create(:custom_button, :applies_to_class => 'Service')
+      api_basic_authorize
+
+      post(api_custom_button_set_url(nil, cb_set), :params => { :action => 'assign_custom_button', :button_id => button.id })
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns not found for an invalid custom button set id when assigning a custom button' do
+      button = FactoryBot.create(:custom_button, :applies_to_class => 'Service')
+      api_basic_authorize action_identifier(:custom_button_sets, :assign_custom_button, :resource_actions, :post)
+
+      post(api_custom_button_set_url(nil, 999_999), :params => { :action => 'assign_custom_button', :button_id => button.id })
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to include('error' => a_hash_including('kind' => 'not_found'))
+    end
+
     it 'can delete a custom button set by id' do
       api_basic_authorize action_identifier(:custom_button_sets, :delete)
 

--- a/spec/requests/service_templates_spec.rb
+++ b/spec/requests/service_templates_spec.rb
@@ -831,6 +831,49 @@ describe "Service Templates API" do
     end
   end
 
+  describe "Service Templates assign custom button" do
+    let(:service_template) { FactoryBot.create(:service_template, :with_provision_resource_action_and_dialog) }
+    let(:button) { FactoryBot.create(:custom_button, :applies_to => service_template, :userid => @user.userid) }
+
+    it "can assign a custom button to a service template" do
+      api_basic_authorize action_identifier(:service_templates, :assign_custom_button, :resource_actions, :post)
+
+      post(api_service_template_url(nil, service_template), :params => { :action => "assign_custom_button", :button_id => button.id })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("message" => "Button added to Service Template order")
+      expect(service_template.reload.options[:button_order]).to include("cb-#{button.id}")
+    end
+
+    it "is idempotent when assigning a custom button to a service template" do
+      api_basic_authorize action_identifier(:service_templates, :assign_custom_button, :resource_actions, :post)
+
+      2.times do
+        post(api_service_template_url(nil, service_template), :params => { :action => "assign_custom_button", :button_id => button.id })
+        expect(response).to have_http_status(:ok)
+      end
+
+      expect(service_template.reload.options[:button_order]).to eq(["cb-#{button.id}"])
+    end
+
+    it "is forbidden without appropriate role" do
+      api_basic_authorize
+
+      post(api_service_template_url(nil, service_template), :params => { :action => "assign_custom_button", :button_id => button.id })
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns not found for an invalid service template id" do
+      api_basic_authorize action_identifier(:service_templates, :assign_custom_button, :resource_actions, :post)
+
+      post(api_service_template_url(nil, 999_999), :params => { :action => "assign_custom_button", :button_id => button.id })
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to include("error" => a_hash_including("kind" => "not_found"))
+    end
+  end
+
   context "schedules subcollection" do
     let!(:service_template) { FactoryBot.create(:service_template, :with_provision_resource_action_and_dialog) }
 


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/23953 

Adds assign_custom_button resource actions for custom button sets and service templates, wires the new actions into config/api.yml

@miq-bot add-label enhancement
@miq-bot add-reviewer @Fryguy
@miq-bot assign @Fryguy